### PR TITLE
Fix/jsmith/actually fix app sync app config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## [0.3.3] - 2025-09-07
+
+### Fixed
+- Filter pydantic args correctly in `get_app_config_class` utility function so we
+    don't attempt to use `typing.TypeVar` as a config class.
+
 ## [0.3.2] - 2025-09-07
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "uv_build"
 
 [project]
 name = "hassette"
-version = "0.3.2"
+version = "0.3.3"
 description = "Hassette is a modern, asynchronous, fully typed Python framework for running Home Assistant scripts and automations."
 readme = "README.md"
 authors = [{ name = "Jessica", email = "12jessicasmith34@gmail.com" }]

--- a/src/hassette/core/apps/utils.py
+++ b/src/hassette/core/apps/utils.py
@@ -44,11 +44,12 @@ def _get_app_config_class(cls: type["App"]) -> type[AppConfig]:
         if args and not isinstance(args[0], typing.TypeVar):
             break
 
-    # if we haven't found a user_config_class, raise an error
-    if not args:
+    # if we haven't found a user_config_class, we'll just return the default
+    pydantic_model_args = [arg for arg in args if isinstance(arg, type) and issubclass(arg, AppConfig)]
+    if not pydantic_model_args:
         return AppConfig
 
-    return args[0]
+    return pydantic_model_args[0]
 
 
 def validate_app(cls: type["App"]) -> type[AppConfig]:

--- a/tests/data/hassette.toml
+++ b/tests/data/hassette.toml
@@ -18,25 +18,8 @@ cover_entity = "cover.ratgdo_door_2"
 test_entity = "light.test_light_2"
 
 
-[apps.battery]
+[apps.my_app_sync]
 enabled = true
-app_path = "examples/battery.py"
-filename = "battery.py"
-class_name = "Battery"
-
-[apps.battery_sync]
-enabled = true
-app_path = "examples/battery.py"
-filename = "battery.py"
-class_name = "BatterySync"
-
-[[apps.battery.config]]
-always_send = false
-force = false
-threshold = 10
-
-
-[[apps.battery_sync.config]]
-always_send = false
-force = false
-threshold = 10
+app_path = "tests/data"
+filename = "my_app.py"
+class_name = "MyAppSync"

--- a/tests/data/my_app.py
+++ b/tests/data/my_app.py
@@ -1,4 +1,4 @@
-from hassette.core.apps import App, AppConfig
+from hassette import App, AppConfig, AppSync
 from hassette.models.entities import LightEntity
 from hassette.models.events import StateChangeEvent
 from hassette.models.states import InputButtonState, LightState
@@ -39,3 +39,28 @@ class MyApp(App[MyAppUserConfig]):
         self.logger.info("Async event: %s", event)
         test = await self.hassette.api.get_state_value("input_button.test")
         self.logger.info("Async state: %s", test)
+
+
+class MyAppSync(AppSync):
+    def initialize_sync(self) -> None:
+        print(self.app_config_cls)
+        print(self.app_config)
+
+        self.hassette.bus.on_entity("input_button.test", handler=self.handle_event)
+        self.hassette.scheduler.run_in(self.hassette.api.get_states, 1)
+
+        self.office_light_exists = self.hassette.api.sync.entity_exists("light.office")
+        self.test_button_exists = self.hassette.api.sync.entity_exists("input_button.test")
+
+    def test_stuff(self) -> None:
+        if self.office_light_exists:
+            self.light_state = self.hassette.api.sync.get_state("light.office", model=LightState)
+            self.light_entity = self.hassette.api.sync.get_entity("light.office", model=LightEntity)
+        elif self.test_button_exists:
+            self.button_state = self.hassette.api.sync.get_state("input_button.test", model=InputButtonState)
+            self.logger.info("Button state: %s", self.button_state)
+
+    def handle_event(self, event: StateChangeEvent) -> None:
+        self.logger.info("event: %s", event)
+        test = self.hassette.api.sync.get_state_value("input_button.test")
+        self.logger.info("state: %s", test)

--- a/uv.lock
+++ b/uv.lock
@@ -419,7 +419,7 @@ wheels = [
 
 [[package]]
 name = "hassette"
-version = "0.3.2"
+version = "0.3.3"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
- Filter pydantic args correctly in `get_app_config_class` utility function so we
    don't attempt to use `typing.TypeVar` as a config class.