### PR TITLE
fix api.call_service target typing to also allow lists of ids

### DIFF
--- a/src/hassette/core/api.py
+++ b/src/hassette/core/api.py
@@ -327,7 +327,7 @@ class Api(Resource):
         self,
         domain: str,
         service: str,
-        target: dict[str, str] | None = None,
+        target: dict[str, str] | dict[str, list[str]] | None = None,
         return_response: bool | None = None,
         **data,
     ) -> HassContext | None:
@@ -968,7 +968,7 @@ class ApiSyncFacade(Resource):
         self,
         domain: str,
         service: str,
-        target: dict[str, str] | None = None,
+        target: dict[str, str] | dict[str, list[str]] | None = None,
         return_response: bool = True,
         **data,
     ):


### PR DESCRIPTION
When invoking an action / calling a service the target map can either be a single id per key or a list of ids per key. You can see this in the docs [here](https://www.home-assistant.io/docs/scripts/perform-actions/#targeting-areas-and-devices).

Great project, really enjoying it so far, thanks!