### PR TITLE
Feature/only decorator and hot reloading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+- hot-reloading support for apps using `watchfiles` library
+  - watches app files, hassette.toml, and .env files for changes
+  - reloads apps on change, removes orphans, reimports apps if source files change
+  - can be disabled with `watch_files = false` in config
+  - add a few new configuration values to control file watcher behavior
+- add utility function to wait for resources to be running with shutdown support
+  - `wait_for_resources_running` function added to `Hassette` class
+  - also available as standalone utility function in `hassette.utils`
+- `@only` decorator to allow marking a single app to run without changing `hassette.toml`
+  - importable from `hassette.core.apps`
+  - useful for development when you want to only run a single app without modifying config file
+  - will raise an error if multiple apps are marked with `@only`
+
+### Changed
+- move service watching logic to it's own service
+- refactor app_handler to handle reloading apps, re-importing, removing orphans, etc.
+
+### Fixed
+- update `api.call_service` target typing to also allow lists of ids - thanks @zlangbert!
+
 ## [0.7.0] - 2025-09-14
 ### Changed
 - rename `cancel` on `Subscription` to `unsubscribe` for clarity

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - importable from `hassette.core.apps`
   - useful for development when you want to only run a single app without modifying config file
   - will raise an error if multiple apps are marked with `@only`
+- add `app_key` to `AppManifest` - reflects the key used to identify the app in config
 
 ### Changed
 - move service watching logic to it's own service

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - refactor app_handler to handle reloading apps, re-importing, removing orphans, etc.
 
 ### Fixed
-- update `api.call_service` target typing to also allow lists of ids - thanks @zlangbert!
+- update `api.call_service` target typing to also allow lists of ids - [thanks @zlangbert](https://github.com/NodeJSmith/hassette/pull/44)!
 
 ## [0.7.0] - 2025-09-14
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## [0.8.0] - 2025-09-23
 ### Added
 - hot-reloading support for apps using `watchfiles` library
   - watches app files, hassette.toml, and .env files for changes

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "uv_build"
 
 [project]
 name = "hassette"
-version = "0.7.2"
+version = "0.8.0"
 description = "Hassette is a simple, modern, async-first Python framework for building Home Assistant automations."
 readme = "README.md"
 authors = [{ name = "Jessica", email = "12jessicasmith34@gmail.com" }]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,12 +37,14 @@ dependencies = [
     "anyio>=4.10.0",
     "coloredlogs>=15.0.1",
     "croniter>=6.0.0",
+    "deepdiff>=8.6.1",
     "orjson>=3.10.18",
     "packaging>=25.0",
     "platformdirs>=4.3.8",
     "pydantic-settings>=2.9.1",
     "python-dotenv>=1.1.0",
     "tenacity>=9.1.2",
+    "watchfiles>=1.1.0",
     "whenever>=0.8.4",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,9 @@ Changelog = "https://github.com/nodejsmith/hassette/blob/main/CHANGELOG.md"
 
 
 [dependency-groups]
-dev = []
+dev = [
+    "tomli-w>=1.2.0",
+]
 test = [
     "docker>=7.1.0",
     "nox>=2025.5.1",

--- a/src/hassette/config/app_manifest.py
+++ b/src/hassette/config/app_manifest.py
@@ -14,6 +14,9 @@ class AppManifest(BaseModel):
 
     model_config = ConfigDict(extra="allow", coerce_numbers_to_str=True)
 
+    app_key: str = Field(default=...)
+    """Reflects the key for this app in hassette.toml"""
+
     enabled: bool = Field(default=True)
     """Whether the app is enabled or not, will default to True if not set"""
 

--- a/src/hassette/config/core_config.py
+++ b/src/hassette/config/core_config.py
@@ -359,6 +359,7 @@ def filter_paths_to_unique_existing(value: Sequence[str | Path | None] | str | P
     """
     value = [value] if isinstance(value, str | Path | None) else value
 
-    paths = set([nv for v in value if v and (nv := Path(v).resolve()).exists()])
+    paths = set(Path(v).resolve() for v in value if v)
+    paths = set(p for p in paths if p.exists())
 
     return paths

--- a/src/hassette/config/core_config.py
+++ b/src/hassette/config/core_config.py
@@ -238,9 +238,10 @@ class HassetteConfig(HassetteBaseSettings):
         app_dir = info.data.get("app_dir")
         if not app_dir:
             return values
-        for v in values.values():
+        for k, v in values.items():
             if not isinstance(v, dict):
                 continue
+            v["app_key"] = k
             if "app_dir" not in v or not v["app_dir"]:
                 LOGGER.info("Setting app_dir for app %s to %s", v["filename"], app_dir)
                 v["app_dir"] = app_dir

--- a/src/hassette/config/core_config.py
+++ b/src/hassette/config/core_config.py
@@ -339,7 +339,7 @@ class HassetteConfig(HassetteBaseSettings):
         self.data_dir.mkdir(parents=True, exist_ok=True)
         self.config_dir.mkdir(parents=True, exist_ok=True)
 
-        envs = set(list(self.config_dir.rglob("*.env")))
+        envs = set(self.config_dir.rglob("*.env"))
         for env in envs:
             LOGGER.info("Loading environment variables from %s", env)
             load_dotenv(env)

--- a/src/hassette/config/core_config.py
+++ b/src/hassette/config/core_config.py
@@ -143,6 +143,9 @@ class HassetteConfig(HassetteBaseSettings):
     file_watcher_step_milliseconds: int = Field(default=50)
     """Time to wait for additional file changes before emitting event in milliseconds."""
 
+    watch_files: bool = Field(default=True)
+    """Whether to watch files for changes and reload apps automatically."""
+
     # user config
     secrets: dict[str, SecretStr] = Field(default_factory=dict, examples=["['my_secret','another_secret']"])
     """User provided secrets that can be referenced in the config."""

--- a/src/hassette/config/core_config.py
+++ b/src/hassette/config/core_config.py
@@ -137,6 +137,12 @@ class HassetteConfig(HassetteBaseSettings):
     health_service_port: int | None = Field(default=8126)
     """Port to run the health service on, ignored if run_health_service is False."""
 
+    file_watcher_debounce_milliseconds: int = Field(default=1_600)
+    """Debounce time for file watcher events in milliseconds."""
+
+    file_watcher_step_milliseconds: int = Field(default=50)
+    """Time to wait for additional file changes before emitting event in milliseconds."""
+
     # user config
     secrets: dict[str, SecretStr] = Field(default_factory=dict, examples=["['my_secret','another_secret']"])
     """User provided secrets that can be referenced in the config."""

--- a/src/hassette/config/core_config.py
+++ b/src/hassette/config/core_config.py
@@ -37,6 +37,10 @@ logging.basicConfig(
 
 LOGGER = logging.getLogger(__name__)
 
+# TODO: allow user to specify servies/resources to call `set_logger_to_debug` on
+# would be cleaner for me as well, so I don't litter the code with `set_logger_to_debug` calls that should probably
+# not be there when we cut a new version
+
 
 def default_config_dir() -> Path:
     if env := os.getenv("HASSETTE__CONFIG_DIR", os.getenv("HASSETTE_CONFIG_DIR")):

--- a/src/hassette/config/core_config.py
+++ b/src/hassette/config/core_config.py
@@ -281,12 +281,12 @@ class HassetteConfig(HassetteBaseSettings):
         return sources
 
     def model_post_init(self, context: Any):
-        self.data_dir.mkdir(parents=True, exist_ok=True)
-
         enable_logging(self.log_level)
 
+        self.data_dir.mkdir(parents=True, exist_ok=True)
         self.config_dir.mkdir(parents=True, exist_ok=True)
-        envs = self.config_dir.rglob("*.env")
+
+        envs = set(list(self.config_dir.rglob("*.env")))
         for env in envs:
             LOGGER.info("Loading environment variables from %s", env)
             load_dotenv(env)

--- a/src/hassette/config/core_config.py
+++ b/src/hassette/config/core_config.py
@@ -37,7 +37,7 @@ logging.basicConfig(
 
 LOGGER = logging.getLogger(__name__)
 
-# TODO: allow user to specify servies/resources to call `set_logger_to_debug` on
+# TODO: allow user to specify services/resources to call `set_logger_to_debug` on
 # would be cleaner for me as well, so I don't litter the code with `set_logger_to_debug` calls that should probably
 # not be there when we cut a new version
 

--- a/src/hassette/core/apps/__init__.py
+++ b/src/hassette/core/apps/__init__.py
@@ -1,4 +1,4 @@
-from .app import App, AppSync
+from .app import App, AppSync, only
 from .app_config import AppConfig, AppConfigT
 
 __all__ = [
@@ -6,4 +6,5 @@ __all__ = [
     "AppConfig",
     "AppConfigT",
     "AppSync",
+    "only",
 ]

--- a/src/hassette/core/apps/app.py
+++ b/src/hassette/core/apps/app.py
@@ -18,6 +18,17 @@ LOGGER = getLogger(__name__)
 AppT = typing.TypeVar("AppT", bound="App")
 
 
+def only(app_cls: type[AppT]) -> type[AppT]:
+    """Decorator to mark an app class as the only one to run. If more than one app is marked with this decorator,
+    an exception will be raised during initialization.
+
+    This is useful for development and testing, where you may want to run only a specific app without
+    modifying configuration files.
+    """
+    app_cls._only = True  # type: ignore[attr-defined]
+    return app_cls
+
+
 class App(Generic[AppConfigT], Resource):
     """Base class for applications in the Hassette framework.
 
@@ -25,6 +36,9 @@ class App(Generic[AppConfigT], Resource):
     within the Hassette ecosystem. Lifecycle will generally be managed for you via the service status events,
     which send an event to the Bus and set the `status` attribute, based on the app's lifecycle.
     """
+
+    _only: ClassVar[bool] = False
+    """If True, only this app will be run. Only one app can be marked as only."""
 
     role: ClassVar[ResourceRole] = ResourceRole.APP
     """Role of the resource, e.g. 'App', 'Service', etc."""

--- a/src/hassette/core/apps/app_handler.py
+++ b/src/hassette/core/apps/app_handler.py
@@ -94,7 +94,7 @@ class _AppWatcher(Service):
             curr_apps_config,
             ignore_order=True,
             # TODO: do not use magic strings here
-            include_paths=["root", "user_config"],
+            include_paths=[ROOT_PATH, USER_CONFIG_PATH],
         )
 
         if not diff:

--- a/src/hassette/core/apps/app_handler.py
+++ b/src/hassette/core/apps/app_handler.py
@@ -316,7 +316,7 @@ class _AppHandler(Resource):
             try:
                 app_class = load_app_class(app_manifest)
                 if app_class._only:
-                    only_apps.append(app_class.app_manifest.app_key)
+                    only_apps.append(app_manifest.app_key)
             except (UndefinedUserConfigError, InvalidInheritanceError):
                 self.logger.error(
                     "Failed to load app %s due to bad configuration - check previous logs for details",
@@ -334,6 +334,8 @@ class _AppHandler(Resource):
 
     async def _initialize_apps(self):
         """Initialize all configured and enabled apps."""
+
+        await self._set_only_app()
 
         for app_key, app_manifest in self.active_apps_config.items():
             try:

--- a/src/hassette/core/apps/app_handler.py
+++ b/src/hassette/core/apps/app_handler.py
@@ -28,8 +28,6 @@ LOGGER = getLogger(__name__)
 FAIL_AFTER_SECONDS = 10
 LOADED_CLASSES: "dict[tuple[str, str], type[App[AppConfig]]]" = {}
 
-CHECK_COUNT = 0
-
 
 def _manifest_key(app_name: str, index: int) -> str:
     # Human-friendly identifier for logs; not used as dict key.

--- a/src/hassette/core/apps/app_handler.py
+++ b/src/hassette/core/apps/app_handler.py
@@ -51,7 +51,6 @@ class _AppWatcher(Service):
 
     async def run_forever(self) -> None:
         """Watch app directories for changes and trigger reloads."""
-        global CHECK_COUNT
         try:
             self.logger.info("Starting app watcher service")
 
@@ -70,9 +69,6 @@ class _AppWatcher(Service):
 
             await self.handle_start()
             async for changes in awatch(*paths, stop_event=self.hassette._shutdown_event):
-                CHECK_COUNT += 1
-                self.logger.info("Watcher iteration %d: detected changes: %s", CHECK_COUNT, changes)
-
                 if self.hassette._shutdown_event.is_set():
                     break
 

--- a/src/hassette/core/apps/app_handler.py
+++ b/src/hassette/core/apps/app_handler.py
@@ -98,7 +98,11 @@ class _AppWatcher(Service):
 
         diff = DeepDiff(original_apps_config, curr_apps_config, ignore_order=True)
         config_diff = DeepDiff(
-            original_apps_config, curr_apps_config, ignore_order=True, include_paths=["root", "user_config"]
+            original_apps_config,
+            curr_apps_config,
+            ignore_order=True,
+            # TODO: do not use magic strings here
+            include_paths=["root", "user_config"],
         )
 
         if not diff:

--- a/src/hassette/core/apps/app_handler.py
+++ b/src/hassette/core/apps/app_handler.py
@@ -51,7 +51,7 @@ class _AppWatcher(Service):
         try:
             self.logger.info("Starting app watcher service")
 
-            if not self.hassette.wait_for_resources_running([self.app_handler]):
+            if not (await self.hassette.wait_for_resources_running([self.app_handler])):
                 self.logger.error("App handler is not running, cannot start app watcher")
                 return
 
@@ -281,7 +281,7 @@ class _AppHandler(Resource):
         await self._initialize_app_instances(app_key, manifest)
 
     async def initialize_apps(self) -> None:
-        if not self.hassette.wait_for_resources_running([self.hassette._websocket]):
+        if not (await self.hassette.wait_for_resources_running([self.hassette._websocket])):
             self.logger.warning("App initialization timed out")
             return
 

--- a/src/hassette/core/apps/app_handler.py
+++ b/src/hassette/core/apps/app_handler.py
@@ -26,6 +26,8 @@ if typing.TYPE_CHECKING:
 LOGGER = getLogger(__name__)
 FAIL_AFTER_SECONDS = 10
 LOADED_CLASSES: "dict[tuple[str, str], type[App[AppConfig]]]" = {}
+ROOT_PATH = "root"
+USER_CONFIG_PATH = "user_config"
 
 
 def _manifest_key(app_name: str, index: int) -> str:
@@ -93,7 +95,6 @@ class _AppWatcher(Service):
             original_apps_config,
             curr_apps_config,
             ignore_order=True,
-            # TODO: do not use magic strings here
             include_paths=[ROOT_PATH, USER_CONFIG_PATH],
         )
 

--- a/src/hassette/core/apps/app_handler.py
+++ b/src/hassette/core/apps/app_handler.py
@@ -90,6 +90,8 @@ class _AppWatcher(Service):
         original_apps_config = deepcopy(self.app_handler.apps_config)
 
         # reinitialize config to pick up changes
+        # note: this is the proper way to do it, even if it feels weird
+        # https://docs.pydantic.dev/latest/concepts/pydantic_settings/#in-place-reloading
         self.hassette.config.__init__()
         self.app_handler.set_apps_configs(self.hassette.config.apps)
         curr_apps_config = deepcopy(self.app_handler.apps_config)

--- a/src/hassette/core/apps/app_handler.py
+++ b/src/hassette/core/apps/app_handler.py
@@ -92,10 +92,7 @@ class _AppWatcher(Service):
 
         diff = DeepDiff(original_apps_config, curr_apps_config, ignore_order=True)
         config_diff = DeepDiff(
-            original_apps_config,
-            curr_apps_config,
-            ignore_order=True,
-            include_paths=[ROOT_PATH, USER_CONFIG_PATH],
+            original_apps_config, curr_apps_config, ignore_order=True, include_paths=[ROOT_PATH, USER_CONFIG_PATH]
         )
 
         if not diff:

--- a/src/hassette/core/apps/app_handler.py
+++ b/src/hassette/core/apps/app_handler.py
@@ -4,6 +4,7 @@ import importlib.util
 import sys
 import typing
 from collections import defaultdict
+from copy import deepcopy
 from logging import getLogger
 from pathlib import Path
 
@@ -46,21 +47,23 @@ class _AppHandler(Resource):
 
     def __init__(self, hassette: "Hassette") -> None:
         super().__init__(hassette)
-        self.hassette = hassette
 
-        # Running instances: { app_name: { index: App } }
+        self.apps_config = deepcopy(self.hassette.config.apps)
+        """Copy of Hassette's config apps"""
+
+        self.active_apps_config: dict[str, AppManifest] = {}
+        """Apps that are enabled"""
+
         self.apps: dict[str, dict[int, App]] = defaultdict(dict)
+        """Running apps"""
 
-        # Failures captured during init: { app_name: [ (index, Exception) ] }
         self.failed_apps: dict[str, list[tuple[int, Exception]]] = defaultdict(list)
-
-        # Cache: loaded classes keyed by (full_path, class_name)
-        self._loaded_classes: dict[tuple[str, str], type[App[AppConfig]]] = {}
+        """Apps we could not start/failed to start"""
 
     async def initialize(self) -> None:
         """Start handler and initialize configured apps."""
-        await super().initialize()
         await self.initialize_apps()
+        await super().initialize()
 
     async def shutdown(self) -> None:
         """Shutdown all app instances gracefully."""
@@ -81,8 +84,6 @@ class _AppHandler(Resource):
         self.failed_apps.clear()
         await super().shutdown()
 
-    # ---------- Public-ish helpers (handy in tests / hot-reload pathways) ----------
-
     def get(self, app_name: str, index: int = 0) -> App | None:
         """Get a specific app instance if running."""
         return self.apps.get(app_name, {}).get(index)
@@ -95,7 +96,9 @@ class _AppHandler(Resource):
         """Stop and remove all instances for a given app_name."""
         instances = self.apps.pop(app_name, None)
         if not instances:
+            self.logger.warning("Cannot stop app %s, not found", app_name)
             return
+        self.logger.info("Stopping %d instance of %s", len(instances), app_name)
         for index, inst in instances.items():
             ident = _manifest_key(app_name, index)
             try:
@@ -107,19 +110,29 @@ class _AppHandler(Resource):
 
     async def reload_app(self, app_name: str) -> None:
         """Stop and reinitialize a single app by name (based on current config)."""
+        self.logger.info("Reloading app %s", app_name)
+
         await self.stop_app(app_name)
         # Initialize only that app from the current config if present and enabled
-        manifest = self.hassette.config.apps.get(app_name)
-        if manifest and manifest.enabled:
-            self._instantiate_apps_from_manifest(app_name, manifest)
-            await self._initialize_apps(app_name, manifest)
+        manifest = self.active_apps_config.get(app_name)
+        if not manifest:
+            if manifest := self.apps_config.get(app_name):
+                self.logger.warning("Cannot reload app %s, not enabled", app_name)
+                return
+            self.logger.warning("Cannot reload app %s, not found", app_name)
+            return
 
-    # ---------- Core initialization logic ----------
+        assert manifest is not None, "Manifest should not be None"
+
+        self._create_app_instances(app_name, manifest)
+        await self._initialize_app_instances(app_name, manifest)
 
     async def initialize_apps(self) -> None:
-        """Initialize all configured and enabled apps."""
-        apps_config = self.hassette.config.apps
-        self.logger.debug("Found %d apps in configuration: %s", len(apps_config), list(apps_config.keys()))
+        self.logger.debug(
+            "Found %d apps in configuration: %s",
+            len(self.apps_config),
+            list(self.apps_config.keys()),
+        )
 
         with anyio.move_on_after(6) as scope:
             while self.hassette._websocket.status != ResourceStatus.RUNNING and not self.hassette._websocket.connected:
@@ -133,24 +146,70 @@ class _AppHandler(Resource):
             self.logger.warning("App initialization timed out")
             return
 
-        if not apps_config:
+        if not self.apps_config:
             self.logger.info("No apps configured, skipping initialization")
             return
+
+        try:
+            self.apps, self.failed_apps = await self._initialize_apps(self.apps_config)
+        except Exception as e:
+            self.logger.exception("Failed to initialize apps")
+            await self.handle_crash(e)
+            raise
+
+    async def _initialize_apps(self, apps_config: dict[str, "AppManifest"]):
+        """Initialize all configured and enabled apps."""
 
         # Rebuild each app_name from manifest (stop any old instances first)
         for app_name, app_manifest in apps_config.items():
             if not app_manifest.enabled:
                 self.logger.debug("App %s is disabled, skipping initialization", app_name)
-                # If previously running, stop it
-                if app_name in self.apps:
-                    await self.stop_app(app_name)
+                continue
+            self.active_apps_config[app_name] = app_manifest
+
+        only_apps: list[type[App[AppConfig]]] = []
+        for app_manifest in self.active_apps_config.values():
+            try:
+                app_class = load_app_class(app_manifest)
+                if app_class._only:
+                    only_apps.append(app_class)
+            except (UndefinedUserConfigError, InvalidInheritanceError):
+                self.logger.error(
+                    "Failed to load app %s due to bad configuration - check previous logs for details",
+                    app_manifest.display_name,
+                )
+            except Exception:
+                self.logger.exception("Failed to load app class for %s", app_manifest.display_name)
+
+        if only_apps:
+            if len(only_apps) > 1:
+                names = ", ".join(app.__name__ for app in only_apps)
+                raise RuntimeError(f"Multiple apps marked as only: {names}")
+            only_app = only_apps[0]
+            self.logger.warning("App %s is marked as only, skipping all others", only_app.__name__)
+            self.active_apps_config = {
+                name: manifest
+                for name, manifest in self.active_apps_config.items()
+                if load_app_class(manifest) is only_app
+            }
+
+        for app_name, app_manifest in self.active_apps_config.items():
+            try:
+                self._create_app_instances(app_name, app_manifest)
+                await self._initialize_app_instances(app_name, app_manifest)
+            except (UndefinedUserConfigError, InvalidInheritanceError):
+                self.logger.error(
+                    "Failed to load app %s due to bad configuration - check previous logs for details",
+                    app_name,
+                )
+                continue
+            except Exception:
+                self.logger.exception("Failed to load app class for %s", app_name)
                 continue
 
-            await self.stop_app(app_name)
-            self._instantiate_apps_from_manifest(app_name, app_manifest)
-            await self._initialize_apps(app_name, app_manifest)
+        return self.apps, self.failed_apps
 
-    def _instantiate_apps_from_manifest(self, app_name: str, app_manifest: "AppManifest") -> None:
+    def _create_app_instances(self, app_name: str, app_manifest: "AppManifest") -> None:
         """Create app instances from a manifest, validating config.
 
         Args:
@@ -158,16 +217,7 @@ class _AppHandler(Resource):
             app_manifest (AppManifest): The manifest containing configuration.
         """
 
-        try:
-            app_class = load_app_class(app_manifest)
-        except (UndefinedUserConfigError, InvalidInheritanceError):
-            self.logger.error(
-                "Failed to load app %s due to bad configuration - check previous logs for details", app_name
-            )
-            return
-        except Exception:
-            self.logger.exception("Failed to load app class for %s", app_name)
-            return
+        app_class = load_app_class(app_manifest)
 
         class_name = app_class.__name__
         app_class.app_manifest = app_manifest
@@ -189,7 +239,7 @@ class _AppHandler(Resource):
                 self.failed_apps[app_name].append((idx, e))
                 continue
 
-    async def _initialize_apps(self, app_name: str, app_manifest: "AppManifest") -> None:
+    async def _initialize_app_instances(self, app_name: str, app_manifest: "AppManifest") -> None:
         """Initialize all instances of a given app_name.
 
         Args:
@@ -212,8 +262,6 @@ class _AppHandler(Resource):
                     self.logger.exception("Failed to start app %s (%s)", ident, class_name)
                 app_instance.status = ResourceStatus.STOPPED
                 self.failed_apps.setdefault(app_name, []).append((idx, e))
-
-    # ---------- Module loading ----------
 
 
 def load_app_class(app_manifest: "AppManifest") -> "type[App[AppConfig]]":

--- a/src/hassette/core/apps/app_handler.py
+++ b/src/hassette/core/apps/app_handler.py
@@ -52,8 +52,6 @@ class _AppHandler(Resource):
         super().__init__(hassette)
         self.apps_config = {}
 
-        # self.set_logger_to_debug()
-
         self.set_apps_configs(self.hassette.config.apps)
 
         self.only_app: str | None = None

--- a/src/hassette/core/apps/app_handler.py
+++ b/src/hassette/core/apps/app_handler.py
@@ -47,7 +47,7 @@ class _AppWatcher(Service):
         super().__init__(hassette, *args, **kwargs)
         self.app_handler = app_handler
 
-        self.set_logger_to_debug()
+        # self.set_logger_to_debug()
 
     async def run_forever(self) -> None:
         """Watch app directories for changes and trigger reloads."""
@@ -159,7 +159,7 @@ class _AppHandler(Resource):
         super().__init__(hassette)
         self.apps_config = {}
 
-        self.set_logger_to_debug()
+        # self.set_logger_to_debug()
 
         self.set_apps_configs(self.hassette.config.apps)
 

--- a/src/hassette/core/core.py
+++ b/src/hassette/core/core.py
@@ -71,7 +71,12 @@ class Hassette:
         self._service_watcher = self._register_resource(_ServiceWatcher)
         self._websocket = self._register_resource(_Websocket)
         self._app_handler = self._register_resource(_AppHandler)
-        self._file_watcher = self._register_resource(_FileWatcher)
+
+        if config.watch_files:
+            self._file_watcher = self._register_resource(_FileWatcher)
+        else:
+            self.logger.info("File watching is disabled")
+
         self._health_service = self._register_resource(_HealthService)
 
         # internal/public pairs

--- a/src/hassette/core/core.py
+++ b/src/hassette/core/core.py
@@ -13,7 +13,7 @@ from ..config import HassetteConfig
 from ..utils import get_traceback_string
 from .api import Api, _Api
 from .apps.app import App
-from .apps.app_handler import _AppHandler
+from .apps.app_handler import _AppHandler, _AppWatcher
 from .bus.bus import Bus, _Bus
 from .classes import Resource, Service
 from .enums import ResourceRole, ResourceStatus
@@ -69,6 +69,7 @@ class Hassette:
         # internal only (so far, at least)
         self._websocket = self._register_resource(_Websocket)
         self._app_handler = self._register_resource(_AppHandler)
+        self._app_watcher = self._register_resource(_AppWatcher, self._app_handler)
         self._health_service = self._register_resource(_HealthService)
 
         # internal/public pairs

--- a/src/hassette/core/core.py
+++ b/src/hassette/core/core.py
@@ -204,6 +204,74 @@ class Hassette:
         """
         return self.loop.create_task(coro)
 
+    async def wait_for_resources_running(
+        self, resources: list[Resource] | Resource, poll_interval: float = 0.1, timeout: int = 20
+    ) -> bool:
+        """Block until all dependent resources are running or shutdown is requested.
+
+        Args:
+            resources (list[Resource] | Resource): The resources to wait for.
+            poll_interval (float): The interval to poll for resource status.
+            timeout (int): The timeout for the wait operation.
+        Returns:
+            bool: True if all resources are running, False if timeout or shutdown.
+        """
+
+        resources = resources if isinstance(resources, list) else [resources]
+
+        with anyio.move_on_after(timeout) as cancel_scope:
+            futures = asyncio.gather(
+                *(self._wait_for_resource_running(resource, poll_interval) for resource in resources)
+            )
+            await futures
+
+        not_running = [r.class_name for r in resources if r.status != ResourceStatus.RUNNING]
+
+        if cancel_scope.cancel_called:
+            self.logger.error(
+                "Timeout waiting for resources to start after %d seconds: %s", timeout, ", ".join(not_running)
+            )
+            return False
+
+        if not_running:
+            self.logger.error("Some resources are not running: %s", ", ".join(not_running))
+            return False
+
+        return True
+
+    async def _wait_for_resource_running(
+        self, resource: Resource, poll_interval: float = 0.1, timeout: int = 20
+    ) -> bool:
+        """Block until a dependent resource is running or shutdown is requested.
+
+        Args:
+            resource (Resource): The resource to wait for.
+            poll_interval (float): The interval to poll for resource status.
+            timeout (int): The timeout for the wait operation.
+
+        Returns:
+            bool: True if the resource is running, False if shutdown.
+        """
+
+        with anyio.move_on_after(timeout) as cancel_scope:
+            while resource.status != ResourceStatus.RUNNING:
+                if self._shutdown_event.is_set():
+                    self.logger.warning("Shutdown in progress, aborting app watcher")
+                    return False
+                await asyncio.sleep(poll_interval)
+
+        if cancel_scope.cancel_called:
+            self.logger.error(
+                "Timeout waiting for resource '%s' to start after %d seconds", resource.class_name, timeout
+            )
+            return False
+
+        if resource.status != ResourceStatus.RUNNING:
+            self.logger.error("Resource '%s' is not running", resource.class_name)
+            return False
+
+        return True
+
     async def restart_service(self, event: HassetteServiceEvent) -> None:
         """Start a service from a service event."""
         data = event.payload.data
@@ -286,22 +354,17 @@ class Hassette:
 
         self.ready_event.set()
 
-        with anyio.move_on_after(5) as scope:
-            while True:
-                if self._shutdown_event.is_set():
-                    self.logger.warning("Shutdown in progress, aborting run loop")
-                    break
-                await anyio.sleep(0.1)
-                all_statuses = [s.status for s in self._resources.values()]
-                if all(s == ResourceStatus.RUNNING for s in all_statuses):
-                    break
+        started = await self.wait_for_resources_running(list(self._resources.values()), timeout=20)
 
-        if scope.cancel_called:
-            not_running = [s.class_name for s in self._resources.values() if s.status != ResourceStatus.RUNNING]
-            self.logger.error("Hassette startup timed out, resources that are not running: %s", not_running)
+        if not started:
+            self.logger.error("Not all resources started successfully, shutting down")
             await self._shutdown()
+            return
 
-        elif self._shutdown_event.is_set():
+        self.logger.info("All resources started successfully")
+        self.logger.info("Hassette is running.")
+
+        if self._shutdown_event.is_set():
             self.logger.warning("Hassette is shutting down, aborting run loop")
             await self._shutdown()
 

--- a/src/hassette/core/core.py
+++ b/src/hassette/core/core.py
@@ -13,11 +13,12 @@ from ..config import HassetteConfig
 from ..utils import get_traceback_string
 from .api import Api, _Api
 from .apps.app import App
-from .apps.app_handler import _AppHandler, _AppWatcher
+from .apps.app_handler import _AppHandler
 from .bus.bus import Bus, _Bus
 from .classes import Resource, Service
 from .enums import ResourceRole, ResourceStatus
 from .events import Event, HassetteServiceEvent
+from .file_watcher import _FileWatcher
 from .health_service import _HealthService
 from .scheduler.scheduler import Scheduler, _Scheduler
 from .websocket import _Websocket
@@ -69,7 +70,7 @@ class Hassette:
         # internal only (so far, at least)
         self._websocket = self._register_resource(_Websocket)
         self._app_handler = self._register_resource(_AppHandler)
-        self._app_watcher = self._register_resource(_AppWatcher, self._app_handler)
+        self._file_watcher = self._register_resource(_FileWatcher)
         self._health_service = self._register_resource(_HealthService)
 
         # internal/public pairs

--- a/src/hassette/core/events/__init__.py
+++ b/src/hassette/core/events/__init__.py
@@ -19,11 +19,13 @@ from .hass import (
     create_event_from_hass,
 )
 from .hassette import (
+    HassetteFileWatcherEvent,
     HassettePayload,
     HassetteServiceEvent,
     HassetteWebsocketStatusEvent,
     ServiceStatusPayload,
     WebsocketStatusEventPayload,
+    create_file_watcher_event,
     create_service_status_event,
     create_websocket_status_event,
 )
@@ -39,6 +41,7 @@ __all__ = [
     "HassEventDict",
     "HassEventEnvelopeDict",
     "HassStateDict",
+    "HassetteFileWatcherEvent",
     "HassettePayload",
     "HassetteServiceEvent",
     "HassetteWebsocketStatusEvent",
@@ -52,6 +55,7 @@ __all__ = [
     "UserRemovedEvent",
     "WebsocketStatusEventPayload",
     "create_event_from_hass",
+    "create_file_watcher_event",
     "create_service_status_event",
     "create_websocket_status_event",
 ]

--- a/src/hassette/core/file_watcher.py
+++ b/src/hassette/core/file_watcher.py
@@ -14,10 +14,6 @@ class _FileWatcher(Service):
         try:
             self.logger.info("Starting file watcher service")
 
-            if not (await self.hassette.wait_for_resources_running([self.hassette._app_handler])):
-                self.logger.error("App handler is not running, cannot start file watcher")
-                return
-
             paths = self.hassette.config.get_watchable_files()
 
             self.logger.info("Watching app directories for changes: %s", ", ".join(str(p) for p in paths))

--- a/src/hassette/core/file_watcher.py
+++ b/src/hassette/core/file_watcher.py
@@ -1,16 +1,9 @@
-import typing
-from copy import deepcopy
 from pathlib import Path
 
-from deepdiff import DeepDiff
 from watchfiles import awatch
 
 from hassette import Service
-from hassette.core.apps.app_handler import ROOT_PATH, USER_CONFIG_PATH
 from hassette.core.events.hassette import create_file_watcher_event
-
-if typing.TYPE_CHECKING:
-    from hassette.config.app_manifest import AppManifest
 
 
 class _FileWatcher(Service):
@@ -39,110 +32,9 @@ class _FileWatcher(Service):
                 for _, changed_path in changes:
                     changed_path = Path(changed_path).resolve()
                     self.logger.info("Detected change in %s", changed_path)
-                    await self.handle_changes(changed_path)
-                    continue
+                    event = create_file_watcher_event(changed_file_path=changed_path)
+                    await self.hassette.send_event(event.topic, event)
         except Exception as e:
             self.logger.exception("App watcher encountered an error, exception args: %s", e.args)
             await self.handle_crash(e)
             raise
-
-    async def handle_changes(self, changed_path: Path) -> None:
-        """Handle changes detected by the watcher."""
-
-        original_apps_config = deepcopy(self.hassette._app_handler.active_apps_config)
-
-        # Reinitialize config to pick up changes.
-        # https://docs.pydantic.dev/latest/concepts/pydantic_settings/#in-place-reloading
-        try:
-            self.hassette.config.__init__()
-        except Exception as e:
-            self.logger.exception("Failed to reload configuration: %s", e)
-            return
-        self.hassette._app_handler.set_apps_configs(self.hassette.config.apps)
-        curr_apps_config = deepcopy(self.hassette._app_handler.active_apps_config)
-
-        config_diff = DeepDiff(
-            original_apps_config, curr_apps_config, ignore_order=True, include_paths=[ROOT_PATH, USER_CONFIG_PATH]
-        )
-
-        orphans, new_apps = self._calculate_app_changes(original_apps_config, curr_apps_config)
-        await self._handle_removed_apps(orphans)
-        await self._handle_new_apps(new_apps)
-
-        force_reload_apps = self._apps_requiring_force_reload(curr_apps_config, changed_path)
-        await self._reload_apps_due_to_file_change(force_reload_apps, new_apps, orphans)
-        await self._reload_apps_due_to_config(config_diff, new_apps, orphans, force_reload_apps)
-
-    def _calculate_app_changes(
-        self, original_apps_config: dict[str, "AppManifest"], curr_apps_config: dict[str, "AppManifest"]
-    ) -> tuple[set[str], set[str]]:
-        """Return removed and newly added app keys."""
-
-        original_app_keys = set(original_apps_config.keys())
-        curr_app_keys = set(curr_apps_config.keys())
-
-        orphans = original_app_keys - curr_app_keys
-        new_apps = curr_app_keys - original_app_keys
-        return orphans, new_apps
-
-    async def _handle_removed_apps(self, orphans: set[str]) -> None:
-        if not orphans:
-            return
-
-        self.logger.info("Apps removed from config: %s", orphans)
-        event = create_file_watcher_event(event_type="orphaned_apps", orphaned_apps=orphans)
-        await self.hassette.send_event(event.topic, event)
-
-    async def _handle_new_apps(self, new_apps: set[str]) -> None:
-        if not new_apps:
-            self.logger.debug("No new apps to add")
-            return
-
-        self.logger.info("New apps added to config: %s", new_apps)
-        event = create_file_watcher_event(event_type="new_apps", new_apps=new_apps)
-        await self.hassette.send_event(event.topic, event)
-
-    def _apps_requiring_force_reload(self, curr_apps_config: dict[str, "AppManifest"], changed_path: Path) -> set[str]:
-        """Identify app keys that must reload because their source file changed."""
-
-        return {app.app_key for app in curr_apps_config.values() if app.full_path == changed_path}
-
-    async def _reload_apps_due_to_file_change(
-        self, force_reload_apps: set[str], new_apps: set[str], orphans: set[str]
-    ) -> None:
-        if not force_reload_apps:
-            return
-
-        apps = {app_key for app_key in force_reload_apps if app_key not in new_apps and app_key not in orphans}
-
-        if not apps:
-            return
-
-        self.logger.debug("Apps to force reload due to file change: %s", apps)
-        event = create_file_watcher_event(event_type="reimport_apps", reimport_apps=apps)
-        await self.hassette.send_event(event.topic, event)
-
-    async def _reload_apps_due_to_config(
-        self,
-        config_diff: DeepDiff,
-        new_apps: set[str],
-        orphans: set[str],
-        force_reload_apps: set[str],
-    ) -> None:
-        if not config_diff:
-            return
-
-        self.logger.debug("App configuration changes detected: %s", config_diff)
-        app_keys = config_diff.affected_root_keys
-
-        apps = {
-            app_key
-            for app_key in app_keys
-            if app_key not in new_apps and app_key not in orphans and app_key not in force_reload_apps
-        }
-        if not apps:
-            return
-
-        self.logger.info("Apps to reload due to config changes: %s", apps)
-        event = create_file_watcher_event(event_type="reload_apps", reload_apps=apps)
-        await self.hassette.send_event(event.topic, event)

--- a/src/hassette/core/file_watcher.py
+++ b/src/hassette/core/file_watcher.py
@@ -19,7 +19,12 @@ class _FileWatcher(Service):
             self.logger.info("Watching app directories for changes: %s", ", ".join(str(p) for p in paths))
 
             await self.handle_start()
-            async for changes in awatch(*paths, stop_event=self.hassette._shutdown_event):
+            async for changes in awatch(
+                *paths,
+                stop_event=self.hassette._shutdown_event,
+                step=self.hassette.config.file_watcher_step_milliseconds,
+                debounce=self.hassette.config.file_watcher_debounce_milliseconds,
+            ):
                 if self.hassette._shutdown_event.is_set():
                     break
 

--- a/src/hassette/core/file_watcher.py
+++ b/src/hassette/core/file_watcher.py
@@ -34,6 +34,9 @@ class _FileWatcher(Service):
                     event = create_file_watcher_event(changed_file_path=changed_path)
                     await self.hassette.send_event(event.topic, event)
 
+                # update paths in case new apps were added
+                paths = self.hassette.config.get_watchable_files()
+
         except Exception as e:
             self.logger.exception("App watcher encountered an error, exception args: %s", e.args)
             await self.handle_crash(e)

--- a/src/hassette/core/file_watcher.py
+++ b/src/hassette/core/file_watcher.py
@@ -1,0 +1,148 @@
+import typing
+from copy import deepcopy
+from pathlib import Path
+
+from deepdiff import DeepDiff
+from watchfiles import awatch
+
+from hassette import Service
+from hassette.core.apps.app_handler import ROOT_PATH, USER_CONFIG_PATH
+from hassette.core.events.hassette import create_file_watcher_event
+
+if typing.TYPE_CHECKING:
+    from hassette.config.app_manifest import AppManifest
+
+
+class _FileWatcher(Service):
+    """Background task to watch for file changes and reload apps."""
+
+    # TODO: double check only_app when any source files change, in case the only flag changed
+
+    async def run_forever(self) -> None:
+        """Watch app directories for changes and trigger reloads."""
+        try:
+            self.logger.info("Starting file watcher service")
+
+            if not (await self.hassette.wait_for_resources_running([self.hassette._app_handler])):
+                self.logger.error("App handler is not running, cannot start file watcher")
+                return
+
+            paths = self.hassette.config.get_watchable_files()
+
+            self.logger.info("Watching app directories for changes: %s", ", ".join(str(p) for p in paths))
+
+            await self.handle_start()
+            async for changes in awatch(*paths, stop_event=self.hassette._shutdown_event):
+                if self.hassette._shutdown_event.is_set():
+                    break
+
+                for _, changed_path in changes:
+                    changed_path = Path(changed_path).resolve()
+                    self.logger.info("Detected change in %s", changed_path)
+                    await self.handle_changes(changed_path)
+                    continue
+        except Exception as e:
+            self.logger.exception("App watcher encountered an error, exception args: %s", e.args)
+            await self.handle_crash(e)
+            raise
+
+    async def handle_changes(self, changed_path: Path) -> None:
+        """Handle changes detected by the watcher."""
+
+        original_apps_config = deepcopy(self.hassette._app_handler.active_apps_config)
+
+        # Reinitialize config to pick up changes.
+        # https://docs.pydantic.dev/latest/concepts/pydantic_settings/#in-place-reloading
+        try:
+            self.hassette.config.__init__()
+        except Exception as e:
+            self.logger.exception("Failed to reload configuration: %s", e)
+            return
+        self.hassette._app_handler.set_apps_configs(self.hassette.config.apps)
+        curr_apps_config = deepcopy(self.hassette._app_handler.active_apps_config)
+
+        config_diff = DeepDiff(
+            original_apps_config, curr_apps_config, ignore_order=True, include_paths=[ROOT_PATH, USER_CONFIG_PATH]
+        )
+
+        orphans, new_apps = self._calculate_app_changes(original_apps_config, curr_apps_config)
+        await self._handle_removed_apps(orphans)
+        await self._handle_new_apps(new_apps)
+
+        force_reload_apps = self._apps_requiring_force_reload(curr_apps_config, changed_path)
+        await self._reload_apps_due_to_file_change(force_reload_apps, new_apps, orphans)
+        await self._reload_apps_due_to_config(config_diff, new_apps, orphans, force_reload_apps)
+
+    def _calculate_app_changes(
+        self, original_apps_config: dict[str, "AppManifest"], curr_apps_config: dict[str, "AppManifest"]
+    ) -> tuple[set[str], set[str]]:
+        """Return removed and newly added app keys."""
+
+        original_app_keys = set(original_apps_config.keys())
+        curr_app_keys = set(curr_apps_config.keys())
+
+        orphans = original_app_keys - curr_app_keys
+        new_apps = curr_app_keys - original_app_keys
+        return orphans, new_apps
+
+    async def _handle_removed_apps(self, orphans: set[str]) -> None:
+        if not orphans:
+            return
+
+        self.logger.info("Apps removed from config: %s", orphans)
+        event = create_file_watcher_event(event_type="orphaned_apps", orphaned_apps=orphans)
+        await self.hassette.send_event(event.topic, event)
+
+    async def _handle_new_apps(self, new_apps: set[str]) -> None:
+        if not new_apps:
+            self.logger.debug("No new apps to add")
+            return
+
+        self.logger.info("New apps added to config: %s", new_apps)
+        event = create_file_watcher_event(event_type="new_apps", new_apps=new_apps)
+        await self.hassette.send_event(event.topic, event)
+
+    def _apps_requiring_force_reload(self, curr_apps_config: dict[str, "AppManifest"], changed_path: Path) -> set[str]:
+        """Identify app keys that must reload because their source file changed."""
+
+        return {app.app_key for app in curr_apps_config.values() if app.full_path == changed_path}
+
+    async def _reload_apps_due_to_file_change(
+        self, force_reload_apps: set[str], new_apps: set[str], orphans: set[str]
+    ) -> None:
+        if not force_reload_apps:
+            return
+
+        apps = {app_key for app_key in force_reload_apps if app_key not in new_apps and app_key not in orphans}
+
+        if not apps:
+            return
+
+        self.logger.debug("Apps to force reload due to file change: %s", apps)
+        event = create_file_watcher_event(event_type="reimport_apps", reimport_apps=apps)
+        await self.hassette.send_event(event.topic, event)
+
+    async def _reload_apps_due_to_config(
+        self,
+        config_diff: DeepDiff,
+        new_apps: set[str],
+        orphans: set[str],
+        force_reload_apps: set[str],
+    ) -> None:
+        if not config_diff:
+            return
+
+        self.logger.debug("App configuration changes detected: %s", config_diff)
+        app_keys = config_diff.affected_root_keys
+
+        apps = {
+            app_key
+            for app_key in app_keys
+            if app_key not in new_apps and app_key not in orphans and app_key not in force_reload_apps
+        }
+        if not apps:
+            return
+
+        self.logger.info("Apps to reload due to config changes: %s", apps)
+        event = create_file_watcher_event(event_type="reload_apps", reload_apps=apps)
+        await self.hassette.send_event(event.topic, event)

--- a/src/hassette/core/file_watcher.py
+++ b/src/hassette/core/file_watcher.py
@@ -9,8 +9,6 @@ from hassette.core.events.hassette import create_file_watcher_event
 class _FileWatcher(Service):
     """Background task to watch for file changes and reload apps."""
 
-    # TODO: double check only_app when any source files change, in case the only flag changed
-
     async def run_forever(self) -> None:
         """Watch app directories for changes and trigger reloads."""
         try:
@@ -34,6 +32,7 @@ class _FileWatcher(Service):
                     self.logger.info("Detected change in %s", changed_path)
                     event = create_file_watcher_event(changed_file_path=changed_path)
                     await self.hassette.send_event(event.topic, event)
+
         except Exception as e:
             self.logger.exception("App watcher encountered an error, exception args: %s", e.args)
             await self.handle_crash(e)

--- a/src/hassette/core/service_watcher.py
+++ b/src/hassette/core/service_watcher.py
@@ -1,0 +1,90 @@
+from .classes import Resource
+from .events import HassetteServiceEvent
+
+
+class _ServiceWatcher(Resource):
+    """Watches for service events and handles them."""
+
+    async def initialize(self, *args, **kwargs) -> None:
+        self._register_internal_event_listeners()
+        return await super().initialize(*args, **kwargs)
+
+    async def restart_service(self, event: HassetteServiceEvent) -> None:
+        """Start a service from a service event."""
+        data = event.payload.data
+        name = data.resource_name
+        role = data.role
+
+        try:
+            if name is None:
+                self.logger.warning("No %s specified to start, skipping", role)
+                return
+
+            self.logger.info("%s '%s' is being restarted after '%s'", role, name, event.payload.event_type)
+
+            self.logger.info("Starting %s '%s'", role, name)
+            service = self.hassette._resources.get(name)
+            if service is None:
+                self.logger.warning("No %s found for '%s', skipping start", role, name)
+                return
+
+            service.cancel()
+            service.start()
+
+        except Exception as e:
+            self.logger.error("Failed to restart %s '%s': %s", role, name, e)
+            raise
+
+    async def log_service_event(self, event: HassetteServiceEvent) -> None:
+        """Log the startup of a service."""
+
+        name = event.payload.data.resource_name
+        role = event.payload.data.role
+
+        if name is None:
+            self.logger.warning("No resource specified for startup, cannot log")
+            return
+
+        status, previous_status = event.payload.data.status, event.payload.data.previous_status
+
+        if status == previous_status:
+            self.logger.debug("%s '%s' status unchanged at '%s', not logging", role, name, status)
+            return
+
+        try:
+            self.logger.info(
+                "%s '%s' transitioned to status '%s' from '%s'",
+                role,
+                name,
+                event.payload.data.status,
+                event.payload.data.previous_status,
+            )
+
+        except Exception as e:
+            self.logger.error("Failed to log %s startup for '%s': %s", role, name, e)
+            raise
+
+    async def shutdown_if_crashed(self, event: HassetteServiceEvent) -> None:
+        """Shutdown the Hassette instance if a service has crashed."""
+        data = event.payload.data
+        name = data.resource_name
+        role = data.role
+
+        try:
+            self.logger.exception(
+                "%s '%s' has crashed (event_id %d), shutting down Hassette, %s",
+                role,
+                name,
+                data.event_id,
+                data.exception_traceback,
+            )
+            self.hassette.shutdown()
+        except Exception:
+            self.logger.error("Failed to handle %s crash for '%s': %s", role, name)
+            raise
+
+    def _register_internal_event_listeners(self) -> None:
+        """Register internal event listeners for resource lifecycle."""
+        self.hassette.bus.on_hassette_service_failed(handler=self.restart_service)
+        self.hassette.bus.on_hassette_service_crashed(handler=self.shutdown_if_crashed)
+        self.hassette.bus.on_hassette_service_status(handler=self.log_service_event)

--- a/src/hassette/core/topics.py
+++ b/src/hassette/core/topics.py
@@ -2,6 +2,7 @@
 
 HASSETTE_EVENT_SERVICE_STATUS = "hassette.event.service_status"
 HASSETTE_EVENT_WEBSOCKET_STATUS = "hassette.event.websocket"
+HASSETTE_EVENT_FILE_WATCHER = "hassette.event.file_watcher"
 
 # Home Assistant events
 HASS_EVENT_STATE_CHANGED = "hass.event.state_changed"

--- a/src/hassette/test_utils/fixtures.py
+++ b/src/hassette/test_utils/fixtures.py
@@ -36,6 +36,8 @@ async def mock_hassette_with_bus():
             self.ready_event = asyncio.Event()
             self.ready_event.set()
 
+            self._resources: dict[str, Resource] = {}
+
         async def send_event(self, topic: str, event: Event[Any]) -> None:
             """Mock method to send an event to the bus."""
             await self._send_stream.send((topic, event))

--- a/src/hassette/utils.py
+++ b/src/hassette/utils.py
@@ -1,9 +1,101 @@
+import asyncio
 import traceback
+import typing
 from logging import getLogger
 
 import aiohttp
+import anyio
+
+if typing.TYPE_CHECKING:
+    from hassette.core.classes import Resource
 
 LOGGER = getLogger(__name__)
+
+
+async def wait_for_resources_running_or_raise(
+    resources: list["Resource"],
+    poll_interval: float = 0.1,
+    timeout: int = 20,
+    shutdown_event: asyncio.Event | None = None,
+) -> None:
+    """Block until all dependent resources are running or shutdown is requested.
+
+    Args:
+        resources (list[Resource]): The resources to wait for.
+        poll_interval (float): The interval to poll for resource status.
+        timeout (int): The timeout for the wait operation.
+        shutdown_event (asyncio.Event | None): Optional event to signal shutdown.
+
+    Raises:
+        RuntimeError: If any resource fails to start or timeout occurs.
+    """
+    results = await wait_for_resources_running(
+        resources, poll_interval=poll_interval, timeout=timeout, shutdown_event=shutdown_event
+    )
+    if not results:
+        failed_to_start = [r.class_name for r in resources if r.status != "running"]
+        LOGGER.error("One or more resources failed to start: %s", ", ".join(failed_to_start))
+        raise RuntimeError(f"One or more resources failed to start: {', '.join(failed_to_start)}")
+
+
+async def wait_for_resources_running(
+    resources: list["Resource"],
+    poll_interval: float = 0.1,
+    timeout: int = 20,
+    shutdown_event: asyncio.Event | None = None,
+) -> bool:
+    """Block until all dependent resources are running or shutdown is requested.
+
+    Args:
+        resources (list[Resource]): The resources to wait for.
+        poll_interval (float): The interval to poll for resource status.
+        timeout (int): The timeout for the wait operation.
+        shutdown_event (asyncio.Event | None): Optional event to signal shutdown.
+
+    Returns:
+        bool: True if all resources are running, False if shutdown is requested.
+    """
+    futures = [
+        wait_for_resource_running(resource, poll_interval=poll_interval, timeout=timeout, shutdown_event=shutdown_event)
+        for resource in resources
+    ]
+
+    results = await asyncio.gather(*futures)
+    return all(results)
+
+
+async def wait_for_resource_running(
+    resource: "Resource", poll_interval: float = 0.1, timeout: int = 20, shutdown_event: asyncio.Event | None = None
+) -> bool:
+    """Block until a dependent resource is running or shutdown is requested.
+
+    Args:
+        resource (Resource): The resource to wait for.
+        poll_interval (float): The interval to poll for resource status.
+        timeout (int): The timeout for the wait operation.
+        shutdown_event (asyncio.Event | None): Optional event to signal shutdown.
+
+    Returns:
+        bool: True if the resource is running, False if shutdown.
+    """
+    from hassette.core.classes import ResourceStatus
+
+    with anyio.move_on_after(timeout) as cancel_scope:
+        while resource.status != ResourceStatus.RUNNING:
+            if shutdown_event and shutdown_event.is_set():
+                LOGGER.warning("Shutdown in progress, aborting app watcher")
+                return False
+            await asyncio.sleep(poll_interval)
+
+    if cancel_scope.cancel_called:
+        LOGGER.error("Timeout waiting for resource '%s' to start after %d seconds", resource.class_name, timeout)
+        return False
+
+    if resource.status != ResourceStatus.RUNNING:
+        LOGGER.error("Resource '%s' is not running", resource.class_name)
+        return False
+
+    return True
 
 
 def get_traceback_string(exception: Exception) -> str:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -284,7 +284,7 @@ def test_config_with_apps(apps_config_file):
             "env_file": [ENV_FILE],
         }
 
-    previous_instance = getattr(HassetteConfig, "_instance", None)
+    previous_instance: HassetteConfig | None = getattr(HassetteConfig, "_instance", None)
     config = AppsTestConfig(
         websocket_timeout_seconds=1,
         run_sync_timeout_seconds=2,
@@ -297,7 +297,7 @@ def test_config_with_apps(apps_config_file):
     try:
         yield config
     finally:
-        HassetteConfig._instance = previous_instance
+        HassetteConfig._instance = previous_instance or HassetteConfig._instance
 
 
 @pytest.fixture

--- a/tests/data/disabled_app.py
+++ b/tests/data/disabled_app.py
@@ -1,0 +1,10 @@
+from hassette import App, AppConfig
+
+
+class MyAppUserConfig(AppConfig):
+    test_entity: str = "input_button.test"
+
+
+class DisabledApp(App[MyAppUserConfig]):
+    async def initialize(self) -> None:
+        await super().initialize()

--- a/tests/data/hassette_apps.toml
+++ b/tests/data/hassette_apps.toml
@@ -1,0 +1,30 @@
+[hassette]
+base_url = "http://127.0.0.1:8123"
+api_port = 8123
+app_dir = "tests/data"
+
+secrets = ["my_secret"]
+
+[apps.my_app]
+enabled = true
+filename = "my_app.py"
+class_name = "MyApp"
+display_name = "My Test App"
+app_dir = "tests/data"
+config = { test_entity = "input_button.test" }
+
+[apps.my_app_sync]
+enabled = true
+filename = "my_app_sync.py"
+class_name = "MyAppSync"
+display_name = "My Test App Sync"
+app_dir = "tests/data"
+config = { test_entity = "input_button.test" }
+
+[apps.disabled_app]
+enabled = false
+filename = "disabled_app.py"
+class_name = "DisabledApp"
+display_name = "Disabled App"
+app_dir = "tests/data"
+config = { test_entity = "input_button.test" }

--- a/tests/data/my_app.py
+++ b/tests/data/my_app.py
@@ -22,6 +22,9 @@ class MyApp(App[MyAppUserConfig]):
         self.office_light_exists = await self.hassette.api.entity_exists("light.office")
         self.test_button_exists = await self.hassette.api.entity_exists("input_button.test")
 
+    async def test_reload_app(self):
+        await self.hassette._app_handler.reload_app(self.app_manifest.app_key)
+
     async def test_stuff(self) -> None:
         if self.office_light_exists:
             self.light_state = await self.hassette.api.get_state("light.office", model=LightState)

--- a/tests/data/my_app.py
+++ b/tests/data/my_app.py
@@ -12,9 +12,6 @@ class MyApp(App[MyAppUserConfig]):
     async def initialize(self) -> None:
         await super().initialize()
 
-        print(self.app_config_cls)
-        print(self.app_config)
-
         self.logger.info("MyApp has been initialized")
         self.hassette.bus.on_entity("input_button.test", handler=self.handle_event_sync)
         self.hassette.scheduler.run_in(self.hassette.api.get_states, 1)

--- a/tests/data/my_app.py
+++ b/tests/data/my_app.py
@@ -1,5 +1,4 @@
 from hassette import App, AppConfig
-from hassette.core.apps.app import only
 from hassette.core.events import StateChangeEvent
 from hassette.models.entities import LightEntity
 from hassette.models.states import InputButtonState, LightState
@@ -9,7 +8,6 @@ class MyAppUserConfig(AppConfig):
     test_entity: str = "input_button.test"
 
 
-@only
 class MyApp(App[MyAppUserConfig]):
     async def initialize(self) -> None:
         await super().initialize()

--- a/tests/data/my_app.py
+++ b/tests/data/my_app.py
@@ -1,4 +1,5 @@
 from hassette import App, AppConfig
+from hassette.core.apps.app import only
 from hassette.core.events import StateChangeEvent
 from hassette.models.entities import LightEntity
 from hassette.models.states import InputButtonState, LightState
@@ -8,6 +9,7 @@ class MyAppUserConfig(AppConfig):
     test_entity: str = "input_button.test"
 
 
+@only
 class MyApp(App[MyAppUserConfig]):
     async def initialize(self) -> None:
         await super().initialize()

--- a/tests/data/my_app_sync.py
+++ b/tests/data/my_app_sync.py
@@ -19,9 +19,6 @@ class MyAppUserConfig(AppConfig):
 # @only
 class MyAppSync(AppSync):
     def initialize_sync(self) -> None:
-        print(self.app_config_cls)
-        print(self.app_config)
-
         self.hassette.bus.on_entity("input_button.test", handler=self.handle_event)
         self.hassette.scheduler.run_in(self.test_stuff, 1)
 

--- a/tests/data/my_app_sync.py
+++ b/tests/data/my_app_sync.py
@@ -3,6 +3,9 @@ from hassette.core.events import StateChangeEvent
 from hassette.models.entities import LightEntity
 from hassette.models.states import InputButtonState, LightState
 
+# from hassette.core.apps.app import only
+
+
 try:
     from .my_app import MyApp
 except ImportError:
@@ -13,6 +16,7 @@ class MyAppUserConfig(AppConfig):
     test_entity: str = "input_button.test"
 
 
+# @only
 class MyAppSync(AppSync):
     def initialize_sync(self) -> None:
         print(self.app_config_cls)

--- a/tests/test_apps.py
+++ b/tests/test_apps.py
@@ -1,37 +1,33 @@
 import asyncio
-from unittest.mock import AsyncMock, Mock
+from copy import deepcopy
+from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 
 from hassette import ResourceStatus
-from hassette.config import HassetteConfig
 from hassette.core.apps.app_handler import _AppHandler, load_app_class
 
 
 @pytest.fixture
-async def app_handler(test_config):
-    tc = HassetteConfig(
-        websocket_timeout_seconds=1,
-        run_sync_timeout_seconds=2,
-        run_health_service=False,
-        apps={
-            "my_app": {"enabled": True, "filename": "my_app.py", "class_name": "MyApp"},
-            "my_app_sync": {"enabled": True, "filename": "my_app_sync.py", "class_name": "MyAppSync"},  # type: ignore
-        },
-        token=test_config.token.get_secret_value(),
-        app_dir=test_config.app_dir,
-    )
-
+async def app_handler(test_config_with_apps):
     hassette = Mock()
+    hassette.bus = Mock()
+    hassette.scheduler = Mock()
     hassette.send_event = AsyncMock()
     hassette.api.entity_exists = AsyncMock(return_value=True)
-    hassette.config = tc
+    hassette.api.sync.entity_exists.return_value = True  # type: ignore[attr-defined]
+    hassette.api.get_states = AsyncMock()
+    hassette.api.get_state_value = AsyncMock()
+    hassette.config = test_config_with_apps
     hassette._websocket = Mock()
     hassette._websocket.connected = True
     hassette._websocket.status = ResourceStatus.RUNNING
     hassette.wait_for_resources_running = AsyncMock(return_value=True)
 
     app_handler = _AppHandler(hassette)
+    hassette._app_handler = app_handler
+    hassette.get_app = app_handler.get  # used by sync apps
+
     await app_handler.initialize()
 
     yield app_handler
@@ -47,6 +43,7 @@ async def test_apps_are_working(app_handler: _AppHandler) -> None:
     assert app_handler.apps, "There should be at least one app group"
     assert "my_app" in app_handler.apps, "my_app should be one of the app groups"
     assert "my_app_sync" in app_handler.apps, "my_app_sync should be one of the app groups"
+    assert "disabled_app" not in app_handler.apps, "disabled_app should remain disabled"
 
     # test that an app that only has config values but no class_name/filename is ignored
     assert "myfakeapp" not in app_handler.apps, "myfakeapp should not be one of the app groups"
@@ -70,3 +67,76 @@ def test_all_apps(app_handler: _AppHandler) -> None:
     class_names = [app.class_name for app in all_apps]
     assert "MyApp" in class_names, "MyApp should be in the list of running apps"
     assert "MyAppSync" in class_names, "MyAppSync should be in the list of running apps"
+
+
+async def test_handle_changes_disables_app(app_handler: _AppHandler) -> None:
+    """Verify that editing hassette.toml to disable an app stops the running instance."""
+
+    assert "my_app" in app_handler.apps, "Precondition: my_app starts enabled"
+    assert app_handler.apps_config["my_app"].enabled is True, "Precondition: my_app config shows enabled"
+
+    with patch.object(app_handler, "_calculate_app_changes") as mock_calc_changes:
+        mock_calc_changes.return_value = (
+            {"my_app"},  # orphans
+            set(),  # new_apps
+            set(),  # reimport_apps
+            set(),  # reload_apps
+        )
+
+        await app_handler.handle_changes()
+        await asyncio.sleep(0)  # let async shutdowns complete
+
+        assert "my_app" not in app_handler.apps, "my_app should stop after being disabled"
+        assert "my_app_sync" in app_handler.apps, "Other enabled apps should continue running"
+
+
+async def test_handle_changes_enables_app(app_handler: _AppHandler) -> None:
+    """Verify that editing hassette.toml to enable a disabled app starts the instance."""
+
+    assert "disabled_app" not in app_handler.apps, "Precondition: disabled_app starts disabled"
+    assert app_handler.apps_config["disabled_app"].enabled is False, "Precondition: disabled_app config shows disabled"
+
+    new_app_config = deepcopy(app_handler.apps_config)
+    new_app_config["disabled_app"].enabled = True
+
+    with (
+        patch.object(app_handler, "_calculate_app_changes") as mock_calc_changes,
+        patch.object(app_handler, "refresh_config") as mock_refresh_config,
+    ):
+        app_handler.apps_config = new_app_config
+        mock_refresh_config.return_value = (app_handler.apps_config, new_app_config)
+        mock_calc_changes.return_value = (
+            set(),  # orphans
+            {"disabled_app"},  # new_apps
+            set(),  # reimport_apps
+            set(),  # reload_apps
+        )
+
+        await app_handler.handle_changes()
+        await asyncio.sleep(0.3)  # let async startups complete
+
+        assert "disabled_app" in app_handler.apps, "disabled_app should start after being enabled"
+        assert "my_app" in app_handler.apps, "Other enabled apps should continue running"
+
+
+async def test_config_changes_are_reflected_after_reload(app_handler: _AppHandler) -> None:
+    """Verify that editing hassette.toml to change an app's config reloads the instance."""
+
+    assert "my_app" in app_handler.apps, "Precondition: my_app starts enabled"
+
+    my_app_instance = app_handler.get("my_app", 0)
+    assert my_app_instance is not None, "Precondition: my_app instance should exist"
+
+    assert my_app_instance.app_config.test_entity == "input_button.test", (
+        "Precondition: my_app config has initial value"
+    )
+
+    app_handler.apps_config["my_app"].user_config = {"test_entity": "light.office"}
+
+    await app_handler._reload_apps_due_to_config({"my_app"})
+    await asyncio.sleep(0.3)  # let async startups complete
+
+    assert "my_app" in app_handler.apps, "my_app should still be running after reload"
+    my_app_instance = app_handler.get("my_app", 0)
+    assert my_app_instance is not None, "my_app instance should still exist after reload"
+    assert my_app_instance.app_config.test_entity == "light.office", "my_app config should be updated after reload"

--- a/tests/test_apps.py
+++ b/tests/test_apps.py
@@ -29,6 +29,7 @@ async def app_handler(test_config):
     hassette._websocket = Mock()
     hassette._websocket.connected = True
     hassette._websocket.status = ResourceStatus.RUNNING
+    hassette.wait_for_resources_running = AsyncMock(return_value=True)
 
     app_handler = _AppHandler(hassette)
     await app_handler.initialize()

--- a/tests/test_file_watcher.py
+++ b/tests/test_file_watcher.py
@@ -1,0 +1,101 @@
+import asyncio
+import contextlib
+import typing
+from collections.abc import Coroutine
+from typing import Any, cast
+from unittest.mock import AsyncMock, Mock
+
+import anyio
+import pytest
+from anyio import create_memory_object_stream
+
+from hassette.core.bus import Bus
+from hassette.core.bus.bus import _Bus
+from hassette.core.events.hassette import Event
+from hassette.core.file_watcher import _FileWatcher
+from hassette.core.topics import HASSETTE_EVENT_FILE_WATCHER
+from hassette.utils import wait_for_resources_running_or_raise
+
+if typing.TYPE_CHECKING:
+    from hassette.core.core import Hassette
+
+
+@pytest.fixture
+async def hassette_with_file_watcher(test_config_with_apps):
+    class MockHassette:
+        task: asyncio.Task
+
+        def __init__(self):
+            self._send_stream, self._receive_stream = create_memory_object_stream[tuple[str, Event]](1000)
+            self._bus = _Bus(cast("Hassette", self), self._receive_stream.clone())
+            self.bus = Bus(cast("Hassette", self), self._bus)
+            self.ready_event = asyncio.Event()
+            self.ready_event.set()
+
+            self._shutdown_event = asyncio.Event()
+            self.logger = Mock()
+            self.config = test_config_with_apps
+            self.wait_for_resources_running = AsyncMock(return_value=True)
+            self._file_watcher = _FileWatcher(cast("Hassette", self))
+
+        async def send_event(self, topic: str, event: Event[typing.Any]) -> None:
+            """Mock method to send an event to the bus."""
+            await self._send_stream.send((topic, event))
+
+        def create_task(self, coro: Coroutine[Any, Any, Any]) -> asyncio.Task:
+            return asyncio.create_task(coro)
+
+    hassette = MockHassette()
+
+    hassette.wait_for_resources_running = AsyncMock(return_value=True)
+
+    hassette.config.file_watcher_debounce_milliseconds = 1
+    hassette.config.file_watcher_step_milliseconds = 5
+
+    bus_task = asyncio.create_task(hassette._bus.run_forever())
+    file_watcher_task = asyncio.create_task(hassette._file_watcher.run_forever())
+
+    await wait_for_resources_running_or_raise([hassette._file_watcher, hassette._bus], timeout=5)
+    yield hassette
+
+    for t in [bus_task, file_watcher_task]:
+        t.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await t
+
+
+async def test_event_emitted_on_file_change(hassette_with_file_watcher: "Hassette"):
+    # make these shorter for convenience
+    hassette = hassette_with_file_watcher
+    file_watcher = hassette._file_watcher
+
+    # we're going to wait for this to be set
+    called_event = asyncio.Event()
+
+    # our handler for the file watcher event
+    async def handler(event: Event[Any]) -> None:
+        called_event.set()
+        assert event.topic == HASSETTE_EVENT_FILE_WATCHER
+
+    hassette.bus.on(topic=HASSETTE_EVENT_FILE_WATCHER, handler=handler)
+
+    # wait a moment to ensure everything is settled
+    await asyncio.sleep(0.2)
+
+    touched_files = []
+    for f in file_watcher.hassette.config.get_watchable_files():
+        if f.is_file():
+            f.write_text(f.read_text())
+            touched_files.append(f)
+            break
+
+    assert touched_files, "No toml files found to touch in test_event_emitted_on_file_change"
+    await asyncio.sleep(0.2)
+
+    # can be flaky, try a couple of times
+    for _ in range(2):
+        with contextlib.suppress(asyncio.TimeoutError):
+            with anyio.fail_after(1):
+                await called_event.wait()
+                assert called_event.is_set()
+                return

--- a/tests/test_service_watcher.py
+++ b/tests/test_service_watcher.py
@@ -1,0 +1,51 @@
+import asyncio
+
+import pytest
+
+from hassette.core.classes import Service
+from hassette.core.enums import ResourceStatus
+from hassette.core.events import create_service_status_event
+from hassette.core.service_watcher import _ServiceWatcher
+
+
+@pytest.fixture
+def get_service_watcher_mock(mock_hassette_with_bus):
+    return _ServiceWatcher(mock_hassette_with_bus)
+
+
+def get_dummy_service(called: dict[str, int], hassette) -> Service:
+    class _Dummy(Service):
+        """Does nothing, just tracks calls."""
+
+        async def run_forever(self):
+            pass
+
+        def cancel(self):
+            called["cancel"] += 1
+
+        def start(self):
+            called["start"] += 1
+
+    return _Dummy(hassette)
+
+
+async def test_restart_service_cancels_then_starts(get_service_watcher_mock: _ServiceWatcher):
+    called = {"cancel": 0, "start": 0}
+
+    get_service_watcher_mock.hassette._resources["_Dummy"] = get_dummy_service(
+        called, get_service_watcher_mock.hassette
+    )
+
+    svc = get_dummy_service(called, get_service_watcher_mock)
+
+    event = create_service_status_event(
+        resource_name=svc.class_name,
+        role=svc.role,
+        status=ResourceStatus.FAILED,
+        exc=Exception("test"),
+    )
+
+    await get_service_watcher_mock.restart_service(event)
+    await asyncio.sleep(0.1)  # allow restart to run
+
+    assert called == {"cancel": 1, "start": 1}

--- a/tests/test_service_watcher.py
+++ b/tests/test_service_watcher.py
@@ -32,11 +32,9 @@ def get_dummy_service(called: dict[str, int], hassette) -> Service:
 async def test_restart_service_cancels_then_starts(get_service_watcher_mock: _ServiceWatcher):
     called = {"cancel": 0, "start": 0}
 
-    get_service_watcher_mock.hassette._resources["_Dummy"] = get_dummy_service(
+    get_service_watcher_mock.hassette._resources["_Dummy"] = svc = get_dummy_service(
         called, get_service_watcher_mock.hassette
     )
-
-    svc = get_dummy_service(called, get_service_watcher_mock)
 
     event = create_service_status_event(
         resource_name=svc.class_name,

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -3,13 +3,13 @@ import asyncio
 import pytest
 
 from hassette.core.classes import Service
-from hassette.core.core import Hassette
 from hassette.core.enums import ResourceStatus
-from hassette.core.events import create_service_status_event
 
 
 class _HoldService(Service):
     """Waits forever until shutdown is called."""
+
+    status = ResourceStatus.RUNNING
 
     async def run_forever(self):
         # park forever until cancelled by shutdown()
@@ -21,22 +21,6 @@ class _HoldService(Service):
         if hasattr(self, "_evt"):
             self._evt.set()
         await super().shutdown(*a, **k)
-
-
-def get_dummy_service(called: dict[str, int], hassette) -> Service:
-    class _Dummy(Service):
-        """Does nothing, just tracks calls."""
-
-        async def run_forever(self):
-            pass
-
-        def cancel(self):
-            called["cancel"] += 1
-
-        def start(self):
-            called["start"] += 1
-
-    return _Dummy(hassette)
 
 
 async def test_service_start_twice_and_shutdown(mock_hassette_with_bus):
@@ -53,22 +37,3 @@ async def test_service_start_twice_and_shutdown(mock_hassette_with_bus):
     await asyncio.sleep(0.1)  # allow shutdown to run
 
     assert not svc.is_running()
-
-
-async def test_restart_service_cancels_then_starts(hassette_core_no_ha: Hassette):
-    called = {"cancel": 0, "start": 0}
-
-    svc = get_dummy_service(called, hassette_core_no_ha)
-    hassette_core_no_ha._resources[svc.class_name] = svc
-
-    event = create_service_status_event(
-        resource_name=svc.class_name,
-        role=svc.role,
-        status=ResourceStatus.FAILED,
-        exc=Exception("test"),
-    )
-
-    await hassette_core_no_ha.restart_service(event)
-    await asyncio.sleep(0.1)  # allow restart to run
-
-    assert called == {"cancel": 1, "start": 1}

--- a/uv.lock
+++ b/uv.lock
@@ -422,6 +422,18 @@ wheels = [
 ]
 
 [[package]]
+name = "deepdiff"
+version = "8.6.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "orderly-set" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/19/76/36c9aab3d5c19a94091f7c6c6e784efca50d87b124bf026c36e94719f33c/deepdiff-8.6.1.tar.gz", hash = "sha256:ec56d7a769ca80891b5200ec7bd41eec300ced91ebcc7797b41eb2b3f3ff643a", size = 634054, upload-time = "2025-09-03T19:40:41.461Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f7/e6/efe534ef0952b531b630780e19cabd416e2032697019d5295defc6ef9bd9/deepdiff-8.6.1-py3-none-any.whl", hash = "sha256:ee8708a7f7d37fb273a541fa24ad010ed484192cd0c4ffc0fa0ed5e2d4b9e78b", size = 91378, upload-time = "2025-09-03T19:40:39.679Z" },
+]
+
+[[package]]
 name = "dependency-groups"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
@@ -627,12 +639,14 @@ dependencies = [
     { name = "anyio" },
     { name = "coloredlogs" },
     { name = "croniter" },
+    { name = "deepdiff" },
     { name = "orjson" },
     { name = "packaging" },
     { name = "platformdirs" },
     { name = "pydantic-settings" },
     { name = "python-dotenv" },
     { name = "tenacity" },
+    { name = "watchfiles" },
     { name = "whenever" },
 ]
 
@@ -671,12 +685,14 @@ requires-dist = [
     { name = "anyio", specifier = ">=4.10.0" },
     { name = "coloredlogs", specifier = ">=15.0.1" },
     { name = "croniter", specifier = ">=6.0.0" },
+    { name = "deepdiff", specifier = ">=8.6.1" },
     { name = "orjson", specifier = ">=3.10.18" },
     { name = "packaging", specifier = ">=25.0" },
     { name = "platformdirs", specifier = ">=4.3.8" },
     { name = "pydantic-settings", specifier = ">=2.9.1" },
     { name = "python-dotenv", specifier = ">=1.1.0" },
     { name = "tenacity", specifier = ">=9.1.2" },
+    { name = "watchfiles", specifier = ">=1.1.0" },
     { name = "whenever", specifier = ">=0.8.4" },
 ]
 
@@ -1112,6 +1128,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/57/62/208293d7d6b2a8998a4a1f23ac758648c3c32182d4ce4346062018362e29/numpy-2.3.3-pp311-pypy311_pp73-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8596ba2f8af5f93b01d97563832686d20206d303024777f6dfc2e7c7c3f1850e", size = 14420354, upload-time = "2025-09-09T15:58:52.704Z" },
     { url = "https://files.pythonhosted.org/packages/ed/0c/8e86e0ff7072e14a71b4c6af63175e40d1e7e933ce9b9e9f765a95b4e0c3/numpy-2.3.3-pp311-pypy311_pp73-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e1ec5615b05369925bd1125f27df33f3b6c8bc10d788d5999ecd8769a1fa04db", size = 16760413, upload-time = "2025-09-09T15:58:55.027Z" },
     { url = "https://files.pythonhosted.org/packages/af/11/0cc63f9f321ccf63886ac203336777140011fb669e739da36d8db3c53b98/numpy-2.3.3-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:2e267c7da5bf7309670523896df97f93f6e469fb931161f483cd6882b3b1a5dc", size = 12971844, upload-time = "2025-09-09T15:58:57.359Z" },
+]
+
+[[package]]
+name = "orderly-set"
+version = "5.5.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4a/88/39c83c35d5e97cc203e9e77a4f93bf87ec89cf6a22ac4818fdcc65d66584/orderly_set-5.5.0.tar.gz", hash = "sha256:e87185c8e4d8afa64e7f8160ee2c542a475b738bc891dc3f58102e654125e6ce", size = 27414, upload-time = "2025-07-10T20:10:55.885Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/12/27/fb8d7338b4d551900fa3e580acbe7a0cf655d940e164cb5c00ec31961094/orderly_set-5.5.0-py3-none-any.whl", hash = "sha256:46f0b801948e98f427b412fcabb831677194c05c3b699b80de260374baa0b1e7", size = 13068, upload-time = "2025-07-10T20:10:54.377Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -651,6 +651,9 @@ dependencies = [
 ]
 
 [package.dev-dependencies]
+dev = [
+    { name = "tomli-w" },
+]
 docs = [
     { name = "autodoc-pydantic" },
     { name = "furo" },
@@ -697,7 +700,7 @@ requires-dist = [
 ]
 
 [package.metadata.requires-dev]
-dev = []
+dev = [{ name = "tomli-w", specifier = ">=1.2.0" }]
 docs = [
     { name = "autodoc-pydantic", specifier = ">=2.2.0" },
     { name = "furo", specifier = ">=2024.8.6" },
@@ -1889,6 +1892,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/5b/b9/1ed31d167be802da0fc95020d04cd27b7d7065cc6fbefdd2f9186f60d7bd/tomli-2.2.1-cp313-cp313-win32.whl", hash = "sha256:d3f5614314d758649ab2ab3a62d4f2004c825922f9e370b29416484086b264ec", size = 98724, upload-time = "2024-11-27T22:38:32.837Z" },
     { url = "https://files.pythonhosted.org/packages/c7/32/b0963458706accd9afcfeb867c0f9175a741bf7b19cd424230714d722198/tomli-2.2.1-cp313-cp313-win_amd64.whl", hash = "sha256:a38aa0308e754b0e3c67e344754dff64999ff9b513e691d0e786265c93583c69", size = 109383, upload-time = "2024-11-27T22:38:34.455Z" },
     { url = "https://files.pythonhosted.org/packages/6e/c2/61d3e0f47e2b74ef40a68b9e6ad5984f6241a942f7cd3bbfbdbd03861ea9/tomli-2.2.1-py3-none-any.whl", hash = "sha256:cb55c73c5f4408779d0cf3eef9f762b9c9f147a77de7b258bef0a5628adc85cc", size = 14257, upload-time = "2024-11-27T22:38:35.385Z" },
+]
+
+[[package]]
+name = "tomli-w"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/19/75/241269d1da26b624c0d5e110e8149093c759b7a286138f4efd61a60e75fe/tomli_w-1.2.0.tar.gz", hash = "sha256:2dd14fac5a47c27be9cd4c976af5a12d87fb1f0b4512f81d69cce3b35ae25021", size = 7184, upload-time = "2025-01-15T12:07:24.262Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c7/18/c86eb8e0202e32dd3df50d43d7ff9854f8e0603945ff398974c1d91ac1ef/tomli_w-1.2.0-py3-none-any.whl", hash = "sha256:188306098d013b691fcadc011abd66727d3c414c571bb01b1a174ba8c983cf90", size = 6675, upload-time = "2025-01-15T12:07:22.074Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -632,7 +632,7 @@ wheels = [
 
 [[package]]
 name = "hassette"
-version = "0.7.2"
+version = "0.8.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
Add `_FileWatcher` to facilitate hot reloading

Add `@only` decorator to allow easily running `hassette` with only a single app running, without changing config file - very useful for debugging

Add `_ServiceWatcher` to facilitate resource/service events

Improve tests for apps, move service handling tests to `test_service_watcher.py`