### PR TITLE
Refine app handler boot and per-instance reloads

### DIFF
--- a/tests/test_apps.py
+++ b/tests/test_apps.py
@@ -7,7 +7,7 @@ import pytest
 
 from hassette.core.core import Hassette
 from hassette.core.resources.bus.listeners import Listener
-from hassette.core.services.app_handler import _AppHandler, load_app_class
+from hassette.core.services.app_handler import AppChangeSet, _AppHandler, load_app_class
 from hassette.topics import HASSETTE_EVENT_APP_LOAD_COMPLETED
 
 if typing.TYPE_CHECKING:
@@ -76,12 +76,7 @@ class TestApps:
         )
 
         with patch.object(self.app_handler, "_calculate_app_changes") as mock_calc_changes:
-            mock_calc_changes.return_value = (
-                {"my_app"},  # orphans
-                set(),  # new_apps
-                set(),  # reimport_apps
-                set(),  # reload_apps
-            )
+            mock_calc_changes.return_value = AppChangeSet(removed_apps={"my_app"})
 
             await self.app_handler.handle_changes()
             await asyncio.wait_for(event.wait(), timeout=1)
@@ -121,12 +116,7 @@ class TestApps:
         ):
             self.app_handler.apps_config = new_app_config
             mock_refresh_config.return_value = (self.app_handler.apps_config, new_app_config)
-            mock_calc_changes.return_value = (
-                set(),  # orphans
-                {"disabled_app"},  # new_apps
-                set(),  # reimport_apps
-                set(),  # reload_apps
-            )
+            mock_calc_changes.return_value = AppChangeSet(new_apps={"disabled_app"})
 
             await self.app_handler.handle_changes()
             await asyncio.wait_for(event.wait(), timeout=1)
@@ -148,7 +138,7 @@ class TestApps:
 
         self.app_handler.apps_config["my_app"].app_config = {"test_entity": "light.office"}
 
-        await self.app_handler._reload_apps_due_to_config({"my_app"})
+        await self.app_handler._reload_apps_due_to_config({"my_app"}, {})
         # using manual sleep here, as the event doesn't get sent unless we call `handle_changes`
         await asyncio.sleep(0.3)
 
@@ -156,6 +146,73 @@ class TestApps:
         my_app_instance = typing.cast("MyApp", self.app_handler.get("my_app", 0))
         assert my_app_instance is not None, "my_app instance should still exist after reload"
         assert my_app_instance.app_config.test_entity == "light.office", "my_app config should be updated after reload"
+
+    async def test_only_modified_instances_are_reloaded(self) -> None:
+        """Ensure that reloading an app only restarts instances whose configuration changed."""
+
+        original_instance = typing.cast("MyApp", self.app_handler.get("my_app", 0))
+        assert original_instance is not None, "Precondition: my_app instance 0 should exist"
+
+        updated_config_add = deepcopy(self.app_handler.apps_config)
+        add_manifest = updated_config_add["my_app"]
+        add_configs = [
+            cfg.model_dump() if hasattr(cfg, "model_dump") else dict(cfg)
+            for cfg in add_manifest.app_config
+        ]
+        add_configs.append({"instance_name": "second_instance", "test_entity": "light.office"})
+        add_manifest.app_config = add_configs
+
+        async def run_handle_changes(new_config):
+            event = asyncio.Event()
+
+            async def handler(*args, **kwargs):  # noqa: ANN001
+                self.hassette.task_bucket.post_to_loop(event.set)
+
+            self.hassette._bus_service.add_listener(
+                Listener.create(
+                    self.app_handler.task_bucket,
+                    owner="test",
+                    topic=HASSETTE_EVENT_APP_LOAD_COMPLETED,
+                    handler=handler,
+                    where=None,
+                    once=True,
+                )
+            )
+
+            async def fake_refresh():
+                original_active = deepcopy(self.app_handler.active_apps_config)
+                self.app_handler.set_apps_configs(new_config)
+                curr_active = deepcopy(self.app_handler.active_apps_config)
+                return original_active, curr_active
+
+            with patch.object(self.app_handler, "refresh_config", side_effect=fake_refresh):
+                await self.app_handler.handle_changes()
+                await asyncio.wait_for(event.wait(), timeout=1)
+
+        await run_handle_changes(updated_config_add)
+
+        instance_after_add = typing.cast("MyApp", self.app_handler.get("my_app", 0))
+        second_instance = self.app_handler.get("my_app", 1)
+        assert instance_after_add is original_instance, "Existing instance should not restart when adding new ones"
+        assert second_instance is not None, "New instance should be created"
+
+        updated_config_change = deepcopy(self.app_handler.apps_config)
+        change_manifest = updated_config_change["my_app"]
+        change_configs = [
+            cfg.model_dump() if hasattr(cfg, "model_dump") else dict(cfg)
+            for cfg in change_manifest.app_config
+        ]
+        change_configs[0]["test_entity"] = "light.lounge"
+        change_manifest.app_config = change_configs
+
+        await run_handle_changes(updated_config_change)
+
+        reloaded_instance = typing.cast("MyApp", self.app_handler.get("my_app", 0))
+        unchanged_instance = self.app_handler.get("my_app", 1)
+
+        assert reloaded_instance is not original_instance, "Modified instance should restart"
+        assert reloaded_instance.app_config.test_entity == "light.lounge"
+        assert unchanged_instance is second_instance, "Unchanged instance should keep running"
 
     async def test_app_with_instance_name(self) -> None:
         """Test that an app with a specific instance_name in config starts correctly."""


### PR DESCRIPTION
## Summary
- delay app initialization until websocket/API readiness events fire and only register watchers during `on_initialize`
- add per-instance stop and reload helpers so config changes only restart affected app indices
- extend app handler tests to cover partial instance reload scenarios

## Testing
- pytest tests/test_apps.py *(fails: missing dependency `whenever` in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68f774f5e460832aa2497c33cfce9f0b