### PR TITLE
Fix Load more replacing entity list instead of appending

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+- Entity browser "Load more" button now appends rows instead of replacing existing ones on domain-filtered views (#247)
+
 ## [0.22.1] - 2026-02-15
 
 ### Added

--- a/src/hassette/web/templates/partials/entity_list.html
+++ b/src/hassette/web/templates/partials/entity_list.html
@@ -46,12 +46,12 @@
     </tr>
   {% endfor %}
   {% if total > limit + offset %}
-    <tr hx-disinherit="hx-select">
+    <tr id="load-more-row" hx-disinherit="hx-select">
       <td colspan="4" class="has-text-centered">
         <button class="button is-small is-link is-outlined"
                 hx-get="/ui/partials/entity-list?offset={{ offset + limit }}&limit={{ limit }}&domain={{ domain | urlencode }}&search={{ search | urlencode }}"
-                hx-target="#entity-list"
-                hx-swap="innerHTML">Load more ({{ total - offset - limit }} remaining)</button>
+                hx-target="#load-more-row"
+                hx-swap="outerHTML">Load more ({{ total - offset - limit }} remaining)</button>
       </td>
     </tr>
   {% endif %}

--- a/tests/e2e/test_entities.py
+++ b/tests/e2e/test_entities.py
@@ -5,6 +5,32 @@ from playwright.sync_api import Page, expect
 
 pytestmark = pytest.mark.e2e
 
+# Number of extra light entities injected by many_light_entities fixture.
+# Must exceed 2x the default entity-list partial limit (50) so the "Load more"
+# button appears on two consecutive pages when filtering by the "light" domain.
+# Total lights = _EXTRA_LIGHT_COUNT + 2 original (bedroom, kitchen).
+_EXTRA_LIGHT_COUNT = 120
+
+
+@pytest.fixture
+def many_light_entities(mock_hassette):
+    """Temporarily inject many light entities so pagination triggers."""
+    states = mock_hassette._state_proxy.states
+    added_keys: list[str] = []
+    for i in range(_EXTRA_LIGHT_COUNT):
+        eid = f"light.room_{i:03d}"
+        states[eid] = {
+            "entity_id": eid,
+            "state": "on" if i % 2 == 0 else "off",
+            "attributes": {"friendly_name": f"Room {i:03d} Light"},
+            "last_changed": "2024-01-01T00:00:00",
+            "last_updated": "2024-01-01T00:00:00",
+        }
+        added_keys.append(eid)
+    yield added_keys
+    for eid in added_keys:
+        states.pop(eid, None)
+
 
 def test_entities_page_loads(page: Page, base_url: str) -> None:
     page.goto(base_url + "/ui/entities")
@@ -46,3 +72,51 @@ def test_domain_filter_has_expected_options(page: Page, base_url: str) -> None:
     # Should have options for each domain in the mock data
     for domain in ("binary_sensor", "light", "sensor", "switch"):
         expect(domain_select.locator(f"option[value='{domain}']")).to_have_count(1)
+
+
+def test_load_more_appends_entities(page: Page, base_url: str, many_light_entities: list[str]) -> None:  # noqa: ARG001
+    """Clicking 'Load more' multiple times should keep appending rows."""
+    page.goto(base_url + "/ui/entities")
+    domain_select = page.locator("#entity-domain-filter")
+    domain_select.select_option("light")
+
+    entity_list = page.locator("#entity-list")
+
+    # Total light entities = 2 original + 120 extra = 122, sorted alphabetically.
+    # With default limit=50, page 1 shows first 50 entities with 72 remaining.
+    # Sorted order: light.bedroom, light.kitchen, light.room_000 … light.room_047
+    expect(entity_list).to_contain_text("light.bedroom")
+
+    load_more = entity_list.locator("button:has-text('Load more')")
+    expect(load_more).to_be_visible()
+    expect(load_more).to_contain_text("72 remaining")
+
+    # --- First "Load more" click ---
+    load_more.click()
+
+    # Page 2 entities (light.room_048 … light.room_097) should appear.
+    expect(entity_list).to_contain_text("light.room_048")
+    expect(entity_list).to_contain_text("light.room_097")
+
+    # Page 1 entities must still be present.
+    expect(entity_list).to_contain_text("light.bedroom")
+    expect(entity_list).to_contain_text("light.room_000")
+
+    # "Load more" should still be visible with 22 remaining.
+    load_more = entity_list.locator("button:has-text('Load more')")
+    expect(load_more).to_be_visible()
+    expect(load_more).to_contain_text("22 remaining")
+
+    # --- Second "Load more" click ---
+    load_more.click()
+
+    # Final batch (light.room_098 … light.room_119) should appear.
+    expect(entity_list).to_contain_text("light.room_119")
+
+    # ALL previous pages must still be present.
+    expect(entity_list).to_contain_text("light.bedroom")
+    expect(entity_list).to_contain_text("light.room_000")
+    expect(entity_list).to_contain_text("light.room_048")
+
+    # No more "Load more" button — all entities are loaded.
+    expect(entity_list.locator("button:has-text('Load more')")).to_have_count(0)


### PR DESCRIPTION
## Summary
- The "Load more" button on the entity browser's domain-filtered view replaced all visible rows with the next page instead of appending, because it used `hx-swap="innerHTML"` targeting the entire `<tbody>`
- Changed the Load more `<tr>` to use `hx-swap="outerHTML"` targeting itself (`#load-more-row`), so each new batch replaces only the button row while preserving all previously loaded entities
- Added E2E test that verifies multi-page pagination by clicking Load more twice across 122 light entities (pages of 50/50/22) and asserting all pages remain visible

Closes #247