### PR TITLE
Add extras property and extra() helper to state models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added autouse cleanup fixtures for bus, scheduler, and mock API to prevent test pollution in module-scoped fixtures (#256)
 
 ### Added
+- `extras` property and `extra()` helper on `BaseState` and `AttributesBase` for safe access to integration-specific attributes (#271)
 - JSDoc comments across all web UI JavaScript files (#251)
 - ESLint linting, TypeScript type-checking, and `mise run lint:js` / `mise run typecheck:js` tasks (#251)
 

--- a/src/hassette/models/states/base.py
+++ b/src/hassette/models/states/base.py
@@ -50,6 +50,15 @@ class AttributesBase(BaseModel):
     supported_features: int | float | None = Field(default=None)
     """Bitfield of supported features."""
 
+    @property
+    def extras(self) -> dict[str, Any]:
+        """Integration-specific attributes not covered by the typed model."""
+        return self.model_extra or {}
+
+    def extra(self, key: str, default: Any = None) -> Any:
+        """Get a single integration-specific attribute with a default."""
+        return self.extras.get(key, default)
+
 
 class BaseState(BaseModel, Generic[StateValueT]):
     """Represents a Home Assistant state object."""
@@ -110,6 +119,15 @@ class BaseState(BaseModel, Generic[StateValueT]):
             return False
 
         return len(self.attributes.entity_id) > 1  # type: ignore
+
+    @property
+    def extras(self) -> dict[str, Any]:
+        """Extra fields not covered by the typed state model."""
+        return self.model_extra or {}
+
+    def extra(self, key: str, default: Any = None) -> Any:
+        """Get a single extra field with a default."""
+        return self.extras.get(key, default)
 
     def __init_subclass__(cls, **kwargs):
         super().__init_subclass__(**kwargs)

--- a/tests/unit/test_extras_property.py
+++ b/tests/unit/test_extras_property.py
@@ -1,0 +1,72 @@
+"""Tests for the `extras` property and `extra()` method on AttributesBase and BaseState."""
+
+from hassette.models.states.light import LightAttributes, LightState
+from hassette.test_utils import make_light_state_dict
+
+
+class TestAttributesBaseExtras:
+    """Tests for AttributesBase.extras and .extra()."""
+
+    def test_extras_returns_extra_fields(self) -> None:
+        attrs = LightAttributes(friendly_name="Kitchen", is_hue_group=True, preset=5)
+        assert attrs.extras == {"is_hue_group": True, "preset": 5}
+
+    def test_extras_returns_empty_dict_when_no_extras(self) -> None:
+        attrs = LightAttributes(friendly_name="Kitchen")
+        assert attrs.extras == {}
+
+    def test_extra_returns_value_when_present(self) -> None:
+        attrs = LightAttributes(friendly_name="Kitchen", is_hue_group=True)
+        assert attrs.extra("is_hue_group") is True
+
+    def test_extra_returns_none_when_missing(self) -> None:
+        attrs = LightAttributes(friendly_name="Kitchen")
+        assert attrs.extra("is_hue_group") is None
+
+    def test_extra_returns_custom_default_when_missing(self) -> None:
+        attrs = LightAttributes(friendly_name="Kitchen")
+        assert attrs.extra("is_hue_group", False) is False
+
+
+class TestBaseStateExtras:
+    """Tests for BaseState.extras and .extra()."""
+
+    def test_extras_returns_extra_fields(self) -> None:
+        data = make_light_state_dict(is_hue_group=True, preset=5)
+        # Add an extra field at the state level (not attributes)
+        data["custom_state_field"] = "hello"
+        state = LightState(**data)
+        assert state.extras == {"custom_state_field": "hello"}
+
+    def test_extras_returns_empty_dict_when_no_extras(self) -> None:
+        data = make_light_state_dict()
+        state = LightState(**data)
+        assert state.extras == {}
+
+    def test_extra_returns_value_when_present(self) -> None:
+        data = make_light_state_dict()
+        data["custom_state_field"] = 42
+        state = LightState(**data)
+        assert state.extra("custom_state_field") == 42
+
+    def test_extra_returns_none_when_missing(self) -> None:
+        data = make_light_state_dict()
+        state = LightState(**data)
+        assert state.extra("custom_state_field") is None
+
+    def test_extra_returns_custom_default_when_missing(self) -> None:
+        data = make_light_state_dict()
+        state = LightState(**data)
+        assert state.extra("custom_state_field", "fallback") == "fallback"
+
+
+class TestExtrasViaInheritance:
+    """Verify extras work correctly through concrete subclasses."""
+
+    def test_light_attributes_extras_via_state(self) -> None:
+        data = make_light_state_dict(is_hue_group=True, preset=5)
+        state = LightState(**data)
+        assert state.attributes.extras == {"is_hue_group": True, "preset": 5}
+        assert state.attributes.extra("is_hue_group") is True
+        assert state.attributes.extra("preset") == 5
+        assert state.attributes.extra("nonexistent") is None


### PR DESCRIPTION
Closes #271

## Summary
- Add `extras` property and `extra(key, default)` method to `BaseState` and `AttributesBase`, giving users a clean API to access integration-specific attributes (e.g., Hue's `is_hue_group`, WLED's `preset`) without touching Pydantic internals like `__pydantic_extra__`
- Uses `model_extra` (Pydantic's public API), consistent with existing usage in `AppManifest`
- 11 unit tests covering both classes: extras present/absent, `extra()` with and without defaults, and inheritance through `LightState`/`LightAttributes`