### PR TITLE
Add supported_features bitmask helpers to domain state models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Collapsible panels and tracebacks no longer flash visible before Alpine.js initializes (#262)
 
 ### Added
+- `supports_*` boolean properties on light, climate, cover, fan, media_player, and vacuum attribute classes for checking entity capabilities without manual bitmask operations (#272)
+- `IntFlag` enums (`LightEntityFeature`, `ClimateEntityFeature`, etc.) matching Home Assistant core feature flags (#272)
 - Global alert banner showing HA disconnect warnings and failed app errors with expandable tracebacks (#262)
 - `ht-btn--ghost` and `ht-btn--xs` button modifier classes (#262)
 

--- a/src/hassette/models/states/__init__.py
+++ b/src/hassette/models/states/__init__.py
@@ -5,10 +5,19 @@ from .automation import AutomationState
 from .base import BaseState
 from .calendar import CalendarState
 from .camera import CameraState
-from .climate import ClimateState
+from .climate import ClimateAttributes, ClimateState
+from .cover import CoverAttributes, CoverState
 from .device_tracker import DeviceTrackerState
 from .event import EventState
-from .fan import FanState
+from .fan import FanAttributes, FanState
+from .features import (
+    ClimateEntityFeature,
+    CoverEntityFeature,
+    FanEntityFeature,
+    LightEntityFeature,
+    MediaPlayerEntityFeature,
+    VacuumEntityFeature,
+)
 from .humidifier import HumidifierState
 from .image_processing import ImageProcessingState
 from .input import (
@@ -19,8 +28,8 @@ from .input import (
     InputSelectState,
     InputTextState,
 )
-from .light import LightState
-from .media_player import MediaPlayerState
+from .light import LightAttributes, LightState
+from .media_player import MediaPlayerAttributes, MediaPlayerState
 from .number import NumberState
 from .person import PersonState
 from .remote import RemoteState
@@ -33,7 +42,6 @@ from .simple import (
     BinarySensorState,
     ButtonState,
     ConversationState,
-    CoverState,
     DateState,
     DateTimeState,
     LockState,
@@ -50,7 +58,7 @@ from .sun import SunState
 from .text import TextState
 from .timer import TimerState
 from .update import UpdateState
-from .vacuum import VacuumState
+from .vacuum import VacuumAttributes, VacuumState
 from .water_heater import WaterHeaterState
 from .weather import WeatherState
 from .zone import ZoneState
@@ -66,13 +74,19 @@ __all__ = [
     "ButtonState",
     "CalendarState",
     "CameraState",
+    "ClimateAttributes",
+    "ClimateEntityFeature",
     "ClimateState",
     "ConversationState",
+    "CoverAttributes",
+    "CoverEntityFeature",
     "CoverState",
     "DateState",
     "DateTimeState",
     "DeviceTrackerState",
     "EventState",
+    "FanAttributes",
+    "FanEntityFeature",
     "FanState",
     "HumidifierState",
     "ImageProcessingState",
@@ -82,8 +96,12 @@ __all__ = [
     "InputNumberState",
     "InputSelectState",
     "InputTextState",
+    "LightAttributes",
+    "LightEntityFeature",
     "LightState",
     "LockState",
+    "MediaPlayerAttributes",
+    "MediaPlayerEntityFeature",
     "MediaPlayerState",
     "NotifyState",
     "NumberState",
@@ -104,6 +122,8 @@ __all__ = [
     "TodoState",
     "TtsState",
     "UpdateState",
+    "VacuumAttributes",
+    "VacuumEntityFeature",
     "VacuumState",
     "ValveState",
     "WaterHeaterState",

--- a/src/hassette/models/states/base.py
+++ b/src/hassette/models/states/base.py
@@ -59,6 +59,12 @@ class AttributesBase(BaseModel):
         """Get a single integration-specific attribute with a default."""
         return self.extras.get(key, default)
 
+    def _has_feature(self, flag: int) -> bool:
+        """Check whether *flag* is set in :pyattr:`supported_features`."""
+        if self.supported_features is None:
+            return False
+        return bool(int(self.supported_features) & flag)
+
 
 class BaseState(BaseModel, Generic[StateValueT]):
     """Represents a Home Assistant state object."""

--- a/src/hassette/models/states/climate.py
+++ b/src/hassette/models/states/climate.py
@@ -3,6 +3,7 @@ from typing import Literal
 from pydantic import Field
 
 from .base import AttributesBase, StringBaseState
+from .features import ClimateEntityFeature
 
 
 class ClimateAttributes(AttributesBase):
@@ -21,6 +22,51 @@ class ClimateAttributes(AttributesBase):
     preset_mode: str | None = Field(default=None)
     swing_mode: str | None = Field(default=None)
     swing_modes: list[str] | None = Field(default=None)
+
+    @property
+    def supports_target_temperature(self) -> bool:
+        """Whether this climate entity supports target temperature."""
+        return self._has_feature(ClimateEntityFeature.TARGET_TEMPERATURE)
+
+    @property
+    def supports_target_temperature_range(self) -> bool:
+        """Whether this climate entity supports target temperature range."""
+        return self._has_feature(ClimateEntityFeature.TARGET_TEMPERATURE_RANGE)
+
+    @property
+    def supports_target_humidity(self) -> bool:
+        """Whether this climate entity supports target humidity."""
+        return self._has_feature(ClimateEntityFeature.TARGET_HUMIDITY)
+
+    @property
+    def supports_fan_mode(self) -> bool:
+        """Whether this climate entity supports fan mode."""
+        return self._has_feature(ClimateEntityFeature.FAN_MODE)
+
+    @property
+    def supports_preset_mode(self) -> bool:
+        """Whether this climate entity supports preset mode."""
+        return self._has_feature(ClimateEntityFeature.PRESET_MODE)
+
+    @property
+    def supports_swing_mode(self) -> bool:
+        """Whether this climate entity supports swing mode."""
+        return self._has_feature(ClimateEntityFeature.SWING_MODE)
+
+    @property
+    def supports_turn_off(self) -> bool:
+        """Whether this climate entity supports turning off."""
+        return self._has_feature(ClimateEntityFeature.TURN_OFF)
+
+    @property
+    def supports_turn_on(self) -> bool:
+        """Whether this climate entity supports turning on."""
+        return self._has_feature(ClimateEntityFeature.TURN_ON)
+
+    @property
+    def supports_swing_horizontal_mode(self) -> bool:
+        """Whether this climate entity supports horizontal swing mode."""
+        return self._has_feature(ClimateEntityFeature.SWING_HORIZONTAL_MODE)
 
 
 class ClimateState(StringBaseState):

--- a/src/hassette/models/states/cover.py
+++ b/src/hassette/models/states/cover.py
@@ -1,0 +1,65 @@
+from typing import Literal
+
+from pydantic import Field
+
+from .base import AttributesBase, StringBaseState
+from .features import CoverEntityFeature
+
+
+class CoverAttributes(AttributesBase):
+    current_position: int | None = Field(default=None)
+    """Current position of the cover (0 = closed, 100 = open)."""
+
+    current_tilt_position: int | None = Field(default=None)
+    """Current tilt position of the cover (0 = closed, 100 = open)."""
+
+    @property
+    def supports_open(self) -> bool:
+        """Whether this cover supports opening."""
+        return self._has_feature(CoverEntityFeature.OPEN)
+
+    @property
+    def supports_close(self) -> bool:
+        """Whether this cover supports closing."""
+        return self._has_feature(CoverEntityFeature.CLOSE)
+
+    @property
+    def supports_set_position(self) -> bool:
+        """Whether this cover supports setting position."""
+        return self._has_feature(CoverEntityFeature.SET_POSITION)
+
+    @property
+    def supports_stop(self) -> bool:
+        """Whether this cover supports stopping."""
+        return self._has_feature(CoverEntityFeature.STOP)
+
+    @property
+    def supports_open_tilt(self) -> bool:
+        """Whether this cover supports opening tilt."""
+        return self._has_feature(CoverEntityFeature.OPEN_TILT)
+
+    @property
+    def supports_close_tilt(self) -> bool:
+        """Whether this cover supports closing tilt."""
+        return self._has_feature(CoverEntityFeature.CLOSE_TILT)
+
+    @property
+    def supports_stop_tilt(self) -> bool:
+        """Whether this cover supports stopping tilt."""
+        return self._has_feature(CoverEntityFeature.STOP_TILT)
+
+    @property
+    def supports_set_tilt_position(self) -> bool:
+        """Whether this cover supports setting tilt position."""
+        return self._has_feature(CoverEntityFeature.SET_TILT_POSITION)
+
+
+class CoverState(StringBaseState):
+    """Representation of a Home Assistant cover state.
+
+    See: https://www.home-assistant.io/integrations/cover/
+    """
+
+    domain: Literal["cover"]
+
+    attributes: CoverAttributes

--- a/src/hassette/models/states/fan.py
+++ b/src/hassette/models/states/fan.py
@@ -3,6 +3,7 @@ from typing import Literal
 from pydantic import Field
 
 from .base import AttributesBase, StringBaseState
+from .features import FanEntityFeature
 
 
 class FanAttributes(AttributesBase):
@@ -18,6 +19,36 @@ class FanAttributes(AttributesBase):
     child_lock: bool | None = Field(default=None)
     night_light: str | None = Field(default=None)
     mode: str | None = Field(default=None)
+
+    @property
+    def supports_set_speed(self) -> bool:
+        """Whether this fan supports setting speed."""
+        return self._has_feature(FanEntityFeature.SET_SPEED)
+
+    @property
+    def supports_oscillate(self) -> bool:
+        """Whether this fan supports oscillation."""
+        return self._has_feature(FanEntityFeature.OSCILLATE)
+
+    @property
+    def supports_direction(self) -> bool:
+        """Whether this fan supports direction."""
+        return self._has_feature(FanEntityFeature.DIRECTION)
+
+    @property
+    def supports_preset_mode(self) -> bool:
+        """Whether this fan supports preset mode."""
+        return self._has_feature(FanEntityFeature.PRESET_MODE)
+
+    @property
+    def supports_turn_off(self) -> bool:
+        """Whether this fan supports turning off."""
+        return self._has_feature(FanEntityFeature.TURN_OFF)
+
+    @property
+    def supports_turn_on(self) -> bool:
+        """Whether this fan supports turning on."""
+        return self._has_feature(FanEntityFeature.TURN_ON)
 
 
 class FanState(StringBaseState):

--- a/src/hassette/models/states/features.py
+++ b/src/hassette/models/states/features.py
@@ -1,0 +1,120 @@
+"""IntFlag enums for Home Assistant entity supported_features bitmasks.
+
+Each enum mirrors the corresponding ``EntityFeature`` IntFlag in HA core so
+that users can check entity capabilities with typed helpers instead of raw
+bitwise operations.
+
+Only the six domains called out in issue #272 are covered here.  Additional
+domains (alarm_control_panel, camera, siren, humidifier, water_heater,
+remote, update, weather, calendar, lock, valve, …) can be added later.
+"""
+
+from enum import IntFlag
+
+
+class LightEntityFeature(IntFlag):
+    """Supported features of the light entity.
+
+    See: https://www.home-assistant.io/integrations/light/
+    """
+
+    EFFECT = 4
+    FLASH = 8
+    TRANSITION = 32
+
+
+class ClimateEntityFeature(IntFlag):
+    """Supported features of the climate entity.
+
+    See: https://www.home-assistant.io/integrations/climate/
+    """
+
+    TARGET_TEMPERATURE = 1
+    TARGET_TEMPERATURE_RANGE = 2
+    TARGET_HUMIDITY = 4
+    FAN_MODE = 8
+    PRESET_MODE = 16
+    SWING_MODE = 32
+    TURN_OFF = 128
+    TURN_ON = 256
+    SWING_HORIZONTAL_MODE = 512
+
+
+class CoverEntityFeature(IntFlag):
+    """Supported features of the cover entity.
+
+    See: https://www.home-assistant.io/integrations/cover/
+    """
+
+    OPEN = 1
+    CLOSE = 2
+    SET_POSITION = 4
+    STOP = 8
+    OPEN_TILT = 16
+    CLOSE_TILT = 32
+    STOP_TILT = 64
+    SET_TILT_POSITION = 128
+
+
+class FanEntityFeature(IntFlag):
+    """Supported features of the fan entity.
+
+    See: https://www.home-assistant.io/integrations/fan/
+    """
+
+    SET_SPEED = 1
+    OSCILLATE = 2
+    DIRECTION = 4
+    PRESET_MODE = 8
+    TURN_OFF = 16
+    TURN_ON = 32
+
+
+class MediaPlayerEntityFeature(IntFlag):
+    """Supported features of the media_player entity.
+
+    See: https://www.home-assistant.io/integrations/media_player/
+    """
+
+    PAUSE = 1
+    SEEK = 2
+    VOLUME_SET = 4
+    VOLUME_MUTE = 8
+    PREVIOUS_TRACK = 16
+    NEXT_TRACK = 32
+    TURN_ON = 128
+    TURN_OFF = 256
+    PLAY_MEDIA = 512
+    VOLUME_STEP = 1024
+    SELECT_SOURCE = 2048
+    STOP = 4096
+    CLEAR_PLAYLIST = 8192
+    PLAY = 16384
+    SHUFFLE_SET = 32768
+    SELECT_SOUND_MODE = 65536
+    BROWSE_MEDIA = 131072
+    REPEAT_SET = 262144
+    GROUPING = 524288
+    MEDIA_ANNOUNCE = 1048576
+    MEDIA_ENQUEUE = 2097152
+    SEARCH_MEDIA = 4194304
+
+
+class VacuumEntityFeature(IntFlag):
+    """Supported features of the vacuum entity.
+
+    Deprecated flags (TURN_ON, TURN_OFF, BATTERY, STATUS, MAP, STATE) are
+    omitted — they are not supported by ``StateVacuumEntity``.
+
+    See: https://www.home-assistant.io/integrations/vacuum/
+    """
+
+    PAUSE = 4
+    STOP = 8
+    RETURN_HOME = 16
+    FAN_SPEED = 32
+    SEND_COMMAND = 256
+    LOCATE = 512
+    CLEAN_SPOT = 1024
+    START = 8192
+    CLEAN_AREA = 16384

--- a/src/hassette/models/states/light.py
+++ b/src/hassette/models/states/light.py
@@ -3,6 +3,7 @@ from typing import Literal
 from pydantic import Field
 
 from .base import AttributesBase, StringBaseState
+from .features import LightEntityFeature
 
 
 class LightAttributes(AttributesBase):
@@ -47,6 +48,21 @@ class LightAttributes(AttributesBase):
 
     color_temp: int | None = Field(default=None, deprecated=True)
     """Deprecated: The CT color value in mireds."""
+
+    @property
+    def supports_effect(self) -> bool:
+        """Whether this light supports effects."""
+        return self._has_feature(LightEntityFeature.EFFECT)
+
+    @property
+    def supports_flash(self) -> bool:
+        """Whether this light supports flash."""
+        return self._has_feature(LightEntityFeature.FLASH)
+
+    @property
+    def supports_transition(self) -> bool:
+        """Whether this light supports transition."""
+        return self._has_feature(LightEntityFeature.TRANSITION)
 
 
 class LightState(StringBaseState):

--- a/src/hassette/models/states/media_player.py
+++ b/src/hassette/models/states/media_player.py
@@ -3,12 +3,123 @@ from typing import Any, Literal
 from pydantic import Field
 
 from .base import AttributesBase, StringBaseState
+from .features import MediaPlayerEntityFeature
 
 
 class MediaPlayerAttributes(AttributesBase):
     assumed_state: bool | None = Field(default=None)
     adb_response: Any | None = Field(default=None)
     hdmi_input: Any | None = Field(default=None)
+
+    @property
+    def supports_pause(self) -> bool:
+        """Whether this media player supports pausing."""
+        return self._has_feature(MediaPlayerEntityFeature.PAUSE)
+
+    @property
+    def supports_seek(self) -> bool:
+        """Whether this media player supports seeking."""
+        return self._has_feature(MediaPlayerEntityFeature.SEEK)
+
+    @property
+    def supports_volume_set(self) -> bool:
+        """Whether this media player supports setting volume."""
+        return self._has_feature(MediaPlayerEntityFeature.VOLUME_SET)
+
+    @property
+    def supports_volume_mute(self) -> bool:
+        """Whether this media player supports muting volume."""
+        return self._has_feature(MediaPlayerEntityFeature.VOLUME_MUTE)
+
+    @property
+    def supports_previous_track(self) -> bool:
+        """Whether this media player supports previous track."""
+        return self._has_feature(MediaPlayerEntityFeature.PREVIOUS_TRACK)
+
+    @property
+    def supports_next_track(self) -> bool:
+        """Whether this media player supports next track."""
+        return self._has_feature(MediaPlayerEntityFeature.NEXT_TRACK)
+
+    @property
+    def supports_turn_on(self) -> bool:
+        """Whether this media player supports turning on."""
+        return self._has_feature(MediaPlayerEntityFeature.TURN_ON)
+
+    @property
+    def supports_turn_off(self) -> bool:
+        """Whether this media player supports turning off."""
+        return self._has_feature(MediaPlayerEntityFeature.TURN_OFF)
+
+    @property
+    def supports_play_media(self) -> bool:
+        """Whether this media player supports playing media."""
+        return self._has_feature(MediaPlayerEntityFeature.PLAY_MEDIA)
+
+    @property
+    def supports_volume_step(self) -> bool:
+        """Whether this media player supports volume stepping."""
+        return self._has_feature(MediaPlayerEntityFeature.VOLUME_STEP)
+
+    @property
+    def supports_select_source(self) -> bool:
+        """Whether this media player supports selecting source."""
+        return self._has_feature(MediaPlayerEntityFeature.SELECT_SOURCE)
+
+    @property
+    def supports_stop(self) -> bool:
+        """Whether this media player supports stopping."""
+        return self._has_feature(MediaPlayerEntityFeature.STOP)
+
+    @property
+    def supports_clear_playlist(self) -> bool:
+        """Whether this media player supports clearing playlist."""
+        return self._has_feature(MediaPlayerEntityFeature.CLEAR_PLAYLIST)
+
+    @property
+    def supports_play(self) -> bool:
+        """Whether this media player supports playing."""
+        return self._has_feature(MediaPlayerEntityFeature.PLAY)
+
+    @property
+    def supports_shuffle_set(self) -> bool:
+        """Whether this media player supports setting shuffle."""
+        return self._has_feature(MediaPlayerEntityFeature.SHUFFLE_SET)
+
+    @property
+    def supports_select_sound_mode(self) -> bool:
+        """Whether this media player supports selecting sound mode."""
+        return self._has_feature(MediaPlayerEntityFeature.SELECT_SOUND_MODE)
+
+    @property
+    def supports_browse_media(self) -> bool:
+        """Whether this media player supports browsing media."""
+        return self._has_feature(MediaPlayerEntityFeature.BROWSE_MEDIA)
+
+    @property
+    def supports_repeat_set(self) -> bool:
+        """Whether this media player supports setting repeat."""
+        return self._has_feature(MediaPlayerEntityFeature.REPEAT_SET)
+
+    @property
+    def supports_grouping(self) -> bool:
+        """Whether this media player supports grouping."""
+        return self._has_feature(MediaPlayerEntityFeature.GROUPING)
+
+    @property
+    def supports_media_announce(self) -> bool:
+        """Whether this media player supports media announcements."""
+        return self._has_feature(MediaPlayerEntityFeature.MEDIA_ANNOUNCE)
+
+    @property
+    def supports_media_enqueue(self) -> bool:
+        """Whether this media player supports media enqueue."""
+        return self._has_feature(MediaPlayerEntityFeature.MEDIA_ENQUEUE)
+
+    @property
+    def supports_search_media(self) -> bool:
+        """Whether this media player supports searching media."""
+        return self._has_feature(MediaPlayerEntityFeature.SEARCH_MEDIA)
 
 
 class MediaPlayerState(StringBaseState):

--- a/src/hassette/models/states/simple.py
+++ b/src/hassette/models/states/simple.py
@@ -30,15 +30,6 @@ class ConversationState(StringBaseState):
     domain: Literal["conversation"]
 
 
-class CoverState(StringBaseState):
-    """Representation of a Home Assistant cover state.
-
-    See: https://www.home-assistant.io/integrations/cover/
-    """
-
-    domain: Literal["cover"]
-
-
 class DateState(DateTimeBaseState):
     """Representation of a Home Assistant date state.
 

--- a/src/hassette/models/states/vacuum.py
+++ b/src/hassette/models/states/vacuum.py
@@ -3,6 +3,7 @@ from typing import Literal
 from pydantic import Field
 
 from .base import AttributesBase, StringBaseState
+from .features import VacuumEntityFeature
 
 
 class VacuumAttributes(AttributesBase):
@@ -11,6 +12,51 @@ class VacuumAttributes(AttributesBase):
     battery_icon: str | None = Field(default=None)
     fan_speed: str | None = Field(default=None)
     cleaned_area: int | float | None = Field(default=None)
+
+    @property
+    def supports_pause(self) -> bool:
+        """Whether this vacuum supports pausing."""
+        return self._has_feature(VacuumEntityFeature.PAUSE)
+
+    @property
+    def supports_stop(self) -> bool:
+        """Whether this vacuum supports stopping."""
+        return self._has_feature(VacuumEntityFeature.STOP)
+
+    @property
+    def supports_return_home(self) -> bool:
+        """Whether this vacuum supports returning home."""
+        return self._has_feature(VacuumEntityFeature.RETURN_HOME)
+
+    @property
+    def supports_fan_speed(self) -> bool:
+        """Whether this vacuum supports fan speed control."""
+        return self._has_feature(VacuumEntityFeature.FAN_SPEED)
+
+    @property
+    def supports_send_command(self) -> bool:
+        """Whether this vacuum supports sending commands."""
+        return self._has_feature(VacuumEntityFeature.SEND_COMMAND)
+
+    @property
+    def supports_locate(self) -> bool:
+        """Whether this vacuum supports locating."""
+        return self._has_feature(VacuumEntityFeature.LOCATE)
+
+    @property
+    def supports_clean_spot(self) -> bool:
+        """Whether this vacuum supports spot cleaning."""
+        return self._has_feature(VacuumEntityFeature.CLEAN_SPOT)
+
+    @property
+    def supports_start(self) -> bool:
+        """Whether this vacuum supports starting."""
+        return self._has_feature(VacuumEntityFeature.START)
+
+    @property
+    def supports_clean_area(self) -> bool:
+        """Whether this vacuum supports area cleaning."""
+        return self._has_feature(VacuumEntityFeature.CLEAN_AREA)
 
 
 class VacuumState(StringBaseState):

--- a/tests/unit/test_supported_features.py
+++ b/tests/unit/test_supported_features.py
@@ -1,0 +1,400 @@
+"""Tests for supported_features bitmask helpers on domain attribute classes."""
+
+import pytest
+
+from hassette.models.states.base import AttributesBase
+from hassette.models.states.climate import ClimateAttributes
+from hassette.models.states.cover import CoverAttributes
+from hassette.models.states.fan import FanAttributes
+from hassette.models.states.features import (
+    ClimateEntityFeature,
+    CoverEntityFeature,
+    FanEntityFeature,
+    LightEntityFeature,
+    MediaPlayerEntityFeature,
+    VacuumEntityFeature,
+)
+from hassette.models.states.light import LightAttributes
+from hassette.models.states.media_player import MediaPlayerAttributes
+from hassette.models.states.vacuum import VacuumAttributes
+
+
+class TestAttributesBaseHasFeature:
+    """Tests for the _has_feature() helper on AttributesBase."""
+
+    def test_returns_false_when_supported_features_is_none(self) -> None:
+        attrs = AttributesBase(supported_features=None)
+        assert attrs._has_feature(1) is False
+
+    def test_returns_false_when_flag_not_set(self) -> None:
+        attrs = AttributesBase(supported_features=0)
+        assert attrs._has_feature(1) is False
+
+    def test_returns_true_when_single_flag_set(self) -> None:
+        attrs = AttributesBase(supported_features=4)
+        assert attrs._has_feature(4) is True
+
+    def test_returns_true_when_flag_in_combined_bitmask(self) -> None:
+        attrs = AttributesBase(supported_features=5)  # 1 | 4
+        assert attrs._has_feature(4) is True
+        assert attrs._has_feature(1) is True
+
+    def test_returns_false_for_missing_flag_in_combined_bitmask(self) -> None:
+        attrs = AttributesBase(supported_features=5)  # 1 | 4
+        assert attrs._has_feature(2) is False
+
+    def test_handles_float_supported_features(self) -> None:
+        attrs = AttributesBase(supported_features=4.0)
+        assert attrs._has_feature(4) is True
+
+    def test_handles_large_bitmask(self) -> None:
+        attrs = AttributesBase(supported_features=4194304)
+        assert attrs._has_feature(4194304) is True
+        assert attrs._has_feature(1) is False
+
+
+# ── Light ──────────────────────────────────────────────────────────────
+
+
+class TestLightSupportedFeatures:
+    @pytest.mark.parametrize(
+        ("feature_value", "property_name"),
+        [
+            (LightEntityFeature.EFFECT, "supports_effect"),
+            (LightEntityFeature.FLASH, "supports_flash"),
+            (LightEntityFeature.TRANSITION, "supports_transition"),
+        ],
+    )
+    def test_feature_present(self, feature_value: int, property_name: str) -> None:
+        attrs = LightAttributes(supported_features=feature_value)
+        assert getattr(attrs, property_name) is True
+
+    @pytest.mark.parametrize(
+        ("feature_value", "property_name"),
+        [
+            (LightEntityFeature.EFFECT, "supports_effect"),
+            (LightEntityFeature.FLASH, "supports_flash"),
+            (LightEntityFeature.TRANSITION, "supports_transition"),
+        ],
+    )
+    def test_feature_absent(self, feature_value: int, property_name: str) -> None:
+        # Use a bitmask that excludes this specific feature
+        all_features = LightEntityFeature.EFFECT | LightEntityFeature.FLASH | LightEntityFeature.TRANSITION
+        attrs = LightAttributes(supported_features=all_features & ~feature_value)
+        assert getattr(attrs, property_name) is False
+
+    def test_combined_bitmask(self) -> None:
+        combined = LightEntityFeature.EFFECT | LightEntityFeature.TRANSITION
+        attrs = LightAttributes(supported_features=combined)
+        assert attrs.supports_effect is True
+        assert attrs.supports_flash is False
+        assert attrs.supports_transition is True
+
+    def test_none_returns_all_false(self) -> None:
+        attrs = LightAttributes(supported_features=None)
+        assert attrs.supports_effect is False
+        assert attrs.supports_flash is False
+        assert attrs.supports_transition is False
+
+
+# ── Climate ────────────────────────────────────────────────────────────
+
+
+class TestClimateSupportedFeatures:
+    @pytest.mark.parametrize(
+        ("feature_value", "property_name"),
+        [
+            (ClimateEntityFeature.TARGET_TEMPERATURE, "supports_target_temperature"),
+            (ClimateEntityFeature.TARGET_TEMPERATURE_RANGE, "supports_target_temperature_range"),
+            (ClimateEntityFeature.TARGET_HUMIDITY, "supports_target_humidity"),
+            (ClimateEntityFeature.FAN_MODE, "supports_fan_mode"),
+            (ClimateEntityFeature.PRESET_MODE, "supports_preset_mode"),
+            (ClimateEntityFeature.SWING_MODE, "supports_swing_mode"),
+            (ClimateEntityFeature.TURN_OFF, "supports_turn_off"),
+            (ClimateEntityFeature.TURN_ON, "supports_turn_on"),
+            (ClimateEntityFeature.SWING_HORIZONTAL_MODE, "supports_swing_horizontal_mode"),
+        ],
+    )
+    def test_feature_present(self, feature_value: int, property_name: str) -> None:
+        attrs = ClimateAttributes(supported_features=feature_value)
+        assert getattr(attrs, property_name) is True
+
+    @pytest.mark.parametrize(
+        ("feature_value", "property_name"),
+        [
+            (ClimateEntityFeature.TARGET_TEMPERATURE, "supports_target_temperature"),
+            (ClimateEntityFeature.TARGET_TEMPERATURE_RANGE, "supports_target_temperature_range"),
+            (ClimateEntityFeature.TARGET_HUMIDITY, "supports_target_humidity"),
+            (ClimateEntityFeature.FAN_MODE, "supports_fan_mode"),
+            (ClimateEntityFeature.PRESET_MODE, "supports_preset_mode"),
+            (ClimateEntityFeature.SWING_MODE, "supports_swing_mode"),
+            (ClimateEntityFeature.TURN_OFF, "supports_turn_off"),
+            (ClimateEntityFeature.TURN_ON, "supports_turn_on"),
+            (ClimateEntityFeature.SWING_HORIZONTAL_MODE, "supports_swing_horizontal_mode"),
+        ],
+    )
+    def test_feature_absent(self, feature_value: int, property_name: str) -> None:
+        attrs = ClimateAttributes(supported_features=0)
+        assert getattr(attrs, property_name) is False
+
+    def test_combined_bitmask(self) -> None:
+        combined = (
+            ClimateEntityFeature.TARGET_TEMPERATURE | ClimateEntityFeature.FAN_MODE | ClimateEntityFeature.TURN_ON
+        )
+        attrs = ClimateAttributes(supported_features=combined)
+        assert attrs.supports_target_temperature is True
+        assert attrs.supports_fan_mode is True
+        assert attrs.supports_turn_on is True
+        assert attrs.supports_preset_mode is False
+        assert attrs.supports_swing_mode is False
+
+    def test_none_returns_all_false(self) -> None:
+        attrs = ClimateAttributes(supported_features=None)
+        assert attrs.supports_target_temperature is False
+        assert attrs.supports_turn_on is False
+        assert attrs.supports_swing_horizontal_mode is False
+
+
+# ── Cover ──────────────────────────────────────────────────────────────
+
+
+class TestCoverSupportedFeatures:
+    @pytest.mark.parametrize(
+        ("feature_value", "property_name"),
+        [
+            (CoverEntityFeature.OPEN, "supports_open"),
+            (CoverEntityFeature.CLOSE, "supports_close"),
+            (CoverEntityFeature.SET_POSITION, "supports_set_position"),
+            (CoverEntityFeature.STOP, "supports_stop"),
+            (CoverEntityFeature.OPEN_TILT, "supports_open_tilt"),
+            (CoverEntityFeature.CLOSE_TILT, "supports_close_tilt"),
+            (CoverEntityFeature.STOP_TILT, "supports_stop_tilt"),
+            (CoverEntityFeature.SET_TILT_POSITION, "supports_set_tilt_position"),
+        ],
+    )
+    def test_feature_present(self, feature_value: int, property_name: str) -> None:
+        attrs = CoverAttributes(supported_features=feature_value)
+        assert getattr(attrs, property_name) is True
+
+    @pytest.mark.parametrize(
+        ("feature_value", "property_name"),
+        [
+            (CoverEntityFeature.OPEN, "supports_open"),
+            (CoverEntityFeature.CLOSE, "supports_close"),
+            (CoverEntityFeature.SET_POSITION, "supports_set_position"),
+            (CoverEntityFeature.STOP, "supports_stop"),
+            (CoverEntityFeature.OPEN_TILT, "supports_open_tilt"),
+            (CoverEntityFeature.CLOSE_TILT, "supports_close_tilt"),
+            (CoverEntityFeature.STOP_TILT, "supports_stop_tilt"),
+            (CoverEntityFeature.SET_TILT_POSITION, "supports_set_tilt_position"),
+        ],
+    )
+    def test_feature_absent(self, feature_value: int, property_name: str) -> None:
+        attrs = CoverAttributes(supported_features=0)
+        assert getattr(attrs, property_name) is False
+
+    def test_combined_bitmask(self) -> None:
+        combined = CoverEntityFeature.OPEN | CoverEntityFeature.CLOSE | CoverEntityFeature.STOP
+        attrs = CoverAttributes(supported_features=combined)
+        assert attrs.supports_open is True
+        assert attrs.supports_close is True
+        assert attrs.supports_stop is True
+        assert attrs.supports_set_position is False
+        assert attrs.supports_open_tilt is False
+
+    def test_none_returns_all_false(self) -> None:
+        attrs = CoverAttributes(supported_features=None)
+        assert attrs.supports_open is False
+        assert attrs.supports_set_tilt_position is False
+
+
+# ── Fan ────────────────────────────────────────────────────────────────
+
+
+class TestFanSupportedFeatures:
+    @pytest.mark.parametrize(
+        ("feature_value", "property_name"),
+        [
+            (FanEntityFeature.SET_SPEED, "supports_set_speed"),
+            (FanEntityFeature.OSCILLATE, "supports_oscillate"),
+            (FanEntityFeature.DIRECTION, "supports_direction"),
+            (FanEntityFeature.PRESET_MODE, "supports_preset_mode"),
+            (FanEntityFeature.TURN_OFF, "supports_turn_off"),
+            (FanEntityFeature.TURN_ON, "supports_turn_on"),
+        ],
+    )
+    def test_feature_present(self, feature_value: int, property_name: str) -> None:
+        attrs = FanAttributes(supported_features=feature_value)
+        assert getattr(attrs, property_name) is True
+
+    @pytest.mark.parametrize(
+        ("feature_value", "property_name"),
+        [
+            (FanEntityFeature.SET_SPEED, "supports_set_speed"),
+            (FanEntityFeature.OSCILLATE, "supports_oscillate"),
+            (FanEntityFeature.DIRECTION, "supports_direction"),
+            (FanEntityFeature.PRESET_MODE, "supports_preset_mode"),
+            (FanEntityFeature.TURN_OFF, "supports_turn_off"),
+            (FanEntityFeature.TURN_ON, "supports_turn_on"),
+        ],
+    )
+    def test_feature_absent(self, feature_value: int, property_name: str) -> None:
+        attrs = FanAttributes(supported_features=0)
+        assert getattr(attrs, property_name) is False
+
+    def test_combined_bitmask(self) -> None:
+        combined = FanEntityFeature.SET_SPEED | FanEntityFeature.OSCILLATE | FanEntityFeature.TURN_ON
+        attrs = FanAttributes(supported_features=combined)
+        assert attrs.supports_set_speed is True
+        assert attrs.supports_oscillate is True
+        assert attrs.supports_turn_on is True
+        assert attrs.supports_direction is False
+        assert attrs.supports_preset_mode is False
+
+    def test_none_returns_all_false(self) -> None:
+        attrs = FanAttributes(supported_features=None)
+        assert attrs.supports_set_speed is False
+        assert attrs.supports_turn_on is False
+
+
+# ── Media Player ───────────────────────────────────────────────────────
+
+
+class TestMediaPlayerSupportedFeatures:
+    @pytest.mark.parametrize(
+        ("feature_value", "property_name"),
+        [
+            (MediaPlayerEntityFeature.PAUSE, "supports_pause"),
+            (MediaPlayerEntityFeature.SEEK, "supports_seek"),
+            (MediaPlayerEntityFeature.VOLUME_SET, "supports_volume_set"),
+            (MediaPlayerEntityFeature.VOLUME_MUTE, "supports_volume_mute"),
+            (MediaPlayerEntityFeature.PREVIOUS_TRACK, "supports_previous_track"),
+            (MediaPlayerEntityFeature.NEXT_TRACK, "supports_next_track"),
+            (MediaPlayerEntityFeature.TURN_ON, "supports_turn_on"),
+            (MediaPlayerEntityFeature.TURN_OFF, "supports_turn_off"),
+            (MediaPlayerEntityFeature.PLAY_MEDIA, "supports_play_media"),
+            (MediaPlayerEntityFeature.VOLUME_STEP, "supports_volume_step"),
+            (MediaPlayerEntityFeature.SELECT_SOURCE, "supports_select_source"),
+            (MediaPlayerEntityFeature.STOP, "supports_stop"),
+            (MediaPlayerEntityFeature.CLEAR_PLAYLIST, "supports_clear_playlist"),
+            (MediaPlayerEntityFeature.PLAY, "supports_play"),
+            (MediaPlayerEntityFeature.SHUFFLE_SET, "supports_shuffle_set"),
+            (MediaPlayerEntityFeature.SELECT_SOUND_MODE, "supports_select_sound_mode"),
+            (MediaPlayerEntityFeature.BROWSE_MEDIA, "supports_browse_media"),
+            (MediaPlayerEntityFeature.REPEAT_SET, "supports_repeat_set"),
+            (MediaPlayerEntityFeature.GROUPING, "supports_grouping"),
+            (MediaPlayerEntityFeature.MEDIA_ANNOUNCE, "supports_media_announce"),
+            (MediaPlayerEntityFeature.MEDIA_ENQUEUE, "supports_media_enqueue"),
+            (MediaPlayerEntityFeature.SEARCH_MEDIA, "supports_search_media"),
+        ],
+    )
+    def test_feature_present(self, feature_value: int, property_name: str) -> None:
+        attrs = MediaPlayerAttributes(supported_features=feature_value)
+        assert getattr(attrs, property_name) is True
+
+    @pytest.mark.parametrize(
+        ("feature_value", "property_name"),
+        [
+            (MediaPlayerEntityFeature.PAUSE, "supports_pause"),
+            (MediaPlayerEntityFeature.SEEK, "supports_seek"),
+            (MediaPlayerEntityFeature.VOLUME_SET, "supports_volume_set"),
+            (MediaPlayerEntityFeature.VOLUME_MUTE, "supports_volume_mute"),
+            (MediaPlayerEntityFeature.PREVIOUS_TRACK, "supports_previous_track"),
+            (MediaPlayerEntityFeature.NEXT_TRACK, "supports_next_track"),
+            (MediaPlayerEntityFeature.TURN_ON, "supports_turn_on"),
+            (MediaPlayerEntityFeature.TURN_OFF, "supports_turn_off"),
+            (MediaPlayerEntityFeature.PLAY_MEDIA, "supports_play_media"),
+            (MediaPlayerEntityFeature.VOLUME_STEP, "supports_volume_step"),
+            (MediaPlayerEntityFeature.SELECT_SOURCE, "supports_select_source"),
+            (MediaPlayerEntityFeature.STOP, "supports_stop"),
+            (MediaPlayerEntityFeature.CLEAR_PLAYLIST, "supports_clear_playlist"),
+            (MediaPlayerEntityFeature.PLAY, "supports_play"),
+            (MediaPlayerEntityFeature.SHUFFLE_SET, "supports_shuffle_set"),
+            (MediaPlayerEntityFeature.SELECT_SOUND_MODE, "supports_select_sound_mode"),
+            (MediaPlayerEntityFeature.BROWSE_MEDIA, "supports_browse_media"),
+            (MediaPlayerEntityFeature.REPEAT_SET, "supports_repeat_set"),
+            (MediaPlayerEntityFeature.GROUPING, "supports_grouping"),
+            (MediaPlayerEntityFeature.MEDIA_ANNOUNCE, "supports_media_announce"),
+            (MediaPlayerEntityFeature.MEDIA_ENQUEUE, "supports_media_enqueue"),
+            (MediaPlayerEntityFeature.SEARCH_MEDIA, "supports_search_media"),
+        ],
+    )
+    def test_feature_absent(self, feature_value: int, property_name: str) -> None:
+        attrs = MediaPlayerAttributes(supported_features=0)
+        assert getattr(attrs, property_name) is False
+
+    def test_combined_bitmask(self) -> None:
+        combined = (
+            MediaPlayerEntityFeature.PAUSE
+            | MediaPlayerEntityFeature.PLAY
+            | MediaPlayerEntityFeature.STOP
+            | MediaPlayerEntityFeature.VOLUME_SET
+        )
+        attrs = MediaPlayerAttributes(supported_features=combined)
+        assert attrs.supports_pause is True
+        assert attrs.supports_play is True
+        assert attrs.supports_stop is True
+        assert attrs.supports_volume_set is True
+        assert attrs.supports_seek is False
+        assert attrs.supports_shuffle_set is False
+
+    def test_none_returns_all_false(self) -> None:
+        attrs = MediaPlayerAttributes(supported_features=None)
+        assert attrs.supports_pause is False
+        assert attrs.supports_play is False
+        assert attrs.supports_search_media is False
+
+
+# ── Vacuum ─────────────────────────────────────────────────────────────
+
+
+class TestVacuumSupportedFeatures:
+    @pytest.mark.parametrize(
+        ("feature_value", "property_name"),
+        [
+            (VacuumEntityFeature.PAUSE, "supports_pause"),
+            (VacuumEntityFeature.STOP, "supports_stop"),
+            (VacuumEntityFeature.RETURN_HOME, "supports_return_home"),
+            (VacuumEntityFeature.FAN_SPEED, "supports_fan_speed"),
+            (VacuumEntityFeature.SEND_COMMAND, "supports_send_command"),
+            (VacuumEntityFeature.LOCATE, "supports_locate"),
+            (VacuumEntityFeature.CLEAN_SPOT, "supports_clean_spot"),
+            (VacuumEntityFeature.START, "supports_start"),
+            (VacuumEntityFeature.CLEAN_AREA, "supports_clean_area"),
+        ],
+    )
+    def test_feature_present(self, feature_value: int, property_name: str) -> None:
+        attrs = VacuumAttributes(supported_features=feature_value)
+        assert getattr(attrs, property_name) is True
+
+    @pytest.mark.parametrize(
+        ("feature_value", "property_name"),
+        [
+            (VacuumEntityFeature.PAUSE, "supports_pause"),
+            (VacuumEntityFeature.STOP, "supports_stop"),
+            (VacuumEntityFeature.RETURN_HOME, "supports_return_home"),
+            (VacuumEntityFeature.FAN_SPEED, "supports_fan_speed"),
+            (VacuumEntityFeature.SEND_COMMAND, "supports_send_command"),
+            (VacuumEntityFeature.LOCATE, "supports_locate"),
+            (VacuumEntityFeature.CLEAN_SPOT, "supports_clean_spot"),
+            (VacuumEntityFeature.START, "supports_start"),
+            (VacuumEntityFeature.CLEAN_AREA, "supports_clean_area"),
+        ],
+    )
+    def test_feature_absent(self, feature_value: int, property_name: str) -> None:
+        attrs = VacuumAttributes(supported_features=0)
+        assert getattr(attrs, property_name) is False
+
+    def test_combined_bitmask(self) -> None:
+        combined = VacuumEntityFeature.START | VacuumEntityFeature.PAUSE | VacuumEntityFeature.RETURN_HOME
+        attrs = VacuumAttributes(supported_features=combined)
+        assert attrs.supports_start is True
+        assert attrs.supports_pause is True
+        assert attrs.supports_return_home is True
+        assert attrs.supports_stop is False
+        assert attrs.supports_locate is False
+
+    def test_none_returns_all_false(self) -> None:
+        attrs = VacuumAttributes(supported_features=None)
+        assert attrs.supports_start is False
+        assert attrs.supports_clean_area is False


### PR DESCRIPTION
Closes #272

## Summary
- Add typed `IntFlag` enums and `supports_*` boolean properties to attribute classes for 6 domains (light, climate, cover, fan, media_player, vacuum) so users can check entity capabilities with `state.attributes.supports_effect` instead of manual bitwise operations
- Add `_has_feature()` helper to `AttributesBase` that handles `None` and float edge cases from HA's JSON deserialization
- Extract `CoverState` to its own module with a new `CoverAttributes` class containing `current_position` and `current_tilt_position` fields

## Test plan
- [x] 133 parameterized unit tests covering all domains (feature present, absent, combined bitmask, None)
- [x] `uv run pyright` — 0 errors
- [x] `uv run pytest -n auto` — 481 unit tests pass, no regressions