### PR TITLE
Fix disconnect event and not-ready on unexpected WebSocket close

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Toggle buttons now show fallback text before Alpine.js initializes and expose `aria-expanded` for accessibility (#262)
 
 ### Fixed
+- WebSocket service now fires disconnect event and marks not-ready immediately on unexpected connection loss, preventing stale state in StateProxy (#270)
 - App detail page now uses the actual instance index instead of hardcoded 0, fixing data/URL desync for non-zero instances (#262)
 - Detail panel labels now have proper text contrast on dark `--ht-surface-code` background (#262)
 - Collapsible panels and tracebacks no longer flash visible before Alpine.js initializes (#262)

--- a/src/hassette/core/websocket_service.py
+++ b/src/hassette/core/websocket_service.py
@@ -149,7 +149,7 @@ class WebsocketService(Service):
                 except Exception:
                     self.logger.warning("WebSocket recv loop failed, notifying downstream consumers")
                     self.mark_not_ready(reason="WebSocket recv loop failed")
-                    with suppress(BaseException):
+                    with suppress(Exception):
                         await self._send_connection_lost_event()
                     raise
 

--- a/tests/integration/test_websocket_service.py
+++ b/tests/integration/test_websocket_service.py
@@ -294,9 +294,13 @@ async def test_disconnect_event_fires_on_recv_loop_failure(websocket_service: We
     websocket_service.hassette.send_event = send_event_mock
 
     with (
-        patch.object(websocket_service, "_make_connection", return_value=_make_failing_recv_task(
-            RetryableConnectionClosedError("peer gone"),
-        )),
+        patch.object(
+            websocket_service,
+            "_make_connection",
+            return_value=_make_failing_recv_task(
+                RetryableConnectionClosedError("peer gone"),
+            ),
+        ),
         pytest.raises(RetryableConnectionClosedError),
     ):
         await websocket_service.serve()
@@ -311,9 +315,13 @@ async def test_marked_not_ready_on_recv_loop_failure(websocket_service: Websocke
     websocket_service.hassette.send_event = AsyncMock()
 
     with (
-        patch.object(websocket_service, "_make_connection", return_value=_make_failing_recv_task(
-            RetryableConnectionClosedError("peer gone"),
-        )),
+        patch.object(
+            websocket_service,
+            "_make_connection",
+            return_value=_make_failing_recv_task(
+                RetryableConnectionClosedError("peer gone"),
+            ),
+        ),
         pytest.raises(RetryableConnectionClosedError),
     ):
         await websocket_service.serve()
@@ -326,9 +334,13 @@ async def test_disconnect_event_failure_does_not_mask_original_error(websocket_s
     websocket_service.hassette.send_event = AsyncMock(side_effect=RuntimeError("bus is down"))
 
     with (
-        patch.object(websocket_service, "_make_connection", return_value=_make_failing_recv_task(
-            RetryableConnectionClosedError("peer gone"),
-        )),
+        patch.object(
+            websocket_service,
+            "_make_connection",
+            return_value=_make_failing_recv_task(
+                RetryableConnectionClosedError("peer gone"),
+            ),
+        ),
         pytest.raises(RetryableConnectionClosedError),
     ):
         await websocket_service.serve()

--- a/tests/integration/test_websocket_service.py
+++ b/tests/integration/test_websocket_service.py
@@ -1,6 +1,7 @@
+import asyncio
 from types import SimpleNamespace
 from typing import TYPE_CHECKING, cast
-from unittest.mock import AsyncMock, Mock
+from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 from aiohttp import ClientWebSocketResponse, WSMsgType
@@ -14,6 +15,7 @@ from hassette.exceptions import (
     ResourceNotReadyError,
     RetryableConnectionClosedError,
 )
+from hassette.types import Topic
 
 if TYPE_CHECKING:
     from hassette import Hassette
@@ -272,3 +274,61 @@ async def test_raw_recv_raises_on_closing_frame(websocket_service: WebsocketServ
 
     with pytest.raises(RetryableConnectionClosedError):
         await websocket_service._raw_recv()
+
+
+# --- Disconnect handling on recv loop failure ---
+
+
+def _make_failing_recv_task(error: Exception) -> asyncio.Task:
+    """Create a task that raises the given error, simulating a failed recv loop."""
+
+    async def _fail():
+        raise error
+
+    return asyncio.ensure_future(_fail())
+
+
+async def test_disconnect_event_fires_on_recv_loop_failure(websocket_service: WebsocketService) -> None:
+    """Fire WEBSOCKET_DISCONNECTED when the recv loop dies unexpectedly."""
+    send_event_mock = AsyncMock()
+    websocket_service.hassette.send_event = send_event_mock
+
+    with (
+        patch.object(websocket_service, "_make_connection", return_value=_make_failing_recv_task(
+            RetryableConnectionClosedError("peer gone"),
+        )),
+        pytest.raises(RetryableConnectionClosedError),
+    ):
+        await websocket_service.serve()
+
+    topics_sent = [call.args[0] for call in send_event_mock.await_args_list]
+    assert Topic.HASSETTE_EVENT_WEBSOCKET_DISCONNECTED in topics_sent
+
+
+async def test_marked_not_ready_on_recv_loop_failure(websocket_service: WebsocketService) -> None:
+    """Mark the service not-ready immediately when the recv loop fails."""
+    websocket_service.mark_ready("test ready")
+    websocket_service.hassette.send_event = AsyncMock()
+
+    with (
+        patch.object(websocket_service, "_make_connection", return_value=_make_failing_recv_task(
+            RetryableConnectionClosedError("peer gone"),
+        )),
+        pytest.raises(RetryableConnectionClosedError),
+    ):
+        await websocket_service.serve()
+
+    assert not websocket_service.is_ready()
+
+
+async def test_disconnect_event_failure_does_not_mask_original_error(websocket_service: WebsocketService) -> None:
+    """Ensure that a broken send_event doesn't swallow the recv loop error."""
+    websocket_service.hassette.send_event = AsyncMock(side_effect=RuntimeError("bus is down"))
+
+    with (
+        patch.object(websocket_service, "_make_connection", return_value=_make_failing_recv_task(
+            RetryableConnectionClosedError("peer gone"),
+        )),
+        pytest.raises(RetryableConnectionClosedError),
+    ):
+        await websocket_service.serve()


### PR DESCRIPTION
## Summary

- When the WebSocket recv loop fails unexpectedly (peer close, network failure, HA restart), `serve()` now fires `WEBSOCKET_DISCONNECTED` and calls `mark_not_ready()` **immediately** — before the exception propagates to `_serve_wrapper()` and the ServiceWatcher restart cycle begins
- This prevents `StateProxy` from holding stale cached state and stops callers from sending messages into a dead connection during the restart window
- If firing the disconnect event itself fails, the original exception still propagates (wrapped in `suppress(BaseException)`)

Closes #270

## Test plan

- [x] `test_disconnect_event_fires_on_recv_loop_failure` — verifies `WEBSOCKET_DISCONNECTED` is sent via `hassette.send_event`
- [x] `test_marked_not_ready_on_recv_loop_failure` — verifies `is_ready()` returns `False` after recv loop exception
- [x] `test_disconnect_event_failure_does_not_mask_original_error` — verifies broken `send_event` doesn't swallow the original `RetryableConnectionClosedError`
- [x] All 22 WebSocket integration tests pass
- [x] Full suite: 899 passed, 2 xfailed
- [x] Pyright: 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)