### PR TITLE
Align state model attributes with HA core

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -212,6 +212,7 @@ docs/code-reference
 
 .claude/settings.local.json
 .claude/plan/
+.claude/plan.done.md
 .mcp.json
 
 # Node (JS dev tooling)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Collapsible panels and tracebacks no longer flash visible before Alpine.js initializes (#262)
 
 ### Added
+- Aligned all state model attributes with Home Assistant core — added missing fields to sensor, humidifier, light, climate, weather, fan, camera, and media_player; created dedicated `LockState` module with `LockAttributes` and `LockEntityFeature`
 - `supports_*` boolean properties on light, climate, cover, fan, media_player, and vacuum attribute classes for checking entity capabilities without manual bitmask operations (#272)
 - `IntFlag` enums (`LightEntityFeature`, `ClimateEntityFeature`, etc.) matching Home Assistant core feature flags (#272)
 - Global alert banner showing HA disconnect warnings and failed app errors with expandable tracebacks (#262)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Collapsible panels and tracebacks no longer flash visible before Alpine.js initializes (#262)
 
 ### Added
-- Aligned all state model attributes with Home Assistant core — added missing fields to sensor, humidifier, light, climate, weather, fan, camera, and media_player; created dedicated `LockState` module with `LockAttributes` and `LockEntityFeature`
+- Aligned all state model attributes with Home Assistant core — added missing fields to sensor, humidifier, light, climate, weather, fan, camera, and media_player; created dedicated `LockState` module with `LockAttributes` and `LockEntityFeature` (#294)
 - `supports_*` boolean properties on light, climate, cover, fan, media_player, and vacuum attribute classes for checking entity capabilities without manual bitmask operations (#272)
 - `IntFlag` enums (`LightEntityFeature`, `ClimateEntityFeature`, etc.) matching Home Assistant core feature flags (#272)
 - Global alert banner showing HA disconnect warnings and failed app errors with expandable tracebacks (#262)

--- a/src/hassette/models/states/__init__.py
+++ b/src/hassette/models/states/__init__.py
@@ -15,6 +15,7 @@ from .features import (
     CoverEntityFeature,
     FanEntityFeature,
     LightEntityFeature,
+    LockEntityFeature,
     MediaPlayerEntityFeature,
     VacuumEntityFeature,
 )
@@ -29,6 +30,7 @@ from .input import (
     InputTextState,
 )
 from .light import LightAttributes, LightState
+from .lock import LockAttributes, LockState
 from .media_player import MediaPlayerAttributes, MediaPlayerState
 from .number import NumberState
 from .person import PersonState
@@ -44,7 +46,6 @@ from .simple import (
     ConversationState,
     DateState,
     DateTimeState,
-    LockState,
     NotifyState,
     SttState,
     SwitchState,
@@ -99,6 +100,8 @@ __all__ = [
     "LightAttributes",
     "LightEntityFeature",
     "LightState",
+    "LockAttributes",
+    "LockEntityFeature",
     "LockState",
     "MediaPlayerAttributes",
     "MediaPlayerEntityFeature",

--- a/src/hassette/models/states/alarm_control_panel.py
+++ b/src/hassette/models/states/alarm_control_panel.py
@@ -1,4 +1,4 @@
-from typing import Any, Literal
+from typing import Literal
 
 from pydantic import Field
 
@@ -7,10 +7,8 @@ from .base import AttributesBase, StringBaseState
 
 class AlarmControlPanelAttributes(AttributesBase):
     code_format: str | None = Field(default=None)
-    changed_by: Any | None = Field(default=None)
+    changed_by: str | None = Field(default=None)
     code_arm_required: bool | None = Field(default=None)
-    previous_state: Any | None = Field(default=None)
-    next_state: Any | None = Field(default=None)
 
 
 class AlarmControlPanelState(StringBaseState):

--- a/src/hassette/models/states/camera.py
+++ b/src/hassette/models/states/camera.py
@@ -11,6 +11,9 @@ class CameraAttributes(AttributesBase):
     brand: str | None = Field(default=None)
     entity_picture: str | None = Field(default=None)
 
+    motion_detection: bool | None = Field(default=None)
+    """Whether motion detection is enabled."""
+
 
 class CameraState(StringBaseState):
     """Representation of a Home Assistant camera state.

--- a/src/hassette/models/states/climate.py
+++ b/src/hassette/models/states/climate.py
@@ -23,6 +23,27 @@ class ClimateAttributes(AttributesBase):
     swing_mode: str | None = Field(default=None)
     swing_modes: list[str] | None = Field(default=None)
 
+    humidity: float | None = Field(default=None)
+    """Target humidity."""
+
+    swing_horizontal_mode: str | None = Field(default=None)
+    """Current horizontal swing mode."""
+
+    target_temp_step: float | None = Field(default=None)
+    """Temperature step granularity."""
+
+    min_humidity: float | None = Field(default=None)
+    """Minimum humidity for target humidity."""
+
+    max_humidity: float | None = Field(default=None)
+    """Maximum humidity for target humidity."""
+
+    target_humidity_step: float | None = Field(default=None)
+    """Step size for target humidity."""
+
+    swing_horizontal_modes: list[str] | None = Field(default=None)
+    """Available horizontal swing modes."""
+
     @property
     def supports_target_temperature(self) -> bool:
         """Whether this climate entity supports target temperature."""

--- a/src/hassette/models/states/fan.py
+++ b/src/hassette/models/states/fan.py
@@ -12,13 +12,9 @@ class FanAttributes(AttributesBase):
     percentage: int | float | None = Field(default=None)
     percentage_step: float | None = Field(default=None)
     preset_mode: str | None = Field(default=None)
-    temperature: int | float | None = Field(default=None)
-    model: str | None = Field(default=None)
-    sn: str | None = Field(default=None)
-    screen_status: bool | None = Field(default=None)
-    child_lock: bool | None = Field(default=None)
-    night_light: str | None = Field(default=None)
-    mode: str | None = Field(default=None)
+
+    direction: str | None = Field(default=None)
+    """Current direction of the fan."""
 
     @property
     def supports_set_speed(self) -> bool:

--- a/src/hassette/models/states/features.py
+++ b/src/hassette/models/states/features.py
@@ -12,6 +12,15 @@ remote, update, weather, calendar, lock, valve, …) can be added later.
 from enum import IntFlag
 
 
+class LockEntityFeature(IntFlag):
+    """Supported features of the lock entity.
+
+    See: https://www.home-assistant.io/integrations/lock/
+    """
+
+    OPEN = 1
+
+
 class LightEntityFeature(IntFlag):
     """Supported features of the light entity.
 

--- a/src/hassette/models/states/humidifier.py
+++ b/src/hassette/models/states/humidifier.py
@@ -14,6 +14,9 @@ class HumidifierAttributes(AttributesBase):
     mode: str | None = Field(default=None)
     action: str | None = Field(default=None)
 
+    target_humidity_step: float | None = Field(default=None)
+    """Step size for target humidity adjustment."""
+
 
 class HumidifierState(StringBaseState):
     """Representation of a Home Assistant humidifier state.

--- a/src/hassette/models/states/light.py
+++ b/src/hassette/models/states/light.py
@@ -37,6 +37,12 @@ class LightAttributes(AttributesBase):
     rgb_color: tuple[int, int, int] | None = Field(default=None)
     """The rgb color value."""
 
+    rgbw_color: tuple[int, int, int, int] | None = Field(default=None)
+    """The RGBW color value (red, green, blue, white)."""
+
+    rgbww_color: tuple[int, int, int, int, int] | None = Field(default=None)
+    """The RGBWW color value (red, green, blue, cold white, warm white)."""
+
     xy_color: list[float] | None = Field(default=None)
     """The x and y color value."""
 

--- a/src/hassette/models/states/lock.py
+++ b/src/hassette/models/states/lock.py
@@ -1,0 +1,29 @@
+from typing import Literal
+
+from pydantic import Field
+
+from .base import AttributesBase, StringBaseState
+from .features import LockEntityFeature
+
+
+class LockAttributes(AttributesBase):
+    changed_by: str | None = Field(default=None)
+    """Who last changed the lock state."""
+
+    code_format: str | None = Field(default=None)
+    """Format of the code required to lock/unlock."""
+
+    @property
+    def supports_open(self) -> bool:
+        """Whether this lock supports the open action."""
+        return self._has_feature(LockEntityFeature.OPEN)
+
+
+class LockState(StringBaseState):
+    """Representation of a Home Assistant lock state.
+
+    See: https://www.home-assistant.io/integrations/lock/
+    """
+
+    domain: Literal["lock"]
+    attributes: LockAttributes

--- a/src/hassette/models/states/media_player.py
+++ b/src/hassette/models/states/media_player.py
@@ -1,4 +1,4 @@
-from typing import Any, Literal
+from typing import Literal
 
 from pydantic import Field
 
@@ -7,9 +7,83 @@ from .features import MediaPlayerEntityFeature
 
 
 class MediaPlayerAttributes(AttributesBase):
-    assumed_state: bool | None = Field(default=None)
-    adb_response: Any | None = Field(default=None)
-    hdmi_input: Any | None = Field(default=None)
+    volume_level: float | None = Field(default=None)
+    """Volume level of the media player (0..1)."""
+
+    is_volume_muted: bool | None = Field(default=None)
+    """Whether volume is currently muted."""
+
+    media_content_id: str | None = Field(default=None)
+    """Content ID of current playing media."""
+
+    media_content_type: str | None = Field(default=None)
+    """Content type of current playing media."""
+
+    media_duration: int | None = Field(default=None)
+    """Duration of current playing media in seconds."""
+
+    media_position: int | None = Field(default=None)
+    """Position of current playing media in seconds."""
+
+    media_position_updated_at: str | None = Field(default=None)
+    """When media position was last updated (ISO datetime)."""
+
+    media_title: str | None = Field(default=None)
+    """Title of current playing media."""
+
+    media_artist: str | None = Field(default=None)
+    """Artist of current playing media."""
+
+    media_album_name: str | None = Field(default=None)
+    """Album name of current playing media."""
+
+    media_album_artist: str | None = Field(default=None)
+    """Album artist of current playing media."""
+
+    media_track: int | None = Field(default=None)
+    """Track number of current playing media."""
+
+    media_series_title: str | None = Field(default=None)
+    """Series title for current playing media."""
+
+    media_season: str | None = Field(default=None)
+    """Season for current playing media."""
+
+    media_episode: str | None = Field(default=None)
+    """Episode for current playing media."""
+
+    media_channel: str | None = Field(default=None)
+    """Channel currently playing."""
+
+    media_playlist: str | None = Field(default=None)
+    """Playlist currently playing."""
+
+    app_id: str | None = Field(default=None)
+    """ID of the current running app."""
+
+    app_name: str | None = Field(default=None)
+    """Name of the current running app."""
+
+    source: str | None = Field(default=None)
+    """Currently selected input source."""
+
+    sound_mode: str | None = Field(default=None)
+    """Currently selected sound mode."""
+
+    shuffle: bool | None = Field(default=None)
+    """Whether shuffle is enabled."""
+
+    repeat: str | None = Field(default=None)
+    """Current repeat mode."""
+
+    group_members: list[str] | None = Field(default=None)
+    """List of group member entity IDs."""
+
+    source_list: list[str] | None = Field(default=None)
+    """List of available input sources."""
+
+    sound_mode_list: list[str] | None = Field(default=None)
+    """List of available sound modes."""
 
     @property
     def supports_pause(self) -> bool:

--- a/src/hassette/models/states/sensor.py
+++ b/src/hassette/models/states/sensor.py
@@ -13,6 +13,9 @@ class SensorAttributes(AttributesBase):
     state_class: STATE_CLASS | str | None = Field(default=None)
     unit_of_measurement: UNIT_OF_MEASUREMENT | str | None = Field(default=None)
 
+    last_reset: str | None = Field(default=None)
+    """ISO datetime of the last meter reset (for sensors with TOTAL state_class)."""
+
     options: list[str] | None = Field(default=None)
 
 

--- a/src/hassette/models/states/simple.py
+++ b/src/hassette/models/states/simple.py
@@ -48,15 +48,6 @@ class DateTimeState(DateTimeBaseState):
     domain: Literal["datetime"]
 
 
-class LockState(StringBaseState):
-    """Representation of a Home Assistant lock state.
-
-    See: https://www.home-assistant.io/integrations/lock/
-    """
-
-    domain: Literal["lock"]
-
-
 class NotifyState(StringBaseState):
     """Representation of a Home Assistant notify state.
 

--- a/src/hassette/models/states/weather.py
+++ b/src/hassette/models/states/weather.py
@@ -21,6 +21,18 @@ class WeatherAttributes(AttributesBase):
     precipitation_unit: str | None = Field(default=None)
     attribution: str | None = Field(default=None)
 
+    ozone: float | None = Field(default=None)
+    """Ozone level."""
+
+    uv_index: float | None = Field(default=None)
+    """UV index."""
+
+    wind_gust_speed: float | None = Field(default=None)
+    """Wind gust speed."""
+
+    visibility: float | None = Field(default=None)
+    """Visibility distance."""
+
 
 class WeatherState(StringBaseState):
     """Representation of a Home Assistant weather state.

--- a/tests/unit/test_state_attributes.py
+++ b/tests/unit/test_state_attributes.py
@@ -16,7 +16,6 @@ from hassette.models.states.media_player import MediaPlayerAttributes
 from hassette.models.states.sensor import SensorAttributes
 from hassette.models.states.weather import WeatherAttributes
 
-
 # ── Sensor (Finding #9) ──────────────────────────────────────────────
 
 

--- a/tests/unit/test_state_attributes.py
+++ b/tests/unit/test_state_attributes.py
@@ -1,0 +1,282 @@
+"""Tests for state model attribute alignment with HA core.
+
+Covers all attributes added and removed as part of #289.
+"""
+
+import pytest
+
+from hassette.models.states.alarm_control_panel import AlarmControlPanelAttributes
+from hassette.models.states.camera import CameraAttributes
+from hassette.models.states.climate import ClimateAttributes
+from hassette.models.states.fan import FanAttributes
+from hassette.models.states.humidifier import HumidifierAttributes
+from hassette.models.states.light import LightAttributes
+from hassette.models.states.lock import LockAttributes
+from hassette.models.states.media_player import MediaPlayerAttributes
+from hassette.models.states.sensor import SensorAttributes
+from hassette.models.states.weather import WeatherAttributes
+
+
+# ── Sensor (Finding #9) ──────────────────────────────────────────────
+
+
+class TestSensorAttributes:
+    def test_last_reset_present(self) -> None:
+        attrs = SensorAttributes(last_reset="2024-01-01T00:00:00+00:00")
+        assert attrs.last_reset == "2024-01-01T00:00:00+00:00"
+
+    def test_last_reset_defaults_to_none(self) -> None:
+        attrs = SensorAttributes()
+        assert attrs.last_reset is None
+
+
+# ── Humidifier (Finding #10) ─────────────────────────────────────────
+
+
+class TestHumidifierAttributes:
+    def test_target_humidity_step_present(self) -> None:
+        attrs = HumidifierAttributes(target_humidity_step=5.0)
+        assert attrs.target_humidity_step == 5.0
+
+    def test_target_humidity_step_defaults_to_none(self) -> None:
+        attrs = HumidifierAttributes()
+        assert attrs.target_humidity_step is None
+
+
+# ── Alarm Control Panel (Finding #11) ────────────────────────────────
+
+
+class TestAlarmControlPanelAttributes:
+    def test_changed_by_is_str(self) -> None:
+        attrs = AlarmControlPanelAttributes(changed_by="user123")
+        assert attrs.changed_by == "user123"
+
+    def test_removed_previous_state_lands_in_extras(self) -> None:
+        attrs = AlarmControlPanelAttributes(previous_state="armed_away")
+        assert attrs.extra("previous_state") == "armed_away"
+
+    def test_removed_next_state_lands_in_extras(self) -> None:
+        attrs = AlarmControlPanelAttributes(next_state="disarmed")
+        assert attrs.extra("next_state") == "disarmed"
+
+
+# ── Light (Finding #4) ───────────────────────────────────────────────
+
+
+class TestLightAttributes:
+    def test_rgbw_color_present(self) -> None:
+        attrs = LightAttributes(rgbw_color=(255, 0, 0, 128))
+        assert attrs.rgbw_color == (255, 0, 0, 128)
+
+    def test_rgbw_color_defaults_to_none(self) -> None:
+        attrs = LightAttributes()
+        assert attrs.rgbw_color is None
+
+    def test_rgbww_color_present(self) -> None:
+        attrs = LightAttributes(rgbww_color=(255, 0, 0, 128, 64))
+        assert attrs.rgbww_color == (255, 0, 0, 128, 64)
+
+    def test_rgbww_color_defaults_to_none(self) -> None:
+        attrs = LightAttributes()
+        assert attrs.rgbww_color is None
+
+
+# ── Climate (Finding #5) ─────────────────────────────────────────────
+
+
+class TestClimateAttributes:
+    @pytest.mark.parametrize(
+        ("field", "value"),
+        [
+            ("humidity", 50.0),
+            ("swing_horizontal_mode", "auto"),
+            ("target_temp_step", 0.5),
+            ("min_humidity", 30.0),
+            ("max_humidity", 70.0),
+            ("target_humidity_step", 5.0),
+            ("swing_horizontal_modes", ["auto", "off"]),
+        ],
+    )
+    def test_new_field_present(self, field: str, value: object) -> None:
+        attrs = ClimateAttributes(**{field: value})
+        assert getattr(attrs, field) == value
+
+    @pytest.mark.parametrize(
+        "field",
+        [
+            "humidity",
+            "swing_horizontal_mode",
+            "target_temp_step",
+            "min_humidity",
+            "max_humidity",
+            "target_humidity_step",
+            "swing_horizontal_modes",
+        ],
+    )
+    def test_new_field_defaults_to_none(self, field: str) -> None:
+        attrs = ClimateAttributes()
+        assert getattr(attrs, field) is None
+
+
+# ── Weather (Finding #6) ─────────────────────────────────────────────
+
+
+class TestWeatherAttributes:
+    @pytest.mark.parametrize(
+        ("field", "value"),
+        [
+            ("ozone", 280.0),
+            ("uv_index", 7.5),
+            ("wind_gust_speed", 25.0),
+            ("visibility", 10.0),
+        ],
+    )
+    def test_new_field_present(self, field: str, value: object) -> None:
+        attrs = WeatherAttributes(**{field: value})
+        assert getattr(attrs, field) == value
+
+    @pytest.mark.parametrize(
+        "field",
+        ["ozone", "uv_index", "wind_gust_speed", "visibility"],
+    )
+    def test_new_field_defaults_to_none(self, field: str) -> None:
+        attrs = WeatherAttributes()
+        assert getattr(attrs, field) is None
+
+
+# ── Fan (Finding #7) ─────────────────────────────────────────────────
+
+
+class TestFanAttributes:
+    def test_direction_present(self) -> None:
+        attrs = FanAttributes(direction="forward")
+        assert attrs.direction == "forward"
+
+    def test_direction_defaults_to_none(self) -> None:
+        attrs = FanAttributes()
+        assert attrs.direction is None
+
+    @pytest.mark.parametrize(
+        "field",
+        ["temperature", "model", "sn", "screen_status", "child_lock", "night_light", "mode"],
+    )
+    def test_removed_field_lands_in_extras(self, field: str) -> None:
+        attrs = FanAttributes(**{field: "test_value"})
+        assert attrs.extra(field) == "test_value"
+
+
+# ── Camera (Finding #8) ──────────────────────────────────────────────
+
+
+class TestCameraAttributes:
+    def test_motion_detection_present(self) -> None:
+        attrs = CameraAttributes(motion_detection=True)
+        assert attrs.motion_detection is True
+
+    def test_motion_detection_defaults_to_none(self) -> None:
+        attrs = CameraAttributes()
+        assert attrs.motion_detection is None
+
+
+# ── Lock (Finding #3) ────────────────────────────────────────────────
+
+
+class TestLockAttributes:
+    def test_changed_by_present(self) -> None:
+        attrs = LockAttributes(changed_by="user123")
+        assert attrs.changed_by == "user123"
+
+    def test_changed_by_defaults_to_none(self) -> None:
+        attrs = LockAttributes()
+        assert attrs.changed_by is None
+
+    def test_code_format_present(self) -> None:
+        attrs = LockAttributes(code_format="^\\d{4}$")
+        assert attrs.code_format == "^\\d{4}$"
+
+    def test_code_format_defaults_to_none(self) -> None:
+        attrs = LockAttributes()
+        assert attrs.code_format is None
+
+
+# ── Media Player (Finding #1) ────────────────────────────────────────
+
+
+class TestMediaPlayerAttributes:
+    @pytest.mark.parametrize(
+        ("field", "value"),
+        [
+            ("volume_level", 0.75),
+            ("is_volume_muted", True),
+            ("media_content_id", "spotify:track:123"),
+            ("media_content_type", "music"),
+            ("media_duration", 300),
+            ("media_position", 120),
+            ("media_position_updated_at", "2024-01-01T12:00:00+00:00"),
+            ("media_title", "Song Title"),
+            ("media_artist", "Artist Name"),
+            ("media_album_name", "Album Name"),
+            ("media_album_artist", "Album Artist"),
+            ("media_track", 5),
+            ("media_series_title", "Series Title"),
+            ("media_season", "1"),
+            ("media_episode", "5"),
+            ("media_channel", "HBO"),
+            ("media_playlist", "My Playlist"),
+            ("app_id", "com.spotify"),
+            ("app_name", "Spotify"),
+            ("source", "HDMI 1"),
+            ("sound_mode", "stereo"),
+            ("shuffle", True),
+            ("repeat", "all"),
+            ("group_members", ["media_player.speaker_1", "media_player.speaker_2"]),
+            ("source_list", ["HDMI 1", "HDMI 2", "AUX"]),
+            ("sound_mode_list", ["stereo", "surround"]),
+        ],
+    )
+    def test_new_field_present(self, field: str, value: object) -> None:
+        attrs = MediaPlayerAttributes(**{field: value})
+        assert getattr(attrs, field) == value
+
+    @pytest.mark.parametrize(
+        "field",
+        [
+            "volume_level",
+            "is_volume_muted",
+            "media_content_id",
+            "media_content_type",
+            "media_duration",
+            "media_position",
+            "media_position_updated_at",
+            "media_title",
+            "media_artist",
+            "media_album_name",
+            "media_album_artist",
+            "media_track",
+            "media_series_title",
+            "media_season",
+            "media_episode",
+            "media_channel",
+            "media_playlist",
+            "app_id",
+            "app_name",
+            "source",
+            "sound_mode",
+            "shuffle",
+            "repeat",
+            "group_members",
+            "source_list",
+            "sound_mode_list",
+        ],
+    )
+    def test_new_field_defaults_to_none(self, field: str) -> None:
+        attrs = MediaPlayerAttributes()
+        assert getattr(attrs, field) is None
+
+    @pytest.mark.parametrize(
+        "field",
+        ["assumed_state", "adb_response", "hdmi_input"],
+    )
+    def test_removed_field_lands_in_extras(self, field: str) -> None:
+        attrs = MediaPlayerAttributes(**{field: "test_value"})
+        assert attrs.extra(field) == "test_value"

--- a/tests/unit/test_supported_features.py
+++ b/tests/unit/test_supported_features.py
@@ -11,10 +11,12 @@ from hassette.models.states.features import (
     CoverEntityFeature,
     FanEntityFeature,
     LightEntityFeature,
+    LockEntityFeature,
     MediaPlayerEntityFeature,
     VacuumEntityFeature,
 )
 from hassette.models.states.light import LightAttributes
+from hassette.models.states.lock import LockAttributes
 from hassette.models.states.media_player import MediaPlayerAttributes
 from hassette.models.states.vacuum import VacuumAttributes
 
@@ -398,3 +400,32 @@ class TestVacuumSupportedFeatures:
         attrs = VacuumAttributes(supported_features=None)
         assert attrs.supports_start is False
         assert attrs.supports_clean_area is False
+
+
+# ── Lock ──────────────────────────────────────────────────────────────
+
+
+class TestLockSupportedFeatures:
+    @pytest.mark.parametrize(
+        ("feature_value", "property_name"),
+        [
+            (LockEntityFeature.OPEN, "supports_open"),
+        ],
+    )
+    def test_feature_present(self, feature_value: int, property_name: str) -> None:
+        attrs = LockAttributes(supported_features=feature_value)
+        assert getattr(attrs, property_name) is True
+
+    @pytest.mark.parametrize(
+        ("feature_value", "property_name"),
+        [
+            (LockEntityFeature.OPEN, "supports_open"),
+        ],
+    )
+    def test_feature_absent(self, feature_value: int, property_name: str) -> None:
+        attrs = LockAttributes(supported_features=0)
+        assert getattr(attrs, property_name) is False
+
+    def test_none_returns_all_false(self) -> None:
+        attrs = LockAttributes(supported_features=None)
+        assert attrs.supports_open is False


### PR DESCRIPTION
## Summary
- Aligned all 10 remaining state models with Home Assistant core's `state_attributes` / `capability_attributes`, adding missing fields and removing integration-specific ones (which remain accessible via `.extras` / `.extra()`)
- Created dedicated `LockState` module with `LockAttributes` and `LockEntityFeature`, replacing the bare `LockState` from `simple.py`
- Replaced `MediaPlayerAttributes`' 3 integration-specific fields with all 26 core attributes (volume, media metadata, source, sound mode, shuffle, repeat, grouping, etc.)

Closes #289