### PR TITLE
Add scheduler job name uniqueness and prereqs for SQLite executor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,17 +8,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 
 ### Added
-- `App.app_key` property for accessing the app's configuration key
-- `if_exists` parameter on all `Scheduler.run_*` methods with `"error"` (default) and `"skip"` modes for idempotent job registration
-- `ScheduledJob.matches()` method for comparing job configuration (callable, trigger, repeat, args, kwargs)
-- `__eq__`/`__hash__` on `IntervalTrigger` and `CronTrigger` comparing configuration only (interval/cron expression)
+- `App.app_key` property for accessing the app's configuration key (#297)
+- `if_exists` parameter on all `Scheduler.run_*` methods with `"error"` (default) and `"skip"` modes for idempotent job registration (#297)
+- `ScheduledJob.matches()` method for comparing job configuration (callable, trigger, repeat, args, kwargs) (#297)
+- `__eq__`/`__hash__` on `IntervalTrigger` and `CronTrigger` comparing configuration only (interval/cron expression) (#297)
 
 ### Changed
-- **Breaking:** Scheduler now enforces job name uniqueness per instance, raising `ValueError` on duplicate names
-- **Breaking:** Renamed `ExecutionResult.started_at` to `monotonic_start` to clarify it stores a monotonic clock value
+- **Breaking:** Scheduler now enforces job name uniqueness per instance, raising `ValueError` on duplicate names (#297)
+- **Breaking:** Renamed `ExecutionResult.started_at` to `monotonic_start` to clarify it stores a monotonic clock value (#297)
 
 ### Fixed
-- StateProxy `on_disconnect` now uses `remove_job()` instead of `cancel()` to properly free the job name slot for reconnection
+- StateProxy `on_disconnect` now uses `remove_job()` instead of `cancel()` to properly free the job name slot for reconnection (#297)
 
 ## [0.23.0] - 2026-02-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+- `App.app_key` property for accessing the app's configuration key
+- `if_exists` parameter on all `Scheduler.run_*` methods with `"error"` (default) and `"skip"` modes for idempotent job registration
+- `ScheduledJob.matches()` method for comparing job configuration (callable, trigger, repeat, args, kwargs)
+- `__eq__`/`__hash__` on `IntervalTrigger` and `CronTrigger` comparing configuration only (interval/cron expression)
+
+### Changed
+- **Breaking:** Scheduler now enforces job name uniqueness per instance, raising `ValueError` on duplicate names
+- **Breaking:** Renamed `ExecutionResult.started_at` to `monotonic_start` to clarify it stores a monotonic clock value
+
+### Fixed
+- StateProxy `on_disconnect` now uses `remove_job()` instead of `cancel()` to properly free the job name slot for reconnection
+
 ## [0.23.0] - 2026-02-19
 
 ### Changed

--- a/src/hassette/app/app.py
+++ b/src/hassette/app/app.py
@@ -117,6 +117,11 @@ class App(Generic[AppConfigT], Resource, metaclass=FinalMeta):
             return self.hassette.config.apps_log_level
 
     @property
+    def app_key(self) -> str:
+        """Key for this app in the hassette.toml configuration."""
+        return self.app_manifest.app_key
+
+    @property
     def instance_name(self) -> str:
         """Name for the instance of the app. Used for logging and ownership of resources."""
         return self.app_config.instance_name

--- a/src/hassette/core/state_proxy.py
+++ b/src/hassette/core/state_proxy.py
@@ -94,7 +94,9 @@ class StateProxy(Resource):
         self.state_change_sub = self.bus.on(topic=Topic.HASS_EVENT_STATE_CHANGED, handler=self._on_state_change)
         if not self.hassette.config.disable_state_proxy_polling:
             self.poll_job = self.scheduler.run_every(
-                self._load_cache, interval=TimeDelta(seconds=self.hassette.config.state_proxy_poll_interval_seconds)
+                self._load_cache,
+                interval=TimeDelta(seconds=self.hassette.config.state_proxy_poll_interval_seconds),
+                if_exists="skip",
             )
         else:
             self.poll_job = None
@@ -292,7 +294,7 @@ class StateProxy(Resource):
             self.state_change_sub = None
 
         if self.poll_job is not None:
-            self.poll_job.cancel()
+            self.scheduler.remove_job(self.poll_job)
             self.poll_job = None
 
         # mark the proxy as not ready

--- a/src/hassette/scheduler/classes.py
+++ b/src/hassette/scheduler/classes.py
@@ -32,6 +32,14 @@ class IntervalTrigger:
         self.interval = interval
         self.start = start or now()
 
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, IntervalTrigger):
+            return NotImplemented
+        return self.interval == other.interval
+
+    def __hash__(self) -> int:
+        return hash(self.interval)
+
     @classmethod
     def from_arguments(
         cls,
@@ -61,6 +69,14 @@ class CronTrigger:
         self.cron_expression = cron_expression
         base = start or now()
         self.cron_iter = croniter(cron_expression, base.py_datetime(), ret_type=datetime)
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, CronTrigger):
+            return NotImplemented
+        return self.cron_expression == other.cron_expression
+
+    def __hash__(self) -> int:
+        return hash(self.cron_expression)
 
     @classmethod
     def from_arguments(
@@ -167,6 +183,20 @@ class ScheduledJob:
 
         self.args = tuple(self.args)
         self.kwargs = dict(self.kwargs)
+
+    def matches(self, other: "ScheduledJob") -> bool:
+        """Check whether two jobs represent the same logical configuration.
+
+        Compares the callable, trigger, repeat flag, args, and kwargs. Does not compare
+        runtime state (job_id, next_run, sort_index, cancelled, owner).
+        """
+        return (
+            self.job == other.job
+            and self.trigger == other.trigger
+            and self.repeat == other.repeat
+            and self.args == other.args
+            and self.kwargs == other.kwargs
+        )
 
     def cancel(self) -> None:
         """Cancel the scheduled job by setting the cancelled flag to True."""

--- a/src/hassette/utils/execution.py
+++ b/src/hassette/utils/execution.py
@@ -16,7 +16,7 @@ from dataclasses import dataclass
 class ExecutionResult:
     """Captures timing and error information from a tracked execution."""
 
-    started_at: float = 0.0
+    monotonic_start: float = 0.0
     duration_ms: float = 0.0
     status: str = "pending"
     error_message: str | None = None
@@ -49,7 +49,7 @@ async def track_execution() -> AsyncIterator[ExecutionResult]:
         # result.status == "success", result.duration_ms populated
     """
     result = ExecutionResult()
-    result.started_at = time.monotonic()
+    result.monotonic_start = time.monotonic()
     try:
         yield result
         result.status = "success"
@@ -63,4 +63,4 @@ async def track_execution() -> AsyncIterator[ExecutionResult]:
         result.error_traceback = traceback.format_exc()
         raise
     finally:
-        result.duration_ms = (time.monotonic() - result.started_at) * 1000
+        result.duration_ms = (time.monotonic() - result.monotonic_start) * 1000

--- a/tests/integration/test_scheduler.py
+++ b/tests/integration/test_scheduler.py
@@ -79,8 +79,12 @@ async def test_jobs_execute_in_run_order(hassette_with_scheduler: Hassette) -> N
         return _job
 
     reference = now()
-    hassette_with_scheduler._scheduler.run_once(make_job("late", late_job_complete), start=reference.add(seconds=0.4))
-    hassette_with_scheduler._scheduler.run_once(make_job("early", early_job_complete), start=reference.add(seconds=0.1))
+    hassette_with_scheduler._scheduler.run_once(
+        make_job("late", late_job_complete), start=reference.add(seconds=0.4), name="late_job"
+    )
+    hassette_with_scheduler._scheduler.run_once(
+        make_job("early", early_job_complete), start=reference.add(seconds=0.1), name="early_job"
+    )
 
     await asyncio.wait_for(early_job_complete.wait(), timeout=2)
     await asyncio.wait_for(late_job_complete.wait(), timeout=2)

--- a/tests/unit/test_app_key.py
+++ b/tests/unit/test_app_key.py
@@ -1,0 +1,16 @@
+"""Tests for App.app_key property."""
+
+from unittest.mock import Mock, patch
+
+from hassette.app.app import App
+
+
+class TestAppKey:
+    def test_app_key_delegates_to_manifest(self) -> None:
+        """App.app_key should return app_manifest.app_key."""
+        app = App.__new__(App)
+        manifest = Mock()
+        manifest.app_key = "my_kitchen_lights"
+
+        with patch.object(App, "app_manifest", manifest):
+            assert app.app_key == "my_kitchen_lights"

--- a/tests/unit/test_app_key.py
+++ b/tests/unit/test_app_key.py
@@ -12,5 +12,5 @@ class TestAppKey:
         manifest = Mock()
         manifest.app_key = "my_kitchen_lights"
 
-        with patch.object(App, "app_manifest", manifest):
+        with patch.object(App, "app_manifest", manifest, create=True):
             assert app.app_key == "my_kitchen_lights"

--- a/tests/unit/test_execution.py
+++ b/tests/unit/test_execution.py
@@ -14,7 +14,7 @@ class TestExecutionResult:
         assert result.duration_ms == 0.0
         assert result.error_message is None
         assert result.error_type is None
-        assert result.started_at == 0.0
+        assert result.monotonic_start == 0.0
 
     def test_is_success(self) -> None:
         result = ExecutionResult(status="success")
@@ -36,7 +36,7 @@ class TestTrackExecution:
 
         assert result.status == "success"
         assert result.duration_ms >= 0.0
-        assert result.started_at > 0.0
+        assert result.monotonic_start > 0.0
         assert result.error_message is None
         assert result.error_type is None
 
@@ -73,11 +73,11 @@ class TestTrackExecution:
         assert result.duration_ms >= 40.0
         assert result.duration_ms < 500.0
 
-    async def test_started_at_is_monotonic(self) -> None:
+    async def test_monotonic_start_is_set(self) -> None:
         async with track_execution() as result:
             pass
 
-        assert result.started_at > 0.0
+        assert result.monotonic_start > 0.0
 
     async def test_hassette_error_subclass(self) -> None:
         """Verify that HassetteError subclasses are properly tracked."""

--- a/tests/unit/test_func_utils.py
+++ b/tests/unit/test_func_utils.py
@@ -1,0 +1,135 @@
+"""Tests for callable_name() and callable_short_name() utility functions."""
+
+import functools
+from functools import partial
+
+from hassette.utils.func_utils import callable_name, callable_short_name
+
+# --- Test helpers ---
+
+
+def plain_function() -> None:
+    pass
+
+
+async def async_plain_function() -> None:
+    pass
+
+
+class MyClass:
+    def method(self) -> None:
+        pass
+
+
+class CallableClass:
+    def __call__(self) -> None:
+        pass
+
+
+def _decorator(fn):
+    @functools.wraps(fn)
+    def wrapper(*args, **kwargs):
+        return fn(*args, **kwargs)
+
+    return wrapper
+
+
+@_decorator
+def decorated_function() -> None:
+    pass
+
+
+# --- callable_name tests ---
+
+
+class TestCallableName:
+    def test_plain_function(self) -> None:
+        name = callable_name(plain_function)
+        assert name.endswith("plain_function")
+        assert "test_func_utils" in name
+
+    def test_bound_method(self) -> None:
+        obj = MyClass()
+        name = callable_name(obj.method)
+        assert "MyClass" in name
+        assert name.endswith("method")
+
+    def test_lambda(self) -> None:
+        fn = lambda: None  # noqa: E731
+        name = callable_name(fn)
+        assert "<lambda>" in name
+
+    def test_partial_single(self) -> None:
+        fn = partial(plain_function)
+        name = callable_name(fn)
+        assert name.startswith("partial(")
+        assert "plain_function" in name
+
+    def test_partial_nested(self) -> None:
+        """Nested partials: inspect.unwrap strips one layer, then partial branch wraps it."""
+        fn = partial(partial(plain_function))
+        name = callable_name(fn)
+        assert "partial(" in name
+        assert "plain_function" in name
+
+    def test_callable_class_instance(self) -> None:
+        obj = CallableClass()
+        name = callable_name(obj)
+        assert "CallableClass" in name
+        assert "__call__" in name
+
+    def test_inner_function(self) -> None:
+        def local_inner() -> None:
+            pass
+
+        name = callable_name(local_inner)
+        assert "local_inner" in name
+
+    def test_decorated_function(self) -> None:
+        """Decorated function with @wraps should resolve to the original name via inspect.unwrap()."""
+        name = callable_name(decorated_function)
+        assert "decorated_function" in name
+
+
+# --- callable_short_name tests ---
+
+
+class TestCallableShortName:
+    def test_default_num_parts(self) -> None:
+        """num_parts=1 returns the last segment."""
+        short = callable_short_name(plain_function)
+        assert short == "plain_function"
+
+    def test_num_parts_two(self) -> None:
+        """num_parts=2 returns the last two dot-separated segments."""
+        short = callable_short_name(plain_function, num_parts=2)
+        parts = short.split(".")
+        assert len(parts) == 2
+        assert parts[-1] == "plain_function"
+
+    def test_num_parts_exceeds_total(self) -> None:
+        """When num_parts exceeds the number of segments, the full name is returned."""
+        full = callable_name(plain_function)
+        total_parts = len(full.split("."))
+        short = callable_short_name(plain_function, num_parts=total_parts + 5)
+        assert short == full
+
+    def test_bound_method_default(self) -> None:
+        obj = MyClass()
+        short = callable_short_name(obj.method)
+        assert short == "method"
+
+    def test_bound_method_two_parts(self) -> None:
+        obj = MyClass()
+        short = callable_short_name(obj.method, num_parts=2)
+        assert short == "MyClass.method"
+
+    def test_lambda_default(self) -> None:
+        fn = lambda: None  # noqa: E731
+        short = callable_short_name(fn)
+        assert "<lambda>" in short
+
+    def test_callable_class_default(self) -> None:
+        obj = CallableClass()
+        short = callable_short_name(obj)
+        assert short == "__call__"

--- a/tests/unit/test_scheduler_job_names.py
+++ b/tests/unit/test_scheduler_job_names.py
@@ -1,0 +1,139 @@
+"""Tests for Scheduler job name uniqueness validation."""
+
+from collections.abc import Callable
+from unittest.mock import Mock
+
+import pytest
+
+from hassette.scheduler.classes import IntervalTrigger, ScheduledJob
+from hassette.scheduler.scheduler import Scheduler
+from hassette.utils.date_utils import now
+
+
+def _make_scheduler() -> Scheduler:
+    """Create a minimal Scheduler instance with mocked internals."""
+    scheduler = Scheduler.__new__(Scheduler)
+    scheduler.scheduler_service = Mock()
+    scheduler._jobs_by_name = {}
+    # owner_id is a property on Resource that reads parent.unique_name
+    type(scheduler).owner_id = property(lambda _self: "test_owner")
+    return scheduler
+
+
+def _make_job(
+    name: str = "",
+    *,
+    job: Callable[..., None] | None = None,
+    trigger: IntervalTrigger | None = None,
+    repeat: bool = False,
+) -> ScheduledJob:
+    """Create a minimal ScheduledJob."""
+    return ScheduledJob(
+        owner="test_owner",
+        next_run=now(),
+        job=job or (lambda: None),
+        name=name,
+        trigger=trigger,
+        repeat=repeat,
+    )
+
+
+class TestJobNameUniqueness:
+    def test_duplicate_name_raises(self) -> None:
+        scheduler = _make_scheduler()
+        scheduler.add_job(_make_job("daily_backup"))
+
+        with pytest.raises(ValueError, match="daily_backup"):
+            scheduler.add_job(_make_job("daily_backup"))
+
+    def test_different_names_ok(self) -> None:
+        scheduler = _make_scheduler()
+        scheduler.add_job(_make_job("job_a"))
+        scheduler.add_job(_make_job("job_b"))
+
+        assert set(scheduler._jobs_by_name) == {"job_a", "job_b"}
+
+    def test_auto_named_jobs_also_enforce_uniqueness(self) -> None:
+        """Jobs with auto-derived names (from callable) are still subject to uniqueness checks."""
+        scheduler = _make_scheduler()
+        # Both jobs use lambda, so __post_init__ auto-names them "<lambda>".
+        job1 = _make_job("")
+        job2 = _make_job("")
+
+        scheduler.add_job(job1)
+
+        with pytest.raises(ValueError, match="<lambda>"):
+            scheduler.add_job(job2)
+
+    def test_removal_allows_reuse(self) -> None:
+        scheduler = _make_scheduler()
+        job = _make_job("ephemeral")
+        scheduler.add_job(job)
+        assert "ephemeral" in scheduler._jobs_by_name
+
+        scheduler.remove_job(job)
+        assert "ephemeral" not in scheduler._jobs_by_name
+
+        # Re-adding with the same name should now succeed
+        scheduler.add_job(_make_job("ephemeral"))
+        assert "ephemeral" in scheduler._jobs_by_name
+
+    def test_remove_all_clears_names(self) -> None:
+        scheduler = _make_scheduler()
+        scheduler.add_job(_make_job("a"))
+        scheduler.add_job(_make_job("b"))
+        assert set(scheduler._jobs_by_name) == {"a", "b"}
+
+        scheduler.remove_all_jobs()
+        assert scheduler._jobs_by_name == {}
+
+
+class TestIfExistsSkip:
+    def test_skip_returns_existing_when_matching(self) -> None:
+        """if_exists='skip' returns the existing job when everything matches."""
+        scheduler = _make_scheduler()
+        fn = lambda: None  # noqa: E731
+        job1 = _make_job("poll", job=fn)
+        added = scheduler.add_job(job1)
+
+        job2 = _make_job("poll", job=fn)
+        result = scheduler.add_job(job2, if_exists="skip")
+
+        assert result is added
+
+    def test_skip_raises_when_config_differs(self) -> None:
+        """if_exists='skip' still raises when the name matches but config differs."""
+        scheduler = _make_scheduler()
+        fn_a = lambda: None  # noqa: E731
+        fn_b = lambda: None  # noqa: E731
+        scheduler.add_job(_make_job("poll", job=fn_a))
+
+        with pytest.raises(ValueError, match="poll"):
+            scheduler.add_job(_make_job("poll", job=fn_b), if_exists="skip")
+
+    def test_skip_checks_trigger_equality(self) -> None:
+        """if_exists='skip' considers trigger type and value."""
+        scheduler = _make_scheduler()
+        fn = lambda: None  # noqa: E731
+        trigger_30s = IntervalTrigger.from_arguments(seconds=30)
+        trigger_60s = IntervalTrigger.from_arguments(seconds=60)
+
+        scheduler.add_job(_make_job("poll", job=fn, trigger=trigger_30s, repeat=True))
+
+        # Same trigger config → skip
+        same_trigger = IntervalTrigger.from_arguments(seconds=30)
+        result = scheduler.add_job(_make_job("poll", job=fn, trigger=same_trigger, repeat=True), if_exists="skip")
+        assert result is scheduler._jobs_by_name["poll"]
+
+        # Different trigger config → error
+        with pytest.raises(ValueError, match="poll"):
+            scheduler.add_job(_make_job("poll", job=fn, trigger=trigger_60s, repeat=True), if_exists="skip")
+
+    def test_error_mode_always_raises_on_duplicate(self) -> None:
+        """Default if_exists='error' raises even when config matches."""
+        scheduler = _make_scheduler()
+        fn = lambda: None  # noqa: E731
+        scheduler.add_job(_make_job("poll", job=fn))
+
+        with pytest.raises(ValueError, match="poll"):
+            scheduler.add_job(_make_job("poll", job=fn))


### PR DESCRIPTION
## Summary

Prerequisite changes for the SQLite command executor (#264):

- **App.app_key property** — exposes the app's configuration key from its manifest, needed for SQLite row identification
- **Scheduler job name uniqueness** — enforces unique names per scheduler instance via `_jobs_by_name` dict tracking. Adds `if_exists` parameter (`"error"` | `"skip"`) to `add_job()` and all `run_*` methods for idempotent registration. `ScheduledJob.matches()` compares callable, trigger, repeat, args, and kwargs to determine if an existing job is logically identical
- **Trigger equality** — `__eq__`/`__hash__` on `IntervalTrigger` (compares interval) and `CronTrigger` (compares cron expression) for configuration-based comparison, excluding runtime state like `start`
- **ExecutionResult rename** — `started_at` → `monotonic_start` to clarify it stores a monotonic clock value, not a wall-clock timestamp
- **StateProxy disconnect fix** — `on_disconnect()` now calls `scheduler.remove_job()` instead of `job.cancel()` to properly free the name slot, and `subscribe_to_events()` uses `if_exists="skip"` for idempotent reconnection

### Breaking changes

- Scheduler raises `ValueError` on duplicate job names (previously allowed)
- `ExecutionResult.started_at` renamed to `monotonic_start`

Closes #264