### PR TITLE
Fix URL parsing when base_url contains literal quote characters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - StateProxy `on_disconnect` now uses `remove_job()` instead of `cancel()` to properly free the job name slot for reconnection (#297)
-- Strip literal quote characters from `base_url` before parsing, fixing connection failures when Docker Compose passes quoted env var values
+- Strip literal quote characters from `base_url` before parsing, fixing connection failures when Docker Compose passes quoted env var values (#298)
 
 ## [0.23.0] - 2026-02-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - StateProxy `on_disconnect` now uses `remove_job()` instead of `cancel()` to properly free the job name slot for reconnection (#297)
+- Strip literal quote characters from `base_url` before parsing, fixing connection failures when Docker Compose passes quoted env var values
 
 ## [0.23.0] - 2026-02-19
 

--- a/src/hassette/utils/url_utils.py
+++ b/src/hassette/utils/url_utils.py
@@ -31,7 +31,7 @@ def _parse_and_normalize_url(config: "HassetteConfig") -> tuple[str, str, int | 
     if "::" in config.base_url:
         raise IPV6NotSupportedError(f"IPv6 addresses are not supported in base_url, got: {config.base_url}")
 
-    yurl = URL(config.base_url.strip())
+    yurl = URL(config.base_url.strip().strip("'\""))
 
     if not yurl.scheme:
         raise SchemeRequiredInBaseUrlError(

--- a/src/hassette/utils/url_utils.py
+++ b/src/hassette/utils/url_utils.py
@@ -31,15 +31,14 @@ def _parse_and_normalize_url(config: "HassetteConfig") -> tuple[str, str, int | 
     if "::" in config.base_url:
         raise IPV6NotSupportedError(f"IPv6 addresses are not supported in base_url, got: {config.base_url}")
 
-    yurl = URL(config.base_url.strip().strip("'\""))
+    cleaned_url = config.base_url.strip().strip("'\"")
+    yurl = URL(cleaned_url)
 
     if not yurl.scheme:
-        raise SchemeRequiredInBaseUrlError(
-            f"base_url must include a scheme (http:// or https://), got: {config.base_url}"
-        )
+        raise SchemeRequiredInBaseUrlError(f"base_url must include a scheme (http:// or https://), got: {cleaned_url}")
 
     if yurl.host is None:
-        raise BaseUrlRequiredError(f"base_url must include a valid hostname, got: {config.base_url}")
+        raise BaseUrlRequiredError(f"base_url must include a valid hostname, got: {cleaned_url}")
 
     return yurl.scheme, yurl.host, yurl.explicit_port
 

--- a/tests/unit/test_url_utils.py
+++ b/tests/unit/test_url_utils.py
@@ -111,3 +111,25 @@ def test_no_scheme_raises_exception(func):
 
     with pytest.raises(SchemeRequiredInBaseUrlError):
         func(config)
+
+
+@pytest.mark.parametrize(
+    ("input_url", "expected_scheme", "expected_host", "expected_port"),
+    [
+        ('"http://homeassistant:8123"', "http", "homeassistant", 8123),
+        ("'http://homeassistant:8123'", "http", "homeassistant", 8123),
+        ('" http://homeassistant:8123 "', "http", "homeassistant", 8123),
+        ("' http://homeassistant:8123 '", "http", "homeassistant", 8123),
+        ('"https://example.com"', "https", "example.com", None),
+        ("'https://example.com'", "https", "example.com", None),
+    ],
+)
+def test_quoted_urls_are_stripped(input_url: str, expected_scheme: str, expected_host: str, expected_port: int | None):
+    """Test that literal quote characters wrapping a URL are stripped before parsing."""
+    config = _make_config(input_url)
+
+    scheme, host, port = _parse_and_normalize_url(config)
+
+    assert scheme == expected_scheme
+    assert host == expected_host
+    assert port == expected_port


### PR DESCRIPTION
## Summary
- Strip literal quote characters (`'` and `"`) from `base_url` before passing it to `yarl.URL` for parsing
- Fixes connection failures when Docker Compose passes quoted env var values as literal strings (e.g., `BASE_URL: "http://homeassistant:8123"` where the quotes become part of the value)
- Adds 6 parametrized test cases covering double-quoted, single-quoted, and quote+whitespace URL variants

Closes #238