### PR TITLE
Consolidate repetitive Bus subscription methods

### DIFF
--- a/src/hassette/bus/bus.py
+++ b/src/hassette/bus/bus.py
@@ -84,7 +84,7 @@ import typing
 from collections.abc import Mapping
 from typing import Any, TypeVar, Unpack
 
-from typing_extensions import TypedDict
+from typing_extensions import Sentinel, TypedDict
 
 from hassette.const import NOT_PROVIDED
 from hassette.event_handling import predicates as P
@@ -220,7 +220,11 @@ class Bus(Resource):
     ) -> Subscription:
         """Common subscription tail: log, normalize where, delegate to on()."""
         if self.logger.isEnabledFor(10):  # DEBUG
-            filtered = {k: v for k, v in log_params.items() if v is not None and v} if log_params else {}
+            filtered = (
+                {k: v for k, v in log_params.items() if v is not None and not isinstance(v, Sentinel)}
+                if log_params
+                else {}
+            )
             params_str = ", ".join(f"{k}='{v}'" for k, v in filtered.items())
 
             self.logger.debug(

--- a/src/hassette/bus/bus.py
+++ b/src/hassette/bus/bus.py
@@ -210,7 +210,7 @@ class Bus(Resource):
         self,
         *,
         method_name: str,
-        topic: str | Topic,
+        topic: str,
         handler: "HandlerType",
         preds: list["Predicate"],
         where: "Predicate | Sequence[Predicate] | None" = None,
@@ -219,14 +219,16 @@ class Bus(Resource):
         **opts: Unpack[Options],
     ) -> Subscription:
         """Common subscription tail: log, normalize where, delegate to on()."""
-        params_str = ", ".join(f"{k}='{v}'" for k, v in log_params.items()) if log_params else ""
+        if self.logger.isEnabledFor(10):  # DEBUG
+            filtered = {k: v for k, v in log_params.items() if v is not None and v} if log_params else {}
+            params_str = ", ".join(f"{k}='{v}'" for k, v in filtered.items())
 
-        self.logger.debug(
-            "Subscribing to %s with %s - being handled by '%s'",
-            method_name,
-            params_str,
-            callable_short_name(handler),
-        )
+            self.logger.debug(
+                "Subscribing to %s with %s - being handled by '%s'",
+                method_name,
+                params_str,
+                callable_short_name(handler),
+            )
 
         if where is not None:
             preds.append(where if callable(where) else P.AllOf.ensure_iterable(where))


### PR DESCRIPTION
## Summary
- Extract shared boilerplate (debug logging, where-clause normalization, `self.on()` delegation) from 7 core Bus subscription methods into a `_subscribe()` private helper
- Extract `on_call_service`'s Mapping-aware where handling into a `_normalize_service_where()` static method
- All public API signatures unchanged; no behavior changes

Closes #295