### PR TITLE
Fix race condition: await remove_all_listeners() in on_shutdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Breaking:** Renamed `ExecutionResult.started_at` to `monotonic_start` to clarify it stores a monotonic clock value (#297)
 
 ### Fixed
+- Await `Bus.remove_all_listeners()` in `ServiceWatcher`, `StateProxy`, and `AppHandler` shutdown to prevent listener cleanup race condition
 - StateProxy `on_disconnect` now uses `remove_job()` instead of `cancel()` to properly free the job name slot for reconnection (#297)
 - Strip literal quote characters from `base_url` before parsing, fixing connection failures when Docker Compose passes quoted env var values (#298)
 - ServiceWatcher now triggers Hassette shutdown when a service exceeds its max restart attempts, instead of silently giving up (#301)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Breaking:** Renamed `ExecutionResult.started_at` to `monotonic_start` to clarify it stores a monotonic clock value (#297)
 
 ### Fixed
-- Await `Bus.remove_all_listeners()` in `ServiceWatcher`, `StateProxy`, and `AppHandler` shutdown to prevent listener cleanup race condition
+- Await `Bus.remove_all_listeners()` in `ServiceWatcher`, `StateProxy`, and `AppHandler` shutdown to prevent listener cleanup race condition (#311)
 - StateProxy `on_disconnect` now uses `remove_job()` instead of `cancel()` to properly free the job name slot for reconnection (#297)
 - Strip literal quote characters from `base_url` before parsing, fixing connection failures when Docker Compose passes quoted env var values (#298)
 - ServiceWatcher now triggers Hassette shutdown when a service exceeds its max restart attempts, instead of silently giving up (#301)

--- a/src/hassette/core/app_handler.py
+++ b/src/hassette/core/app_handler.py
@@ -127,7 +127,7 @@ class AppHandler(Resource):
         self.logger.debug("Stopping '%s' %s", self.class_name, self.role)
         self.mark_not_ready(reason="shutting-down")
 
-        self.bus.remove_all_listeners()
+        await self.bus.remove_all_listeners()
         await self.lifecycle.shutdown_all()
 
     def get(self, app_key: str, index: int = 0) -> "App[AppConfig] | None":

--- a/src/hassette/core/service_watcher.py
+++ b/src/hassette/core/service_watcher.py
@@ -36,7 +36,7 @@ class ServiceWatcher(Resource):
         self.mark_ready(reason="Service watcher initialized")
 
     async def on_shutdown(self) -> None:
-        self.bus.remove_all_listeners()
+        await self.bus.remove_all_listeners()
 
     @staticmethod
     def _service_key(name: str, role: object) -> str:

--- a/src/hassette/core/state_proxy.py
+++ b/src/hassette/core/state_proxy.py
@@ -106,7 +106,7 @@ class StateProxy(Resource):
         """Shutdown the state proxy and clean up resources."""
         self.logger.debug("Shutting down state proxy")
         self.mark_not_ready(reason="Shutting down")
-        self.bus.remove_all_listeners()
+        await self.bus.remove_all_listeners()
         self.scheduler.remove_all_jobs()
 
         self.poll_job = None

--- a/tests/integration/test_state_proxy.py
+++ b/tests/integration/test_state_proxy.py
@@ -120,6 +120,12 @@ def state_proxy():
     mock_hassette.config.log_level = "DEBUG"
     mock_hassette.config.bus_service_log_level = "DEBUG"
 
+    # Bus.remove_all_listeners() delegates to bus_service.remove_listeners_by_owner()
+    # which must return an awaitable Task, not a plain Mock.
+    mock_hassette._bus_service.remove_listeners_by_owner.side_effect = lambda *_args, **_kwargs: asyncio.ensure_future(
+        asyncio.sleep(0)
+    )
+
     proxy = StateProxy.create(mock_hassette, mock_hassette)
     proxy.mark_ready(reason="Test setup")
     return proxy


### PR DESCRIPTION
## Summary
- `Bus.remove_all_listeners()` returns an `asyncio.Task` but three `on_shutdown` methods (`ServiceWatcher`, `StateProxy`, `AppHandler`) called it without `await`, creating a race condition where listeners could survive shutdown if the task bucket was cancelled first
- Added `await` to all three call sites and fixed the test fixture mock to return an awaitable task

Closes #309