### PR TITLE
ci: sync uv.lock on release-please PR after version bump

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -1,29 +1,30 @@
 name: PR Title
 
 on:
-  pull_request:
-    types: [opened, edited, synchronize]
+    pull_request:
+        types: [opened, edited, synchronize]
 
 permissions:
-  pull-requests: read
+    pull-requests: read
 
 jobs:
-  validate:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: amannn/action-semantic-pull-request@v5
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          types: |
-            feat
-            fix
-            refactor
-            docs
-            test
-            chore
-            perf
-            ci
-          requireScope: false
-          subjectPattern: ^.+$
-          subjectPatternError: "PR title must have a description after the type prefix"
+    validate:
+        runs-on: ubuntu-latest
+        timeout-minutes: 5
+        steps:
+            - uses: amannn/action-semantic-pull-request@v5
+              env:
+                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+              with:
+                  types: |
+                      feat
+                      fix
+                      refactor
+                      docs
+                      test
+                      chore
+                      perf
+                      ci
+                  requireScope: false
+                  subjectPattern: ^.+$
+                  subjectPatternError: "PR title must have a description after the type prefix"

--- a/.github/workflows/python_package.yml
+++ b/.github/workflows/python_package.yml
@@ -1,78 +1,78 @@
 name: Publish Python package
 
 on:
-  workflow_call:
-    inputs:
-      tag_name:
-        description: "Release tag (e.g. v0.24.0) — passed by release-please"
-        required: true
-        type: string
-  workflow_dispatch:
-    inputs:
-      tag_name:
-        description: "Release tag to publish (e.g. v0.24.0)"
-        required: true
-        type: string
+    workflow_call:
+        inputs:
+            tag_name:
+                description: "Release tag (e.g. v0.24.0) — passed by release-please"
+                required: true
+                type: string
+    workflow_dispatch:
+        inputs:
+            tag_name:
+                description: "Release tag to publish (e.g. v0.24.0)"
+                required: true
+                type: string
 
 jobs:
-  build-pypi-dists:
-    name: Build Python package
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
+    build-pypi-dists:
+        name: Build Python package
+        runs-on: ubuntu-latest
+        timeout-minutes: 10
 
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          ref: ${{ inputs.tag_name || github.ref }}
+        steps:
+            - uses: actions/checkout@v4
+              with:
+                  ref: ${{ inputs.tag_name || github.ref }}
 
-      - name: Install uv
-        uses: astral-sh/setup-uv@v6
-        with:
-          activate-environment: true
-          enable-cache: true
+            - name: Install uv
+              uses: astral-sh/setup-uv@v6
+              with:
+                  activate-environment: true
+                  enable-cache: true
 
-      - name: Set up Python
-        run: uv python install
+            - name: Set up Python
+              run: uv python install
 
-      - name: Install python packages
-        run: uv sync
+            - name: Install python packages
+              run: uv sync
 
-      - name: Verify tag matches project version
-        if: inputs.tag_name != ''
-        env:
-          TAG_NAME: ${{ inputs.tag_name }}
-        run: |
-          PROJECT_VERSION=$(uv version --short)
-          uv run ./tools/check_tag_version.py --ref-name "$TAG_NAME" --project-version "$PROJECT_VERSION"
+            - name: Verify tag matches project version
+              if: inputs.tag_name != ''
+              env:
+                  TAG_NAME: ${{ inputs.tag_name }}
+              run: |
+                  PROJECT_VERSION=$(uv version --short)
+                  uv run ./tools/check_tag_version.py --ref-name "$TAG_NAME" --project-version "$PROJECT_VERSION"
 
-      - name: Build a binary wheel and a source tarball
-        run: uv build
+            - name: Build a binary wheel and a source tarball
+              run: uv build
 
-      - name: Publish build artifacts
-        uses: actions/upload-artifact@v4
-        with:
-          name: pypi-dists
-          path: "./dist"
+            - name: Publish build artifacts
+              uses: actions/upload-artifact@v4
+              with:
+                  name: pypi-dists
+                  path: "./dist"
 
-  publish-pypi-dists:
-    name: Publish to PyPI
-    environment:
-      name: release
-      url: https://pypi.org/p/hassette
-    needs: [build-pypi-dists]
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    permissions:
-      id-token: write # IMPORTANT: this permission is mandatory for trusted publishing
+    publish-pypi-dists:
+        name: Publish to PyPI
+        environment:
+            name: release
+            url: https://pypi.org/p/hassette
+        needs: [build-pypi-dists]
+        runs-on: ubuntu-latest
+        timeout-minutes: 5
+        permissions:
+            id-token: write # IMPORTANT: this permission is mandatory for trusted publishing
 
-    steps:
-      - name: Download build artifacts
-        uses: actions/download-artifact@v4
-        with:
-          name: pypi-dists
-          path: "./dist"
+        steps:
+            - name: Download build artifacts
+              uses: actions/download-artifact@v4
+              with:
+                  name: pypi-dists
+                  path: "./dist"
 
-      - name: Publish distribution to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          skip-existing: true
+            - name: Publish distribution to PyPI
+              uses: pypa/gh-action-pypi-publish@release/v1
+              with:
+                  skip-existing: true

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -36,7 +36,7 @@ jobs:
 
     sync-lockfile:
         needs: release-please
-        if: needs.release-please.outputs.pr && !needs.release-please.outputs.release_created
+        if: needs.release-please.outputs.pr && needs.release-please.outputs.release_created != 'true'
         runs-on: ubuntu-latest
         timeout-minutes: 10
         steps:
@@ -67,7 +67,7 @@ jobs:
                       git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
                       git add uv.lock
                       git commit -m "chore: sync uv.lock with version bump"
-                      git push
+                      git push origin HEAD
                   fi
 
     publish-pypi:

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -19,6 +19,7 @@ jobs:
     outputs:
       release_created: ${{ steps.release.outputs.release_created }}
       tag_name: ${{ steps.release.outputs.tag_name }}
+      pr: ${{ steps.release.outputs.pr }}
     steps:
       - uses: actions/create-github-app-token@v1
         id: app-token
@@ -32,6 +33,42 @@ jobs:
           token: ${{ steps.app-token.outputs.token }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
+
+  sync-lockfile:
+    needs: release-please
+    if: needs.release-please.outputs.pr && !needs.release-please.outputs.release_created
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ secrets.RELEASE_PLEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_PLEASE_APP_PRIVATE_KEY }}
+
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ fromJSON(needs.release-please.outputs.pr).headBranchName }}
+          token: ${{ steps.app-token.outputs.token }}
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+        with:
+          enable-cache: true
+
+      - name: Sync uv.lock
+        run: |
+          set -euo pipefail
+          uv lock
+          if git diff --quiet uv.lock; then
+            echo "uv.lock is already up to date"
+          else
+            git config user.name "github-actions[bot]"
+            git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+            git add uv.lock
+            git commit -m "chore: sync uv.lock with version bump"
+            git push
+          fi
 
   publish-pypi:
     needs: release-please

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,123 +1,123 @@
 name: Release Please
 
 on:
-  push:
-    branches: [main]
+    push:
+        branches: [main]
 
 permissions:
-  contents: write
-  pull-requests: write
+    contents: write
+    pull-requests: write
 
 concurrency:
-  group: release-please
-  cancel-in-progress: false
+    group: release-please
+    cancel-in-progress: false
 
 jobs:
-  release-please:
-    runs-on: ubuntu-latest
-    timeout-minutes: 15
-    outputs:
-      release_created: ${{ steps.release.outputs.release_created }}
-      tag_name: ${{ steps.release.outputs.tag_name }}
-      pr: ${{ steps.release.outputs.pr }}
-    steps:
-      - uses: actions/create-github-app-token@v1
-        id: app-token
+    release-please:
+        runs-on: ubuntu-latest
+        timeout-minutes: 15
+        outputs:
+            release_created: ${{ steps.release.outputs.release_created }}
+            tag_name: ${{ steps.release.outputs.tag_name }}
+            pr: ${{ steps.release.outputs.pr }}
+        steps:
+            - uses: actions/create-github-app-token@v1
+              id: app-token
+              with:
+                  app-id: ${{ secrets.RELEASE_PLEASE_APP_ID }}
+                  private-key: ${{ secrets.RELEASE_PLEASE_APP_PRIVATE_KEY }}
+
+            - uses: googleapis/release-please-action@v4
+              id: release
+              with:
+                  token: ${{ steps.app-token.outputs.token }}
+                  config-file: release-please-config.json
+                  manifest-file: .release-please-manifest.json
+
+    sync-lockfile:
+        needs: release-please
+        if: needs.release-please.outputs.pr && !needs.release-please.outputs.release_created
+        runs-on: ubuntu-latest
+        timeout-minutes: 10
+        steps:
+            - uses: actions/create-github-app-token@v1
+              id: app-token
+              with:
+                  app-id: ${{ secrets.RELEASE_PLEASE_APP_ID }}
+                  private-key: ${{ secrets.RELEASE_PLEASE_APP_PRIVATE_KEY }}
+
+            - uses: actions/checkout@v4
+              with:
+                  ref: ${{ fromJSON(needs.release-please.outputs.pr).headBranchName }}
+                  token: ${{ steps.app-token.outputs.token }}
+
+            - name: Install uv
+              uses: astral-sh/setup-uv@v6
+              with:
+                  enable-cache: true
+
+            - name: Sync uv.lock
+              run: |
+                  set -euo pipefail
+                  uv lock
+                  if git diff --quiet uv.lock; then
+                      echo "uv.lock is already up to date"
+                  else
+                      git config user.name "github-actions[bot]"
+                      git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+                      git add uv.lock
+                      git commit -m "chore: sync uv.lock with version bump"
+                      git push
+                  fi
+
+    publish-pypi:
+        needs: release-please
+        if: needs.release-please.outputs.release_created == 'true'
+        uses: ./.github/workflows/python_package.yml
         with:
-          app-id: ${{ secrets.RELEASE_PLEASE_APP_ID }}
-          private-key: ${{ secrets.RELEASE_PLEASE_APP_PRIVATE_KEY }}
+            tag_name: ${{ needs.release-please.outputs.tag_name }}
+        permissions:
+            contents: read
+            id-token: write
 
-      - uses: googleapis/release-please-action@v4
-        id: release
+    publish-docker:
+        needs: release-please
+        if: needs.release-please.outputs.release_created == 'true'
+        uses: ./.github/workflows/build_and_publish_image.yml
         with:
-          token: ${{ steps.app-token.outputs.token }}
-          config-file: release-please-config.json
-          manifest-file: .release-please-manifest.json
+            tag_name: ${{ needs.release-please.outputs.tag_name }}
+        permissions:
+            contents: read
+            packages: write
+            id-token: write
 
-  sync-lockfile:
-    needs: release-please
-    if: needs.release-please.outputs.pr && !needs.release-please.outputs.release_created
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    steps:
-      - uses: actions/create-github-app-token@v1
-        id: app-token
-        with:
-          app-id: ${{ secrets.RELEASE_PLEASE_APP_ID }}
-          private-key: ${{ secrets.RELEASE_PLEASE_APP_PRIVATE_KEY }}
+    release-verify:
+        needs: [release-please, publish-pypi, publish-docker]
+        if: always() && needs.release-please.outputs.release_created == 'true'
+        runs-on: ubuntu-latest
+        steps:
+            - name: Check publish results
+              env:
+                  PYPI_RESULT: ${{ needs.publish-pypi.result }}
+                  DOCKER_RESULT: ${{ needs.publish-docker.result }}
+                  TAG_NAME: ${{ needs.release-please.outputs.tag_name }}
+              run: |
+                  # Detect unexpected state where release was created but both publish jobs were skipped
+                  if [ "$PYPI_RESULT" = "skipped" ] && [ "$DOCKER_RESULT" = "skipped" ]; then
+                      echo "::error::Both publish jobs were skipped unexpectedly for release $TAG_NAME — inspect the publish workflow conditions and logs"
+                      exit 1
+                  fi
 
-      - uses: actions/checkout@v4
-        with:
-          ref: ${{ fromJSON(needs.release-please.outputs.pr).headBranchName }}
-          token: ${{ steps.app-token.outputs.token }}
-
-      - name: Install uv
-        uses: astral-sh/setup-uv@v6
-        with:
-          enable-cache: true
-
-      - name: Sync uv.lock
-        run: |
-          set -euo pipefail
-          uv lock
-          if git diff --quiet uv.lock; then
-            echo "uv.lock is already up to date"
-          else
-            git config user.name "github-actions[bot]"
-            git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-            git add uv.lock
-            git commit -m "chore: sync uv.lock with version bump"
-            git push
-          fi
-
-  publish-pypi:
-    needs: release-please
-    if: needs.release-please.outputs.release_created == 'true'
-    uses: ./.github/workflows/python_package.yml
-    with:
-      tag_name: ${{ needs.release-please.outputs.tag_name }}
-    permissions:
-      contents: read
-      id-token: write
-
-  publish-docker:
-    needs: release-please
-    if: needs.release-please.outputs.release_created == 'true'
-    uses: ./.github/workflows/build_and_publish_image.yml
-    with:
-      tag_name: ${{ needs.release-please.outputs.tag_name }}
-    permissions:
-      contents: read
-      packages: write
-      id-token: write
-
-  release-verify:
-    needs: [release-please, publish-pypi, publish-docker]
-    if: always() && needs.release-please.outputs.release_created == 'true'
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check publish results
-        env:
-          PYPI_RESULT: ${{ needs.publish-pypi.result }}
-          DOCKER_RESULT: ${{ needs.publish-docker.result }}
-          TAG_NAME: ${{ needs.release-please.outputs.tag_name }}
-        run: |
-          # Detect unexpected state where release was created but both publish jobs were skipped
-          if [ "$PYPI_RESULT" = "skipped" ] && [ "$DOCKER_RESULT" = "skipped" ]; then
-            echo "::error::Both publish jobs were skipped unexpectedly for release $TAG_NAME — inspect the publish workflow conditions and logs"
-            exit 1
-          fi
-
-          failed=""
-          if [ "$PYPI_RESULT" != "success" ]; then
-            failed="$failed PyPI($PYPI_RESULT)"
-          fi
-          if [ "$DOCKER_RESULT" != "success" ]; then
-            failed="$failed Docker($DOCKER_RESULT)"
-          fi
-          if [ -n "$failed" ]; then
-            echo "::error::Partial release $TAG_NAME — failed:$failed"
-            echo "::notice::Recovery: re-run failed jobs, or trigger workflow_dispatch with tag_name=$TAG_NAME"
-            exit 1
-          fi
-          echo "All publish jobs succeeded for $TAG_NAME"
+                  failed=""
+                  if [ "$PYPI_RESULT" != "success" ]; then
+                      failed="$failed PyPI($PYPI_RESULT)"
+                  fi
+                  if [ "$DOCKER_RESULT" != "success" ]; then
+                      failed="$failed Docker($DOCKER_RESULT)"
+                  fi
+                  if [ -n "$failed" ]; then
+                      echo "::error::Partial release $TAG_NAME — failed:$failed"
+                      echo "::notice::Recovery: re-run failed jobs, or trigger workflow_dispatch with tag_name=$TAG_NAME"
+                      exit 1
+                  fi
+                  echo "All publish jobs succeeded for $TAG_NAME"

--- a/.gitignore
+++ b/.gitignore
@@ -213,6 +213,7 @@ docs/code-reference
 .claude/settings.local.json
 .claude/plan/
 .claude/plan.done.md
+.claude/worktrees/
 .mcp.json
 
 # Node (JS dev tooling)


### PR DESCRIPTION
## Summary

- Release-please bumps `pyproject.toml` but doesn't regenerate `uv.lock`, causing Docker builds to fail with `--locked` on the release PR
- Adds a post-step in `release-please.yml` that checks out the release PR branch, runs `uv lock`, and pushes the updated lockfile if it changed
- Only runs when release-please creates/updates a PR (not on release creation)

Fixes the CI failure on #475.
