### PR TITLE
feat: color system overhaul + responsive mobile adaptation

### DIFF
--- a/.claude/audits/critique-2026-04-05.md
+++ b/.claude/audits/critique-2026-04-05.md
@@ -1,0 +1,168 @@
+# Design Critique: Hassette Web UI
+
+**Date**: 2026-04-05
+**Scope**: All pages — Dashboard, Apps, Logs, Sessions
+**Design context**: `design/context.md` (Graphite + Emerald, diagnostic tool, developer audience)
+
+---
+
+## Anti-Patterns Verdict
+
+**Partial fail.** This doesn't scream "AI made this" in the obvious ways — no indigo/violet, no glassmorphism, no gradient text, no bouncy animations. The font choices are intentional and the color palette has real rationale. But it does trigger several subtler AI-slop patterns:
+
+1. **Hero metric layout template** — The KPI strip is five identical cards: big number, small label, supporting stat. This is the exact "dashboard stat card" pattern every AI generates. The cards have no visual differentiation between them — same size, same weight, same treatment. A designed version would vary these: the error rate card should look different from the uptime card because they answer different questions with different urgency.
+
+2. **Identical card grid** — The App Health section is same-sized cards with the same internal layout repeated. Every card has: name + badge, handler/job counts, health bar, last activity. The uniformity reads as "generated from a template" rather than "designed for scanning."
+
+3. **Default to dark mode with glowing accents** — Emerald on near-black *is* the "dark terminal" cliche. The rationale is sound (green LED, Pi, "alive"), but the execution doesn't yet distinguish itself from the hundreds of dark-mode developer tools with green accents. The distinction needs to come from *how* the color is used, not just *which* color.
+
+4. **Same spacing everywhere** — `--ht-sp-4` (16px) appears as the dominant gap in KPI strip, app grid, card padding, and section separation. No visual rhythm — just uniform 16px gaps producing the "monotonous grid" pattern.
+
+---
+
+## Overall Impression
+
+The bones are right. The information architecture is logical, the component choices are appropriate for a diagnostic tool, and the rejected defaults (no card nesting, no indigo, no borders-only) show real taste. The problem is execution flatness — everything has the same visual weight, the same surface treatment, the same spacing. It reads as a well-structured wireframe that got colors applied, not as a designed product.
+
+**Single biggest opportunity**: Surface hierarchy. Right now, bg → surface is a 3% luminance jump that's invisible in practice. Every card, every section, every panel looks the same. Creating a real surface ladder — where KPI cards feel like they're *on top* of the page, the App Health container is a distinct zone, and the error feed has visual weight proportional to its importance — would transform this from "correct" to "crafted."
+
+---
+
+## What's Working
+
+1. **The three-font system is genuinely good.** Space Grotesk for headings, DM Sans for body, JetBrains Mono for data creates a real typographic hierarchy that most developer tools don't attempt. The mono-heavy approach is honest about what this UI actually shows (entity IDs, timestamps, counts) rather than forcing body text where data belongs.
+
+2. **The breathing pulse dot is a real signature element.** It's conceptually earned (WebSocket liveness), visually distinctive (only continuous animation), and semantically meaningful (emerald = alive, red = dead). Most developer tools have no signature interaction at all.
+
+3. **Information density is appropriately high.** Handler counts, job counts, error rates, last activity — all visible without drilling down. The dashboard answers "is everything OK?" at a glance, which is exactly the diagnostic-tool job. No wasted space on decorative illustrations or marketing copy.
+
+---
+
+## Priority Issues
+
+### 1. Surface Hierarchy is Functionally Absent
+
+**What**: `--ht-bg` (#111113) and `--ht-surface` (#1a1a1e) are nearly indistinguishable. Cards don't lift off the page. The `shadow-sm` token (0 1px 3px rgba(0,0,0,0.3)) is invisible against a near-black background — shadows need light to cast against.
+
+**Why it matters**: Without surface differentiation, the user can't quickly parse page structure. KPI cards, App Health container, error feed, and session bar all blend into the same dark plane. The eye has no landmarks. For a diagnostic tool where speed-to-answer matters, this forces the user to *read* the page instead of *scanning* it.
+
+**Evidence in code**: `.ht-health-card` gets `background: var(--ht-surface); border: 1px solid var(--ht-border)` — that's a 6% opacity white border on a 3% luminance-difference surface. Combined effect: barely visible rectangle.
+
+**Fix**: This needs a multi-pronged approach:
+- Increase surface luminance separation (bg → surface should be perceptible in peripheral vision)
+- Add top-edge border highlights on cards (`border-top: 1px solid rgba(255,255,255,0.04)`) to simulate a light source
+- Use `--ht-surface-recessed` as the *default* page background in the main content area, making `--ht-surface` cards stand out more
+- Consider a subtle inset shadow on the main content area to create "inside a panel" depth
+
+**Command**: `/i-colorize` (surface ladder and depth tokens need reworking)
+
+---
+
+### 2. KPI Cards Have No Hierarchy — All Five Carry Equal Weight
+
+**What**: All five KPI cards (Apps, Error Rate, Handlers, Jobs, Uptime) use identical sizing, typography, and color treatment. The error rate value gets semantic color when it's non-zero, but at 0.0% it's emerald — the same color as everything else.
+
+**Why it matters**: Not all KPIs are equal. Error Rate is the most critical — it's the "is anything broken?" signal. Apps and Uptime are secondary. Handlers and Jobs are tertiary context. Treating them identically forces left-to-right reading instead of enabling priority scanning. A developer mid-incident should see the error rate *first*, without looking for it.
+
+**Evidence in screenshots**: Dashboard screenshot shows five uniform gray boxes. The eye has no entry point. "0.0%" in emerald actually *disappears* because emerald is the default accent color — it blends into the ambient visual noise of all the other green elements.
+
+**Fix**:
+- Give Error Rate more visual prominence — larger value, or a distinct background tint based on status (emerald-tinted when healthy, red-tinted when elevated)
+- Consider making the hero number sizes vary: Error Rate at `--ht-text-2xl`, others at `--ht-text-xl`
+- The "0 / 1 invocation" detail text is competing with the hero number — reduce its size or dim it further
+- Consider whether all five cards need to be equal-width columns. Error Rate could span wider.
+
+**Command**: `/i-arrange` (layout hierarchy and visual weight distribution)
+
+---
+
+### 3. Emerald Accent Is Diluted Across Too Many Roles
+
+**What**: `--ht-accent` (#34d399) is used for: status badges ("running"), the pulse dot, "Manage Apps" link, `<a>` tag default color, active nav item, focus ring, session scope toggle, and 0.0% error rate. The design context says "Emerald means alive" — but it's also doing duty as link color, UI chrome, and decoration.
+
+**Why it matters**: When the accent color means "alive/connected/running" AND "clickable link" AND "active navigation" AND "healthy error rate" AND "focus indicator," it stops meaning anything specific. The user's eye can't use color as a diagnostic shortcut because green is everywhere. The design principle "Emerald means alive" is stated but not enforced.
+
+**Evidence in code**: `global.css` line 182: `a { color: var(--ht-accent); }` — every link on every page is emerald by default. The "Manage Apps" link on the dashboard is the same green as the "running" badges above it.
+
+**Fix**:
+- Links should use `--ht-text` (primary text color) with underline-on-hover, not accent color
+- Active nav item should use `--ht-text` on a subtle recessed background, not accent color
+- Focus ring can stay accent — it's transient and accessibility-critical
+- Reserve emerald exclusively for: status badges (running/healthy), pulse dot, health bar fills, and error rate when healthy
+- "Manage Apps" should be a ghost button or text link in secondary color, not an accent-colored link
+
+**Command**: `/i-colorize` (accent usage audit and semantic color enforcement)
+
+---
+
+### 4. Health Bars Are Invisible UI Noise
+
+**What**: The `HealthBar` component is a 4px-tall strip with no label, no percentage, and no container. In the "no data" state, it's a solid dim-gray line. In the "healthy" state, it's a full-width emerald line. The component exists on every app card but communicates almost nothing.
+
+**Why it matters**: A 4px emerald bar at 100% width against a dark card background is visually indistinguishable from a horizontal rule. The user gains no information from it. It occupies vertical space in every app card without earning that space. In the screenshot, the health bars on apps with no activity are gray lines that look like dividers, not health indicators.
+
+**Evidence in code**: `.ht-health-bar { height: 4px; }` — at this height, the distinction between 98% and 100% fill is one pixel. The `aria-label` provides the data ("Health: 100% success rate") but it's screen-reader-only.
+
+**Fix**: Either make health bars meaningful or remove them:
+- **Option A**: Remove from app cards entirely — the error rate percentage already communicates health, and the status badge communicates running/stopped. Health bars are redundant.
+- **Option B**: Make them visible — 8px height, visible percentage label, wider color range (distinct shades for 100% vs 95% vs 80%), and only show when there's actual data (hide when total = 0 instead of showing a meaningless gray bar).
+
+**Command**: `/i-distill` (remove or rethink a component that isn't earning its place)
+
+---
+
+### 5. Empty States Are Absent — Blank Space Is Not a State
+
+**What**: The Sessions page with one row shows a single table row floating in a void. The dashboard "No recent errors" state is a one-line message with a warning icon. There's no treatment for "no apps configured," "no handlers registered," or "first run."
+
+**Why it matters**: A developer opening Hassette for the first time sees a nearly empty dashboard. A sessions page with one row and five empty columns ("—", "—", "0s", "—", "—") communicates nothing — it's visual debris. Empty states are the highest-leverage design surface because they're seen first and they set expectations.
+
+**Evidence in screenshots**: Sessions page screenshot shows a single row with most columns displaying "—". Below that: void. No guidance, no context, no reassurance that this is expected.
+
+**Fix**:
+- Sessions page with few rows: collapse the empty columns (Stopped At, Duration, Error Type, Error Message are all "—") or show a summary card instead of a table row
+- "No recent errors" should feel like a positive signal, not a warning-icon afterthought — a brief "All systems healthy" with the pulse dot or a subtle emerald tint
+- First-run state: "No apps configured. See the [getting started guide]." — one line, one link, zero decoration
+- Log viewer with no entries: "Waiting for events..." with connection status
+
+**Command**: `/i-onboard` (empty states and first-run experience)
+
+---
+
+## Minor Observations
+
+- **Session bar at dashboard bottom** looks like a footer afterthought. "Hassette Started 4/3/2026, 4:57:02 PM" in a gray bar with no visual relationship to the page above it. Consider moving uptime into the KPI strip (it's already there) and removing this bar.
+
+- **"Manage Apps" link** at the bottom of App Health feels misplaced — it's a navigation action buried below content. The sidebar already has an Apps nav item. Consider removing it or making it a subtle inline element in the section heading.
+
+- **Status badge repetition** — every app card shows "running" in emerald. When all five apps are running, five identical green badges create noise without information. Consider only badging non-running states (failed, stopped, disabled) and leaving running as the implied default.
+
+- **The sidebar has no pulse dot in the screenshots** — the design context describes it but it's either not visible or not in these captures. Verify it's implemented. If it's in the sidebar footer (below the fold on short nav lists), it's in the right place.
+
+- **Heading icons** (heart icon for "App Health", warning icon for "Recent Errors") are generic and don't add information the text doesn't already convey. Consider removing them — the design context says "no icons without text labels in main content areas" but doesn't address whether icons-with-labels are adding value.
+
+- **No hover cursor on app cards** — the entire card is a link (via `ht-app-card__link`) but there's no visual affordance beyond the hover shadow lift. On a dark background where shadows are invisible, there's no hover feedback at all.
+
+---
+
+## Questions to Consider
+
+- **What would a "confident" version of this dashboard look like?** Right now it hedges — five equal KPI cards, uniform app cards, every state treated the same. A confident diagnostic tool would have an opinion about what matters most and present it first, largest, most prominently.
+
+- **Does the 5-card KPI strip need to exist as a separate component from App Health?** The KPI strip shows aggregate numbers. The app cards show per-app breakdowns. The user looking at error rate will immediately want to know *which* app — could the KPI strip be integrated into the app grid as a summary row?
+
+- **What does this UI look like when things are *broken*?** All screenshots show a healthy system. The real test of a diagnostic tool is the incident state: multiple apps failed, error rate elevated, handler invocations spiking. Design for that scenario — it's the one where craft matters most.
+
+- **Is the sidebar earning its 56px?** Four nav items in a collapsed icon rail. No labels, no search, no quick actions. On a 1440px screen, that's 4% of horizontal space for four icons. Would a top nav free up space for the content area and eliminate the "what do these icons mean" problem?
+
+---
+
+## Summary
+
+| # | Issue | Severity | Fix via |
+|---|-------|----------|---------|
+| 1 | Surface hierarchy absent — cards invisible against background | Critical | `/i-colorize` |
+| 2 | KPI cards uniform — no visual weight hierarchy | High | `/i-arrange` |
+| 3 | Emerald accent diluted — used for status AND links AND chrome | High | `/i-colorize` |
+| 4 | Health bars invisible — 4px noise communicating nothing | Medium | `/i-distill` |
+| 5 | Empty states absent — blank space instead of guidance | Medium | `/i-onboard` |

--- a/design/context.md
+++ b/design/context.md
@@ -1,0 +1,222 @@
+---
+schema_version: 1
+updated_at: 2026-04-05
+---
+
+## Users & Purpose
+
+A developer at their desk — either verifying a fresh deployment is green, or mid-incident figuring out why the garage door automation didn't fire. Pulls up the UI with a question already in mind, not for passive monitoring.
+
+**Task**: Diagnose. Verify. Confirm or refute a hypothesis fast. "Did my handler fire? What values did it see? Did it error? What was the exception?" — then close the tab.
+
+**Context**: Home Assistant power users who write Python automations. Comfortable with terminals, logs, entity IDs. They don't need hand-holding — they need fast answers.
+
+## Brand Personality
+
+Like opening a well-organized toolbox. Everything has a place, you grab what you need, close it, move on. Not a dashboard you stare at — a diagnostic instrument you reach for.
+
+**Tone**: Quiet confidence. Technical without being hostile. Dense without being cluttered. The UI should feel like it was built by someone who uses it daily.
+
+## Aesthetic Direction
+
+### References
+
+- **Linear** — information density and monospace meta text. Compact rows that expand on click. Dense but scannable. Everything where you expect it.
+  - **Take**: Row density, expand-on-click pattern, monospace for IDs/timestamps
+  - **Leave**: The cool blue palette, the breadcrumb-heavy navigation
+
+- **Vercel dashboard** — KPI strip, status badges, flat-but-not-flat surface hierarchy. Quiet confidence.
+  - **Take**: KPI card pattern, status badge language, surface layering approach
+  - **Leave**: The aggressive minimalism that sacrifices information density
+
+- **Terminal aesthetic (grown up)** — near-black with emerald and amber has the vibe of a terminal that evolved into a product. Data-forward, chrome-minimal.
+  - **Take**: The color temperature, the monospace-heavy data presentation
+  - **Leave**: The raw/unpolished feel — this needs to look like a product, not a prototype
+
+- **Prefect (Miter Design)** — state-driven color where every hue earns its place by representing a workflow state. Colorblind-accessible themes. Speed as a feature.
+  - **Take**: Deliberateness of state color assignment, the visual hierarchy in flow run pages
+  - **Leave**: Radial/constellation visualizations (Hassette's domain is flat lists, not DAGs)
+
+**Visual movement**: Data-dense utility — the "developer tool that happens to have a UI" school. Not editorial minimalism, not SaaS product, not consumer app.
+
+### Domain Concepts
+
+- **Wiring** — handlers connected to entities
+- **Pulse** — system liveness via WebSocket
+- **Threshold** — state transitions trigger actions
+- **Trace** — following what happened from effect to cause
+- **Registry** — what's registered, active, dormant
+
+### Color World
+
+The green LED on a running Raspberry Pi. The cool gray of a breaker panel. The red blink of a low-battery smoke detector. The soft glow of a phone screen in a dark room pulling up the UI at midnight. The matte black of a well-made tool.
+
+### Signature Element
+
+The breathing pulse dot — a slow inhale/exhale animation on the WebSocket connection indicator. Emerald when connected (breathing). Red and static when disconnected. The only continuously animated element. It exists because the system maintains a persistent WebSocket to Home Assistant — the dot breathes because the connection is alive.
+
+- Appears in the sidebar, anchored to the bottom
+- 8px circle, `--ht-accent` color with `breathe` keyframe animation (2.5s ease-in-out infinite)
+- Reduced motion: static dot, no animation
+
+### Defaults Rejected
+
+| Default | Why it's wrong | Better alternative |
+|---------|---------------|-------------------|
+| Indigo/violet accent | Tailwind default, every AI-generated UI uses this — zero personality | Emerald: "alive, connected, working" — the LED on a running Pi |
+| Dark sidebar on light page | Jarring mixed-mode contrast that fights for attention | Sidebar uses same `--ht-bg` and `--ht-surface`, separated by border not color |
+| Borders-only depth | Makes the UI feel flat and cheap at low information density | Subtle shadows + borders; shadows establish card hierarchy, borders separate rows |
+| Inter/Roboto/system-ui | Generic, says nothing about the product | DM Sans body, Space Grotesk headings, JetBrains Mono data |
+| Card nesting | Cards inside cards creates visual noise | Handler rows are list items in bordered containers |
+| Bounce/elastic easing | The UI is a tool, not a toy | All transitions use ease-out |
+| Warm amber as primary accent | Was the old palette — rejected by user | Amber reserved for state values only |
+
+## Concrete Constraints
+
+- **No rounded corners above 10px** (except pills/badges at `radius-full`) — the product is technical
+- **Body text is DM Sans, never a serif** — the diagnostic-tool feel requires geometric sans
+- **Maximum 3 color families beyond neutrals** (emerald accent, amber values, red errors) — density demands restraint
+- **No drop shadows as primary depth in dark mode** — use border highlights and surface tint differentiation instead; shadows supplement but don't carry depth alone against near-black backgrounds
+- **Monospace for all data** — entity IDs, timestamps, handler names, invocation counts, log entries. Most content on the page is mono.
+- **No icons without text labels** in main content areas (sidebar icon rail is the exception)
+- **Density is a feature** — row padding is compact (10-12px vertical), meta text gaps are tight (12-16px), whitespace is for section separation not breathing room inside components
+
+## Design Principles
+
+1. **Answer the question** — every page exists to answer a specific diagnostic question. If a component doesn't help answer it, remove it.
+2. **Hierarchy through type, not decoration** — font family (heading vs body vs mono), weight, and size create hierarchy. Not borders, backgrounds, or color.
+3. **Emerald means alive** — green is reserved for "connected, running, healthy." Don't dilute it on links, buttons, or decorative elements.
+4. **Show state, don't narrate it** — a red dot says "failed" faster than a paragraph. Status badges, health bars, and color-coded values over prose descriptions.
+5. **Respect the developer** — no onboarding tours, no tooltips on obvious things, no confirmation dialogs for reversible actions. The user knows what they're doing.
+
+## Design Tokens
+
+### Color — Dark Mode (Graphite + Emerald) — Default
+
+| Token | Value | Role |
+|-------|-------|------|
+| `--ht-bg` | `#111113` | Page canvas — near-black graphite |
+| `--ht-surface` | `#222226` | Cards, panels, list rows — perceptible separation from bg |
+| `--ht-surface-recessed` | `#2a2a2f` | Hover states, inset areas, expanded details |
+| `--ht-surface-sticky` | `#222226` | Sticky headers (same as surface) |
+| `--ht-border` | `rgba(255, 255, 255, 0.06)` | Default separation — visible when you look, invisible when you don't |
+| `--ht-border-strong` | `rgba(255, 255, 255, 0.10)` | Interactive element borders (inputs, buttons, toggles) |
+| `--ht-border-highlight` | `rgba(255, 255, 255, 0.08)` | Card top-edge highlight — simulates light source for depth |
+| `--ht-text` | `#ececef` | Primary text |
+| `--ht-text-secondary` | `#9898a0` | Secondary labels, meta text |
+| `--ht-text-dim` | `#5c5c66` | Tertiary text, timestamps, placeholders |
+| `--ht-link` | `#6bab94` | Interactive text — muted emerald, distinct from vivid accent and neutral text |
+| `--ht-link-hover` | `#8cc4ad` | Interactive hover state |
+| `--ht-accent` | `#34d399` | Status accent — emerald. Reserved for alive/connected/running states, pulse dot |
+| `--ht-accent-light` | `rgba(52, 211, 153, 0.10)` | Status accent backgrounds (badges, highlights) |
+| `--ht-value` | `#fbbf24` | State values in handler summaries — amber, distinct from accent |
+| `--ht-success` | `#34d399` | Healthy/running — same as accent (emerald = "all systems go") |
+| `--ht-success-light` | `rgba(52, 211, 153, 0.10)` | Success badge backgrounds |
+| `--ht-danger` | `#f87171` | Error, failed, disconnected |
+| `--ht-danger-light` | `rgba(248, 113, 113, 0.10)` | Error badge/trace backgrounds |
+| `--ht-warning` | `#fbbf24` | Warning states, elevated error rates |
+| `--ht-warning-light` | `rgba(251, 191, 36, 0.08)` | Warning badge backgrounds |
+| `--ht-shadow-sm` | `0 1px 3px rgba(0, 0, 0, 0.3)` | Cards, containers |
+| `--ht-shadow-md` | `0 4px 12px rgba(0, 0, 0, 0.4), 0 1px 3px rgba(0, 0, 0, 0.2)` | Hover lift, dropdowns |
+
+**Rationale**: Graphite neutrals (no blue tint, no warm tint — true neutral gray) keep the same temperature in both modes. Emerald as the primary accent because green = "alive, connected, working" in this domain — the LED on a running Pi, the "all systems go" signal. Amber for state values creates semantic separation from the accent without adding a third hue family. Red for errors is universal and unambiguous.
+
+### Color — Light Mode (Chalk + Emerald)
+
+| Token | Value | Role |
+|-------|-------|------|
+| `--ht-bg` | `#f7f7f8` | Page canvas — cool chalk, no warmth |
+| `--ht-surface` | `#ffffff` | Cards, panels, list rows |
+| `--ht-surface-recessed` | `#f0f0f2` | Hover states, inset areas, expanded details |
+| `--ht-surface-sticky` | `#ffffff` | Sticky headers |
+| `--ht-border` | `rgba(0, 0, 0, 0.06)` | Default separation |
+| `--ht-border-strong` | `rgba(0, 0, 0, 0.10)` | Interactive element borders |
+| `--ht-border-highlight` | `rgba(0, 0, 0, 0.03)` | Card top-edge highlight |
+| `--ht-text` | `#111113` | Primary text — near-black graphite |
+| `--ht-text-secondary` | `#55555e` | Secondary labels, meta text |
+| `--ht-text-dim` | `#9898a0` | Tertiary text, timestamps |
+| `--ht-link` | `#1a7a5a` | Interactive text — muted emerald for light backgrounds |
+| `--ht-link-hover` | `#0f5c42` | Interactive hover state |
+| `--ht-accent` | `#047857` | Status accent — deeper emerald, WCAG AA compliant (5.0:1 on white) |
+| `--ht-accent-light` | `rgba(4, 120, 87, 0.07)` | Status accent backgrounds |
+| `--ht-value` | `#b45309` | State values — darker amber for light backgrounds |
+| `--ht-success` | `#047857` | Healthy/running |
+| `--ht-success-light` | `rgba(4, 120, 87, 0.07)` | Success badge backgrounds |
+| `--ht-danger` | `#dc2626` | Error, failed, disconnected |
+| `--ht-danger-light` | `rgba(220, 38, 38, 0.07)` | Error badge/trace backgrounds |
+| `--ht-warning` | `#a16207` | Warning states |
+| `--ht-warning-light` | `rgba(161, 98, 7, 0.06)` | Warning badge backgrounds |
+| `--ht-shadow-sm` | `0 1px 2px rgba(0, 0, 0, 0.04)` | Cards, containers |
+| `--ht-shadow-md` | `0 4px 12px rgba(0, 0, 0, 0.06), 0 1px 3px rgba(0, 0, 0, 0.03)` | Hover lift, dropdowns |
+
+### Typography
+
+- **Headings**: Space Grotesk (600/700) — geometric, technical character. Distinguishes Hassette from generic admin panels. The only place personality shows in the type system.
+- **Body**: DM Sans (400/500) — clean geometric sans that pairs with Space Grotesk without competing. Readable at small sizes for meta text and descriptions.
+- **Mono**: JetBrains Mono (400/500/600) — entity IDs, timestamps, handler names, invocation data, log entries. The workhorse font — most data on the page is monospace.
+- **Scale**:
+  - `--ht-text-xs`: 12px — uppercase labels (INIT STATUS, FIRES, AVG)
+  - `--ht-text-sm`: 13px — meta text, badge text, timestamps
+  - `--ht-text-base`: 15px — handler summaries, table data, log entries
+  - `--ht-text-md`: 16px — body text, descriptions
+  - `--ht-text-lg`: 18px — section headings (Event Handlers, Scheduled Jobs)
+  - `--ht-text-xl`: 22px — page titles (Garage Proximity)
+  - `--ht-text-2xl`: 26px — hero numbers in health cards (0.4%, 18ms, 3m ago)
+- **Weights**: 400 (body), 500 (mono emphasis, meta strong values), 600 (headings, stat values), 700 (page title only)
+- **Self-hosted**: WOFF2 files in `/frontend/public/fonts/` — DM Sans 400/500/700, Space Grotesk 400/500/600/700, JetBrains Mono 400/500
+
+### Spacing
+
+- **Base**: 4px (`--ht-sp-1`)
+- **Scale**: `--ht-sp-1` (4px), `--ht-sp-2` (8px), `--ht-sp-3` (12px), `--ht-sp-4` (16px), `--ht-sp-5` (20px), `--ht-sp-6` (24px), `--ht-sp-8` (32px), `--ht-sp-10` (40px)
+- **Density**: Diagnostic tool — density is a feature. Row padding compact (10-12px vertical). Meta text gaps tight (12-16px). Health strip cards modest padding (12px 14px). Whitespace for section separation, not breathing room inside components.
+
+### Depth
+
+- **Strategy**: Subtle shadows + borders. Shadows establish card-level hierarchy. Borders separate rows within lists.
+- **Why**: Borders-only was explicitly rejected ("flat and cheap"). Full Bulma-style shadows are too heavy. Single shadow-sm on cards adds dimensionality without weight.
+- **Levels**: `--ht-shadow-sm` on cards and containers, `--ht-shadow-md` on hover lift and dropdowns.
+- **Dark mode**: Surface bump (#111113 → #222226) provides perceptible luminance separation. Border highlights (`--ht-border-highlight` at 0.08 alpha) on card top edges simulate a light source. Together with shadows, cards are unambiguously visible.
+
+### Border Radius
+
+- **Scale**: `--ht-radius-sm` (6px), `--ht-radius-md` (9px), `--ht-radius-lg` (10px), `--ht-radius-full` (9999px)
+- **Character**: Slightly rounded — not sharp (too clinical), not pill-shaped (too playful). 9-10px on cards and list containers. 6px on buttons and inputs. Full round on badges and status dots. The radius says "tool with considered edges."
+
+### Motion
+
+- **Micro**: 120ms `ease-out` — hover state transitions (background, border color)
+- **Transition**: 200ms `ease-out` — expand/collapse handler detail, tab switching
+- **Signature**: 2.5s `ease-in-out` infinite — the pulse dot breathe animation. Only continuous animation.
+- **Reduced motion**: All animations and transitions collapse to `0.01ms`. Pulse dot becomes static.
+
+### Anti-patterns
+
+- **No warm amber/gold as primary accent** — amber is reserved for state values only
+- **No dark sidebar on light page** — sidebar uses same `--ht-bg` and `--ht-surface` as main content
+- **No borders-only depth** — every card and list container gets `--ht-shadow-sm`, supplemented by border highlights in dark mode
+- **No pure black or pure gray** — all neutrals have the graphite tint (`#111113`, `#1a1a1e`)
+- **No Inter, Roboto, or system-ui as primary font**
+- **No indigo/violet accents** — Tailwind default, AI slop signal
+- **No card nesting** — handler rows are list items in bordered containers, not cards inside cards
+- **No bounce/elastic easing** — all transitions use `ease-out`
+- **No emerald on non-status elements** — accent is reserved for status (alive/connected/running). Links use `--ht-link` (muted emerald). Nav, tabs, toggles, and buttons use neutral treatments. Three semantic layers: vivid emerald = status, muted emerald = interactive, neutral = static text.
+
+## Component Notes
+
+- **Handler rows**: Grid layout — `8px dot | 1fr content | auto stats`. Plain-language summary as primary text. Invocation count, last-fired, avg duration as mono meta text below. Expandable.
+- **Health strip**: 4-column grid of compact cards at top of App Detail. Init status, error rate, avg duration, last activity.
+- **Pulse dot**: 8px circle in sidebar. `--ht-accent` with breathe animation when connected. `--ht-danger` and static when disconnected.
+- **Status badges**: Pill-shaped (radius-full), mono font, colored dot + text. Running = emerald, Failed = red, Stopped/Disabled = dim gray. Background uses `-light` token variant.
+- **Log level toggle**: Segmented button group (DEBUG | INFO | WARN). Active state uses `--ht-accent-light` background with `--ht-accent` text.
+- **Sidebar**: 56px collapsed icon rail. Same background temperature as page. Pulse dot anchored to bottom. Active nav item highlighted with accent background tint.
+
+## Open Questions
+
+### Remaining polish opportunities
+
+Surface hierarchy and accent reservation are addressed. Remaining gaps from the critique:
+
+- **KPI card hierarchy**: labels and values still lack visual weight differentiation. Consider varying hero number sizes by importance. → `/i-arrange`
+- **Health bar treatment**: 4px bars with no label or percentage. Either make them visible (8px, percentage label) or remove from app cards. → `/i-distill`
+- **Empty states**: blank space with no guidance. Sessions page, first-run, no-logs states need treatment. → `/i-onboard`

--- a/design/direction.md
+++ b/design/direction.md
@@ -1,7 +1,7 @@
 # Design Direction: Hassette Web UI
 
 **Date:** 2026-03-19
-**Updated:** 2026-03-19
+**Updated:** 2026-04-05
 **Completeness:** full
 
 ## Intent
@@ -13,6 +13,7 @@
 - **Linear**: The information density and monospace meta text. Compact rows that expand on click. Dense but scannable. Everything where you expect it.
 - **Vercel dashboard**: The KPI strip, status badges, flat-but-not-flat surface hierarchy. Quiet confidence.
 - **Terminal aesthetic (grown up)**: The dark mode direction — near-black with emerald and amber — has the vibe of a terminal that evolved into a product. Data-forward, chrome-minimal.
+- **Prefect (Miter Design)**: State-driven color where every hue earns its place by representing a workflow state. Colorblind-accessible themes. Speed as a core feature. Take the deliberateness of state color assignment; leave the radial/constellation visualizations (Hassette's domain is flat lists, not DAGs).
 
 ## Domain
 - **Concepts**: Wiring (handlers connected to entities), Pulse (system liveness via WebSocket), Threshold (state transitions trigger actions), Trace (following what happened from effect to cause), Registry (what's registered, active, dormant)
@@ -77,13 +78,13 @@
 - **Body**: DM Sans (400/500) — clean geometric sans that pairs well with Space Grotesk without competing. Readable at small sizes for meta text and descriptions.
 - **Mono**: JetBrains Mono (400/500/600) — entity IDs, timestamps, handler names, invocation data, log entries. The workhorse font — most data on the page is monospace.
 - **Scale**:
-  - `--ht-text-xs`: 10px — uppercase labels (INIT STATUS, FIRES, AVG)
-  - `--ht-text-sm`: 11px — meta text, badge text, timestamps
-  - `--ht-text-base`: 13px — handler summaries, table data, log entries
-  - `--ht-text-md`: 14px — body text, descriptions
-  - `--ht-text-lg`: 15px — section headings (Event Handlers, Scheduled Jobs)
-  - `--ht-text-xl`: 19px — page titles (Garage Proximity)
-  - `--ht-text-2xl`: 22px — hero numbers in health cards (0.4%, 18ms, 3m ago)
+  - `--ht-text-xs`: 12px — uppercase labels (INIT STATUS, FIRES, AVG)
+  - `--ht-text-sm`: 13px — meta text, badge text, timestamps
+  - `--ht-text-base`: 15px — handler summaries, table data, log entries
+  - `--ht-text-md`: 16px — body text, descriptions
+  - `--ht-text-lg`: 18px — section headings (Event Handlers, Scheduled Jobs)
+  - `--ht-text-xl`: 22px — page titles (Garage Proximity)
+  - `--ht-text-2xl`: 26px — hero numbers in health cards (0.4%, 18ms, 3m ago)
 - **Weights**: 400 (body), 500 (mono emphasis, meta strong values), 600 (headings, stat values), 700 (page title only)
 
 ### Spacing

--- a/design/specs/responsive-mobile/design.md
+++ b/design/specs/responsive-mobile/design.md
@@ -1,6 +1,6 @@
 # Design: Responsive Mobile Adaptation
 
-**Status:** Draft
+**Status:** Approved
 **Feature:** responsive-mobile
 **Date:** 2026-04-05
 

--- a/design/specs/responsive-mobile/design.md
+++ b/design/specs/responsive-mobile/design.md
@@ -1,0 +1,149 @@
+# Design: Responsive Mobile Adaptation
+
+**Status:** Draft
+**Feature:** responsive-mobile
+**Date:** 2026-04-05
+
+## Problem
+
+The Hassette web UI is non-functional on mobile devices (<768px):
+
+1. **No navigation** — sidebar is `display: none` with no replacement. Users are stranded on whatever page they land on. This is a shipping bug.
+2. **Apps table unusable** — Status, Error, and Actions columns clip off-screen. No way to see app status or take actions.
+3. **Log table truncates** — App and Message columns clip. Sort state can reference hidden columns.
+4. **Touch targets undersized** — scope toggle (~23px), theme toggle (30px), tab buttons (~27px), action buttons are all below 44px minimum.
+5. **Pulse dot disappears** — the signature connection indicator lives in the hidden sidebar.
+6. **KPI strip orphans** — 5 cards in a 2-col grid leaves 1 orphan card on its own row.
+
+The user is a developer doing a quick diagnostic check on their phone: "Is everything running? What's the error rate?" Quick glance, not prolonged monitoring.
+
+## Architecture
+
+### Component Changes
+
+**New: `BottomNav` component** (`frontend/src/components/layout/bottom-nav.tsx`)
+- Renders at <768px only (CSS `display: none` at >=768px)
+- Fixed to bottom of viewport, above safe area
+- 4 tabs: Dashboard, Apps, Logs, Sessions — reuses icon components from `shared/icons.tsx`
+- Active state: neutral treatment (recessed surface + text color), matching desktop sidebar convention
+- 52px height + safe-area inset
+
+**BottomNav owns its own nav items** — the `NAV_ITEMS` array in `sidebar.tsx` contains JSX icon elements that don't belong in a constants file. BottomNav duplicates the 4-item list (these are stable, rarely-changed items). If nav items change, both components need updating — an acceptable tradeoff for 4 items vs the indirection of a shared constants file with JSX.
+
+**New: `ManifestCardList` component** (`frontend/src/components/apps/manifest-card-list.tsx`)
+- Card-based layout for <768px, replacing the `<table>` in `ManifestList`
+- Each card: app name + status badge top line, handler/job counts below, link to detail page
+- Action buttons render below counts, full width. No confirmation — all actions are reversible per design principle #5.
+- Multi-instance apps show expand chevron, accordion-style expansion
+
+**New: `useManifestState` hook** (`frontend/src/hooks/use-manifest-state.ts`)
+- Extracts filter state, expanded state, and localStorage persistence from `ManifestList`
+- Both `ManifestList` (table) and `ManifestCardList` consume this hook
+- `ManifestList` conditionally renders the card list or table based on a `useMediaQuery` hook
+
+**New: `useMediaQuery` hook** (`frontend/src/hooks/use-media-query.ts`)
+- `useMediaQuery(maxWidth: number): boolean`
+- Uses `window.matchMedia`, cleans up listener on unmount
+- Returns `true` when viewport <= maxWidth
+- **Breakpoint sync**: the 768px value must match the CSS `@media (max-width: 768px)` breakpoint. Define as `BREAKPOINT_MOBILE = 768` in the hook file, and add `/* sync: BREAKPOINT_MOBILE in use-media-query.ts */` comments in global.css at each <768px media query.
+
+**Modify: `StatusBar`** (`frontend/src/components/layout/status-bar.tsx`)
+- Already renders the pulse dot via `.ht-ws-indicator`
+- No component changes needed — pulse dot is already in the status bar
+- **CSS change**: make StatusBar `position: sticky; top: 0` at <768px so the connection indicator stays visible while scrolling
+
+**Modify: `App` layout** (`frontend/src/app.tsx`)
+- Add `<BottomNav />` after the main content area
+- CSS handles show/hide based on viewport
+
+### CSS Changes (global.css)
+
+**Bottom nav styles:**
+- `.ht-bottom-nav`: fixed bottom, 52px height, flex row, 4 equal items
+- `.ht-bottom-nav__item`: 44px min touch target, flex column (icon + label), 10px label
+- `display: none` at >=768px
+- `env(safe-area-inset-bottom)` padding for iOS
+
+**Main content padding:**
+- At <768px: `padding-bottom: calc(var(--ht-sp-4) + 52px + env(safe-area-inset-bottom, 0px))`
+- Prevents bottom nav overlap with content
+
+**KPI strip reflow:**
+- **JSX reorder**: move Error Rate to first position in `KpiStrip` component (currently 2nd). This makes it the most prominent card on all viewports — if it's the most important metric, it should be first everywhere.
+- At <768px: `:first-child` spans full width, remaining 4 in 2x2 grid
+- All cards visible without scrolling
+
+**Touch target enforcement at <768px:**
+- `.ht-scope-toggle__btn`: min-height 44px, padding increase
+- `.ht-theme-toggle`: min-width/height 44px
+- `.ht-tabs li button`: min-height 44px, padding increase
+- `.ht-btn--sm`, `.ht-btn--xs`: min-height 44px at <768px
+- Action buttons in apps: min-height 44px
+
+**Log table adaptation at <768px:**
+- Hide Source column (already done at <1024px)
+- Hide App column — show app name as a colored tag (using existing `.ht-tag` component) before the message text. Sort-by-app is handled via the existing app dropdown filter, so removing the column header doesn't lose functionality.
+- Timestamp column: narrower, truncate seconds
+- Level column: abbreviate (INFO→I, WARNING→W, etc.) or use color-only dots
+
+**StatusBar sticky on mobile:**
+- At <768px: `position: sticky; top: 0; z-index: 20; background: var(--ht-surface-sticky)`
+- Keeps pulse dot and scope toggle visible while scrolling
+
+**App grid on dashboard:**
+- At <480px: single column
+- Already `auto-fill, minmax(220px, 1fr)` which handles most sizes
+
+### Token Compliance
+
+All values must reference `--ht-*` tokens:
+- Bottom nav background: `--ht-surface`
+- Bottom nav border-top: `--ht-border`
+- Active item: `--ht-surface-recessed` bg + `--ht-text` color
+- Inactive item: `--ht-text-dim` color
+- Touch target spacing: `--ht-sp-*` scale
+- Bottom nav icon size: 20px (matches sidebar icon size)
+- Bottom nav label: `--ht-text-xs` (12px), `--ht-font-body`
+
+## Alternatives Considered
+
+### Horizontal scroll KPI strip
+Rejected: hides Error Rate (the most critical metric) behind a scroll interaction. Challenge finding #3 flagged this — "vertical space is cheap on mobile, horizontal scroll is an anti-pattern for critical diagnostic data."
+
+### Hamburger menu instead of bottom nav
+Rejected: hides navigation behind an extra tap. The design context says "everything has a place, you grab what you need" — a hamburger menu contradicts this by hiding the toolbox.
+
+### Simplified "quick check" mobile view (dashboard only, no navigation)
+Considered but deferred: the challenge produced a TENSION finding (#8) on this. For now, full responsive adaptation is the baseline — a simplified quick-check view can be layered on top later if usage data shows >90% dashboard-only mobile usage.
+
+### CSS-only adaptation (no new components)
+Rejected: the challenge found (finding #1) that the apps table cannot be transformed to cards via CSS alone — `<table>/<thead>/<tbody>` requires JSX restructuring.
+
+## Test Strategy
+
+### Unit tests
+- `BottomNav` renders 4 items, active state matches current route, hidden at >=768px
+- `ManifestCardList` renders card per app, shows status badge, handles expand toggle
+- `useMediaQuery` hook responds to viewport changes
+- `useManifestState` hook manages expanded state and localStorage persistence
+
+### E2E tests (Playwright)
+- Navigate between all 4 pages via bottom nav at 375px viewport
+- Apps page shows card layout at 375px, table at 1024px
+- KPI strip: Error Rate card spans full width at 375px, all 5 visible without scrolling
+- Bottom nav does not overlap last content item (scroll to bottom, assert last element is visible above nav)
+- Touch target assertion: all interactive elements at 375px have computed min-height >= 44px
+- Breakpoint boundary: at exactly 768px, verify table/card transition is clean (no mixed state)
+
+### Visual regression (Playwright screenshots)
+- Dashboard at 375px, 768px, 1440px (dark mode)
+- Apps page at 375px, 768px, 1440px (dark mode)
+- Logs page at 375px, 768px, 1440px (dark mode)
+- Dashboard at 375px (light mode)
+- Compare before/after for each viewport
+
+## Risks
+
+- **iOS Safari dynamic toolbar**: bottom nav may overlap with Safari's toolbar. Mitigated by `env(safe-area-inset-bottom)` and `min-height: 100dvh` on the layout.
+- **Expansion state shared between table/card views**: if user expands an app on desktop then checks on mobile, the card view should respect the expanded state. Both views share the same state via `useManifestState` hook.
+- **JS/CSS breakpoint drift**: `useMediaQuery(768)` and `@media (max-width: 768px)` must stay in sync. Mitigated by TS constant + CSS comments + E2E test at exactly 768px.

--- a/design/specs/responsive-mobile/tasks/.gitignore
+++ b/design/specs/responsive-mobile/tasks/.gitignore
@@ -1,0 +1,1 @@
+.orchestrate-state.md

--- a/design/specs/responsive-mobile/tasks/WP01.md
+++ b/design/specs/responsive-mobile/tasks/WP01.md
@@ -1,9 +1,9 @@
 ---
-work_package_id: "WP01"
-title: "Add useMediaQuery hook and CSS touch target / layout foundations"
-lane: "planned"
-plan_section: "CSS Changes (global.css)"
 depends_on: []
+lane: done
+plan_section: CSS Changes (global.css)
+title: Add useMediaQuery hook and CSS touch target / layout foundations
+work_package_id: WP01
 ---
 
 ## Objectives & Success Criteria
@@ -64,3 +64,5 @@ CSS-only responsive foundations that improve mobile usability without new compon
 ## Activity Log
 
 - 2026-04-05T20:30:00Z — system — lane=planned — WP created
+- 2026-04-06T03:55:08Z — system — lane=doing — moved from planned
+- 2026-04-06T04:07:03Z — system — lane=done — moved from doing

--- a/design/specs/responsive-mobile/tasks/WP01.md
+++ b/design/specs/responsive-mobile/tasks/WP01.md
@@ -1,0 +1,66 @@
+---
+work_package_id: "WP01"
+title: "Add useMediaQuery hook and CSS touch target / layout foundations"
+lane: "planned"
+plan_section: "CSS Changes (global.css)"
+depends_on: []
+---
+
+## Objectives & Success Criteria
+
+CSS-only responsive foundations that improve mobile usability without new components. After this WP:
+
+- All interactive elements at <768px have min-height 44px (scope toggle, theme toggle, tab buttons, action buttons)
+- StatusBar is sticky at <768px, keeping pulse dot and scope toggle visible while scrolling
+- Main content has bottom padding to accommodate a future bottom nav (52px + safe-area)
+- KPI strip at <768px: first child spans full width, remaining 4 in 2x2 grid
+- Log table at <768px: App column hidden (CSS only — tag integration is WP03)
+- `useMediaQuery` hook exists and is tested
+- `BREAKPOINT_MOBILE` constant defined and CSS comments added for sync
+
+## Subtasks
+
+1. Create `frontend/src/hooks/use-media-query.ts` — export `BREAKPOINT_MOBILE = 768` constant and `useMediaQuery(maxWidth)` hook using `window.matchMedia` with cleanup on unmount
+2. Create `frontend/src/hooks/use-media-query.test.ts` — test that the hook returns true/false based on matchMedia, and responds to change events
+3. In `frontend/src/global.css` at the <768px media query blocks, add `/* sync: BREAKPOINT_MOBILE in use-media-query.ts */` comments
+4. Add touch target enforcement in the <768px media query:
+   - `.ht-scope-toggle__btn`: `min-height: 44px; padding: var(--ht-sp-2) var(--ht-sp-3)`
+   - `.ht-theme-toggle`: `min-width: 44px; min-height: 44px`
+   - `.ht-tabs li button`: `min-height: 44px; padding: var(--ht-sp-2) var(--ht-sp-3)`
+   - `.ht-btn--sm, .ht-btn--xs`: `min-height: 44px`
+5. Add StatusBar sticky at <768px: `.ht-status-bar { position: sticky; top: 0; z-index: 20; background: var(--ht-surface-sticky); }`
+6. Add main content bottom padding at <768px: `.ht-main { padding-bottom: calc(var(--ht-sp-4) + 52px + env(safe-area-inset-bottom, 0px)); }`
+7. Update KPI strip media queries:
+   - At <768px: `.ht-kpi-strip { grid-template-columns: repeat(2, 1fr); }` and `.ht-kpi-strip > :first-child { grid-column: 1 / -1; }`
+   - Remove the existing <480px 2-col rule (now redundant)
+8. Reorder KPI cards in `frontend/src/components/dashboard/kpi-strip.tsx` — move Error Rate `<div>` to first position (before Apps)
+9. Add log table <768px rule: `.ht-table-log .ht-col-app { display: none; }`
+
+## Test Strategy
+
+- `frontend/src/hooks/use-media-query.test.ts`:
+  - `test_useMediaQuery_returns_true_when_below_breakpoint` — mock matchMedia to return matches=true
+  - `test_useMediaQuery_returns_false_when_above_breakpoint` — mock matchMedia to return matches=false
+  - `test_useMediaQuery_responds_to_change_event` — trigger change event, verify signal update
+  - `test_useMediaQuery_cleans_up_listener_on_unmount` — verify removeEventListener called
+  - `test_BREAKPOINT_MOBILE_exported_as_768` — verify the constant value
+
+## Review Guidance
+
+- Verify all CSS values use `--ht-*` tokens — no raw hex or raw px outside the token scale
+- Verify `/* sync: BREAKPOINT_MOBILE */` comments appear at every `max-width: 768px` media query
+- Verify KPI strip JSX reorder puts Error Rate first
+- Check that touch target min-heights are exactly 44px (WCAG 2.5.8)
+- StatusBar sticky must use `--ht-surface-sticky` background to prevent content showing through
+
+## Visual Verification
+
+| Page | Setup | Verify |
+|------|-------|--------|
+| Dashboard | View at 375px viewport, dark mode | KPI strip: Error Rate card spans full width at top, 4 remaining cards in 2x2 grid below. StatusBar stays visible when scrolling down. Bottom padding visible below session bar. |
+| Apps page | View at 375px viewport, dark mode, multiple apps running | Tab buttons have visible 44px height. Scope toggle buttons are tappable size. |
+| Logs page | View at 375px viewport, dark mode, log entries present | App column hidden. Level + Timestamp + Message visible. Table doesn't overflow horizontally. |
+
+## Activity Log
+
+- 2026-04-05T20:30:00Z — system — lane=planned — WP created

--- a/design/specs/responsive-mobile/tasks/WP02.md
+++ b/design/specs/responsive-mobile/tasks/WP02.md
@@ -1,9 +1,10 @@
 ---
-work_package_id: "WP02"
-title: "Add BottomNav component for mobile navigation"
-lane: "planned"
-plan_section: "Component Changes"
-depends_on: ["WP01"]
+depends_on:
+- WP01
+lane: done
+plan_section: Component Changes
+title: Add BottomNav component for mobile navigation
+work_package_id: WP02
 ---
 
 ## Objectives & Success Criteria
@@ -69,3 +70,5 @@ Mobile users can navigate between all 4 pages via a fixed bottom navigation bar.
 ## Activity Log
 
 - 2026-04-05T20:30:00Z — system — lane=planned — WP created
+- 2026-04-06T04:07:10Z — system — lane=doing — moved from planned
+- 2026-04-06T04:21:32Z — system — lane=done — moved from doing

--- a/design/specs/responsive-mobile/tasks/WP02.md
+++ b/design/specs/responsive-mobile/tasks/WP02.md
@@ -1,0 +1,71 @@
+---
+work_package_id: "WP02"
+title: "Add BottomNav component for mobile navigation"
+lane: "planned"
+plan_section: "Component Changes"
+depends_on: ["WP01"]
+---
+
+## Objectives & Success Criteria
+
+Mobile users can navigate between all 4 pages via a fixed bottom navigation bar. After this WP:
+
+- `BottomNav` component renders 4 tabs: Dashboard, Apps, Logs, Sessions
+- Bottom nav is fixed to the viewport bottom with safe-area padding
+- Active tab matches the current route (uses wouter's `useLocation`)
+- Bottom nav is hidden at >=768px (CSS `display: none`)
+- Bottom nav is visible at <768px
+- `App` layout includes `<BottomNav />` after the main content
+- Bottom nav uses neutral active state treatment (recessed surface + text color) matching sidebar convention
+
+## Subtasks
+
+1. Create `frontend/src/components/layout/bottom-nav.tsx`:
+   - Define `NAV_ITEMS` array (duplicate of sidebar's 4 items with same icons from `shared/icons.tsx`, same paths, same testIds suffixed with `-mobile`)
+   - Render `<nav>` with `class="ht-bottom-nav"` and `aria-label="Mobile navigation"`
+   - Each item: `<Link>` wrapping icon + label, `class="ht-bottom-nav__item"` with `is-active` when route matches
+   - Use `useLocation()` from wouter for active detection (same logic as `sidebar.tsx`)
+2. Create `frontend/src/components/layout/bottom-nav.test.tsx`:
+   - Test renders 4 navigation items
+   - Test active state applied to current route item
+   - Test all links point to correct paths
+3. Add CSS for bottom nav in `frontend/src/global.css`:
+   - `.ht-bottom-nav`: `position: fixed; bottom: 0; left: 0; right: 0; height: 52px; display: flex; background: var(--ht-surface); border-top: 1px solid var(--ht-border); padding-bottom: env(safe-area-inset-bottom, 0px); z-index: 30;`
+   - `.ht-bottom-nav__item`: `flex: 1; display: flex; flex-direction: column; align-items: center; justify-content: center; gap: 2px; min-height: 44px; color: var(--ht-text-dim); text-decoration: none; font-size: var(--ht-text-xs); font-family: var(--ht-font-body); transition: color var(--ht-motion-micro);`
+   - `.ht-bottom-nav__item:hover, .ht-bottom-nav__item.is-active`: `color: var(--ht-text); background: var(--ht-surface-recessed);`
+   - `.ht-bottom-nav__item svg`: same size as sidebar icons (20px)
+   - At >=768px: `.ht-bottom-nav { display: none; }`
+4. Modify `frontend/src/app.tsx`:
+   - Import `BottomNav`
+   - Add `<BottomNav />` as a sibling after the `.ht-layout` div (fixed position, not inside the grid)
+
+## Test Strategy
+
+- `frontend/src/components/layout/bottom-nav.test.tsx`:
+  - `test_renders_four_navigation_items` — query all nav links, assert count = 4
+  - `test_dashboard_item_links_to_root` — verify href="/"
+  - `test_apps_item_links_to_apps` — verify href="/apps"
+  - `test_logs_item_links_to_logs` — verify href="/logs"
+  - `test_sessions_item_links_to_sessions` — verify href="/sessions"
+  - `test_active_state_on_current_route` — mock useLocation to return "/apps", verify is-active class on Apps item
+  - `test_accessibility_label_present` — verify aria-label="Mobile navigation"
+
+## Review Guidance
+
+- BottomNav must NOT import from sidebar.tsx — it owns its own NAV_ITEMS (design decision: no shared constants file for JSX items)
+- Active state must use `--ht-surface-recessed` + `--ht-text`, NOT accent color
+- z-index must be >= 30 to sit above content
+- `env(safe-area-inset-bottom)` must be present for iOS compatibility
+- The `<BottomNav />` placement in app.tsx must be OUTSIDE the `.ht-layout` grid (fixed positioning, not a grid child)
+
+## Visual Verification
+
+| Page | Setup | Verify |
+|------|-------|--------|
+| Dashboard | View at 375px, dark mode | Bottom nav visible with 4 tabs. Dashboard icon is active (recessed bg + white text). Tapping Apps navigates to /apps. |
+| Apps page | View at 375px, dark mode | Apps icon is active. Bottom nav doesn't overlap content (scroll to bottom to verify). |
+| Dashboard | View at 1440px, dark mode | Bottom nav is NOT visible. Sidebar is visible. |
+
+## Activity Log
+
+- 2026-04-05T20:30:00Z — system — lane=planned — WP created

--- a/design/specs/responsive-mobile/tasks/WP03.md
+++ b/design/specs/responsive-mobile/tasks/WP03.md
@@ -1,0 +1,90 @@
+---
+work_package_id: "WP03"
+title: "Add ManifestCardList and useManifestState for mobile apps view"
+lane: "planned"
+plan_section: "Component Changes"
+depends_on: ["WP01"]
+---
+
+## Objectives & Success Criteria
+
+The apps page renders a card-based layout at <768px instead of the table. After this WP:
+
+- `useManifestState` hook extracts expanded state, localStorage persistence, and pruning logic from `ManifestList`
+- `ManifestCardList` renders one card per app with: name + status badge, handler/job counts, action buttons, link to detail
+- Multi-instance apps have an expand chevron with accordion expansion showing instance sub-cards
+- `ManifestList` conditionally renders `ManifestCardList` (mobile) or `<table>` (desktop) based on `useMediaQuery(BREAKPOINT_MOBILE)`
+- Both views share the same expanded state via `useManifestState`
+
+## Subtasks
+
+1. Create `frontend/src/hooks/use-manifest-state.ts`:
+   - Extract from `manifest-list.tsx`: `expandedRef` signal, `getStoredSet`/`setStoredSet` localStorage logic, pruning on first manifest load, `toggleExpand` function
+   - Export: `useManifestState(manifests: AppManifest[] | null)` returning `{ expanded: Signal<Set<string>>, toggleExpand: (key: string) => void }`
+   - The hook owns the signal and localStorage sync; consumers are read-only on `expanded`
+2. Create `frontend/src/hooks/use-manifest-state.test.ts`:
+   - Test initial state loaded from localStorage
+   - Test toggleExpand adds/removes keys
+   - Test pruning removes stale keys not in manifests
+   - Test localStorage sync on state change
+3. Refactor `frontend/src/components/apps/manifest-list.tsx`:
+   - Replace inline expanded state management with `useManifestState(manifests)` hook
+   - Import `useMediaQuery` and `BREAKPOINT_MOBILE` from `use-media-query.ts`
+   - Conditionally render: `isMobile ? <ManifestCardList ... /> : <table>...</table>`
+   - Pass `manifests`, `filter`, `expanded`, `toggleExpand`, `appStatus` to both views
+4. Create `frontend/src/components/apps/manifest-card-list.tsx`:
+   - Props: `manifests: AppManifest[]`, `expanded: Signal<Set<string>>`, `toggleExpand`, `appStatus`
+   - Each card: `<div class="ht-manifest-card">` wrapping:
+     - Header row: `<a href="/apps/{key}">` with app name + `<StatusBadge>` + instance count badge if >1
+     - Stats row: handler count + job count (text-xs, text-muted)
+     - Action row: `<ActionButtons>` full width
+     - If multi-instance + expanded: instance sub-cards with name + status + per-instance actions
+   - Expand toggle: chevron button with `aria-expanded`, same pattern as `ManifestRow`
+5. Create `frontend/src/components/apps/manifest-card-list.test.tsx`:
+   - Test renders one card per manifest
+   - Test each card shows app name, status badge, handler/job counts
+   - Test action buttons present on each card
+   - Test expand toggle visible for multi-instance apps
+   - Test expand toggle shows instance sub-cards when expanded
+6. Add CSS in `frontend/src/global.css`:
+   - `.ht-manifest-card`: `background: var(--ht-surface); border: 1px solid var(--ht-border); border-top: 1px solid var(--ht-border-highlight); border-radius: var(--ht-radius-md); padding: var(--ht-sp-4); display: flex; flex-direction: column; gap: var(--ht-sp-2);`
+   - `.ht-manifest-card + .ht-manifest-card`: `margin-top: var(--ht-sp-3);`
+   - `.ht-manifest-card__header`: flex row, space-between, align-center
+   - `.ht-manifest-card__actions`: flex row, gap sp-2, flex-wrap
+7. Update `frontend/src/components/apps/manifest-list.test.tsx` — update existing tests to work with the refactored component (hook extraction may change how mocks are structured)
+
+## Test Strategy
+
+- `frontend/src/hooks/use-manifest-state.test.ts`:
+  - `test_initial_expanded_from_localStorage` — mock getStoredSet, verify signal value
+  - `test_toggleExpand_adds_key` — call toggle, verify key in set
+  - `test_toggleExpand_removes_key` — pre-add key, call toggle, verify key removed
+  - `test_prunes_stale_keys_on_manifest_load` — provide manifests missing a stored key, verify pruned
+  - `test_syncs_to_localStorage_on_change` — toggle, verify setStoredSet called
+- `frontend/src/components/apps/manifest-card-list.test.tsx`:
+  - `test_renders_card_per_manifest` — 3 manifests → 3 cards
+  - `test_card_shows_status_badge` — running manifest → running badge
+  - `test_card_shows_handler_job_counts` — "2 handlers", "1 job"
+  - `test_card_has_action_buttons` — Stop/Reload buttons present for running app
+  - `test_expand_toggle_for_multi_instance` — chevron visible, click expands instances
+  - `test_no_expand_for_single_instance` — no chevron for instance_count=1
+
+## Review Guidance
+
+- `ManifestList` must remain the single entry point — `ManifestCardList` is a child, not a sibling in the page
+- Expanded state hook must be consumed identically by both table and card views — verify no divergence
+- Card layout must use `--ht-*` tokens for all spacing, colors, borders
+- Action buttons: NO confirmation dialogs (design principle #5)
+- Cards must link to app detail via `<a href="/apps/{key}">`, not `onClick` navigation
+
+## Visual Verification
+
+| Page | Setup | Verify |
+|------|-------|--------|
+| Apps page | View at 375px, dark mode, 9 apps (8 running, 1 disabled) | Card layout: each app is a card with name, status badge, counts, action buttons. No table visible. |
+| Apps page | View at 375px, dark mode, expand a multi-instance app | Expanded card shows instance sub-cards with individual status badges and actions |
+| Apps page | View at 1440px, dark mode | Table layout visible (unchanged from current behavior). No card layout. |
+
+## Activity Log
+
+- 2026-04-05T20:30:00Z — system — lane=planned — WP created

--- a/design/specs/responsive-mobile/tasks/WP03.md
+++ b/design/specs/responsive-mobile/tasks/WP03.md
@@ -1,9 +1,10 @@
 ---
-work_package_id: "WP03"
-title: "Add ManifestCardList and useManifestState for mobile apps view"
-lane: "planned"
-plan_section: "Component Changes"
-depends_on: ["WP01"]
+depends_on:
+- WP01
+lane: done
+plan_section: Component Changes
+title: Add ManifestCardList and useManifestState for mobile apps view
+work_package_id: WP03
 ---
 
 ## Objectives & Success Criteria
@@ -88,3 +89,5 @@ The apps page renders a card-based layout at <768px instead of the table. After 
 ## Activity Log
 
 - 2026-04-05T20:30:00Z — system — lane=planned — WP created
+- 2026-04-06T04:07:10Z — system — lane=doing — moved from planned
+- 2026-04-06T04:21:45Z — system — lane=done — moved from doing

--- a/design/specs/responsive-mobile/tasks/WP03.md
+++ b/design/specs/responsive-mobile/tasks/WP03.md
@@ -19,7 +19,7 @@ The apps page renders a card-based layout at <768px instead of the table. After 
 ## Subtasks
 
 1. Create `frontend/src/hooks/use-manifest-state.ts`:
-   - Extract from `manifest-list.tsx`: `expandedRef` signal, `getStoredSet`/`setStoredSet` localStorage logic, pruning on first manifest load, `toggleExpand` function
+   - Extract from `manifest-list.tsx` (lines 20-60): the `expandedRef` signal (line 23), `getStoredSet`/`setStoredSet` localStorage logic (lines 22-49), pruning on first manifest load (lines 25-36), and `toggleExpand` function (lines 51-59)
    - Export: `useManifestState(manifests: AppManifest[] | null)` returning `{ expanded: Signal<Set<string>>, toggleExpand: (key: string) => void }`
    - The hook owns the signal and localStorage sync; consumers are read-only on `expanded`
 2. Create `frontend/src/hooks/use-manifest-state.test.ts`:

--- a/design/specs/responsive-mobile/tasks/WP04.md
+++ b/design/specs/responsive-mobile/tasks/WP04.md
@@ -28,7 +28,8 @@ Log table is usable on mobile, and E2E tests validate all responsive behavior. A
 3. Add/update CSS in `frontend/src/global.css` at <768px:
    - `.ht-table-log .ht-col-app { display: none; }` (hide the column)
    - `.ht-log-app-tag`: styled as inline tag before message text, uses `.ht-tag` base styles
-4. Create `tests/e2e/test_responsive.py` with E2E tests:
+4. Capture "before" screenshots at 375px, 768px for dashboard, apps, logs pages using the current `hassette:prettify` Docker image (build from worktree, deploy to hautomate compose, take screenshots via Playwright, then restore original image). Save to `.claude/audits/screenshots/before/` with `-mobile-375` and `-tablet-768` suffixes.
+5. Create `tests/e2e/test_responsive.py` with E2E tests:
    - `test_bottom_nav_visible_at_375px` — viewport 375x812, verify 4 nav items visible
    - `test_bottom_nav_hidden_at_1024px` — viewport 1024x768, verify no bottom nav
    - `test_bottom_nav_navigation` — at 375px, click each tab, verify URL changes
@@ -39,7 +40,7 @@ Log table is usable on mobile, and E2E tests validate all responsive behavior. A
    - `test_bottom_nav_no_content_overlap` — scroll to bottom, verify last content element's bottom edge is above bottom nav's top edge
    - `test_breakpoint_boundary_768px` — at exactly 768px, verify card/table transition is clean
    - `test_log_table_app_tag_at_375px` — verify app name appears as tag in message column, no App column header
-5. Take Playwright screenshots at 375px, 768px, 1440px for dashboard, apps, and logs pages (dark mode) — save to `.claude/audits/screenshots/after/`
+6. After all changes, rebuild the Docker image, deploy, and take "after" Playwright screenshots at 375px, 768px, 1440px for dashboard, apps, and logs (dark mode) — save to `.claude/audits/screenshots/after/`. Compare with "before" screenshots to verify improvements and catch regressions. Restore compose file to original image when done.
 
 ## Test Strategy
 
@@ -58,6 +59,7 @@ Log table is usable on mobile, and E2E tests validate all responsive behavior. A
 - E2E tests must set viewport explicitly via `page.set_viewport_size()` — do not rely on default viewport
 - E2E test for bottom nav overlap must account for the `padding-bottom` added in WP01
 - All E2E tests must use `data-testid` attributes for element selection where possible
+- E2E tests use the existing conftest.py fixtures (`tests/e2e/conftest.py`) which spin up a uvicorn server on a dynamic port — follow the same pattern as `test_navigation.py`
 
 ## Visual Verification
 

--- a/design/specs/responsive-mobile/tasks/WP04.md
+++ b/design/specs/responsive-mobile/tasks/WP04.md
@@ -1,9 +1,12 @@
 ---
-work_package_id: "WP04"
-title: "Log table mobile adaptation and E2E responsive tests"
-lane: "planned"
-plan_section: "CSS Changes (global.css)"
-depends_on: ["WP01", "WP02", "WP03"]
+depends_on:
+- WP01
+- WP02
+- WP03
+lane: done
+plan_section: CSS Changes (global.css)
+title: Log table mobile adaptation and E2E responsive tests
+work_package_id: WP04
 ---
 
 ## Objectives & Success Criteria
@@ -72,3 +75,5 @@ Log table is usable on mobile, and E2E tests validate all responsive behavior. A
 ## Activity Log
 
 - 2026-04-05T20:30:00Z — system — lane=planned — WP created
+- 2026-04-06T04:21:51Z — system — lane=doing — moved from planned
+- 2026-04-06T04:34:29Z — system — lane=done — moved from doing

--- a/design/specs/responsive-mobile/tasks/WP04.md
+++ b/design/specs/responsive-mobile/tasks/WP04.md
@@ -1,0 +1,72 @@
+---
+work_package_id: "WP04"
+title: "Log table mobile adaptation and E2E responsive tests"
+lane: "planned"
+plan_section: "CSS Changes (global.css)"
+depends_on: ["WP01", "WP02", "WP03"]
+---
+
+## Objectives & Success Criteria
+
+Log table is usable on mobile, and E2E tests validate all responsive behavior. After this WP:
+
+- Log table at <768px shows app name as a colored tag before message text (not a separate column)
+- Level column shows abbreviated labels (I/W/E/D) at <768px
+- Timestamp column truncates seconds at <768px
+- E2E tests verify: bottom nav navigation, card/table switching, KPI reflow, touch targets, bottom nav overlap, breakpoint boundary
+
+## Subtasks
+
+1. Modify `frontend/src/components/shared/log-table.tsx`:
+   - Import `useMediaQuery` and `BREAKPOINT_MOBILE`
+   - When `isMobile`: hide the App column `<th>` and `<td>`, instead prepend a `<span class="ht-tag ht-tag--neutral">` with the app name before the message text in the Message column
+   - When `isMobile`: render level as abbreviated single letter (INFO→I, WARNING→W, ERROR→E, DEBUG→D) using a lookup map
+   - When `isMobile`: format timestamp without seconds (drop the `:SS` from the time portion)
+2. Update `frontend/src/components/shared/log-table.test.tsx`:
+   - Add tests for mobile rendering: app tag in message column, abbreviated level, truncated timestamp
+   - Mock `useMediaQuery` to return true for mobile tests
+3. Add/update CSS in `frontend/src/global.css` at <768px:
+   - `.ht-table-log .ht-col-app { display: none; }` (hide the column)
+   - `.ht-log-app-tag`: styled as inline tag before message text, uses `.ht-tag` base styles
+4. Create `tests/e2e/test_responsive.py` with E2E tests:
+   - `test_bottom_nav_visible_at_375px` — viewport 375x812, verify 4 nav items visible
+   - `test_bottom_nav_hidden_at_1024px` — viewport 1024x768, verify no bottom nav
+   - `test_bottom_nav_navigation` — at 375px, click each tab, verify URL changes
+   - `test_apps_card_layout_at_375px` — verify `.ht-manifest-card` elements exist, no `<table>` with class `ht-table--dense`
+   - `test_apps_table_layout_at_1024px` — verify `<table>` exists, no `.ht-manifest-card`
+   - `test_kpi_error_rate_first_at_375px` — verify first KPI card contains "Error Rate"
+   - `test_touch_targets_44px` — at 375px, check computed height of scope toggle, theme toggle, tab buttons >= 44
+   - `test_bottom_nav_no_content_overlap` — scroll to bottom, verify last content element's bottom edge is above bottom nav's top edge
+   - `test_breakpoint_boundary_768px` — at exactly 768px, verify card/table transition is clean
+   - `test_log_table_app_tag_at_375px` — verify app name appears as tag in message column, no App column header
+5. Take Playwright screenshots at 375px, 768px, 1440px for dashboard, apps, and logs pages (dark mode) — save to `.claude/audits/screenshots/after/`
+
+## Test Strategy
+
+- `frontend/src/components/shared/log-table.test.tsx` (additions):
+  - `test_mobile_shows_app_tag_in_message` — mock useMediaQuery(true), verify tag element with app name in message cell
+  - `test_mobile_hides_app_column` — mock useMediaQuery(true), verify no App column header
+  - `test_mobile_abbreviates_level` — mock useMediaQuery(true), verify "I" instead of "INFO"
+  - `test_mobile_truncates_timestamp` — mock useMediaQuery(true), verify no seconds in time
+- `tests/e2e/test_responsive.py`: all 10 tests listed in subtask 4 above
+
+## Review Guidance
+
+- Log table app tag must use the existing `.ht-tag` component/class pattern — not a new styling approach
+- Level abbreviation must handle all 4 levels: DEBUG, INFO, WARNING, ERROR
+- Timestamp truncation must only affect the time portion, not the date
+- E2E tests must set viewport explicitly via `page.set_viewport_size()` — do not rely on default viewport
+- E2E test for bottom nav overlap must account for the `padding-bottom` added in WP01
+- All E2E tests must use `data-testid` attributes for element selection where possible
+
+## Visual Verification
+
+| Page | Setup | Verify |
+|------|-------|--------|
+| Logs page | View at 375px, dark mode, 20+ log entries with mixed levels and apps | Level shows as I/W/E letters. No App column. App name appears as colored tag before each message. Timestamp has no seconds. Table fits within viewport width. |
+| Logs page | View at 1440px, dark mode | Full table with all columns (Level, Timestamp, App, Source, Message). No abbreviated levels. |
+| Dashboard | View at 375px, dark mode | Full page screenshot showing: Error Rate first in KPI strip spanning full width, bottom nav at bottom, sticky status bar at top |
+
+## Activity Log
+
+- 2026-04-05T20:30:00Z — system — lane=planned — WP created

--- a/frontend/src/app.tsx
+++ b/frontend/src/app.tsx
@@ -3,6 +3,7 @@ import { Route, Switch, useLocation } from "wouter";
 import { getManifests } from "./api/endpoints";
 import { AlertBanner } from "./components/layout/alert-banner";
 import { ErrorBoundary } from "./components/layout/error-boundary";
+import { BottomNav } from "./components/layout/bottom-nav";
 import { Sidebar } from "./components/layout/sidebar";
 import { StatusBar } from "./components/layout/status-bar";
 import { useApi } from "./hooks/use-api";
@@ -49,6 +50,7 @@ export function App() {
           </ErrorBoundary>
         </main>
       </div>
+      <BottomNav />
     </AppStateContext.Provider>
   );
 }

--- a/frontend/src/components/apps/manifest-card-list.test.tsx
+++ b/frontend/src/components/apps/manifest-card-list.test.tsx
@@ -1,0 +1,255 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { render, fireEvent } from "@testing-library/preact";
+import { h } from "preact";
+import { signal } from "@preact/signals";
+import type { Signal } from "@preact/signals";
+import type { ComponentChildren } from "preact";
+import { ManifestCardList } from "./manifest-card-list";
+import { AppStateContext } from "../../state/context";
+import { createAppState, type AppState } from "../../state/create-app-state";
+import type { AppManifest, AppInstance } from "../../api/endpoints";
+
+// Mock endpoints to prevent real API calls from ActionButtons
+vi.mock("../../api/endpoints", () => ({
+  startApp: vi.fn(),
+  stopApp: vi.fn(),
+  reloadApp: vi.fn(),
+}));
+
+function createInstance(overrides: Partial<AppInstance> = {}): AppInstance {
+  return {
+    app_key: "test_app",
+    index: 0,
+    instance_name: "inst_0",
+    class_name: "TestApp",
+    status: "running",
+    error_message: null,
+    error_traceback: null,
+    owner_id: null,
+    ...overrides,
+  };
+}
+
+function createManifest(overrides: Partial<AppManifest> = {}): AppManifest {
+  return {
+    app_key: "test_app",
+    class_name: "TestApp",
+    display_name: "Test App",
+    filename: "test_app.py",
+    enabled: true,
+    auto_loaded: true,
+    status: "running",
+    block_reason: null,
+    instance_count: 1,
+    instances: [],
+    error_message: null,
+    error_traceback: null,
+    ...overrides,
+  };
+}
+
+function createMultiInstanceManifest(appKey = "multi"): AppManifest {
+  return createManifest({
+    app_key: appKey,
+    display_name: "Multi App",
+    instance_count: 2,
+    instances: [
+      createInstance({ app_key: appKey, index: 0, instance_name: "inst_0" }),
+      createInstance({ app_key: appKey, index: 1, instance_name: "inst_1" }),
+    ],
+  });
+}
+
+function createWrapper(state: AppState) {
+  return function Wrapper({ children }: { children: ComponentChildren }) {
+    return h(AppStateContext.Provider, { value: state }, children);
+  };
+}
+
+describe("ManifestCardList", () => {
+  let state: AppState;
+  let expanded: Signal<Set<string>>;
+  let toggleExpand: ReturnType<typeof vi.fn<(appKey: string) => void>>;
+
+  beforeEach(() => {
+    state = createAppState();
+    expanded = signal(new Set<string>());
+    toggleExpand = vi.fn<(appKey: string) => void>();
+  });
+
+  it("renders one card per manifest", () => {
+    const manifests = [
+      createManifest({ app_key: "app_a", display_name: "App A" }),
+      createManifest({ app_key: "app_b", display_name: "App B" }),
+      createManifest({ app_key: "app_c", display_name: "App C" }),
+    ];
+
+    const { getAllByTestId } = render(
+      <ManifestCardList
+        manifests={manifests}
+        expanded={expanded}
+        toggleExpand={toggleExpand}
+        appStatus={state.appStatus}
+      />,
+      { wrapper: createWrapper(state) },
+    );
+
+    expect(getAllByTestId(/^manifest-card-/)).toHaveLength(3);
+  });
+
+  it("shows app name and status badge on each card", () => {
+    const manifests = [createManifest({ app_key: "my_app", display_name: "My App", status: "running" })];
+
+    const { getByTestId, getByText } = render(
+      <ManifestCardList
+        manifests={manifests}
+        expanded={expanded}
+        toggleExpand={toggleExpand}
+        appStatus={state.appStatus}
+      />,
+      { wrapper: createWrapper(state) },
+    );
+
+    expect(getByTestId("manifest-card-my_app")).toBeDefined();
+    expect(getByText("My App")).toBeDefined();
+    expect(getByText("running")).toBeDefined();
+  });
+
+  it("shows action buttons on each card", () => {
+    const manifests = [createManifest({ app_key: "my_app", status: "running" })];
+
+    const { getByTestId } = render(
+      <ManifestCardList
+        manifests={manifests}
+        expanded={expanded}
+        toggleExpand={toggleExpand}
+        appStatus={state.appStatus}
+      />,
+      { wrapper: createWrapper(state) },
+    );
+
+    // Running app should have Stop and Reload buttons
+    expect(getByTestId("btn-stop-my_app")).toBeDefined();
+    expect(getByTestId("btn-reload-my_app")).toBeDefined();
+  });
+
+  it("shows expand toggle for multi-instance apps", () => {
+    const manifests = [createMultiInstanceManifest("multi_app")];
+
+    const { getByTestId } = render(
+      <ManifestCardList
+        manifests={manifests}
+        expanded={expanded}
+        toggleExpand={toggleExpand}
+        appStatus={state.appStatus}
+      />,
+      { wrapper: createWrapper(state) },
+    );
+
+    const toggle = getByTestId("expand-toggle-multi_app");
+    expect(toggle).toBeDefined();
+    expect(toggle.getAttribute("aria-expanded")).toBe("false");
+  });
+
+  it("does not show expand toggle for single-instance apps", () => {
+    const manifests = [createManifest({ app_key: "single", instance_count: 1 })];
+
+    const { queryByTestId } = render(
+      <ManifestCardList
+        manifests={manifests}
+        expanded={expanded}
+        toggleExpand={toggleExpand}
+        appStatus={state.appStatus}
+      />,
+      { wrapper: createWrapper(state) },
+    );
+
+    expect(queryByTestId("expand-toggle-single")).toBeNull();
+  });
+
+  it("shows instance sub-cards when expanded", () => {
+    expanded = signal(new Set(["multi_app"]));
+    const manifests = [createMultiInstanceManifest("multi_app")];
+
+    const { getByText } = render(
+      <ManifestCardList
+        manifests={manifests}
+        expanded={expanded}
+        toggleExpand={toggleExpand}
+        appStatus={state.appStatus}
+      />,
+      { wrapper: createWrapper(state) },
+    );
+
+    expect(getByText("inst_0")).toBeDefined();
+    expect(getByText("inst_1")).toBeDefined();
+  });
+
+  it("calls toggleExpand when expand toggle is clicked", () => {
+    const manifests = [createMultiInstanceManifest("multi_app")];
+
+    const { getByTestId } = render(
+      <ManifestCardList
+        manifests={manifests}
+        expanded={expanded}
+        toggleExpand={toggleExpand}
+        appStatus={state.appStatus}
+      />,
+      { wrapper: createWrapper(state) },
+    );
+
+    fireEvent.click(getByTestId("expand-toggle-multi_app"));
+    expect(toggleExpand).toHaveBeenCalledWith("multi_app");
+  });
+
+  it("links app name to detail page", () => {
+    const manifests = [createManifest({ app_key: "my_app", display_name: "My App" })];
+
+    const { getByText } = render(
+      <ManifestCardList
+        manifests={manifests}
+        expanded={expanded}
+        toggleExpand={toggleExpand}
+        appStatus={state.appStatus}
+      />,
+      { wrapper: createWrapper(state) },
+    );
+
+    const link = getByText("My App").closest("a");
+    expect(link?.getAttribute("href")).toBe("/apps/my_app");
+  });
+
+  it("shows instance count badge for multi-instance apps", () => {
+    const manifests = [createMultiInstanceManifest("multi_app")];
+
+    const { getByText } = render(
+      <ManifestCardList
+        manifests={manifests}
+        expanded={expanded}
+        toggleExpand={toggleExpand}
+        appStatus={state.appStatus}
+      />,
+      { wrapper: createWrapper(state) },
+    );
+
+    expect(getByText("2 instances")).toBeDefined();
+  });
+
+  it("uses live WS status over manifest status", () => {
+    const manifests = [createManifest({ app_key: "my_app", status: "stopped" })];
+    state.appStatus.value = { my_app: { status: "running", index: 0 } };
+
+    const { getByText } = render(
+      <ManifestCardList
+        manifests={manifests}
+        expanded={expanded}
+        toggleExpand={toggleExpand}
+        appStatus={state.appStatus}
+      />,
+      { wrapper: createWrapper(state) },
+    );
+
+    // Should show live status "running" not manifest "stopped"
+    expect(getByText("running")).toBeDefined();
+  });
+});

--- a/frontend/src/components/apps/manifest-card-list.tsx
+++ b/frontend/src/components/apps/manifest-card-list.tsx
@@ -58,6 +58,8 @@ export function ManifestCardList({ manifests, expanded, toggleExpand, appStatus 
                 )}
               </div>
             </div>
+            {/* TODO: handler/job counts — requires backend to expose handler_count/job_count
+               on AppManifestResponse (currently only on DashboardAppGridEntry). See design spec. */}
             <div class="ht-manifest-card__actions">
               <ActionButtons appKey={m.app_key} status={status} />
             </div>

--- a/frontend/src/components/apps/manifest-card-list.tsx
+++ b/frontend/src/components/apps/manifest-card-list.tsx
@@ -1,0 +1,89 @@
+import type { Signal } from "@preact/signals";
+import type { AppManifest } from "../../api/endpoints";
+import { StatusBadge } from "../shared/status-badge";
+import { ActionButtons } from "./action-buttons";
+import { pluralize } from "../../utils/format";
+
+interface AppStatusEntry {
+  status: string;
+  index: number;
+}
+
+interface Props {
+  manifests: AppManifest[];
+  expanded: Signal<Set<string>>;
+  toggleExpand: (appKey: string) => void;
+  appStatus: Signal<Record<string, AppStatusEntry>>;
+}
+
+export function ManifestCardList({ manifests, expanded, toggleExpand, appStatus }: Props) {
+  const expandedValue = expanded.value;
+
+  return (
+    <div class="ht-manifest-card-list">
+      {manifests.map((m) => {
+        const status = appStatus.value[m.app_key]?.status ?? m.status;
+        const isMultiInstance = m.instance_count > 1;
+        const isExpanded = isMultiInstance && expandedValue.has(m.app_key);
+        const expandLabel = isExpanded
+          ? `Collapse instances for ${m.app_key}`
+          : `Expand instances for ${m.app_key}`;
+
+        return (
+          <div key={m.app_key} class="ht-manifest-card" data-testid={`manifest-card-${m.app_key}`}>
+            <div class="ht-manifest-card__header">
+              <div class="ht-manifest-card__title">
+                {isMultiInstance && (
+                  <button
+                    type="button"
+                    class="ht-manifest-card__chevron"
+                    onClick={() => toggleExpand(m.app_key)}
+                    aria-label={expandLabel}
+                    aria-expanded={isExpanded}
+                    data-testid={`expand-toggle-${m.app_key}`}
+                  >
+                    {isExpanded ? "▾" : "▸"}
+                  </button>
+                )}
+                <a href={`/apps/${m.app_key}`} class="ht-manifest-card__name">
+                  {m.display_name}
+                </a>
+              </div>
+              <div class="ht-manifest-card__badges">
+                <StatusBadge status={status} size="small" />
+                {isMultiInstance && (
+                  <span class="ht-badge ht-badge--sm ht-badge--neutral">
+                    {pluralize(m.instance_count, "instance")}
+                  </span>
+                )}
+              </div>
+            </div>
+            <div class="ht-manifest-card__actions">
+              <ActionButtons appKey={m.app_key} status={status} />
+            </div>
+            {isMultiInstance && isExpanded && m.instances?.map((inst) => (
+              <div
+                key={`${m.app_key}-${inst.index}`}
+                class="ht-manifest-card__instance"
+                data-testid={`instance-card-${m.app_key}-${inst.index}`}
+              >
+                <div class="ht-manifest-card__instance-header">
+                  <a
+                    href={`/apps/${m.app_key}/${inst.index}`}
+                    class="ht-manifest-card__instance-name"
+                  >
+                    {inst.instance_name}
+                  </a>
+                  <StatusBadge status={inst.status} size="small" />
+                </div>
+                <div class="ht-manifest-card__instance-actions">
+                  <ActionButtons appKey={m.app_key} status={inst.status} />
+                </div>
+              </div>
+            ))}
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/frontend/src/components/apps/manifest-list.test.tsx
+++ b/frontend/src/components/apps/manifest-list.test.tsx
@@ -9,6 +9,12 @@ import { createAppState, type AppState } from "../../state/create-app-state";
 import type { AppManifest, AppInstance } from "../../api/endpoints";
 import type { FilterValue } from "./status-filter";
 
+// Mock useMediaQuery to return desktop (false) so the table renders
+vi.mock("../../hooks/use-media-query", () => ({
+  useMediaQuery: () => false,
+  BREAKPOINT_MOBILE: 768,
+}));
+
 // Mock localStorage utilities — must include all exports used by createAppState
 vi.mock("../../utils/local-storage", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../../utils/local-storage")>();

--- a/frontend/src/components/apps/manifest-list.tsx
+++ b/frontend/src/components/apps/manifest-list.tsx
@@ -1,13 +1,13 @@
-import { signal, useSignalEffect } from "@preact/signals";
 import type { Signal } from "@preact/signals";
-import { useEffect, useRef } from "preact/hooks";
 import type { AppManifest } from "../../api/endpoints";
-import { getStoredSet, setStoredSet } from "../../utils/local-storage";
 import { useAppState } from "../../state/context";
+import { useManifestState, EXPANDED_KEY } from "../../hooks/use-manifest-state";
+import { useMediaQuery, BREAKPOINT_MOBILE } from "../../hooks/use-media-query";
 import { ManifestRow } from "./manifest-row";
+import { ManifestCardList } from "./manifest-card-list";
 import type { FilterValue } from "./status-filter";
 
-export const EXPANDED_KEY = "expanded-apps";
+export { EXPANDED_KEY };
 
 interface Props {
   manifests: AppManifest[] | null;
@@ -16,48 +16,8 @@ interface Props {
 
 export function ManifestList({ manifests, filter }: Props) {
   const { appStatus } = useAppState();
-
-  // Single source of truth for expanded app keys — owned by this component.
-  // Initialized from localStorage, synced back on changes via useSignalEffect.
-  const expandedRef = useRef(signal(getStoredSet(EXPANDED_KEY)));
-
-  // Prune stale keys once after manifests first load.
-  const prunedRef = useRef(false);
-  useEffect(() => {
-    if (!manifests || prunedRef.current) return;
-    prunedRef.current = true;
-
-    const current = expandedRef.current.value;
-    const validKeys = new Set(manifests.map((m) => m.app_key));
-    const pruned = new Set([...current].filter((k) => validKeys.has(k)));
-    if (pruned.size !== current.size) {
-      expandedRef.current.value = pruned;
-    }
-  }, [manifests]);
-
-  // Persist expanded state to localStorage only when the signal changes —
-  // useSignalEffect subscribes to the signal, not the render cycle.
-  const isFirstRef = useRef(true);
-  useSignalEffect(() => {
-    const current = expandedRef.current.value;
-    // Skip the initial value (already in localStorage from getStoredSet).
-    if (isFirstRef.current) {
-      isFirstRef.current = false;
-      return;
-    }
-    setStoredSet(EXPANDED_KEY, current);
-  });
-
-  const toggleExpand = (appKey: string) => {
-    const current = expandedRef.current.value;
-    const next = new Set(current);
-    if (next.has(appKey)) {
-      next.delete(appKey);
-    } else {
-      next.add(appKey);
-    }
-    expandedRef.current.value = next;
-  };
+  const { expanded, toggleExpand } = useManifestState(manifests);
+  const isMobile = useMediaQuery(BREAKPOINT_MOBILE);
 
   if (!manifests) return null;
 
@@ -73,7 +33,18 @@ export function ManifestList({ manifests, filter }: Props) {
     return <p class="ht-text-secondary">No apps match this filter.</p>;
   }
 
-  const expanded = expandedRef.current.value;
+  if (isMobile) {
+    return (
+      <ManifestCardList
+        manifests={filtered}
+        expanded={expanded}
+        toggleExpand={toggleExpand}
+        appStatus={appStatus}
+      />
+    );
+  }
+
+  const expandedValue = expanded.value;
 
   return (
     <table class="ht-table ht-table--dense">
@@ -92,7 +63,7 @@ export function ManifestList({ manifests, filter }: Props) {
             key={m.app_key}
             manifest={m}
             liveStatus={appStatus.value[m.app_key]?.status}
-            isExpanded={m.instance_count > 1 && expanded.has(m.app_key)}
+            isExpanded={m.instance_count > 1 && expandedValue.has(m.app_key)}
             onToggleExpand={() => toggleExpand(m.app_key)}
           />
         ))}

--- a/frontend/src/components/dashboard/app-card.test.tsx
+++ b/frontend/src/components/dashboard/app-card.test.tsx
@@ -46,10 +46,10 @@ describe("AppCard", () => {
   });
 
   it("shows instance badge when count > 1", () => {
-    const { getByTitle } = render(<AppCard app={createApp({ instance_count: 3 })} />);
-    const badge = getByTitle("3 instances");
+    const { getByText } = render(<AppCard app={createApp({ instance_count: 3 })} />);
+    const badge = getByText("3 instances");
     expect(badge).toBeDefined();
-    expect(badge.textContent).toContain("3");
+    expect(badge.className).toContain("ht-badge--neutral");
   });
 
   it("does not show instance badge when count is 0", () => {

--- a/frontend/src/components/dashboard/app-card.tsx
+++ b/frontend/src/components/dashboard/app-card.tsx
@@ -21,8 +21,8 @@ export function AppCard({ app }: Props) {
           <span class="ht-app-card__name">
             {app.display_name}
             {app.instance_count > 1 && (
-              <span class="ht-badge ht-badge--sm ht-badge--neutral" title={`${app.instance_count} instances`}>
-                {" "}&times;{app.instance_count}
+              <span class="ht-badge ht-badge--sm ht-badge--neutral ht-ml-1">
+                {pluralize(app.instance_count, "instance")}
               </span>
             )}
           </span>

--- a/frontend/src/components/dashboard/kpi-strip.tsx
+++ b/frontend/src/components/dashboard/kpi-strip.tsx
@@ -17,11 +17,6 @@ export function KpiStrip({ data, appCount = 0, runningCount = 0 }: Props) {
   return (
     <div class="ht-kpi-strip" data-testid="kpi-strip">
       <div class="ht-health-card">
-        <span class="ht-health-card__label">Apps</span>
-        <span class="ht-health-card__value">{appCount}</span>
-        <span class="ht-health-card__detail">{runningCount} running</span>
-      </div>
-      <div class="ht-health-card">
         <span class="ht-health-card__label">Error Rate</span>
         <span class={`ht-health-card__value ht-health-card__value--${errorRateToVariant(data.error_rate_class)}`}>
           {data.error_rate.toFixed(1)}%
@@ -31,6 +26,11 @@ export function KpiStrip({ data, appCount = 0, runningCount = 0 }: Props) {
             ? `${data.total_errors + data.total_job_errors} / ${pluralize(data.total_invocations + data.total_executions, "invocation")}`
             : "No data"}
         </span>
+      </div>
+      <div class="ht-health-card">
+        <span class="ht-health-card__label">Apps</span>
+        <span class="ht-health-card__value">{appCount}</span>
+        <span class="ht-health-card__detail">{runningCount} running</span>
       </div>
       <div class="ht-health-card">
         <span class="ht-health-card__label">Handlers</span>

--- a/frontend/src/components/dashboard/kpi-strip.tsx
+++ b/frontend/src/components/dashboard/kpi-strip.tsx
@@ -16,7 +16,7 @@ export function KpiStrip({ data, appCount = 0, runningCount = 0 }: Props) {
 
   return (
     <div class="ht-kpi-strip" data-testid="kpi-strip">
-      <div class="ht-health-card">
+      <div class="ht-health-card" data-kpi="error-rate">
         <span class="ht-health-card__label">Error Rate</span>
         <span class={`ht-health-card__value ht-health-card__value--${errorRateToVariant(data.error_rate_class)}`}>
           {data.error_rate.toFixed(1)}%

--- a/frontend/src/components/layout/bottom-nav.test.tsx
+++ b/frontend/src/components/layout/bottom-nav.test.tsx
@@ -1,0 +1,58 @@
+import { describe, expect, it, vi } from "vitest";
+import { render } from "@testing-library/preact";
+import { h } from "preact";
+import { BottomNav } from "./bottom-nav";
+
+// Mock wouter to control the current location
+vi.mock("wouter", () => ({
+  Link: ({ href, class: cls, children, ...rest }: Record<string, unknown>) =>
+    h("a", { href, class: cls, ...rest }, children as never),
+  useLocation: vi.fn().mockReturnValue(["/", vi.fn()]),
+}));
+
+const wouter = await import("wouter");
+const useLocation = wouter.useLocation as ReturnType<typeof vi.fn>;
+
+describe("BottomNav", () => {
+  it("renders four navigation items", () => {
+    const { getAllByRole } = render(<BottomNav />);
+    const links = getAllByRole("link");
+    expect(links).toHaveLength(4);
+  });
+
+  it("dashboard item links to root", () => {
+    const { getByTestId } = render(<BottomNav />);
+    expect(getByTestId("nav-dashboard-mobile").getAttribute("href")).toBe("/");
+  });
+
+  it("apps item links to /apps", () => {
+    const { getByTestId } = render(<BottomNav />);
+    expect(getByTestId("nav-apps-mobile").getAttribute("href")).toBe("/apps");
+  });
+
+  it("logs item links to /logs", () => {
+    const { getByTestId } = render(<BottomNav />);
+    expect(getByTestId("nav-logs-mobile").getAttribute("href")).toBe("/logs");
+  });
+
+  it("sessions item links to /sessions", () => {
+    const { getByTestId } = render(<BottomNav />);
+    expect(getByTestId("nav-sessions-mobile").getAttribute("href")).toBe("/sessions");
+  });
+
+  it("applies is-active class to current route item", () => {
+    useLocation.mockReturnValue(["/apps", vi.fn()]);
+
+    const { getByTestId } = render(<BottomNav />);
+
+    expect(getByTestId("nav-apps-mobile").className).toContain("is-active");
+    expect(getByTestId("nav-dashboard-mobile").className).not.toContain("is-active");
+    expect(getByTestId("nav-logs-mobile").className).not.toContain("is-active");
+    expect(getByTestId("nav-sessions-mobile").className).not.toContain("is-active");
+  });
+
+  it("has accessibility label on nav element", () => {
+    const { getByLabelText } = render(<BottomNav />);
+    expect(getByLabelText("Mobile navigation")).toBeDefined();
+  });
+});

--- a/frontend/src/components/layout/bottom-nav.tsx
+++ b/frontend/src/components/layout/bottom-nav.tsx
@@ -45,6 +45,7 @@ export function BottomNav() {
             class={`ht-bottom-nav__item${isActive ? " is-active" : ""}`}
             data-testid={item.testId}
             aria-label={item.label}
+            aria-current={isActive ? "page" : undefined}
           >
             {item.icon}
             <span>{item.label}</span>

--- a/frontend/src/components/layout/bottom-nav.tsx
+++ b/frontend/src/components/layout/bottom-nav.tsx
@@ -1,0 +1,56 @@
+import { Link, useLocation } from "wouter";
+import { IconBoxes, IconDashboard, IconHistory, IconScrollText } from "../shared/icons";
+
+const NAV_ITEMS = [
+  {
+    path: "/",
+    label: "Dashboard",
+    testId: "nav-dashboard-mobile",
+    icon: <IconDashboard />,
+  },
+  {
+    path: "/apps",
+    label: "Apps",
+    testId: "nav-apps-mobile",
+    icon: <IconBoxes />,
+  },
+  {
+    path: "/logs",
+    label: "Logs",
+    testId: "nav-logs-mobile",
+    icon: <IconScrollText />,
+  },
+  {
+    path: "/sessions",
+    label: "Sessions",
+    testId: "nav-sessions-mobile",
+    icon: <IconHistory />,
+  },
+] as const;
+
+export function BottomNav() {
+  const [location] = useLocation();
+
+  return (
+    <nav class="ht-bottom-nav" aria-label="Mobile navigation">
+      {NAV_ITEMS.map((item) => {
+        const isActive =
+          item.path === "/"
+            ? location === "/"
+            : location.startsWith(item.path);
+        return (
+          <Link
+            key={item.path}
+            href={item.path}
+            class={`ht-bottom-nav__item${isActive ? " is-active" : ""}`}
+            data-testid={item.testId}
+            aria-label={item.label}
+          >
+            {item.icon}
+            <span>{item.label}</span>
+          </Link>
+        );
+      })}
+    </nav>
+  );
+}

--- a/frontend/src/components/layout/sidebar.tsx
+++ b/frontend/src/components/layout/sidebar.tsx
@@ -52,6 +52,7 @@ export function Sidebar() {
                   class={`ht-nav-item${isActive ? " is-active" : ""}`}
                   data-testid={item.testId}
                   aria-label={item.label}
+                  aria-current={isActive ? "page" : undefined}
                 >
                   {item.icon}
                 </Link>

--- a/frontend/src/components/shared/icons.tsx
+++ b/frontend/src/components/shared/icons.tsx
@@ -64,6 +64,12 @@ export const IconWarning = () => (
   </svg>
 );
 
+export const IconCheck = () => (
+  <svg class="ht-icon-svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+    <path d="M20 6 9 17l-5-5" />
+  </svg>
+);
+
 export const IconGrid = () => (
   <svg class="ht-icon-svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
     <rect width="7" height="7" x="3" y="3" rx="1" />

--- a/frontend/src/components/shared/log-table.test.tsx
+++ b/frontend/src/components/shared/log-table.test.tsx
@@ -8,6 +8,13 @@ import { AppStateContext } from "../../state/context";
 import { createAppState, type AppState } from "../../state/create-app-state";
 import type { WsLogPayload } from "../../api/ws-types";
 
+// Mock useMediaQuery — default to desktop (false), overridden in mobile tests
+const mockUseMediaQuery = vi.fn((_maxWidth: number) => false);
+vi.mock("../../hooks/use-media-query", () => ({
+  useMediaQuery: (maxWidth: number) => mockUseMediaQuery(maxWidth),
+  BREAKPOINT_MOBILE: 768,
+}));
+
 // Mock the API endpoint for initial log fetch
 vi.mock("../../api/endpoints", () => ({
   getRecentLogs: vi.fn().mockResolvedValue([]),
@@ -988,5 +995,101 @@ describe("Live streaming pause", () => {
     // REST entry still visible, WS entry hidden
     expect(queryByText("rest-entry")).not.toBeNull();
     expect(queryByText("ws-entry")).toBeNull();
+  });
+});
+
+// -- Mobile responsive rendering --
+
+describe("Mobile responsive rendering", () => {
+  let state: AppState;
+
+  beforeEach(() => {
+    state = createAppState();
+    vi.clearAllMocks();
+    entrySeq = 0;
+    mockUseMediaQuery.mockReturnValue(true); // mobile
+  });
+
+  afterEach(() => {
+    mockUseMediaQuery.mockReturnValue(false); // restore desktop
+  });
+
+  it("abbreviates level labels on mobile (INFO -> I)", () => {
+    state.logs.push(createLogEntry({ level: "INFO", message: "info msg" }));
+    state.logs.push(createLogEntry({ level: "WARNING", message: "warn msg" }));
+    state.logs.push(createLogEntry({ level: "ERROR", message: "error msg" }));
+    state.logs.push(createLogEntry({ level: "DEBUG", message: "debug msg" }));
+
+    // Need all levels visible
+    const { container, getByTestId } = render(
+      <LogTable />,
+      { wrapper: createWrapper(state) },
+    );
+    fireEvent.change(getByTestId("filter-level"), { target: { value: "" } });
+
+    const badges = container.querySelectorAll(".ht-badge");
+    const badgeTexts = Array.from(badges).map((b) => b.textContent);
+    expect(badgeTexts).toContain("I");
+    expect(badgeTexts).toContain("W");
+    expect(badgeTexts).toContain("E");
+    expect(badgeTexts).toContain("D");
+    // Full labels should NOT appear
+    expect(badgeTexts).not.toContain("INFO");
+    expect(badgeTexts).not.toContain("WARNING");
+    expect(badgeTexts).not.toContain("ERROR");
+    expect(badgeTexts).not.toContain("DEBUG");
+  });
+
+  it("hides App column header on mobile", () => {
+    state.logs.push(createLogEntry({ app_key: "my_app" }));
+
+    const { container } = render(
+      <LogTable showAppColumn appKeys={["my_app"]} />,
+      { wrapper: createWrapper(state) },
+    );
+
+    const headers = container.querySelectorAll("th");
+    const headerTexts = Array.from(headers).map((h) => h.textContent ?? "");
+    expect(headerTexts.some((t) => t.includes("App"))).toBe(false);
+  });
+
+  it("shows app name as tag in message column on mobile", () => {
+    state.logs.push(createLogEntry({ app_key: "my_app", message: "test message" }));
+
+    const { container } = render(
+      <LogTable showAppColumn appKeys={["my_app"]} />,
+      { wrapper: createWrapper(state) },
+    );
+
+    const appTag = container.querySelector(".ht-log-app-tag");
+    expect(appTag).not.toBeNull();
+    expect(appTag!.textContent).toBe("my_app");
+    expect(appTag!.classList.contains("ht-tag")).toBe(true);
+    expect(appTag!.classList.contains("ht-tag--neutral")).toBe(true);
+  });
+
+  it("truncates timestamp seconds on mobile", () => {
+    // Timestamp for 2024-01-01 12:30:45 UTC
+    const ts = new Date("2024-01-01T12:30:45Z").getTime() / 1000;
+    state.logs.push(createLogEntry({ timestamp: ts, message: "ts test" }));
+
+    const { container } = render(
+      <LogTable />,
+      { wrapper: createWrapper(state) },
+    );
+
+    const timeCells = container.querySelectorAll("td.ht-text-mono");
+    // Find the cell with the timestamp (not source cells)
+    const tsCell = Array.from(timeCells).find((td) => {
+      const text = td.textContent ?? "";
+      return text.includes("/") && text.includes(":");
+    });
+    expect(tsCell).not.toBeNull();
+    // Should NOT contain seconds (i.e., no ":45" pattern at end)
+    const tsText = tsCell!.textContent ?? "";
+    // Format should be MM/DD HH:MM AM/PM (no seconds)
+    // The full format has two colons (HH:MM:SS), short has only one (HH:MM)
+    const colonCount = (tsText.match(/:/g) ?? []).length;
+    expect(colonCount).toBe(1);
   });
 });

--- a/frontend/src/components/shared/log-table.test.tsx
+++ b/frontend/src/components/shared/log-table.test.tsx
@@ -13,6 +13,7 @@ const mockUseMediaQuery = vi.fn((_maxWidth: number) => false);
 vi.mock("../../hooks/use-media-query", () => ({
   useMediaQuery: (maxWidth: number) => mockUseMediaQuery(maxWidth),
   BREAKPOINT_MOBILE: 768,
+  BREAKPOINT_TABLET: 1024,
 }));
 
 // Mock the API endpoint for initial log fetch

--- a/frontend/src/components/shared/log-table.test.tsx
+++ b/frontend/src/components/shared/log-table.test.tsx
@@ -1068,9 +1068,9 @@ describe("Mobile responsive rendering", () => {
     expect(appTag!.classList.contains("ht-tag--neutral")).toBe(true);
   });
 
-  it("truncates timestamp seconds on mobile", () => {
-    // Timestamp for 2024-01-01 12:30:45 UTC
-    const ts = new Date("2024-01-01T12:30:45Z").getTime() / 1000;
+  it("shows relative timestamps on mobile", () => {
+    // Timestamp 5 minutes ago
+    const ts = Date.now() / 1000 - 300;
     state.logs.push(createLogEntry({ timestamp: ts, message: "ts test" }));
 
     const { container } = render(
@@ -1079,17 +1079,10 @@ describe("Mobile responsive rendering", () => {
     );
 
     const timeCells = container.querySelectorAll("td.ht-text-mono");
-    // Find the cell with the timestamp (not source cells)
     const tsCell = Array.from(timeCells).find((td) => {
       const text = td.textContent ?? "";
-      return text.includes("/") && text.includes(":");
+      return text.includes("ago") || text.includes("just now");
     });
     expect(tsCell).not.toBeNull();
-    // Should NOT contain seconds (i.e., no ":45" pattern at end)
-    const tsText = tsCell!.textContent ?? "";
-    // Format should be MM/DD HH:MM AM/PM (no seconds)
-    // The full format has two colons (HH:MM:SS), short has only one (HH:MM)
-    const colonCount = (tsText.match(/:/g) ?? []).length;
-    expect(colonCount).toBe(1);
   });
 });

--- a/frontend/src/components/shared/log-table.tsx
+++ b/frontend/src/components/shared/log-table.tsx
@@ -4,7 +4,7 @@ import type { LogEntry } from "../../api/endpoints";
 import { getRecentLogs } from "../../api/endpoints";
 import { useMediaQuery, BREAKPOINT_MOBILE } from "../../hooks/use-media-query";
 import { useAppState } from "../../state/context";
-import { formatTimestamp, formatTimestampShort, pluralize } from "../../utils/format";
+import { formatTimestamp, formatRelativeTime, pluralize } from "../../utils/format";
 
 const LEVELS = ["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"] as const;
 
@@ -311,7 +311,7 @@ export function LogTable({ showAppColumn = true, appKey, appKeys }: Props) {
           <tbody>
             {sorted.length === 0 && (
               <tr>
-                <td colSpan={showAppColumn && !isMobile ? 5 : 4} class="ht-text-center ht-text-muted">
+                <td colSpan={isMobile ? 3 : showAppColumn ? 5 : 4} class="ht-text-center ht-text-muted"> {/* source col CSS-hidden at mobile: -1 */}
                   No log entries.
                 </td>
               </tr>
@@ -325,7 +325,7 @@ export function LogTable({ showAppColumn = true, appKey, appKeys }: Props) {
                     {isMobile ? (LEVEL_ABBREV[entry.level] ?? entry.level) : entry.level}
                   </span>
                 </td>
-                <td class="ht-text-mono">{isMobile ? formatTimestampShort(entry.timestamp) : formatTimestamp(entry.timestamp)}</td>
+                <td class="ht-text-mono">{isMobile ? formatRelativeTime(entry.timestamp) : formatTimestamp(entry.timestamp)}</td>
                 {showAppColumn && !isMobile && (
                   <td>
                     {entry.app_key ? (

--- a/frontend/src/components/shared/log-table.tsx
+++ b/frontend/src/components/shared/log-table.tsx
@@ -2,8 +2,9 @@ import { signal } from "@preact/signals";
 import { useEffect, useRef, useCallback } from "preact/hooks";
 import type { LogEntry } from "../../api/endpoints";
 import { getRecentLogs } from "../../api/endpoints";
+import { useMediaQuery, BREAKPOINT_MOBILE } from "../../hooks/use-media-query";
 import { useAppState } from "../../state/context";
-import { formatTimestamp, pluralize } from "../../utils/format";
+import { formatTimestamp, formatTimestampShort, pluralize } from "../../utils/format";
 
 const LEVELS = ["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"] as const;
 
@@ -48,6 +49,14 @@ export function sortEntries(entries: readonly LogEntry[], column: SortColumn, as
   });
 }
 
+const LEVEL_ABBREV: Record<string, string> = {
+  DEBUG: "D",
+  INFO: "I",
+  WARNING: "W",
+  ERROR: "E",
+  CRITICAL: "C",
+};
+
 interface Props {
   showAppColumn?: boolean;
   appKey?: string;
@@ -56,6 +65,7 @@ interface Props {
 }
 
 export function LogTable({ showAppColumn = true, appKey, appKeys }: Props) {
+  const isMobile = useMediaQuery(BREAKPOINT_MOBILE);
   const { logs, updateLogSubscription, reconnectVersion } = useAppState();
   const minLevel = useRef(signal("INFO")).current; // default = INFO (matches WS subscription)
   const appFilter = useRef(signal("")).current; // "" = All Apps
@@ -283,7 +293,7 @@ export function LogTable({ showAppColumn = true, appKey, appKeys }: Props) {
                   <span>Timestamp</span>{" "}<span aria-hidden="true">{sortArrow("timestamp")}</span>
                 </button>
               </th>
-              {showAppColumn && (
+              {showAppColumn && !isMobile && (
                 <th class="ht-col-app" aria-sort={ariaSortFor("app")} data-testid="sort-app">
                   <button type="button" class="ht-sortable" onClick={() => handleSort("app")}>
                     <span>App</span>{" "}<span aria-hidden="true">{sortArrow("app")}</span>
@@ -301,7 +311,7 @@ export function LogTable({ showAppColumn = true, appKey, appKeys }: Props) {
           <tbody>
             {sorted.length === 0 && (
               <tr>
-                <td colSpan={showAppColumn ? 5 : 4} class="ht-text-center ht-text-muted">
+                <td colSpan={showAppColumn && !isMobile ? 5 : 4} class="ht-text-center ht-text-muted">
                   No log entries.
                 </td>
               </tr>
@@ -312,11 +322,11 @@ export function LogTable({ showAppColumn = true, appKey, appKeys }: Props) {
               <tr key={rowKey}>
                 <td>
                   <span class={`ht-badge ht-badge--sm ht-badge--${entry.level === "ERROR" || entry.level === "CRITICAL" ? "danger" : entry.level === "WARNING" ? "warning" : entry.level === "DEBUG" ? "neutral" : "success"}`}>
-                    {entry.level}
+                    {isMobile ? (LEVEL_ABBREV[entry.level] ?? entry.level) : entry.level}
                   </span>
                 </td>
-                <td class="ht-text-mono">{formatTimestamp(entry.timestamp)}</td>
-                {showAppColumn && (
+                <td class="ht-text-mono">{isMobile ? formatTimestampShort(entry.timestamp) : formatTimestamp(entry.timestamp)}</td>
+                {showAppColumn && !isMobile && (
                   <td>
                     {entry.app_key ? (
                       <a href={`/apps/${entry.app_key}`} class="ht-text-mono">
@@ -347,7 +357,12 @@ export function LogTable({ showAppColumn = true, appKey, appKeys }: Props) {
                       onClick={toggle}
                       onKeyDown={(e: KeyboardEvent) => { if (e.key === "Enter" || e.key === " ") { e.preventDefault(); toggle(); } }}
                     >
-                      <div data-row-key={rowKey} class={`ht-log-message__text${isExpanded ? " is-expanded" : ""}`}>{entry.message}</div>
+                      <div data-row-key={rowKey} class={`ht-log-message__text${isExpanded ? " is-expanded" : ""}`}>
+                        {isMobile && showAppColumn && entry.app_key && (
+                          <span class="ht-log-app-tag ht-tag ht-tag--neutral">{entry.app_key}</span>
+                        )}
+                        {entry.message}
+                      </div>
                     </td>
                   );
                 })()}

--- a/frontend/src/components/shared/log-table.tsx
+++ b/frontend/src/components/shared/log-table.tsx
@@ -2,7 +2,7 @@ import { signal } from "@preact/signals";
 import { useEffect, useRef, useCallback } from "preact/hooks";
 import type { LogEntry } from "../../api/endpoints";
 import { getRecentLogs } from "../../api/endpoints";
-import { useMediaQuery, BREAKPOINT_MOBILE } from "../../hooks/use-media-query";
+import { useMediaQuery, BREAKPOINT_MOBILE, BREAKPOINT_TABLET } from "../../hooks/use-media-query";
 import { useAppState } from "../../state/context";
 import { formatTimestamp, formatRelativeTime, pluralize } from "../../utils/format";
 
@@ -66,6 +66,11 @@ interface Props {
 
 export function LogTable({ showAppColumn = true, appKey, appKeys }: Props) {
   const isMobile = useMediaQuery(BREAKPOINT_MOBILE);
+  // Source column is CSS-hidden at max-width: 1024px (see global.css .ht-table-log .ht-col-source)
+  // Ideally the Source <th>/<td> would be conditionally rendered like the App column,
+  // but for now we just adjust the colSpan to match the CSS-only hide.
+  const isTablet = useMediaQuery(BREAKPOINT_TABLET);
+  const showSourceColumn = !isTablet;
   const { logs, updateLogSubscription, reconnectVersion, tick } = useAppState();
 
   // Subscribe to tick signal so relative timestamps re-render every 30s on mobile
@@ -314,7 +319,7 @@ export function LogTable({ showAppColumn = true, appKey, appKeys }: Props) {
           <tbody>
             {sorted.length === 0 && (
               <tr>
-                <td colSpan={isMobile ? 3 : showAppColumn ? 5 : 4} class="ht-text-center ht-text-muted"> {/* source col CSS-hidden at mobile: -1 */}
+                <td colSpan={isMobile ? 3 : (showAppColumn ? (showSourceColumn ? 5 : 4) : (showSourceColumn ? 4 : 3))} class="ht-text-center ht-text-muted">
                   No log entries.
                 </td>
               </tr>
@@ -330,7 +335,8 @@ export function LogTable({ showAppColumn = true, appKey, appKeys }: Props) {
                 expandedRows.value = next;
               };
               const mobileColCount = 3; // level + time + message (source hidden, app hidden on mobile)
-              const desktopColCount = showAppColumn ? 5 : 4;
+              const sourceAdjust = showSourceColumn ? 0 : -1;
+              const desktopColCount = (showAppColumn ? 5 : 4) + sourceAdjust;
               const colCount = isMobile ? mobileColCount : desktopColCount;
               const rows = [
               <tr key={rowKey}>

--- a/frontend/src/components/shared/log-table.tsx
+++ b/frontend/src/components/shared/log-table.tsx
@@ -318,7 +318,18 @@ export function LogTable({ showAppColumn = true, appKey, appKeys }: Props) {
             )}
             {sorted.slice(0, 500).map((entry) => {
               const rowKey = entry.seq ? String(entry.seq) : `${entry.timestamp}-${entry.logger_name}-${entry.lineno}`;
-              return (
+              const isExpanded = expandedRows.value.has(rowKey);
+              const canExpand = truncatedRows.value.has(rowKey) || isExpanded;
+              const toggle = () => {
+                if (!canExpand) return;
+                const next = new Set(expandedRows.value);
+                if (next.has(rowKey)) next.delete(rowKey); else next.add(rowKey);
+                expandedRows.value = next;
+              };
+              const mobileColCount = showAppColumn ? 3 : 3; // level + time + message (source hidden, app hidden on mobile)
+              const desktopColCount = showAppColumn ? 5 : 4;
+              const colCount = isMobile ? mobileColCount : desktopColCount;
+              const rows = [
               <tr key={rowKey}>
                 <td>
                   <span class={`ht-badge ht-badge--sm ht-badge--${entry.level === "ERROR" || entry.level === "CRITICAL" ? "danger" : entry.level === "WARNING" ? "warning" : entry.level === "DEBUG" ? "neutral" : "success"}`}>
@@ -340,34 +351,32 @@ export function LogTable({ showAppColumn = true, appKey, appKeys }: Props) {
                 <td class="ht-col-source ht-text-mono ht-text-xs ht-text-muted" title={`${entry.logger_name}:${entry.func_name}:${entry.lineno}`}>
                   {entry.func_name}:{entry.lineno}
                 </td>
-                {(() => {
-                  const isExpanded = expandedRows.value.has(rowKey);
-                  const canExpand = truncatedRows.value.has(rowKey) || isExpanded;
-                  const toggle = () => {
-                    if (!canExpand) return;
-                    const next = new Set(expandedRows.value);
-                    if (next.has(rowKey)) next.delete(rowKey); else next.add(rowKey);
-                    expandedRows.value = next;
-                  };
-                  return (
-                    <td
-                      class={`ht-log-message-cell${canExpand ? " is-expandable" : ""}${isExpanded ? " is-expanded" : ""}`}
-                      {...(canExpand ? { role: "button", tabIndex: 0, "aria-expanded": isExpanded,
-                        "aria-label": isExpanded ? "Collapse log message" : "Expand log message" } : {})}
-                      onClick={toggle}
-                      onKeyDown={(e: KeyboardEvent) => { if (e.key === "Enter" || e.key === " ") { e.preventDefault(); toggle(); } }}
-                    >
-                      <div data-row-key={rowKey} class={`ht-log-message__text${isExpanded ? " is-expanded" : ""}`}>
-                        {isMobile && showAppColumn && entry.app_key && (
-                          <span class="ht-log-app-tag ht-tag ht-tag--neutral">{entry.app_key}</span>
-                        )}
-                        {entry.message}
-                      </div>
+                <td
+                  class={`ht-log-message-cell${canExpand ? " is-expandable" : ""}${isExpanded ? " is-expanded" : ""}${isMobile && isExpanded ? " is-mobile-expanded" : ""}`}
+                  {...(canExpand ? { role: "button", tabIndex: 0, "aria-expanded": isExpanded,
+                    "aria-label": isExpanded ? "Collapse log message" : "Expand log message" } : {})}
+                  onClick={toggle}
+                  onKeyDown={(e: KeyboardEvent) => { if (e.key === "Enter" || e.key === " ") { e.preventDefault(); toggle(); } }}
+                >
+                  <div data-row-key={rowKey} class={`ht-log-message__text${isExpanded && !isMobile ? " is-expanded" : ""}`}>
+                    {isMobile && showAppColumn && entry.app_key && (
+                      <span class="ht-log-app-tag ht-tag ht-tag--neutral">{entry.app_key}</span>
+                    )}
+                    {entry.message}
+                  </div>
+                </td>
+              </tr>,
+              ];
+              if (isMobile && isExpanded) {
+                rows.push(
+                  <tr key={`${rowKey}-expanded`} class="ht-log-expanded-row">
+                    <td colSpan={colCount} class="ht-log-expanded-cell">
+                      <div class="ht-log-expanded-message">{entry.message}</div>
                     </td>
-                  );
-                })()}
-              </tr>
-              );
+                  </tr>,
+                );
+              }
+              return rows;
             })}
           </tbody>
         </table>

--- a/frontend/src/components/shared/log-table.tsx
+++ b/frontend/src/components/shared/log-table.tsx
@@ -66,7 +66,10 @@ interface Props {
 
 export function LogTable({ showAppColumn = true, appKey, appKeys }: Props) {
   const isMobile = useMediaQuery(BREAKPOINT_MOBILE);
-  const { logs, updateLogSubscription, reconnectVersion } = useAppState();
+  const { logs, updateLogSubscription, reconnectVersion, tick } = useAppState();
+
+  // Subscribe to tick signal so relative timestamps re-render every 30s on mobile
+  if (isMobile) void tick.value;
   const minLevel = useRef(signal("INFO")).current; // default = INFO (matches WS subscription)
   const appFilter = useRef(signal("")).current; // "" = All Apps
   const search = useRef(signal("")).current;
@@ -326,7 +329,7 @@ export function LogTable({ showAppColumn = true, appKey, appKeys }: Props) {
                 if (next.has(rowKey)) next.delete(rowKey); else next.add(rowKey);
                 expandedRows.value = next;
               };
-              const mobileColCount = showAppColumn ? 3 : 3; // level + time + message (source hidden, app hidden on mobile)
+              const mobileColCount = 3; // level + time + message (source hidden, app hidden on mobile)
               const desktopColCount = showAppColumn ? 5 : 4;
               const colCount = isMobile ? mobileColCount : desktopColCount;
               const rows = [

--- a/frontend/src/global.css
+++ b/frontend/src/global.css
@@ -179,16 +179,17 @@ code, pre {
 }
 
 a {
-  color: var(--ht-accent);
+  color: var(--ht-link);
   text-decoration: none;
 }
 
 a:hover {
+  color: var(--ht-link-hover);
   text-decoration: underline;
 }
 
 a code {
-  color: var(--ht-accent);
+  color: var(--ht-link);
 }
 
 a:hover code {
@@ -287,7 +288,7 @@ strong {
   display: flex;
   align-items: center;
   justify-content: center;
-  color: var(--ht-accent);
+  color: var(--ht-text-secondary);
   text-decoration: none;
 }
 
@@ -322,14 +323,14 @@ strong {
 }
 
 .ht-nav-item:hover {
-  background: var(--ht-accent-light);
+  background: var(--ht-surface-recessed);
   color: var(--ht-text);
   text-decoration: none;
 }
 
 .ht-nav-item.is-active {
-  background: var(--ht-accent-light);
-  color: var(--ht-accent);
+  background: var(--ht-surface-recessed);
+  color: var(--ht-text);
 }
 
 .ht-nav-item svg {
@@ -408,13 +409,14 @@ strong {
 }
 
 .ht-scope-toggle__btn:hover:not(.is-active) {
-  background: var(--ht-accent-light);
+  background: var(--ht-surface-recessed);
   color: var(--ht-text);
 }
 
 .ht-scope-toggle__btn.is-active {
-  background: var(--ht-accent);
-  color: var(--ht-bg);
+  color: var(--ht-text);
+  background: var(--ht-surface-recessed);
+  border-bottom: 2px solid var(--ht-border-strong);
 }
 
 /* — Theme Toggle ——————————————————————————————————————— */
@@ -434,7 +436,7 @@ strong {
 }
 
 .ht-theme-toggle:hover {
-  background: var(--ht-accent-light);
+  background: var(--ht-surface-recessed);
   color: var(--ht-text);
   border-color: var(--ht-border-strong);
 }
@@ -471,6 +473,7 @@ strong {
 .ht-card {
   background: var(--ht-surface);
   border: 1px solid var(--ht-border);
+  border-top: 1px solid var(--ht-border-highlight);
   border-radius: var(--ht-radius-md);
   box-shadow: var(--ht-shadow-sm);
   padding: var(--ht-sp-5);
@@ -660,7 +663,7 @@ strong {
 
 .ht-btn--ghost.ht-btn--success:hover { background: var(--ht-success-light); }
 .ht-btn--ghost.ht-btn--warning:hover { background: var(--ht-warning-light); }
-.ht-btn--ghost.ht-btn--info:hover { background: var(--ht-accent-light); }
+.ht-btn--ghost.ht-btn--info:hover { background: var(--ht-surface-recessed); }
 .ht-btn--ghost.ht-btn--danger:hover { background: var(--ht-danger-light); }
 
 .ht-btn--primary {
@@ -692,12 +695,12 @@ strong {
 }
 
 .ht-btn--info {
-  border-color: var(--ht-accent);
-  color: var(--ht-accent);
+  border-color: var(--ht-border-strong);
+  color: var(--ht-text);
 }
 
 .ht-btn--info:hover {
-  background: var(--ht-accent-light);
+  background: var(--ht-surface-recessed);
 }
 
 .ht-btn-group {
@@ -784,8 +787,8 @@ strong {
 }
 
 .ht-tabs li button[aria-pressed="true"] {
-  color: var(--ht-accent);
-  border-bottom-color: var(--ht-accent);
+  color: var(--ht-text);
+  border-bottom-color: var(--ht-text-secondary);
   font-weight: var(--ht-weight-semibold);
 }
 
@@ -990,6 +993,7 @@ strong {
   padding: var(--ht-sp-4);
   background: var(--ht-surface);
   border: 1px solid var(--ht-border);
+  border-top: 1px solid var(--ht-border-highlight);
   border-radius: var(--ht-radius-md);
 }
 
@@ -1026,6 +1030,7 @@ strong {
   gap: var(--ht-sp-4);
 }
 
+/* sync: BREAKPOINT_MOBILE in use-media-query.ts */
 @media screen and (max-width: 768px) {
   .ht-health-strip {
     grid-template-columns: repeat(2, 1fr);
@@ -1174,7 +1179,7 @@ strong {
 }
 
 .ht-breadcrumb a:hover {
-  color: var(--ht-accent);
+  color: var(--ht-text);
   text-decoration: underline;
 }
 
@@ -1200,6 +1205,7 @@ strong {
 }
 
 /* — Responsive: sidebar hidden below 768px ————————————— */
+/* sync: BREAKPOINT_MOBILE in use-media-query.ts */
 @media screen and (max-width: 768px) {
   .ht-layout {
     grid-template-columns: 1fr;
@@ -1274,6 +1280,45 @@ strong {
   .ht-heading-5 {
     font-size: var(--ht-text-base);
   }
+
+  /* Touch target enforcement (WCAG 2.5.8 — 44px minimum) */
+  .ht-scope-toggle__btn {
+    min-height: 44px;
+    padding: var(--ht-sp-2) var(--ht-sp-3);
+  }
+
+  .ht-theme-toggle {
+    min-width: 44px;
+    min-height: 44px;
+  }
+
+  .ht-tabs li button {
+    min-height: 44px;
+    padding: var(--ht-sp-2) var(--ht-sp-3);
+  }
+
+  .ht-btn--sm,
+  .ht-btn--xs {
+    min-height: 44px;
+  }
+
+  /* StatusBar: sticky so pulse dot and scope toggle stay visible */
+  .ht-status-bar {
+    position: sticky;
+    top: 0;
+    z-index: 20;
+    background: var(--ht-surface-sticky);
+  }
+
+  /* Main content: bottom padding for future bottom nav */
+  .ht-main {
+    padding-bottom: calc(var(--ht-sp-4) + 52px + env(safe-area-inset-bottom, 0px));
+  }
+
+  /* Log table: hide App column (tag integration is WP03) */
+  .ht-table-log .ht-col-app {
+    display: none;
+  }
 }
 
 /* — Responsive: small phones (max-width: 480px) ———————— */
@@ -1295,15 +1340,14 @@ strong {
   margin-bottom: var(--ht-sp-6);
 }
 
+/* sync: BREAKPOINT_MOBILE in use-media-query.ts */
 @media screen and (max-width: 768px) {
   .ht-kpi-strip {
-    grid-template-columns: repeat(3, 1fr);
-  }
-}
-
-@media screen and (max-width: 480px) {
-  .ht-kpi-strip {
     grid-template-columns: repeat(2, 1fr);
+  }
+
+  .ht-kpi-strip > :first-child {
+    grid-column: 1 / -1;
   }
 }
 
@@ -1317,12 +1361,14 @@ strong {
 .ht-app-card {
   background: var(--ht-surface);
   border: 1px solid var(--ht-border);
+  border-top: 1px solid var(--ht-border-highlight);
   border-radius: var(--ht-radius-md);
-  transition: box-shadow var(--ht-motion-micro);
+  transition: background var(--ht-motion-micro), box-shadow var(--ht-motion-micro);
   overflow: hidden;
 }
 
 .ht-app-card:hover {
+  background: var(--ht-surface-recessed);
   box-shadow: var(--ht-shadow-md);
 }
 
@@ -1595,7 +1641,7 @@ strong {
 .ht-btn--link {
   border-color: transparent;
   background: transparent;
-  color: var(--ht-accent);
+  color: var(--ht-link);
   padding: 0;
 }
 
@@ -1617,6 +1663,7 @@ strong {
 /* — Light Mode Overrides ——————————————————————————————— */
 [data-theme="light"] .ht-card {
   border: 1px solid var(--ht-border);
+  border-top: 1px solid var(--ht-border-highlight);
   box-shadow: 0 1px 3px rgba(0, 0, 0, 0.06);
 }
 
@@ -1640,7 +1687,7 @@ strong {
   height: auto;
   padding: var(--ht-sp-2) var(--ht-sp-4);
   background: var(--ht-surface);
-  color: var(--ht-accent);
+  color: var(--ht-text);
   border: 2px solid var(--ht-accent);
   border-radius: var(--ht-radius-md);
   font-family: var(--ht-font-body);

--- a/frontend/src/global.css
+++ b/frontend/src/global.css
@@ -1695,6 +1695,161 @@ strong {
   z-index: 1000;
 }
 
+/* — Bottom Navigation (mobile) ————————————————————————— */
+/* sync: BREAKPOINT_MOBILE in use-media-query.ts */
+.ht-bottom-nav {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  height: 52px;
+  display: flex;
+  background: var(--ht-surface);
+  border-top: 1px solid var(--ht-border);
+  padding-bottom: env(safe-area-inset-bottom, 0px);
+  z-index: 30;
+}
+
+.ht-bottom-nav__item {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: var(--ht-sp-1);
+  min-height: 44px;
+  color: var(--ht-text-dim);
+  text-decoration: none;
+  font-size: var(--ht-text-xs);
+  font-family: var(--ht-font-body);
+  transition: color var(--ht-motion-micro);
+}
+
+.ht-bottom-nav__item:hover,
+.ht-bottom-nav__item.is-active {
+  color: var(--ht-text);
+  background: var(--ht-surface-recessed);
+}
+
+.ht-bottom-nav__item svg {
+  width: 20px;
+  height: 20px;
+}
+
+@media screen and (min-width: 769px) {
+  .ht-bottom-nav {
+    display: none;
+  }
+}
+
+/* — Manifest Card List (mobile apps view) —————————————— */
+/* sync: BREAKPOINT_MOBILE in use-media-query.ts */
+.ht-manifest-card-list {
+  display: flex;
+  flex-direction: column;
+  gap: var(--ht-sp-3);
+}
+
+.ht-manifest-card {
+  background: var(--ht-surface);
+  border: 1px solid var(--ht-border);
+  border-top: 1px solid var(--ht-border-highlight);
+  border-radius: var(--ht-radius-md);
+  padding: var(--ht-sp-4);
+  display: flex;
+  flex-direction: column;
+  gap: var(--ht-sp-2);
+}
+
+.ht-manifest-card__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: var(--ht-sp-2);
+}
+
+.ht-manifest-card__title {
+  display: flex;
+  align-items: center;
+  gap: var(--ht-sp-1);
+  min-width: 0;
+}
+
+.ht-manifest-card__chevron {
+  background: none;
+  border: none;
+  color: var(--ht-text-dim);
+  cursor: pointer;
+  padding: var(--ht-sp-1);
+  font-size: var(--ht-text-sm);
+  line-height: 1;
+  min-width: 44px;
+  min-height: 44px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.ht-manifest-card__name {
+  color: var(--ht-link);
+  text-decoration: none;
+  font-weight: var(--ht-weight-medium);
+  font-size: var(--ht-text-base);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.ht-manifest-card__name:hover {
+  color: var(--ht-link-hover);
+}
+
+.ht-manifest-card__badges {
+  display: flex;
+  align-items: center;
+  gap: var(--ht-sp-1);
+  flex-shrink: 0;
+}
+
+.ht-manifest-card__actions {
+  display: flex;
+  gap: var(--ht-sp-2);
+  flex-wrap: wrap;
+}
+
+.ht-manifest-card__instance {
+  background: var(--ht-surface-recessed);
+  border-radius: var(--ht-radius-sm);
+  padding: var(--ht-sp-3);
+  display: flex;
+  flex-direction: column;
+  gap: var(--ht-sp-2);
+}
+
+.ht-manifest-card__instance-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: var(--ht-sp-2);
+}
+
+.ht-manifest-card__instance-name {
+  color: var(--ht-link);
+  text-decoration: none;
+  font-family: var(--ht-font-mono);
+  font-size: var(--ht-text-sm);
+}
+
+.ht-manifest-card__instance-name:hover {
+  color: var(--ht-link-hover);
+}
+
+.ht-manifest-card__instance-actions {
+  display: flex;
+  gap: var(--ht-sp-2);
+  flex-wrap: wrap;
+}
+
 /* — Reduced Motion ————————————————————————————————————— */
 @media (prefers-reduced-motion: reduce) {
   *,

--- a/frontend/src/global.css
+++ b/frontend/src/global.css
@@ -205,6 +205,7 @@ strong {
   display: grid;
   grid-template-columns: 56px 1fr;
   min-height: 100vh;
+  min-height: 100dvh;
   position: relative;
 }
 
@@ -1310,7 +1311,7 @@ strong {
     background: var(--ht-surface-sticky);
   }
 
-  /* Main content: bottom padding for future bottom nav */
+  /* Bottom padding prevents content from hiding behind the fixed bottom nav (52px height + safe-area inset) */
   .ht-main {
     padding-bottom: calc(var(--ht-sp-4) + 52px + env(safe-area-inset-bottom, 0px));
   }
@@ -1346,7 +1347,7 @@ strong {
     grid-template-columns: repeat(2, 1fr);
   }
 
-  .ht-kpi-strip > :first-child {
+  .ht-kpi-strip > [data-kpi="error-rate"] {
     grid-column: 1 / -1;
   }
 }
@@ -1711,7 +1712,7 @@ strong {
   bottom: 0;
   left: 0;
   right: 0;
-  height: 52px;
+  min-height: 52px;
   display: flex;
   background: var(--ht-surface);
   border-top: 1px solid var(--ht-border);
@@ -1743,8 +1744,14 @@ strong {
 .ht-bottom-nav__item svg {
   width: 20px;
   height: 20px;
+  stroke: currentColor;
+  fill: none;
+  stroke-width: 2;
+  stroke-linecap: round;
+  stroke-linejoin: round;
 }
 
+/* 769px = 768px + 1 — hides bottom nav when sidebar becomes visible at max-width:768px */
 @media screen and (min-width: 769px) {
   .ht-bottom-nav {
     display: none;

--- a/frontend/src/global.css
+++ b/frontend/src/global.css
@@ -552,6 +552,26 @@ strong {
   word-break: break-all;
 }
 
+/* Mobile: expanded message shown in full-width row below */
+.ht-log-message-cell.is-mobile-expanded .ht-log-message__text {
+  /* Keep collapsed appearance — the full text is in the row below */
+}
+
+.ht-log-expanded-row {
+  background: var(--ht-surface-recessed);
+}
+
+.ht-log-expanded-cell {
+  padding: var(--ht-sp-2) var(--ht-sp-3) !important;
+}
+
+.ht-log-expanded-message {
+  white-space: pre-wrap;
+  word-break: break-word;
+  line-height: 1.5;
+  font-size: var(--ht-text-sm);
+}
+
 .ht-table--dense th,
 .ht-table--dense td {
   padding: var(--ht-sp-1) var(--ht-sp-2);

--- a/frontend/src/global.css
+++ b/frontend/src/global.css
@@ -1315,7 +1315,7 @@ strong {
     padding-bottom: calc(var(--ht-sp-4) + 52px + env(safe-area-inset-bottom, 0px));
   }
 
-  /* Log table: hide App column (tag integration is WP03) */
+  /* Log table: hide App column — app name shown as tag in message column */
   .ht-table-log .ht-col-app {
     display: none;
   }
@@ -1510,6 +1510,15 @@ strong {
 .ht-tag--neutral {
   color: var(--ht-text-secondary);
   background: var(--ht-surface-recessed);
+}
+
+.ht-log-app-tag {
+  margin-right: var(--ht-sp-1);
+  max-width: 100px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  vertical-align: baseline;
+  flex-shrink: 0;
 }
 
 .ht-tag--truncated {

--- a/frontend/src/global.css
+++ b/frontend/src/global.css
@@ -535,7 +535,7 @@ strong {
 .ht-log-message-cell.is-expandable:hover,
 .ht-log-message-cell.is-expandable:focus-visible,
 .ht-log-message-cell.is-expanded {
-  background: var(--ht-surface-hover, rgba(255, 255, 255, 0.04));
+  background: var(--ht-surface-recessed);
 }
 
 .ht-log-message__text {
@@ -1311,9 +1311,9 @@ strong {
     background: var(--ht-surface-sticky);
   }
 
-  /* Bottom padding prevents content from hiding behind the fixed bottom nav (52px height + safe-area inset) */
+  /* Bottom padding prevents content from hiding behind the fixed bottom nav */
   .ht-main {
-    padding-bottom: calc(var(--ht-sp-4) + 52px + env(safe-area-inset-bottom, 0px));
+    padding-bottom: calc(var(--ht-sp-4) + var(--ht-bottom-nav-height, 52px) + env(safe-area-inset-bottom, 0px));
   }
 
   /* Log table: hide App column — app name shown as tag in message column */
@@ -1708,11 +1708,12 @@ strong {
 /* — Bottom Navigation (mobile) ————————————————————————— */
 /* sync: BREAKPOINT_MOBILE in use-media-query.ts */
 .ht-bottom-nav {
+  --ht-bottom-nav-height: 52px;
   position: fixed;
   bottom: 0;
   left: 0;
   right: 0;
-  min-height: 52px;
+  min-height: var(--ht-bottom-nav-height);
   display: flex;
   background: var(--ht-surface);
   border-top: 1px solid var(--ht-border);

--- a/frontend/src/hooks/use-manifest-state.test.ts
+++ b/frontend/src/hooks/use-manifest-state.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { renderHook, act } from "@testing-library/preact";
+import type { AppManifest } from "../api/endpoints";
+
+// Mock localStorage utilities
+vi.mock("../utils/local-storage", () => ({
+  getStoredSet: vi.fn().mockReturnValue(new Set<string>()),
+  setStoredSet: vi.fn(),
+}));
+
+const localStorage = await import("../utils/local-storage");
+const getStoredSet = localStorage.getStoredSet as ReturnType<typeof vi.fn>;
+const setStoredSet = localStorage.setStoredSet as ReturnType<typeof vi.fn>;
+
+function createManifest(appKey: string): AppManifest {
+  return {
+    app_key: appKey,
+    class_name: "TestApp",
+    display_name: "Test App",
+    filename: "test.py",
+    enabled: true,
+    auto_loaded: true,
+    status: "running",
+    block_reason: null,
+    instance_count: 1,
+    instances: [],
+    error_message: null,
+    error_traceback: null,
+  };
+}
+
+describe("useManifestState", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getStoredSet.mockReturnValue(new Set<string>());
+  });
+
+  it("initializes expanded from localStorage", async () => {
+    getStoredSet.mockReturnValue(new Set(["app_a"]));
+
+    const { useManifestState } = await import("./use-manifest-state");
+    const { result } = renderHook(() =>
+      useManifestState([createManifest("app_a")]),
+    );
+
+    expect(result.current.expanded.value).toEqual(new Set(["app_a"]));
+  });
+
+  it("toggleExpand adds a key", async () => {
+    const { useManifestState } = await import("./use-manifest-state");
+    const { result } = renderHook(() =>
+      useManifestState([createManifest("app_a")]),
+    );
+
+    act(() => {
+      result.current.toggleExpand("app_a");
+    });
+
+    expect(result.current.expanded.value.has("app_a")).toBe(true);
+  });
+
+  it("toggleExpand removes a key that is already expanded", async () => {
+    getStoredSet.mockReturnValue(new Set(["app_a"]));
+
+    const { useManifestState } = await import("./use-manifest-state");
+    const { result } = renderHook(() =>
+      useManifestState([createManifest("app_a")]),
+    );
+
+    act(() => {
+      result.current.toggleExpand("app_a");
+    });
+
+    expect(result.current.expanded.value.has("app_a")).toBe(false);
+  });
+
+  it("prunes stale keys not present in manifests", async () => {
+    getStoredSet.mockReturnValue(new Set(["stale_app", "valid_app"]));
+
+    const { useManifestState } = await import("./use-manifest-state");
+    const { result } = renderHook(() =>
+      useManifestState([createManifest("valid_app")]),
+    );
+
+    expect(result.current.expanded.value.has("valid_app")).toBe(true);
+    expect(result.current.expanded.value.has("stale_app")).toBe(false);
+  });
+
+  it("syncs to localStorage on state change", async () => {
+    const { useManifestState, EXPANDED_KEY } = await import(
+      "./use-manifest-state"
+    );
+    const { result } = renderHook(() =>
+      useManifestState([createManifest("app_a")]),
+    );
+
+    act(() => {
+      result.current.toggleExpand("app_a");
+    });
+
+    expect(setStoredSet).toHaveBeenCalledWith(
+      EXPANDED_KEY,
+      new Set(["app_a"]),
+    );
+  });
+});

--- a/frontend/src/hooks/use-manifest-state.ts
+++ b/frontend/src/hooks/use-manifest-state.ts
@@ -1,0 +1,65 @@
+import { signal, useSignalEffect } from "@preact/signals";
+import type { Signal } from "@preact/signals";
+import { useEffect, useRef } from "preact/hooks";
+import type { AppManifest } from "../api/endpoints";
+import { getStoredSet, setStoredSet } from "../utils/local-storage";
+
+export const EXPANDED_KEY = "expanded-apps";
+
+interface ManifestState {
+  expanded: Signal<Set<string>>;
+  toggleExpand: (appKey: string) => void;
+}
+
+/**
+ * Manages expanded state for the apps list with localStorage persistence.
+ *
+ * - Initializes from localStorage
+ * - Prunes stale keys when manifests first load
+ * - Syncs changes back to localStorage via signal effect
+ */
+export function useManifestState(manifests: AppManifest[] | null): ManifestState {
+  // Single source of truth for expanded app keys.
+  // Initialized from localStorage, synced back on changes via useSignalEffect.
+  const expandedRef = useRef(signal(getStoredSet(EXPANDED_KEY)));
+
+  // Prune stale keys once after manifests first load.
+  const prunedRef = useRef(false);
+  useEffect(() => {
+    if (!manifests || prunedRef.current) return;
+    prunedRef.current = true;
+
+    const current = expandedRef.current.value;
+    const validKeys = new Set(manifests.map((m) => m.app_key));
+    const pruned = new Set([...current].filter((k) => validKeys.has(k)));
+    if (pruned.size !== current.size) {
+      expandedRef.current.value = pruned;
+    }
+  }, [manifests]);
+
+  // Persist expanded state to localStorage only when the signal changes —
+  // useSignalEffect subscribes to the signal, not the render cycle.
+  const isFirstRef = useRef(true);
+  useSignalEffect(() => {
+    const current = expandedRef.current.value;
+    // Skip the initial value (already in localStorage from getStoredSet).
+    if (isFirstRef.current) {
+      isFirstRef.current = false;
+      return;
+    }
+    setStoredSet(EXPANDED_KEY, current);
+  });
+
+  const toggleExpand = (appKey: string) => {
+    const current = expandedRef.current.value;
+    const next = new Set(current);
+    if (next.has(appKey)) {
+      next.delete(appKey);
+    } else {
+      next.add(appKey);
+    }
+    expandedRef.current.value = next;
+  };
+
+  return { expanded: expandedRef.current, toggleExpand };
+}

--- a/frontend/src/hooks/use-media-query.test.ts
+++ b/frontend/src/hooks/use-media-query.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import { renderHook, act } from "@testing-library/preact";
+
+describe("BREAKPOINT_MOBILE", () => {
+  it("is exported as 768", async () => {
+    const { BREAKPOINT_MOBILE } = await import("./use-media-query");
+    expect(BREAKPOINT_MOBILE).toBe(768);
+  });
+});
+
+describe("useMediaQuery", () => {
+  let listeners: Array<(e: { matches: boolean }) => void>;
+  let currentMatches: boolean;
+  let removeSpy: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    listeners = [];
+    currentMatches = false;
+    removeSpy = vi.fn();
+
+    Object.defineProperty(window, "matchMedia", {
+      writable: true,
+      value: vi.fn().mockImplementation((query: string) => ({
+        matches: currentMatches,
+        media: query,
+        addEventListener: vi.fn((_event: string, cb: (e: { matches: boolean }) => void) => {
+          listeners.push(cb);
+        }),
+        removeEventListener: removeSpy,
+        onchange: null,
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+        dispatchEvent: vi.fn(),
+      })),
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("returns true when below breakpoint", async () => {
+    currentMatches = true;
+    const { useMediaQuery } = await import("./use-media-query");
+
+    const { result } = renderHook(() => useMediaQuery(768));
+
+    expect(result.current).toBe(true);
+  });
+
+  it("returns false when above breakpoint", async () => {
+    currentMatches = false;
+    const { useMediaQuery } = await import("./use-media-query");
+
+    const { result } = renderHook(() => useMediaQuery(768));
+
+    expect(result.current).toBe(false);
+  });
+
+  it("responds to change event", async () => {
+    currentMatches = false;
+    const { useMediaQuery } = await import("./use-media-query");
+
+    const { result } = renderHook(() => useMediaQuery(768));
+    expect(result.current).toBe(false);
+
+    act(() => {
+      for (const listener of listeners) {
+        listener({ matches: true });
+      }
+    });
+
+    expect(result.current).toBe(true);
+  });
+
+  it("cleans up listener on unmount", async () => {
+    currentMatches = false;
+    const { useMediaQuery } = await import("./use-media-query");
+
+    const { unmount } = renderHook(() => useMediaQuery(768));
+    unmount();
+
+    expect(removeSpy).toHaveBeenCalledWith("change", expect.any(Function));
+  });
+});

--- a/frontend/src/hooks/use-media-query.test.ts
+++ b/frontend/src/hooks/use-media-query.test.ts
@@ -8,6 +8,13 @@ describe("BREAKPOINT_MOBILE", () => {
   });
 });
 
+describe("BREAKPOINT_TABLET", () => {
+  it("is exported as 1024", async () => {
+    const { BREAKPOINT_TABLET } = await import("./use-media-query");
+    expect(BREAKPOINT_TABLET).toBe(1024);
+  });
+});
+
 describe("useMediaQuery", () => {
   let listeners: Array<(e: { matches: boolean }) => void>;
   let currentMatches: boolean;

--- a/frontend/src/hooks/use-media-query.ts
+++ b/frontend/src/hooks/use-media-query.ts
@@ -1,0 +1,29 @@
+import { useEffect, useState } from "preact/hooks";
+
+/** Must match CSS `@media (max-width: 768px)` breakpoints in global.css */
+export const BREAKPOINT_MOBILE = 768;
+
+/**
+ * Returns true when the viewport width is at or below `maxWidth`.
+ * Uses `window.matchMedia` and cleans up the listener on unmount.
+ */
+export function useMediaQuery(maxWidth: number): boolean {
+  const query = `(max-width: ${maxWidth}px)`;
+  const [matches, setMatches] = useState(() => window.matchMedia(query).matches);
+
+  useEffect(() => {
+    const mql = window.matchMedia(query);
+    setMatches(mql.matches);
+
+    const handler = (e: MediaQueryListEvent | { matches: boolean }) => {
+      setMatches(e.matches);
+    };
+
+    mql.addEventListener("change", handler);
+    return () => {
+      mql.removeEventListener("change", handler);
+    };
+  }, [query]);
+
+  return matches;
+}

--- a/frontend/src/hooks/use-media-query.ts
+++ b/frontend/src/hooks/use-media-query.ts
@@ -3,6 +3,9 @@ import { useEffect, useState } from "preact/hooks";
 /** Must match CSS `@media (max-width: 768px)` breakpoints in global.css */
 export const BREAKPOINT_MOBILE = 768;
 
+/** Must match CSS `@media (max-width: 1024px)` breakpoints in global.css */
+export const BREAKPOINT_TABLET = 1024;
+
 /**
  * Returns true when the viewport width is at or below `maxWidth`.
  * Uses `window.matchMedia` and cleans up the listener on unmount.

--- a/frontend/src/pages/dashboard.tsx
+++ b/frontend/src/pages/dashboard.tsx
@@ -7,7 +7,7 @@ import {
 import { AppGrid } from "../components/dashboard/app-grid";
 import { ErrorFeed } from "../components/dashboard/error-feed";
 import { KpiStrip } from "../components/dashboard/kpi-strip";
-import { IconHeart, IconWarning } from "../components/shared/icons";
+import { IconCheck, IconHeart, IconWarning } from "../components/shared/icons";
 import { Spinner } from "../components/shared/spinner";
 import { useScopedApi } from "../hooks/use-scoped-api";
 import { useDebouncedEffect } from "../hooks/use-debounced-effect";
@@ -91,7 +91,7 @@ export function DashboardPage() {
         </div>
       ) : (
         <div class="ht-empty-section ht-mb-4">
-          <IconWarning />
+          <IconCheck />
           <span class="ht-text-muted ht-text-xs">No recent errors. All systems healthy.</span>
         </div>
       )}

--- a/frontend/src/pages/sessions.tsx
+++ b/frontend/src/pages/sessions.tsx
@@ -2,38 +2,27 @@ import { useEffect } from "preact/hooks";
 import { getSessionList, type SessionListEntry } from "../api/endpoints";
 import { IconHistory } from "../components/shared/icons";
 import { Spinner } from "../components/shared/spinner";
+import { StatusBadge } from "../components/shared/status-badge";
 import { useApi } from "../hooks/use-api";
 import { formatTimestamp } from "../utils/format";
-import type { StatusVariant } from "../utils/status";
-
-const SESSION_STATUS_MAP: ReadonlyMap<string, StatusVariant> = new Map([
-  ["running", "success"],
-  ["success", "success"],
-  ["failure", "danger"],
-  ["unknown", "neutral"],
-]);
-
-function sessionStatusToVariant(status: string): StatusVariant {
-  return SESSION_STATUS_MAP.get(status) ?? "neutral";
-}
 
 function formatSessionDuration(seconds: number | null): string {
   if (seconds === null) return "-";
-  if (seconds < 60) return `${Math.round(seconds)}s`;
-  if (seconds < 3600) return `${Math.floor(seconds / 60)}m ${Math.round(seconds % 60)}s`;
-  const hours = Math.floor(seconds / 3600);
-  const minutes = Math.floor((seconds % 3600) / 60);
-  return `${hours}h ${minutes}m`;
+  const totalSeconds = Math.round(seconds);
+  if (totalSeconds < 60) return `${totalSeconds}s`;
+  const totalMinutes = Math.floor(totalSeconds / 60);
+  const remainingSeconds = totalSeconds % 60;
+  if (totalSeconds < 3600) return remainingSeconds > 0 ? `${totalMinutes}m ${remainingSeconds}s` : `${totalMinutes}m`;
+  const hours = Math.floor(totalMinutes / 60);
+  const remainingMinutes = totalMinutes % 60;
+  return remainingMinutes > 0 ? `${hours}h ${remainingMinutes}m` : `${hours}h`;
 }
 
 function SessionRow({ session }: { session: SessionListEntry }) {
-  const variant = sessionStatusToVariant(session.status);
   return (
     <tr>
       <td>
-        <span class={`ht-badge ht-badge--sm ht-badge--${variant}`}>
-          {session.status}
-        </span>
+        <StatusBadge status={session.status} size="small" />
       </td>
       <td>{formatTimestamp(session.started_at)}</td>
       <td>{session.stopped_at !== null ? formatTimestamp(session.stopped_at) : "-"}</td>

--- a/frontend/src/tokens.css
+++ b/frontend/src/tokens.css
@@ -11,20 +11,25 @@
 [data-theme="dark"] {
   /* Surfaces */
   --ht-bg: #111113;
-  --ht-surface: #1a1a1e;
-  --ht-surface-recessed: #222226;
-  --ht-surface-sticky: #1a1a1e;
+  --ht-surface: #222226;
+  --ht-surface-recessed: #2a2a2f;
+  --ht-surface-sticky: #222226;
 
   /* Borders */
   --ht-border: rgba(255, 255, 255, 0.06);
   --ht-border-strong: rgba(255, 255, 255, 0.10);
+  --ht-border-highlight: rgba(255, 255, 255, 0.08);
 
   /* Text */
   --ht-text: #ececef;
   --ht-text-secondary: #9898a0;
   --ht-text-dim: #5c5c66;
 
-  /* Accent (Emerald) */
+  /* Interactive (muted emerald — distinct from vivid status accent and neutral text) */
+  --ht-link: #6bab94;
+  --ht-link-hover: #8cc4ad;
+
+  /* Accent (Emerald — reserved for status: alive/connected/running) */
   --ht-accent: #34d399;
   --ht-accent-light: rgba(52, 211, 153, 0.10);
 
@@ -57,22 +62,27 @@
   /* Borders */
   --ht-border: rgba(0, 0, 0, 0.06);
   --ht-border-strong: rgba(0, 0, 0, 0.10);
+  --ht-border-highlight: rgba(0, 0, 0, 0.03);
 
   /* Text */
   --ht-text: #111113;
   --ht-text-secondary: #55555e;
   --ht-text-dim: #9898a0;
 
-  /* Accent (Emerald) */
-  --ht-accent: #059669;
-  --ht-accent-light: rgba(5, 150, 105, 0.07);
+  /* Interactive (muted emerald) */
+  --ht-link: #1a7a5a;
+  --ht-link-hover: #0f5c42;
+
+  /* Accent (Emerald — reserved for status) */
+  --ht-accent: #047857;
+  --ht-accent-light: rgba(4, 120, 87, 0.07);
 
   /* Value */
   --ht-value: #b45309;
 
   /* Semantic */
-  --ht-success: #059669;
-  --ht-success-light: rgba(5, 150, 105, 0.07);
+  --ht-success: #047857;
+  --ht-success-light: rgba(4, 120, 87, 0.07);
 
   --ht-danger: #dc2626;
   --ht-danger-light: rgba(220, 38, 38, 0.07);

--- a/frontend/src/utils/format.ts
+++ b/frontend/src/utils/format.ts
@@ -7,6 +7,15 @@ export function formatTimestamp(ts: number): string {
   return `${month}/${day} ${time}`;
 }
 
+/** Format a Unix timestamp as "MM/DD HH:MM AM/PM" (no seconds) for mobile. */
+export function formatTimestampShort(ts: number): string {
+  const d = new Date(ts * 1000);
+  const month = String(d.getMonth() + 1).padStart(2, "0");
+  const day = String(d.getDate()).padStart(2, "0");
+  const time = d.toLocaleTimeString("en-US", { hour: "numeric", minute: "2-digit", hour12: true });
+  return `${month}/${day} ${time}`;
+}
+
 /** Format a duration in milliseconds with one decimal (e.g., "158.0ms"). */
 export function formatDuration(ms: number): string {
   if (ms < 1) return "<1ms";

--- a/frontend/src/utils/format.ts
+++ b/frontend/src/utils/format.ts
@@ -7,14 +7,6 @@ export function formatTimestamp(ts: number): string {
   return `${month}/${day} ${time}`;
 }
 
-/** Format a Unix timestamp as "MM/DD HH:MM AM/PM" (no seconds) for mobile. */
-export function formatTimestampShort(ts: number): string {
-  const d = new Date(ts * 1000);
-  const month = String(d.getMonth() + 1).padStart(2, "0");
-  const day = String(d.getDate()).padStart(2, "0");
-  const time = d.toLocaleTimeString("en-US", { hour: "numeric", minute: "2-digit", hour12: true });
-  return `${month}/${day} ${time}`;
-}
 
 /** Format a duration in milliseconds with one decimal (e.g., "158.0ms"). */
 export function formatDuration(ms: number): string {

--- a/frontend/src/utils/status.test.ts
+++ b/frontend/src/utils/status.test.ts
@@ -15,7 +15,7 @@ describe("statusToVariant", () => {
   it("returns neutral and warns for unknown status", () => {
     const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
     expect(statusToVariant("exploding")).toBe("neutral");
-    expect(warnSpy).toHaveBeenCalledWith('Unknown app status: "exploding"');
+    expect(warnSpy).toHaveBeenCalledWith('Unknown status: "exploding"');
     warnSpy.mockRestore();
   });
 });

--- a/frontend/src/utils/status.ts
+++ b/frontend/src/utils/status.ts
@@ -35,11 +35,11 @@ export const APP_STATUSES: ReadonlySet<string> = new Set(APP_STATUS_MAP.keys());
 export const HEALTH_GRADES: ReadonlySet<string> = new Set(HEALTH_GRADE_MAP.keys());
 export const ERROR_RATE_CLASSES: ReadonlySet<string> = new Set(ERROR_RATE_MAP.keys());
 
-/** Map an app status string to a StatusVariant. Unknown values return "neutral" with a console.warn. */
+/** Map a status string to a StatusVariant. Unknown values return "neutral" with a console.warn. */
 export function statusToVariant(status: string): StatusVariant {
   const variant = APP_STATUS_MAP.get(status);
   if (variant !== undefined) return variant;
-  console.warn(`Unknown app status: "${status}"`);
+  console.warn(`Unknown status: "${status}"`);
   return "neutral";
 }
 

--- a/frontend/src/utils/status.ts
+++ b/frontend/src/utils/status.ts
@@ -12,6 +12,10 @@ const APP_STATUS_MAP: ReadonlyMap<string, StatusVariant> = new Map<string, Statu
   ["blocked", "warning"],  // Intentional: blocked = needs attention (matches small badge behavior)
   ["starting", "neutral"],
   ["shutting_down", "neutral"],
+  // Session statuses (shared map so StatusBadge works for both apps and sessions)
+  ["success", "success"],
+  ["failure", "danger"],
+  ["unknown", "neutral"],
 ]);
 
 const HEALTH_GRADE_MAP: ReadonlyMap<string, StatusVariant> = new Map<string, StatusVariant>([

--- a/src/hassette/web/static/css/tokens.css
+++ b/src/hassette/web/static/css/tokens.css
@@ -11,20 +11,25 @@
 [data-theme="dark"] {
   /* Surfaces */
   --ht-bg: #111113;
-  --ht-surface: #1a1a1e;
-  --ht-surface-recessed: #222226;
-  --ht-surface-sticky: #1a1a1e;
+  --ht-surface: #222226;
+  --ht-surface-recessed: #2a2a2f;
+  --ht-surface-sticky: #222226;
 
   /* Borders */
   --ht-border: rgba(255, 255, 255, 0.06);
   --ht-border-strong: rgba(255, 255, 255, 0.10);
+  --ht-border-highlight: rgba(255, 255, 255, 0.08);
 
   /* Text */
   --ht-text: #ececef;
   --ht-text-secondary: #9898a0;
   --ht-text-dim: #5c5c66;
 
-  /* Accent (Emerald) */
+  /* Interactive (muted emerald — distinct from vivid status accent and neutral text) */
+  --ht-link: #6bab94;
+  --ht-link-hover: #8cc4ad;
+
+  /* Accent (Emerald — reserved for status: alive/connected/running) */
   --ht-accent: #34d399;
   --ht-accent-light: rgba(52, 211, 153, 0.10);
 
@@ -57,22 +62,27 @@
   /* Borders */
   --ht-border: rgba(0, 0, 0, 0.06);
   --ht-border-strong: rgba(0, 0, 0, 0.10);
+  --ht-border-highlight: rgba(0, 0, 0, 0.03);
 
   /* Text */
   --ht-text: #111113;
   --ht-text-secondary: #55555e;
   --ht-text-dim: #9898a0;
 
-  /* Accent (Emerald) */
-  --ht-accent: #059669;
-  --ht-accent-light: rgba(5, 150, 105, 0.07);
+  /* Interactive (muted emerald) */
+  --ht-link: #1a7a5a;
+  --ht-link-hover: #0f5c42;
+
+  /* Accent (Emerald — reserved for status) */
+  --ht-accent: #047857;
+  --ht-accent-light: rgba(4, 120, 87, 0.07);
 
   /* Value */
   --ht-value: #b45309;
 
   /* Semantic */
-  --ht-success: #059669;
-  --ht-success-light: rgba(5, 150, 105, 0.07);
+  --ht-success: #047857;
+  --ht-success-light: rgba(4, 120, 87, 0.07);
 
   --ht-danger: #dc2626;
   --ht-danger-light: rgba(220, 38, 38, 0.07);

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -34,6 +34,12 @@ from hassette.test_utils.web_mocks import create_hassette_stub, create_mock_runt
 from hassette.types.enums import ResourceStatus
 from hassette.web.app import create_fastapi_app
 
+# Shared viewport constants for e2e tests.
+# Mobile height 812 = iPhone X (safe-area / notch testing).
+# Desktop 1024x768 = standard desktop above mobile breakpoint.
+MOBILE_VIEWPORT = {"width": 375, "height": 812}
+DESKTOP_VIEWPORT = {"width": 1024, "height": 768}
+
 
 def _build_manifests() -> list:
     """Build a rich set of app manifests for e2e tests."""

--- a/tests/e2e/test_navigation.py
+++ b/tests/e2e/test_navigation.py
@@ -5,10 +5,9 @@ import re
 import pytest
 from playwright.sync_api import Page, expect
 
-pytestmark = pytest.mark.e2e
+from tests.e2e.conftest import DESKTOP_VIEWPORT, MOBILE_VIEWPORT
 
-DESKTOP_VIEWPORT = {"width": 1280, "height": 720}
-MOBILE_VIEWPORT = {"width": 375, "height": 667}
+pytestmark = pytest.mark.e2e
 
 PAGES = [
     ("/", "App Health"),

--- a/tests/e2e/test_responsive.py
+++ b/tests/e2e/test_responsive.py
@@ -1,0 +1,214 @@
+"""E2E tests for responsive layout behavior across mobile and desktop viewports."""
+
+import re
+
+import pytest
+from playwright.sync_api import Page, expect
+
+pytestmark = pytest.mark.e2e
+
+MOBILE_VIEWPORT = {"width": 375, "height": 812}
+TABLET_VIEWPORT = {"width": 768, "height": 1024}
+DESKTOP_VIEWPORT = {"width": 1024, "height": 768}
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Bottom nav visibility
+# ──────────────────────────────────────────────────────────────────────
+
+
+def test_bottom_nav_visible_at_375px(page: Page, base_url: str) -> None:
+    """Bottom navigation bar is visible on mobile with 4 items."""
+    page.set_viewport_size(MOBILE_VIEWPORT)
+    page.goto(base_url + "/")
+    nav = page.locator(".ht-bottom-nav")
+    expect(nav).to_be_visible()
+    items = nav.locator(".ht-bottom-nav__item")
+    expect(items).to_have_count(4)
+
+
+def test_bottom_nav_hidden_at_1024px(page: Page, base_url: str) -> None:
+    """Bottom navigation bar is hidden on desktop viewports."""
+    page.set_viewport_size(DESKTOP_VIEWPORT)
+    page.goto(base_url + "/")
+    nav = page.locator(".ht-bottom-nav")
+    expect(nav).not_to_be_visible()
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Bottom nav navigation
+# ──────────────────────────────────────────────────────────────────────
+
+BOTTOM_NAV_TABS = [
+    ("nav-dashboard-mobile", "/"),
+    ("nav-apps-mobile", "/apps"),
+    ("nav-logs-mobile", "/logs"),
+    ("nav-sessions-mobile", "/sessions"),
+]
+
+
+@pytest.mark.parametrize(
+    ("testid", "expected_path"),
+    BOTTOM_NAV_TABS,
+    ids=[t for t, _ in BOTTOM_NAV_TABS],
+)
+def test_bottom_nav_navigation(page: Page, base_url: str, testid: str, expected_path: str) -> None:
+    """Clicking bottom nav tabs navigates to the correct page."""
+    page.set_viewport_size(MOBILE_VIEWPORT)
+    page.goto(base_url + "/")
+    page.locator(f'[data-testid="{testid}"]').click()
+    page.wait_for_timeout(300)
+    if expected_path == "/":
+        expect(page).to_have_url(base_url + "/")
+    else:
+        assert page.url.rstrip("/").endswith(expected_path.rstrip("/"))
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Apps list: card layout on mobile, table on desktop
+# ──────────────────────────────────────────────────────────────────────
+
+
+def test_apps_card_layout_at_375px(page: Page, base_url: str) -> None:
+    """Mobile viewport shows app cards, not the dense table."""
+    page.set_viewport_size(MOBILE_VIEWPORT)
+    page.goto(base_url + "/apps")
+    page.wait_for_timeout(500)
+    cards = page.locator(".ht-manifest-card")
+    expect(cards.first).to_be_visible()
+    dense_table = page.locator("table.ht-table--dense")
+    expect(dense_table).to_have_count(0)
+
+
+def test_apps_table_layout_at_1024px(page: Page, base_url: str) -> None:
+    """Desktop viewport shows the dense table, not cards."""
+    page.set_viewport_size(DESKTOP_VIEWPORT)
+    page.goto(base_url + "/apps")
+    page.wait_for_timeout(500)
+    dense_table = page.locator("table.ht-table--dense")
+    expect(dense_table).to_be_visible()
+    cards = page.locator(".ht-manifest-card")
+    expect(cards).to_have_count(0)
+
+
+# ──────────────────────────────────────────────────────────────────────
+# KPI strip ordering at mobile
+# ──────────────────────────────────────────────────────────────────────
+
+
+def test_kpi_error_rate_first_at_375px(page: Page, base_url: str) -> None:
+    """Error Rate KPI card is the first in the strip on mobile (spans full width)."""
+    page.set_viewport_size(MOBILE_VIEWPORT)
+    page.goto(base_url + "/")
+    page.wait_for_timeout(500)
+    kpi_strip = page.locator('[data-testid="kpi-strip"]')
+    first_label = kpi_strip.locator(".ht-health-card__label").first
+    expect(first_label).to_have_text("Error Rate")
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Touch targets
+# ──────────────────────────────────────────────────────────────────────
+
+
+def test_touch_targets_44px(page: Page, base_url: str) -> None:
+    """Interactive elements meet the 44px minimum touch target on mobile."""
+    page.set_viewport_size(MOBILE_VIEWPORT)
+    page.goto(base_url + "/")
+    page.wait_for_timeout(500)
+
+    # Scope toggle buttons
+    scope_toggle = page.locator('[data-testid="scope-toggle"] button').first
+    if scope_toggle.count() > 0:
+        box = scope_toggle.bounding_box()
+        assert box is not None
+        assert box["height"] >= 44, f"Scope toggle height {box['height']}px < 44px"
+
+    # Theme toggle button
+    theme_toggle = page.locator('[data-testid="theme-toggle"]')
+    if theme_toggle.count() > 0:
+        box = theme_toggle.bounding_box()
+        assert box is not None
+        assert box["height"] >= 44, f"Theme toggle height {box['height']}px < 44px"
+
+    # Bottom nav items
+    nav_items = page.locator(".ht-bottom-nav__item")
+    for i in range(nav_items.count()):
+        box = nav_items.nth(i).bounding_box()
+        assert box is not None
+        assert box["height"] >= 44, f"Bottom nav item {i} height {box['height']}px < 44px"
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Bottom nav does not overlap content
+# ──────────────────────────────────────────────────────────────────────
+
+
+def test_bottom_nav_no_content_overlap(page: Page, base_url: str) -> None:
+    """Content does not visually overlap with the fixed bottom nav."""
+    page.set_viewport_size(MOBILE_VIEWPORT)
+    page.goto(base_url + "/")
+    page.wait_for_timeout(500)
+
+    # Scroll to bottom to expose last content element
+    page.evaluate("window.scrollTo(0, document.body.scrollHeight)")
+    page.wait_for_timeout(300)
+
+    nav_box = page.locator(".ht-bottom-nav").bounding_box()
+    assert nav_box is not None
+
+    # The main content area should have bottom padding preventing overlap.
+    # Check that the main element's bottom (in viewport) is at or above the nav top.
+    main_bottom = page.evaluate("""
+        () => {
+            const main = document.querySelector('.ht-main');
+            if (!main) return 0;
+            const rect = main.getBoundingClientRect();
+            return rect.bottom;
+        }
+    """)
+    # main_bottom should be <= viewport height (i.e., content ends before or at bottom of page)
+    # The padding-bottom on .ht-main ensures content doesn't hide behind the nav
+    viewport_height = MOBILE_VIEWPORT["height"]
+    assert main_bottom <= viewport_height + 1, (
+        f"Main content bottom ({main_bottom}px) exceeds viewport ({viewport_height}px)"
+    )
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Breakpoint boundary
+# ──────────────────────────────────────────────────────────────────────
+
+
+def test_breakpoint_boundary_768px(page: Page, base_url: str) -> None:
+    """At exactly 768px, the card layout shows (768 triggers max-width: 768px)."""
+    page.set_viewport_size(TABLET_VIEWPORT)
+    page.goto(base_url + "/apps")
+    page.wait_for_timeout(500)
+    # At 768px, the mobile card layout should be active (max-width: 768px matches)
+    cards = page.locator(".ht-manifest-card")
+    expect(cards.first).to_be_visible()
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Log table app tag on mobile
+# ──────────────────────────────────────────────────────────────────────
+
+
+def test_log_table_app_tag_at_375px(page: Page, base_url: str) -> None:
+    """Log table on mobile shows app name as tag in message column, no App column header."""
+    page.set_viewport_size(MOBILE_VIEWPORT)
+    page.goto(base_url + "/logs")
+    page.wait_for_timeout(500)
+
+    # App column header should not be visible
+    headers = page.locator(".ht-table-log th")
+    header_texts = [headers.nth(i).text_content() for i in range(headers.count())]
+    assert not any("App" in (t or "") for t in header_texts), f"App header found in: {header_texts}"
+
+    # App name should appear as a tag inside the message column
+    app_tags = page.locator(".ht-log-app-tag")
+    # The e2e fixture seeds entries with app_key="my_app" (and some without)
+    if app_tags.count() > 0:
+        expect(app_tags.first).to_be_visible()
+        expect(app_tags.first).to_have_class(re.compile(r"ht-tag"))

--- a/tests/e2e/test_responsive.py
+++ b/tests/e2e/test_responsive.py
@@ -72,7 +72,6 @@ def test_apps_card_layout_at_375px(page: Page, base_url: str) -> None:
     """Mobile viewport shows app cards, not the dense table."""
     page.set_viewport_size(MOBILE_VIEWPORT)
     page.goto(base_url + "/apps")
-    page.wait_for_timeout(500)
     cards = page.locator(".ht-manifest-card")
     expect(cards.first).to_be_visible()
     dense_table = page.locator("table.ht-table--dense")
@@ -83,7 +82,6 @@ def test_apps_table_layout_at_1024px(page: Page, base_url: str) -> None:
     """Desktop viewport shows the dense table, not cards."""
     page.set_viewport_size(DESKTOP_VIEWPORT)
     page.goto(base_url + "/apps")
-    page.wait_for_timeout(500)
     dense_table = page.locator("table.ht-table--dense")
     expect(dense_table).to_be_visible()
     cards = page.locator(".ht-manifest-card")
@@ -99,7 +97,6 @@ def test_kpi_error_rate_first_at_375px(page: Page, base_url: str) -> None:
     """Error Rate KPI card is the first in the strip on mobile (spans full width)."""
     page.set_viewport_size(MOBILE_VIEWPORT)
     page.goto(base_url + "/")
-    page.wait_for_timeout(500)
     kpi_strip = page.locator('[data-testid="kpi-strip"]')
     first_label = kpi_strip.locator(".ht-health-card__label").first
     expect(first_label).to_have_text("Error Rate")
@@ -114,21 +111,20 @@ def test_touch_targets_44px(page: Page, base_url: str) -> None:
     """Interactive elements meet the 44px minimum touch target on mobile."""
     page.set_viewport_size(MOBILE_VIEWPORT)
     page.goto(base_url + "/")
-    page.wait_for_timeout(500)
 
     # Scope toggle buttons
     scope_toggle = page.locator('[data-testid="scope-toggle"] button').first
-    if scope_toggle.count() > 0:
-        box = scope_toggle.bounding_box()
-        assert box is not None
-        assert box["height"] >= 44, f"Scope toggle height {box['height']}px < 44px"
+    expect(scope_toggle).to_be_visible()
+    box = scope_toggle.bounding_box()
+    assert box is not None
+    assert box["height"] >= 44, f"Scope toggle height {box['height']}px < 44px"
 
     # Theme toggle button
     theme_toggle = page.locator('[data-testid="theme-toggle"]')
-    if theme_toggle.count() > 0:
-        box = theme_toggle.bounding_box()
-        assert box is not None
-        assert box["height"] >= 44, f"Theme toggle height {box['height']}px < 44px"
+    expect(theme_toggle).to_be_visible()
+    box = theme_toggle.bounding_box()
+    assert box is not None
+    assert box["height"] >= 44, f"Theme toggle height {box['height']}px < 44px"
 
     # Bottom nav items
     nav_items = page.locator(".ht-bottom-nav__item")
@@ -183,7 +179,6 @@ def test_breakpoint_boundary_768px(page: Page, base_url: str) -> None:
     """At exactly 768px, the card layout shows (768 triggers max-width: 768px)."""
     page.set_viewport_size(TABLET_VIEWPORT)
     page.goto(base_url + "/apps")
-    page.wait_for_timeout(500)
     # At 768px, the mobile card layout should be active (max-width: 768px matches)
     cards = page.locator(".ht-manifest-card")
     expect(cards.first).to_be_visible()
@@ -198,7 +193,6 @@ def test_log_table_app_tag_at_375px(page: Page, base_url: str) -> None:
     """Log table on mobile shows app name as tag in message column, no App column header."""
     page.set_viewport_size(MOBILE_VIEWPORT)
     page.goto(base_url + "/logs")
-    page.wait_for_timeout(500)
 
     # App column header should not be visible
     headers = page.locator(".ht-table-log th")

--- a/tests/e2e/test_responsive.py
+++ b/tests/e2e/test_responsive.py
@@ -57,11 +57,10 @@ def test_bottom_nav_navigation(page: Page, base_url: str, testid: str, expected_
     page.set_viewport_size(MOBILE_VIEWPORT)
     page.goto(base_url + "/")
     page.locator(f'[data-testid="{testid}"]').click()
-    page.wait_for_timeout(300)
     if expected_path == "/":
         expect(page).to_have_url(base_url + "/")
     else:
-        assert page.url.rstrip("/").endswith(expected_path.rstrip("/"))
+        expect(page).to_have_url(re.compile(re.escape(expected_path.rstrip("/")) + r"/?$"))
 
 
 # ──────────────────────────────────────────────────────────────────────
@@ -154,19 +153,23 @@ def test_bottom_nav_no_content_overlap(page: Page, base_url: str) -> None:
     page.evaluate("() => { const m = document.querySelector('.ht-main'); if (m) m.scrollTop = m.scrollHeight; }")
     page.wait_for_timeout(300)
 
-    nav_box = page.locator(".ht-bottom-nav").bounding_box()
-    assert nav_box is not None
-
-    # Find the last content child inside .ht-main and verify it doesn't overlap with the bottom nav.
-    last_content_bottom = page.evaluate("""
+    # Use getBoundingClientRect for both elements so coordinates are in the same
+    # viewport-relative system (bounding_box uses document coordinates which
+    # differ from viewport coordinates after scrolling).
+    overlap = page.evaluate("""
         () => {
             const main = document.querySelector('.ht-main');
-            if (!main || !main.lastElementChild) return 0;
-            return main.lastElementChild.getBoundingClientRect().bottom;
+            if (!main || !main.lastElementChild) return null;
+            const nav = document.querySelector('.ht-bottom-nav');
+            if (!nav) return null;
+            const contentBottom = main.lastElementChild.getBoundingClientRect().bottom;
+            const navTop = nav.getBoundingClientRect().top;
+            return { contentBottom, navTop };
         }
     """)
-    assert last_content_bottom <= nav_box["y"] + 1, (
-        f"Last content element bottom ({last_content_bottom}px) overlaps bottom nav top ({nav_box['y']}px)"
+    assert overlap is not None, "Could not find .ht-main content or .ht-bottom-nav"
+    assert overlap["contentBottom"] <= overlap["navTop"] + 1, (
+        f"Last content element bottom ({overlap['contentBottom']}px) overlaps bottom nav top ({overlap['navTop']}px)"
     )
 
 
@@ -203,7 +206,6 @@ def test_log_table_app_tag_at_375px(page: Page, base_url: str) -> None:
 
     # App name should appear as a tag inside the message column
     app_tags = page.locator(".ht-log-app-tag")
-    # The e2e fixture seeds entries with app_key="my_app" (and some without)
-    if app_tags.count() > 0:
-        expect(app_tags.first).to_be_visible()
-        expect(app_tags.first).to_have_class(re.compile(r"ht-tag"))
+    assert app_tags.count() > 0, "Expected at least one .ht-log-app-tag element"
+    expect(app_tags.first).to_be_visible()
+    expect(app_tags.first).to_have_class(re.compile(r"ht-tag"))

--- a/tests/e2e/test_responsive.py
+++ b/tests/e2e/test_responsive.py
@@ -5,11 +5,11 @@ import re
 import pytest
 from playwright.sync_api import Page, expect
 
+from tests.e2e.conftest import DESKTOP_VIEWPORT, MOBILE_VIEWPORT
+
 pytestmark = pytest.mark.e2e
 
-MOBILE_VIEWPORT = {"width": 375, "height": 812}
 TABLET_VIEWPORT = {"width": 768, "height": 1024}
-DESKTOP_VIEWPORT = {"width": 1024, "height": 768}
 
 
 # ──────────────────────────────────────────────────────────────────────

--- a/tests/e2e/test_responsive.py
+++ b/tests/e2e/test_responsive.py
@@ -149,8 +149,9 @@ def test_bottom_nav_no_content_overlap(page: Page, base_url: str) -> None:
     page.goto(base_url + "/")
     page.wait_for_timeout(500)
 
-    # Scroll the inner .ht-main container (not window — .ht-main is the scroll container)
-    page.evaluate("() => { const m = document.querySelector('.ht-main'); if (m) m.scrollTop = m.scrollHeight; }")
+    # Scroll the window to the bottom — .ht-main uses min-height (not height),
+    # so it grows to fit content and the actual scroll container is the viewport.
+    page.evaluate("window.scrollTo(0, document.documentElement.scrollHeight)")
     page.wait_for_timeout(300)
 
     # Use getBoundingClientRect for both elements so coordinates are in the same

--- a/tests/e2e/test_responsive.py
+++ b/tests/e2e/test_responsive.py
@@ -150,28 +150,23 @@ def test_bottom_nav_no_content_overlap(page: Page, base_url: str) -> None:
     page.goto(base_url + "/")
     page.wait_for_timeout(500)
 
-    # Scroll to bottom to expose last content element
-    page.evaluate("window.scrollTo(0, document.body.scrollHeight)")
+    # Scroll the inner .ht-main container (not window — .ht-main is the scroll container)
+    page.evaluate("() => { const m = document.querySelector('.ht-main'); if (m) m.scrollTop = m.scrollHeight; }")
     page.wait_for_timeout(300)
 
     nav_box = page.locator(".ht-bottom-nav").bounding_box()
     assert nav_box is not None
 
-    # The main content area should have bottom padding preventing overlap.
-    # Check that the main element's bottom (in viewport) is at or above the nav top.
-    main_bottom = page.evaluate("""
+    # Find the last content child inside .ht-main and verify it doesn't overlap with the bottom nav.
+    last_content_bottom = page.evaluate("""
         () => {
             const main = document.querySelector('.ht-main');
-            if (!main) return 0;
-            const rect = main.getBoundingClientRect();
-            return rect.bottom;
+            if (!main || !main.lastElementChild) return 0;
+            return main.lastElementChild.getBoundingClientRect().bottom;
         }
     """)
-    # main_bottom should be <= viewport height (i.e., content ends before or at bottom of page)
-    # The padding-bottom on .ht-main ensures content doesn't hide behind the nav
-    viewport_height = MOBILE_VIEWPORT["height"]
-    assert main_bottom <= viewport_height + 1, (
-        f"Main content bottom ({main_bottom}px) exceeds viewport ({viewport_height}px)"
+    assert last_content_bottom <= nav_box["y"] + 1, (
+        f"Last content element bottom ({last_content_bottom}px) overlaps bottom nav top ({nav_box['y']}px)"
     )
 
 


### PR DESCRIPTION
## Summary

- **Color system overhaul**: reserve emerald accent for status indicators only, introduce muted emerald for interactive elements, increase surface contrast in dark mode, fix light-mode WCAG AA compliance, add card depth via border highlights
- **Full responsive mobile adaptation**: bottom navigation bar, app manifest card view, KPI strip reflow (Error Rate first + full-width on mobile), log table with relative timestamps and abbreviated levels, sticky status bar, 44px touch targets, safe-area padding
- **Visual QA fixes**: full-width log row expansion on mobile, duration formatting bug, warning→checkmark icon on healthy state, status badge unification across pages, instance count display consistency
- **Design system**: new `design/context.md` with complete token documentation, design critique audit, responsive-mobile design doc with 4 work packages

### New components
- `BottomNav` — fixed mobile navigation (4 tabs, hidden >=768px)
- `ManifestCardList` — card-based app list for mobile (<768px)
- `useMediaQuery` hook with `BREAKPOINT_MOBILE` constant
- `useManifestState` hook (extracted from ManifestList)

### Tests
- 24 new frontend unit tests across 6 new test files
- 13 new E2E Playwright tests for responsive behavior (bottom nav, card/table switching, KPI reflow, touch targets, content overlap)
- All 1416 existing tests pass with 0 regressions
