### PR TITLE
ci: install fd-find so docker requirements tests run in CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -96,6 +96,9 @@ jobs:
             - name: Checkout code
               uses: actions/checkout@v4
 
+            - name: Install fd-find
+              run: sudo apt-get update && sudo apt-get install -y fd-find
+
             - name: Install uv and set the Python version
               uses: astral-sh/setup-uv@v6
               with:


### PR DESCRIPTION
## Summary
Install `fd-find` in CI so the 5 Docker requirements discovery tests actually run.

## Motivation
Fixes #637

The 5 tests in `tests/test_docker_requirements_discovery.py` are skipped on every CI run because GitHub Actions runners don't have `fd` (or `fdfind`) installed. The tests guard with `@pytest.mark.skipif(fd_path is None)`, so they pass silently — but never execute. Locally (where `fd` is installed) all 5 run and pass (2539 passed vs CI's 2534 passed + 5 skipped).

## Changes
- Add `sudo apt-get install -y fd-find` step to the `test` job in `tests.yml`, before `uv sync`
- The binary is `fdfind` on Ubuntu; the test already checks for both `fd` and `fdfind` names via `shutil.which()`

## Verification
- CI should show 0 skipped tests (currently 5 skipped)
- All 5 `test_docker_requirements_discovery` tests should run and pass
