### PR TITLE
ci: bump Node 20-era actions to Node 24-compatible releases

### DIFF
--- a/.github/workflows/build_and_publish_image.yml
+++ b/.github/workflows/build_and_publish_image.yml
@@ -46,26 +46,26 @@ jobs:
             PYTHON_VERSION: ${{ matrix.python-version }}
             IS_RELEASE: ${{ github.event_name == 'workflow_call' || github.event_name == 'workflow_dispatch' }}
         steps:
-            - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+            - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
               with:
                   ref: ${{ inputs.tag_name || github.ref }}
                   persist-credentials: false
 
             - name: Set up QEMU
-              uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3
+              uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3 # v4
 
             - name: Set up Docker Buildx
-              uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
+              uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4
 
             - name: Login to GHCR
-              uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
+              uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4
               with:
                   registry: ${{ env.REGISTRY }}
                   username: ${{ github.actor }}
                   password: ${{ secrets.GITHUB_TOKEN }}
 
             - name: Install uv
-              uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6
+              uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8
               with:
                   activate-environment: true
                   enable-cache: false
@@ -92,7 +92,7 @@ jobs:
 
             - name: Docker metadata
               id: meta
-              uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5
+              uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9 # v6
               with:
                   images: ${{ env.REGISTRY }}/${{ env.OWNER }}/${{ env.IMAGE_NAME }}
                   flavor: |
@@ -108,7 +108,7 @@ jobs:
               # Fork-PR guard: skip only when the PR comes from a fork (forks can't push to GHCR).
               # push/workflow_call/workflow_dispatch always publish.
               if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
-              uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
+              uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7
               with:
                   context: .
                   push: true

--- a/.github/workflows/docker-tests.yml
+++ b/.github/workflows/docker-tests.yml
@@ -25,15 +25,15 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           persist-credentials: false
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4
 
       - name: Build Docker image
-        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7
         with:
           context: .
           load: true
@@ -44,7 +44,7 @@ jobs:
             PYTHON_VERSION=${{ matrix.python-version }}
 
       - name: Install uv
-        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8
         with:
           enable-cache: false
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -28,12 +28,12 @@ jobs:
 
         steps:
             - name: Checkout code
-              uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+              uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
               with:
                 persist-credentials: false
 
             - name: Install uv and set the Python version
-              uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6
+              uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8
               with:
                   python-version: "3.13"
 
@@ -48,7 +48,7 @@ jobs:
               run: uv run python tools/docs/check_snippet_orphans.py
 
             - name: Upload site artifact
-              uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+              uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
               with:
                   name: docs-site
                   path: site/
@@ -61,13 +61,13 @@ jobs:
 
         steps:
             - name: Download site artifact
-              uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+              uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
               with:
                   name: docs-site
                   path: site/
 
             - name: Set up Go
-              uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5
+              uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
               with:
                   go-version: "stable"
                   cache: false
@@ -98,12 +98,12 @@ jobs:
 
         steps:
             - name: Checkout code
-              uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+              uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
               with:
                 persist-credentials: false
 
             - name: Install uv and set the Python version
-              uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6
+              uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8
               with:
                   python-version: "3.13"
 

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -16,10 +16,10 @@ jobs:
         outputs:
             code: ${{ steps.filter.outputs.code }}
         steps:
-            - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+            - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
               with:
                 persist-credentials: false
-            - uses: dorny/paths-filter@d1c1ffe0248fe513906c8e24db8ea791d46f8590 # v3
+            - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4
               id: filter
               with:
                   filters: |
@@ -48,12 +48,12 @@ jobs:
 
         steps:
             - name: Checkout code
-              uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+              uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
               with:
                 persist-credentials: false
 
             - name: Install uv and set the Python version
-              uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6
+              uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8
               with:
                   python-version: ${{ matrix.python-version }}
 
@@ -64,7 +64,7 @@ jobs:
 
             - name: Upload test results
               if: failure()
-              uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+              uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
               with:
                   name: e2e-test-results
                   path: test-results/

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -19,10 +19,10 @@ jobs:
             docs: ${{ steps.filter.outputs.docs }}
             codegen: ${{ steps.filter.outputs.codegen }}
         steps:
-            - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+            - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
               with:
                 persist-credentials: false
-            - uses: dorny/paths-filter@d1c1ffe0248fe513906c8e24db8ea791d46f8590 # v3
+            - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4
               id: filter
               with:
                   filters: |
@@ -60,12 +60,12 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Checkout code
-              uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+              uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
               with:
                 persist-credentials: false
 
             - name: Install uv and set the Python version
-              uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6
+              uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8
               with:
                   python-version: "3.13"
 
@@ -77,7 +77,7 @@ jobs:
                   install-only: true
 
             - name: Cache prek environments
-              uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+              uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
               with:
                   path: ~/.cache/prek
                   key: prek-${{ runner.os }}-${{ hashFiles('.pre-commit-config.yaml') }}
@@ -110,19 +110,19 @@ jobs:
         if: needs.changes.outputs.frontend == 'true' || github.event_name == 'workflow_dispatch'
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+            - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
               with:
                 persist-credentials: false
 
             - name: Set up Node.js
-              uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+              uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
               with:
                   node-version: "22"
                   cache: "npm"
                   cache-dependency-path: frontend/package-lock.json
 
             - name: Install uv
-              uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6
+              uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8
 
             - name: Install frontend dependencies
               run: npm ci
@@ -167,21 +167,21 @@ jobs:
         if: needs.changes.outputs.codegen == 'true' || github.event_name == 'workflow_dispatch'
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+            - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
               with:
                 persist-credentials: false
 
             - name: Set up Python 3.14
-              uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+              uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
               with:
                   python-version: "3.14"
 
             - name: Install uv
-              uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5
+              uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8
 
             - name: Cache HA core checkout
               id: cache-ha
-              uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+              uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
               with:
                   path: ha-core
                   key: ha-core-${{ hashFiles('codegen/ha-version.txt') }}
@@ -218,12 +218,12 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Checkout code
-              uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+              uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
               with:
                 persist-credentials: false
 
             - name: Install uv
-              uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6
+              uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8
               with:
                   python-version: "3.13"
 
@@ -239,12 +239,12 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Checkout code
-              uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+              uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
               with:
                 persist-credentials: false
 
             - name: Install uv
-              uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6
+              uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8
               with:
                   python-version: "3.13"
 
@@ -260,7 +260,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Checkout code
-              uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+              uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
               with:
                 persist-credentials: false
 

--- a/.github/workflows/pr-screenshots.yml
+++ b/.github/workflows/pr-screenshots.yml
@@ -22,7 +22,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Checkout code
-              uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+              uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
               with:
                 persist-credentials: false
 

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -12,7 +12,7 @@ jobs:
         runs-on: ubuntu-latest
         timeout-minutes: 5
         steps:
-            - uses: amannn/action-semantic-pull-request@e32d7e603df1aa1ba07e981f2a23455dee596825 # v5
+            - uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6
               env:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
               with:

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -28,13 +28,13 @@ jobs:
             tag_name: ${{ steps.release.outputs.tag_name }}
             pr: ${{ steps.release.outputs.pr }}
         steps:
-            - uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1
+            - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
               id: app-token
               with:
                   app-id: ${{ secrets.RELEASE_PLEASE_APP_ID }}
                   private-key: ${{ secrets.RELEASE_PLEASE_APP_PRIVATE_KEY }}
 
-            - uses: googleapis/release-please-action@5c625bfb5d1ff62eadeeb3772007f7f66fdcf071 # v4
+            - uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5
               id: release
               with:
                   token: ${{ steps.app-token.outputs.token }}
@@ -48,20 +48,20 @@ jobs:
         runs-on: ubuntu-latest
         timeout-minutes: 10
         steps:
-            - uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1
+            - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
               id: app-token
               with:
                   app-id: ${{ secrets.RELEASE_PLEASE_APP_ID }}
                   private-key: ${{ secrets.RELEASE_PLEASE_APP_PRIVATE_KEY }}
 
-            - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+            - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
               with:
                   ref: ${{ fromJSON(needs.release-please.outputs.pr).headBranchName }}
                   token: ${{ steps.app-token.outputs.token }}
                   persist-credentials: false
 
             - name: Install uv
-              uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6
+              uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8
               with:
                   enable-cache: true
 
@@ -95,19 +95,19 @@ jobs:
         permissions:
             contents: read
         steps:
-            - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+            - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
               with:
                   ref: ${{ needs.release-please.outputs.tag_name || inputs.tag_name }}
                   persist-credentials: false
 
             - name: Install uv
-              uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6
+              uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8
               with:
                   activate-environment: true
                   enable-cache: true
 
             - name: Set up Node.js
-              uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+              uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
               with:
                   node-version: "22"
                   cache: "npm"
@@ -136,7 +136,7 @@ jobs:
               run: uv run ./tools/release/check_wheel_spa.py
 
             - name: Publish build artifacts
-              uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+              uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
               with:
                   name: pypi-dists
                   path: "./dist"
@@ -155,7 +155,7 @@ jobs:
             id-token: write
         steps:
             - name: Download build artifacts
-              uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+              uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
               with:
                   name: pypi-dists
                   path: "./dist"
@@ -250,7 +250,7 @@ jobs:
 
             - name: Verify package on PyPI
               if: needs.publish-pypi.result == 'success'
-              uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+              uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
               with:
                   ref: ${{ needs.release-please.outputs.tag_name || inputs.tag_name }}
                   sparse-checkout: tools/release/check_pypi_wheel.py

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,10 +16,10 @@ jobs:
         outputs:
             code: ${{ steps.filter.outputs.code }}
         steps:
-            - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+            - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
               with:
                 persist-credentials: false
-            - uses: dorny/paths-filter@d1c1ffe0248fe513906c8e24db8ea791d46f8590 # v3
+            - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4
               id: filter
               with:
                   filters: |
@@ -39,19 +39,19 @@ jobs:
         runs-on: ubuntu-latest
         timeout-minutes: 10
         steps:
-            - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+            - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
               with:
                 persist-credentials: false
 
             - name: Install uv and set the Python version
-              uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6
+              uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8
               with:
                   python-version: "3.13"
 
             - run: uv sync
 
             - name: Set up Node.js
-              uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+              uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
               with:
                   node-version: "22"
                   cache: "npm"
@@ -66,7 +66,7 @@ jobs:
               working-directory: frontend
 
             - name: Upload frontend coverage
-              uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+              uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
               with:
                   name: frontend-coverage
                   path: frontend/coverage/lcov.info
@@ -109,7 +109,7 @@ jobs:
 
         steps:
             - name: Checkout code
-              uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+              uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
               with:
                 persist-credentials: false
 
@@ -117,7 +117,7 @@ jobs:
               run: sudo apt-get update && sudo apt-get install -y fd-find
 
             - name: Install uv and set the Python version
-              uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6
+              uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8
               with:
                   python-version: ${{ matrix.python-version }}
 
@@ -127,7 +127,7 @@ jobs:
               run: uv run nox -t coverage -p ${{ matrix.python-version }}
 
             - name: Upload coverage data
-              uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+              uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
               with:
                   name: .coverage.${{ matrix.python-version }}
                   path: .coverage.${{ matrix.python-version }}
@@ -149,12 +149,12 @@ jobs:
 
         steps:
             - name: Checkout code
-              uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+              uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
               with:
                 persist-credentials: false
 
             - name: Install uv
-              uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6
+              uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8
               with:
                   python-version: ${{ matrix.python-version }}
 
@@ -164,7 +164,7 @@ jobs:
               run: uv run nox -s system_with_coverage -p ${{ matrix.python-version }}
 
             - name: Upload coverage data
-              uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+              uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
               with:
                   name: .coverage.system.${{ matrix.python-version }}
                   path: .coverage.system.${{ matrix.python-version }}
@@ -179,12 +179,12 @@ jobs:
             (needs.frontend.result == 'success' || needs.test.result == 'success' || needs.system.result == 'success')
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+            - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
               with:
                 persist-credentials: false
 
             - name: Install uv and set the Python version
-              uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6
+              uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8
               with:
                   python-version: 3.11
 
@@ -193,14 +193,14 @@ jobs:
                   uv venv
                   uv pip install -U 'coverage[toml]'
 
-            - uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5
+            - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
               with:
                   path: coverage-parts
                   pattern: .coverage.*
                   merge-multiple: true
 
             - name: Download frontend coverage
-              uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5
+              uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
               with:
                   name: frontend-coverage
                   path: frontend-coverage
@@ -212,13 +212,13 @@ jobs:
                   uv run coverage report
 
             - name: Upload HTML report (artifact)
-              uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+              uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
               with:
                   name: coverage-html
                   path: htmlcov
 
             - name: Upload XML for integrations
-              uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+              uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
               with:
                   name: coverage-xml
                   path: coverage.xml


### PR DESCRIPTION
## Summary

GitHub made Node 24 the default Actions runtime on 2026-06-16 and will **remove Node 20 entirely on 2026-09-16**. Every action still pinned to a Node 20-era release would start warning now and break in September. This re-pins all of them to their latest Node 24-compatible release.

The change is purely mechanical: each `uses:` line keeps its SHA pin and `# vN` comment convention — only the SHA and version label move.

### Action bumps

All 19 distinct node20-era pins, updated uniformly across 10 workflow files:

- **`actions/*`** — checkout `v4→v7`, upload-artifact `v4→v7`, download-artifact `v4/v5→v8`, setup-node `v4→v6`, setup-python `v5→v6`, setup-go `v5→v6`, cache `v4→v5`, create-github-app-token `v1→v3`
- **`astral-sh/setup-uv`** — `v5/v6→v8` (the split v5/v6 pins are normalized to a single v8)
- **`docker/*`** — setup-qemu `v3→v4`, setup-buildx `v3→v4`, login `v3→v4`, metadata `v5→v6`, build-push `v6→v7`
- **`googleapis/release-please-action`** `v4→v5`, **`dorny/paths-filter`** `v3→v4`, **`amannn/action-semantic-pull-request`** `v5→v6`

The issue named 7 files; the actual node20 surface spanned 10 (it also missed `pr-title.yml`, `pr-screenshots.yml`, and several `actions/*` helpers). Composite actions (`pypa/gh-action-pypi-publish`, `codecov/codecov-action`, `lycheeverse/lychee-action`) have no Node runtime and `j178/prek-action` was already node24 — all left unchanged.

### Verification

- Confirmed each **old** pin reported `using: node20` and each **new** pin reports `using: node24` (read each action's `action.yml` at the pinned ref).
- Each new SHA is the exact commit its version tag points to (`gh api repos/<repo>/commits/<tag>`).
- All workflows still parse as YAML; the `zizmor` Actions-security pre-commit hook passed.

### Reviewer notes

A code-reviewer pass initially flagged a `release-please-action` v5 input rename (`config-file`/`manifest-file`). Checked against the v5 `action.yml` at the pinned SHA — both inputs are still valid in v5, so no change was made; the suggested "fix" would have passed unknown inputs.

Most workflows are exercised the moment this PR opens (tests, lint, docs, e2e, docker-tests, pr-title, paths-filter). The two paths a PR can't exercise — **release-please/PyPI publish** and **docker image publish** (push-to-main / release only) — are worth a watchful eye on the first release after merge.

Closes #1065
