### PR TITLE
chore: bump Home Assistant test image to 2026.6 and add self-hosted Renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,38 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "description": [
+    "Per-repo Renovate config, processed by the self-hosted runner on smithfamily.",
+    "docker-compose managerFilePatterns lists both patterns explicitly: the standard compose pattern (covers tests/system/docker-compose.yml) and ha-demo.yml (covers scripts/docker/ha-demo.yml, which is not named compose* and would otherwise be missed).",
+    "ignorePaths replaces config:recommended's defaults so tests/ is NOT ignored (the CI compose file lives under tests/), while the docs snippet compose files are excluded.",
+    "chore(deps) commits keep dependency bumps out of the release-please changelog."
+  ],
+  "extends": ["config:recommended"],
+  "schedule": ["before 9am on monday"],
+  "timezone": "America/New_York",
+  "semanticCommits": "enabled",
+  "semanticCommitType": "chore",
+  "semanticCommitScope": "deps",
+  "prConcurrentLimit": 5,
+  "ignorePaths": ["docs/**", "**/node_modules/**"],
+  "docker-compose": {
+    "managerFilePatterns": [
+      "/(^|/)(docker-)?compose[^/]*\\.ya?ml$/",
+      "/(^|/)ha-demo\\.ya?ml$/"
+    ]
+  },
+  "packageRules": [
+    {
+      "description": "Group both compose files' HA image bumps into one PR",
+      "matchDatasources": ["docker"],
+      "matchPackageNames": ["homeassistant/home-assistant"],
+      "groupName": "home-assistant image"
+    },
+    {
+      "description": "Major HA jumps (year rollover) wait for dashboard approval",
+      "matchDatasources": ["docker"],
+      "matchPackageNames": ["homeassistant/home-assistant"],
+      "matchUpdateTypes": ["major"],
+      "dependencyDashboardApproval": true
+    }
+  ]
+}

--- a/scripts/docker/ha-demo.yml
+++ b/scripts/docker/ha-demo.yml
@@ -1,6 +1,6 @@
 services:
   homeassistant:
-    image: homeassistant/home-assistant:2025.3
+    image: homeassistant/home-assistant:2026.6
     container_name: "hassette-demo-ha-${HA_PORT:-8123}"
     ports:
       - "${HA_PORT:-8123}:8123"

--- a/tests/fixtures/demo-ha-config/.storage/auth
+++ b/tests/fixtures/demo-ha-config/.storage/auth
@@ -57,7 +57,7 @@
         "last_used_ip": null,
         "expire_at": null,
         "credential_id": null,
-        "version": "2025.3.4"
+        "version": "2026.6.3"
       }
     ]
   }

--- a/tests/fixtures/ha-config/.storage/auth
+++ b/tests/fixtures/ha-config/.storage/auth
@@ -57,7 +57,7 @@
         "last_used_ip": null,
         "expire_at": null,
         "credential_id": null,
-        "version": "2025.3.4"
+        "version": "2026.6.3"
       }
     ]
   }

--- a/tests/system/docker-compose.yml
+++ b/tests/system/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   homeassistant:
-    image: homeassistant/home-assistant:2025.3
+    image: homeassistant/home-assistant:2026.6
     container_name: hassette-system-ha
     volumes:
       - ${HA_CONFIG_PATH:-../../tests/fixtures/ha-config}:/config

--- a/tests/system/generate_ha_fixtures.py
+++ b/tests/system/generate_ha_fixtures.py
@@ -107,7 +107,10 @@ def write_auth() -> None:
                     "last_used_ip": None,
                     "expire_at": None,
                     "credential_id": None,
-                    "version": "2025.3.4",
+                    # Cosmetic: the HA version that minted this token. HA records it
+                    # but does not use it for JWT/bcrypt validation. Keep loosely in
+                    # sync with the image tag in tests/system/docker-compose.yml.
+                    "version": "2026.6.3",
                 }
             ],
         },


### PR DESCRIPTION
## Summary

- Bumps the Home Assistant Docker image used by the system tests and the demo stack from `2025.3` (~15 months old) to `2026.6` (`2026.6.3`).
- Adds `renovate.json` so the self-hosted Renovate runner keeps the image — and other dependencies — current going forward.

## Why

The image tag was pinned and nothing watched it, so it silently aged 15 months. Renovate closes that gap: when a new HA release lands it opens a `chore(deps)` PR, which CI's `system` job validates against the fixtures before merge.

## Verification

- HA 2026.6.3 boots against the committed fixtures, auth (the long-lived JWT) returns 200, and the instance reaches `RUNNING` — only benign recorder schema migrations in the log.
- Full `nox -s system` suite: **60 passed**.
- `renovate.json` validated with `renovate-config-validator --strict`.
- A real self-hosted Renovate dry-run against this repo confirms `tests/system/docker-compose.yml` is detected by Renovate's default docker-compose manager; the `ha-demo.yml` file-match regex was verified against its path with Renovate's regex engine.
- e2e uses a mock backend (no HA image), so the bump does not affect it.

## Renovate config

The new `renovate.json` is the per-repo config for the self-hosted runner on `smithfamily`:

- Tracks the HA image in both compose files, plus frontend npm, uv, and the SHA-pinned GitHub Actions.
- `chore(deps)` commit prefix keeps dependency bumps out of the release-please changelog.
- Major HA jumps (year rollover) wait for Dependency Dashboard approval; minor bumps auto-open.
- `docs/**` is ignored so the teaching-example compose snippets are left alone.

Companion change (separate repo): `NodeJSmith/hassette` was added to the runner's repository list in `homelab`.

## Note

The custom `ha-demo.yml` file-match and the `docs/**` ignore only take full effect once this `renovate.json` is on `main` — Renovate reads repo config from the default branch. The first run after merge (Monday's timer, or a manual trigger) will surface both on the Dependency Dashboard.
