### PR TITLE
test: harden local pytest runs (dot-dirs, xdist order, venv scan)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -126,7 +126,9 @@ module-name = "hassette"
 
 [tool.pytest.ini_options]
 pythonpath = ["src", "tools", "tools/frontend", "scripts"]
-norecursedirs = ["codegen", "tests/pyright_probes"]
+# ".*" restores pytest's default skip of dot-directories, which a custom norecursedirs otherwise
+# clobbers — without it, collection descends into .claude/worktrees, .venv, .nox from the repo root.
+norecursedirs = [".*", "codegen", "tests/pyright_probes"]
 asyncio_mode = "auto"
 asyncio_default_fixture_loop_scope = "session"
 asyncio_default_test_loop_scope = "session"

--- a/tests/unit/test_forgotten_await_completeness.py
+++ b/tests/unit/test_forgotten_await_completeness.py
@@ -424,8 +424,12 @@ def _bus_call(method_name: str):
     return _calls[method_name]
 
 
-# add_listener is handled separately (requires a Listener object)
-_BUS_METHODS_PARAMETRIZED = [m for m in CANONICAL_PROTECTED[Bus] if m != "add_listener"]
+# add_listener is handled separately (requires a Listener object).
+# sorted() pins the parametrize order: CANONICAL_PROTECTED[Bus] is a set, and unsorted set
+# iteration order varies with PYTHONHASHSEED across processes. Without the sort, xdist workers
+# collect these cases in different orders and abort with "Different tests were collected between
+# gw0 and gwN" under `-n` (the suite only survived because pytest-randomly syncs the seed).
+_BUS_METHODS_PARAMETRIZED = sorted(m for m in CANONICAL_PROTECTED[Bus] if m != "add_listener")
 
 # Scheduler fixtures
 
@@ -471,8 +475,9 @@ def _sched_call(method_name: str):
     return _calls[method_name]
 
 
-# add_job is handled separately (requires a ScheduledJob object)
-_SCHED_METHODS_PARAMETRIZED = [m for m in CANONICAL_PROTECTED[Scheduler] if m != "add_job"]
+# add_job is handled separately (requires a ScheduledJob object).
+# sorted() for the same cross-process determinism reason as _BUS_METHODS_PARAMETRIZED above.
+_SCHED_METHODS_PARAMETRIZED = sorted(m for m in CANONICAL_PROTECTED[Scheduler] if m != "add_job")
 
 # Api fixtures
 

--- a/tests/unit/tools/test_exclusion_parity.py
+++ b/tests/unit/tools/test_exclusion_parity.py
@@ -1,0 +1,13 @@
+"""Guard: the two venv/cache exclusion sets stay in sync.
+
+tools/check_for_missing_attribute.py duplicates lint_helpers.EXCLUDED_PARTS inline because it runs
+as a standalone ``uv run --script`` (isolated env — it can't import lint_helpers). This test fails
+if the copies drift, so the duplication can't silently diverge.
+"""
+
+from check_for_missing_attribute import EXCLUDED_PARTS as STANDALONE_EXCLUDED
+from lint_helpers import EXCLUDED_PARTS as SHARED_EXCLUDED
+
+
+def test_exclusion_sets_match() -> None:
+    assert set(STANDALONE_EXCLUDED) == set(SHARED_EXCLUDED)

--- a/tools/check_for_missing_attribute.py
+++ b/tools/check_for_missing_attribute.py
@@ -8,7 +8,7 @@ ROOT = Path("src")
 # Mirror of lint_helpers.EXCLUDED_PARTS — duplicated (not imported) because this file runs as a
 # standalone `uv run --script` in an isolated env. tests/unit/tools/test_exclusion_parity.py asserts
 # the two stay equal so the copies can't silently drift.
-EXCLUDED_PARTS = {".venv", "site-packages", "__pycache__", ".nox", ".git", "node_modules"}
+EXCLUDED_PARTS = frozenset({".venv", "site-packages", "__pycache__", ".nox", ".git", "node_modules"})
 
 
 class StateInfo:
@@ -23,7 +23,7 @@ class StateInfo:
 
 def iter_py_files(root: Path):
     for path in root.rglob("*.py"):
-        if any(part in EXCLUDED_PARTS for part in path.parts):
+        if any(part in EXCLUDED_PARTS for part in path.relative_to(root).parts):
             continue
         yield path
 

--- a/tools/check_for_missing_attribute.py
+++ b/tools/check_for_missing_attribute.py
@@ -17,9 +17,11 @@ class StateInfo:
 
 
 def iter_py_files(root: Path):
+    # Canonical exclusion set is lint_helpers.EXCLUDED_PARTS; kept in sync inline here because this
+    # file runs as a standalone `uv run --script` (isolated env — it can't import lint_helpers).
+    excluded = {".venv", "site-packages", "__pycache__", ".nox", ".git", "node_modules"}
     for path in root.rglob("*.py"):
-        # Skip caches/venv/build-ish
-        if any(part in {".venv", "__pycache__", ".nox"} for part in path.parts):
+        if any(part in excluded for part in path.parts):
             continue
         yield path
 

--- a/tools/check_for_missing_attribute.py
+++ b/tools/check_for_missing_attribute.py
@@ -5,6 +5,11 @@ from typing import cast
 
 ROOT = Path("src")
 
+# Mirror of lint_helpers.EXCLUDED_PARTS — duplicated (not imported) because this file runs as a
+# standalone `uv run --script` in an isolated env. tests/unit/tools/test_exclusion_parity.py asserts
+# the two stay equal so the copies can't silently drift.
+EXCLUDED_PARTS = {".venv", "site-packages", "__pycache__", ".nox", ".git", "node_modules"}
+
 
 class StateInfo:
     def __init__(self, file, class_name, lineno, has_attributes_field, nested_attr_classes, module_attr_classes):
@@ -17,11 +22,8 @@ class StateInfo:
 
 
 def iter_py_files(root: Path):
-    # Canonical exclusion set is lint_helpers.EXCLUDED_PARTS; kept in sync inline here because this
-    # file runs as a standalone `uv run --script` (isolated env — it can't import lint_helpers).
-    excluded = {".venv", "site-packages", "__pycache__", ".nox", ".git", "node_modules"}
     for path in root.rglob("*.py"):
-        if any(part in excluded for part in path.parts):
+        if any(part in EXCLUDED_PARTS for part in path.parts):
             continue
         yield path
 

--- a/tools/lint_helpers.py
+++ b/tools/lint_helpers.py
@@ -75,13 +75,11 @@ def docstring_spans(tree: ast.AST) -> list[tuple[int, int]]:
 def iter_py_files(repo_root: Path, scan_dirs: list[str]) -> list[Path]:
     """Return every first-party .py file under the given repo-relative directories, sorted.
 
-    Skips virtualenv, cache, and build directories (notably the nested ``codegen/.venv``) so the
-    linters scan first-party source only, never installed third-party packages.
+    Skips the dirs in EXCLUDED_PARTS so the linters never scan installed third-party packages —
+    notably the nested ``codegen/.venv``.
     """
-    # A file is first-party when none of its repo-relative path components is an excluded dir.
-    # relative_to(repo_root) scopes the check to the repo itself, so an ancestor directory that
-    # happens to share an excluded name (e.g. a checkout under /opt/node_modules/...) can't blank
-    # the scan.
+    # relative_to(repo_root) scopes the check to repo-internal components, so an ancestor directory
+    # sharing an excluded name (e.g. a checkout under /opt/node_modules/) can't blank the scan.
     return sorted(
         path
         for scan_dir in scan_dirs

--- a/tools/lint_helpers.py
+++ b/tools/lint_helpers.py
@@ -11,6 +11,12 @@ import ast
 from collections.abc import Callable
 from pathlib import Path
 
+#: Directory components that are never first-party source: virtualenvs (notably the nested
+#: ``codegen/.venv``), caches, and build output. Without this filter, rglob over the ``codegen``
+#: scan dir pulls in third-party site-packages and reports them as house-style violations — which
+#: fails the linters' own characterization tests on any machine that has a local ``codegen/.venv``.
+EXCLUDED_PARTS = frozenset({".venv", "site-packages", "__pycache__", ".nox", ".git", "node_modules"})
+
 
 def run_check(
     paths: list[Path],
@@ -67,8 +73,18 @@ def docstring_spans(tree: ast.AST) -> list[tuple[int, int]]:
 
 
 def iter_py_files(repo_root: Path, scan_dirs: list[str]) -> list[Path]:
-    """Return every .py file under the given repo-relative directories, sorted for stable output."""
-    paths: list[Path] = []
-    for scan_dir in scan_dirs:
-        paths.extend((repo_root / scan_dir).rglob("*.py"))
-    return sorted(paths)
+    """Return every first-party .py file under the given repo-relative directories, sorted.
+
+    Skips virtualenv, cache, and build directories (notably the nested ``codegen/.venv``) so the
+    linters scan first-party source only, never installed third-party packages.
+    """
+    # A file is first-party when none of its repo-relative path components is an excluded dir.
+    # relative_to(repo_root) scopes the check to the repo itself, so an ancestor directory that
+    # happens to share an excluded name (e.g. a checkout under /opt/node_modules/...) can't blank
+    # the scan.
+    return sorted(
+        path
+        for scan_dir in scan_dirs
+        for path in (repo_root / scan_dir).rglob("*.py")
+        if EXCLUDED_PARTS.isdisjoint(path.relative_to(repo_root).parts)
+    )


### PR DESCRIPTION
Three small, independent fixes that make the test suite behave correctly when `pytest` is run locally from the repo root — surfaced while benchmarking `pytest -n` on a multi-worktree checkout. All are internal/test-infra, so none produce changelog entries.

### Skip dot-directories during collection

- `norecursedirs` was a custom list (`["codegen", "tests/pyright_probes"]`), which silently *replaces* pytest's built-in default — and that default includes `.*`. Without it, running `pytest` from the repo root descends into `.claude/worktrees/`, `.venv`, and `.nox`, producing `ImportPathMismatchError` collection errors from sibling worktrees. Restoring `.*` fixes collection from the repo root and doesn't affect CI, which scopes runs by marker.

### Deterministic xdist collection order

- `test_forgotten_await_completeness.py` built two parametrize lists from unsorted `set` iteration, whose order varies with `PYTHONHASHSEED` across processes. Under `-n`, xdist workers then collected the cases in different orders and aborted with `Different tests were collected between gw0 and gwN`. The suite only survived because `pytest-randomly` happens to sync the seed across workers — disabling it (`-p no:randomly`) or removing the plugin broke every parallel run. Wrapping the lists in `sorted()` makes collection order deterministic regardless of hash seed, so parallelism no longer depends on `pytest-randomly`.

### Linters skip nested virtualenvs

- The hand-written linters' shared `iter_py_files` rglob'd `*.py` under `SCAN_DIRS` (which includes `codegen`) with no exclusions, so on any machine with a local `codegen/.venv` it scanned third-party site-packages (pygments, ruff, …) and reported them as house-style violations — failing the linters' own characterization tests with ~100 false positives. `iter_py_files` now skips a shared `EXCLUDED_PARTS` set (virtualenvs, caches, build dirs), scoped to repo-relative path components so an ancestor directory that shares an excluded name can't blank the scan.
- `check_for_missing_attribute.py` keeps its own copy of that set — it runs as a standalone `uv run --script` (isolated env) and can't import `lint_helpers`. A new parity test (`test_exclusion_parity.py`) asserts the two copies stay equal so they can't silently drift.

### Verification

- `ruff check` + `ruff format --check` clean, `pyright` clean on all changed files.
- `tests/unit/tools/` 3302 passed (was 104 failing locally before the venv fix).
- `test_forgotten_await_completeness.py` passes under `-n 4 -p no:randomly` (the exact repro that aborted before the `sorted()` fix).
