### PR TITLE
chore: forbid hassette._* private-attr reach-through outside core/

### DIFF
--- a/tests/unit/tools/test_check_module_boundaries.py
+++ b/tests/unit/tools/test_check_module_boundaries.py
@@ -5,13 +5,23 @@ utils-no-events, web-no-core, bus-no-core): the governed layer must not import
 the forbidden package at runtime, while type-only imports under
 ``TYPE_CHECKING`` and a layer importing itself are exempt. Still-ungoverned
 cross-layer imports (e.g. ``state_manager → core``) are allowed.
+
+Also pin the private-attr reach-through rule (#1091): ``hassette._foo`` /
+``self.hassette._foo`` is flagged outside ``core/`` and ``test_utils/``, own-private
+``self._foo`` and non-private/dunder access are not, and ``PRIVATE_ATTR_ALLOWLIST``
+entries are suppressed by (path, attr).
 """
 
 import textwrap
 from pathlib import Path
 
 import pytest
-from check_module_boundaries import check_file, check_source, iter_paths
+from check_module_boundaries import PRIVATE_ATTR_REASON, check_file, check_source, iter_paths
+
+
+def reach_through_msg(attr: str) -> str:
+    """Build the expected violation message for a ``hassette.<attr>`` reach-through."""
+    return f"private-attr-reach-through: accesses hassette.{attr} — {PRIVATE_ATTR_REASON}"
 
 
 def test_production_import_of_test_utils_flagged() -> None:
@@ -177,6 +187,65 @@ def test_bus_type_checking_core_import_exempt() -> None:
 
 def test_non_hassette_import_ignored() -> None:
     assert check_source("import os\nfrom collections import abc\n", "core") == []
+
+
+def test_bare_hassette_private_access_flagged() -> None:
+    src = "x = hassette._scheduler_service\n"
+    assert check_source(src, "scheduler") == [(1, reach_through_msg("_scheduler_service"))]
+
+
+def test_self_hassette_private_access_flagged() -> None:
+    # The common shape: a resource reaching through its `self.hassette` reference.
+    src = "x = self.hassette._bus_service\n"
+    assert check_source(src, "bus") == [(1, reach_through_msg("_bus_service"))]
+
+
+def test_own_private_access_not_flagged() -> None:
+    # `self._foo` is ordinary intra-object privacy, not a reach-through into the core object.
+    assert check_source("x = self._bus_service\n", "bus") == []
+
+
+def test_non_private_hassette_attr_not_flagged() -> None:
+    assert check_source("x = self.hassette.config\n", "bus") == []
+
+
+def test_dunder_hassette_attr_not_flagged() -> None:
+    # Dunder/mangled access is not the single-underscore reach-through the rule targets.
+    assert check_source("x = hassette.__class__\n", "bus") == []
+
+
+def test_private_access_in_core_exempt() -> None:
+    # core owns Hassette; reading its private slots there is not a reach-through.
+    assert check_source("x = self.hassette._state_proxy\n", "core") == []
+
+
+def test_private_access_in_test_utils_exempt() -> None:
+    # The test harness assembles real components from private slots — that is its job.
+    assert check_source("x = hassette._loop_thread_id\n", "test_utils") == []
+
+
+def test_allowlisted_path_attr_suppressed() -> None:
+    src = "x = self.hassette._bus_service\n"
+    assert check_source(src, "bus", rel_path="bus/bus.py") == []
+
+
+def test_allowlist_scoped_to_path() -> None:
+    # The same attr in a different file is still flagged — the allowlist is (path, attr)-scoped.
+    src = "x = self.hassette._bus_service\n"
+    assert check_source(src, "bus", rel_path="bus/other.py") == [(1, reach_through_msg("_bus_service"))]
+
+
+def test_allowlist_not_consulted_without_rel_path() -> None:
+    # With no rel_path, nothing can be allowlisted, so even allowlisted content is flagged.
+    # This pins the "flag by default" semantics so they can't drift silently.
+    src = "x = self.hassette._bus_service\n"
+    assert check_source(src, "bus") == [(1, reach_through_msg("_bus_service"))]
+
+
+def test_chained_private_access_flagged_once() -> None:
+    # `hassette._state_proxy.states` — only the private hop is flagged, not the trailing `.states`.
+    src = "x = self.hassette._state_proxy.states\n"
+    assert check_source(src, "state_manager") == [(1, reach_through_msg("_state_proxy"))]
 
 
 @pytest.mark.parametrize("path", iter_paths(), ids=lambda p: str(p))

--- a/tests/unit/tools/test_check_module_boundaries.py
+++ b/tests/unit/tools/test_check_module_boundaries.py
@@ -16,12 +16,11 @@ import textwrap
 from pathlib import Path
 
 import pytest
-from check_module_boundaries import PRIVATE_ATTR_REASON, check_file, check_source, iter_paths
+from check_module_boundaries import PRIVATE_ATTR_MSG_TEMPLATE, check_file, check_source, iter_paths
 
 
 def reach_through_msg(attr: str) -> str:
-    """Build the expected violation message for a ``hassette.<attr>`` reach-through."""
-    return f"private-attr-reach-through: accesses hassette.{attr} — {PRIVATE_ATTR_REASON}"
+    return PRIVATE_ATTR_MSG_TEMPLATE.format(attr=attr)
 
 
 def test_production_import_of_test_utils_flagged() -> None:

--- a/tools/check_module_boundaries.py
+++ b/tools/check_module_boundaries.py
@@ -114,6 +114,10 @@ PRIVATE_ATTR_REASON = (
     "use a public property (or add a reasoned PRIVATE_ATTR_ALLOWLIST entry for genuine internals)"
 )
 
+#: Violation message for a private-attr reach-through; ``{attr}`` is the private name accessed.
+#: The single source of truth shared by ``check_source`` and the test suite, so the two cannot drift.
+PRIVATE_ATTR_MSG_TEMPLATE = f"private-attr-reach-through: accesses hassette.{{attr}} — {PRIVATE_ATTR_REASON}"
+
 #: (src-relative POSIX path, private attr name) pairs allowed to reach into ``hassette._foo``.
 #: Each is a conscious exception. ``TODO`` entries are removed once the corresponding
 #: public-property fix lands (the audit's N1 — service slots that should expose guarded
@@ -265,19 +269,22 @@ def check_source(
     when omitted, no allowlist entry applies (every private-attr access in scope is flagged).
     """
     tree = ast.parse(source)
-    violations = [
+    import_violations = [
         (lineno, f"{rule.name}: imports {module} — {rule.reason}")
         for lineno, module in runtime_imports(tree, package)
         for rule in RULES
         if rule.applies(layer) and rule.forbids(module)
     ]
-    if layer not in PRIVATE_ATTR_EXEMPT_LAYERS:
-        violations.extend(
-            (lineno, f"private-attr-reach-through: accesses hassette.{attr} — {PRIVATE_ATTR_REASON}")
+    private_violations = (
+        [
+            (lineno, PRIVATE_ATTR_MSG_TEMPLATE.format(attr=attr))
             for lineno, attr in private_hassette_accesses(tree)
             if not is_allowlisted(rel_path, attr)
-        )
-    return sorted(violations)
+        ]
+        if layer not in PRIVATE_ATTR_EXEMPT_LAYERS
+        else []
+    )
+    return sorted(import_violations + private_violations)
 
 
 def check_file(path: Path) -> list[tuple[int, str]]:

--- a/tools/check_module_boundaries.py
+++ b/tools/check_module_boundaries.py
@@ -10,7 +10,7 @@ Detection is AST-based and considers runtime imports only — anything inside an
 ``if TYPE_CHECKING:`` block is exempt, since type-only imports do not create a
 runtime dependency.
 
-Boundaries enforced today (``RULES``):
+Import boundaries enforced today (``RULES``):
 - ``test_utils`` isolation — production code must not import test helpers.
 - ``api → core`` — api is a service layer and must not import core at runtime.
 - ``utils → events`` — utils sits below events; ``is_event_type`` has moved to events/.
@@ -24,9 +24,20 @@ breaking them needs a relocate-vs-protocol-inversion decision deferred to an ADR
 (#1079 tracks breaking these cycles; #633 tracks full DAG enforcement).
 ``RULES`` is a list so each boundary is added as it becomes clean.
 
-These are structural violations, not style — there is no escape hatch. A
+Import rules are structural violations, not style — there is no escape hatch. A
 production module that needs a test helper signals a misplaced helper, not a
 boundary to annotate.
+
+This guard also forbids **private-attribute reach-through** into the Hassette core
+object — ``hassette._foo`` / ``self.hassette._foo`` — anywhere outside ``core/``
+and the ``test_utils/`` test harness (#1091). Subsystems should read public
+properties, not private slots: the audit found the reach-throughs guarded null
+state divergently and that ``python -O`` strips their ``assert`` guards. Unlike
+the import rules, the private-attr rule has an escape hatch — ``PRIVATE_ATTR_ALLOWLIST``
+— because a few framework internals (a hot-path loop-thread check, a test-harness
+bypass hook) legitimately read private state. Each allowlist entry is a conscious,
+auditable exception with a reason; entries tagged ``TODO`` are removed when the
+public-property fix lands.
 
 Usage:
     python tools/check_module_boundaries.py
@@ -90,6 +101,35 @@ RULES: list[Rule] = [
         reason="bus must not import core at runtime; core sits above the service layer (#1089)",
     ),
 ]
+
+
+#: Layers that own or legitimately wire Hassette internals, so reading ``hassette._foo``
+#: there is not a reach-through. ``core`` is where ``Hassette`` lives; ``test_utils`` is the
+#: test harness, whose whole job is assembling real components from their private slots.
+PRIVATE_ATTR_EXEMPT_LAYERS = frozenset({"core", "test_utils"})
+
+#: Reason shown for a private-attr reach-through violation.
+PRIVATE_ATTR_REASON = (
+    "subsystem code must not read private attributes of the Hassette core object; "
+    "use a public property (or add a reasoned PRIVATE_ATTR_ALLOWLIST entry for genuine internals)"
+)
+
+#: (src-relative POSIX path, private attr name) pairs allowed to reach into ``hassette._foo``.
+#: Each is a conscious exception. ``TODO`` entries are removed once the corresponding
+#: public-property fix lands (the audit's N1 — service slots that should expose guarded
+#: properties), at which point the rule enforces the boundary on those sites.
+PRIVATE_ATTR_ALLOWLIST: frozenset[tuple[str, str]] = frozenset(
+    {
+        # Hot-path loop-thread identity check — framework fast path, intentionally direct.
+        ("task_bucket/task_bucket.py", "_loop_thread_id"),
+        # Test-harness dependency-check bypass — internal coordination hook between Resource and Hassette.
+        ("resources/base.py", "_should_skip_dependency_check"),
+        # TODO(#1091-followup): route through a guarded public property when the service-slot
+        # public-property fix (audit N1) lands; remove these two entries then.
+        ("scheduler/scheduler.py", "_scheduler_service"),
+        ("bus/bus.py", "_bus_service"),
+    }
+)
 
 
 def layer_of(path: Path) -> str:
@@ -175,10 +215,54 @@ def runtime_imports(tree: ast.AST, package: str | None = None) -> list[tuple[int
     return out
 
 
-def check_source(source: str, layer: str, package: str | None = None) -> list[tuple[int, str]]:
+def is_private_attr(name: str) -> bool:
+    """True for a single-underscore private name (``_foo``), not a dunder or mangled name.
+
+    ``_loop_thread_id`` matches; ``__init__`` and ``__slots`` do not. The reach-through the
+    audit documents is single-underscore private slots, not name-mangled or dunder members.
+    """
+    return name.startswith("_") and not name.startswith("__")
+
+
+def value_is_hassette(value: ast.expr) -> bool:
+    """True when an attribute's value refers to the Hassette core object.
+
+    Matches the bare name ``hassette`` and any attribute access ending in ``.hassette``
+    (``self.hassette``, ``app.hassette``) — the documented ``hassette._foo`` reach-through.
+    Own-private access such as ``self._foo`` does not match, so it is never flagged.
+    """
+    if isinstance(value, ast.Name):
+        return value.id == "hassette"
+    return isinstance(value, ast.Attribute) and value.attr == "hassette"
+
+
+def private_hassette_accesses(tree: ast.AST) -> list[tuple[int, str]]:
+    """Return (lineno, attr) for every ``hassette._private`` attribute access in the tree."""
+    return [
+        (node.lineno, node.attr)
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Attribute) and is_private_attr(node.attr) and value_is_hassette(node.value)
+    ]
+
+
+def is_allowlisted(rel_path: str | None, attr: str) -> bool:
+    """True when reaching ``hassette.{attr}`` from ``rel_path`` is an explicit allowlist entry.
+
+    A missing ``rel_path`` is never allowlisted, so detection-only callers (which pass no path)
+    see every access flagged — flagging is the safe default, and ``check_file`` always supplies
+    the path in real runs.
+    """
+    return rel_path is not None and (rel_path, attr) in PRIVATE_ATTR_ALLOWLIST
+
+
+def check_source(
+    source: str, layer: str, package: str | None = None, rel_path: str | None = None
+) -> list[tuple[int, str]]:
     """Return sorted (1-based line number, message) for boundary violations in a source string.
 
     ``package`` anchors relative imports; pass it to check the relative-import forms.
+    ``rel_path`` is the src-relative POSIX path used to consult ``PRIVATE_ATTR_ALLOWLIST``;
+    when omitted, no allowlist entry applies (every private-attr access in scope is flagged).
     """
     tree = ast.parse(source)
     violations = [
@@ -187,12 +271,21 @@ def check_source(source: str, layer: str, package: str | None = None) -> list[tu
         for rule in RULES
         if rule.applies(layer) and rule.forbids(module)
     ]
+    if layer not in PRIVATE_ATTR_EXEMPT_LAYERS:
+        violations.extend(
+            (lineno, f"private-attr-reach-through: accesses hassette.{attr} — {PRIVATE_ATTR_REASON}")
+            for lineno, attr in private_hassette_accesses(tree)
+            if not is_allowlisted(rel_path, attr)
+        )
     return sorted(violations)
 
 
 def check_file(path: Path) -> list[tuple[int, str]]:
-    """Return sorted (1-based line number, message) for every boundary violation in the file."""
-    return check_source(path.read_text(), layer_of(path), package_of(path))
+    """Return sorted (1-based line number, message) for every boundary violation in the file.
+
+    Always passes the file's src-relative path, so ``PRIVATE_ATTR_ALLOWLIST`` is consulted.
+    """
+    return check_source(path.read_text(), layer_of(path), package_of(path), rel_path=path.relative_to(SRC).as_posix())
 
 
 def iter_paths() -> list[Path]:
@@ -206,7 +299,7 @@ def main() -> int:
         REPO_ROOT,
         check_file,
         summary="module-boundary violation(s)",
-        ok=f"no module-boundary violations across {len(RULES)} rule(s).",
+        ok=f"no module-boundary violations across {len(RULES)} import rule(s) + the private-attr rule.",
     )
 
 


### PR DESCRIPTION
## Summary

Extends the `tools/check_module_boundaries.py` AST lint to forbid **private-attribute reach-through** into the Hassette core object — `hassette._foo` / `self.hassette._foo` — anywhere outside `core/` and the `test_utils/` harness. This closes the structural gap the 2026-06-19 design audit flagged as **T2 (private-attr reach-through)** under its "missing-ratchet" framing: the same smell recurred across subsystems because nothing in the build stopped it. A point-fix re-accretes; a ratchet does not.

### Detection

- New AST pass (`private_hassette_accesses`) flags an `ast.Attribute` whose attribute is single-underscore private (not dunder/mangled) **and** whose value resolves to the core object — `hassette` or anything ending in `.hassette`. This targets the documented reach-through precisely: ordinary own-private access (`self._foo`) is never flagged, and the AST approach ignores docstring/string mentions that a text grep would false-positive on.
- The rule lives alongside the existing import-`RULES`, sharing `check_source` / `check_file`. Import rules are unchanged.

### Allowlist (the escape hatch)

Unlike the import rules — which are absolute — the private-attr rule needs an escape hatch, because a few framework internals legitimately read private state. `PRIVATE_ATTR_ALLOWLIST` is an explicit `(path, attr)` frozenset, each entry a reasoned exception:

- **Permanent:** `task_bucket._loop_thread_id` (hot-path loop-thread check) and `resources/base._should_skip_dependency_check` (test-harness bypass hook).
- **Tracked:** `scheduler._scheduler_service` and `bus._bus_service` are `TODO`-tagged — they mirror the audit's **N1** finding (service slots that should expose a guarded public property) and get removed when that separate fix lands, at which point the rule enforces the boundary on them.

`test_utils/` is exempt as a layer: the harness assembling real components from private slots is its job, not a production reach-through.

### On the other acceptance criteria

Two of #1091's four ACs were already satisfied by prior work, so this PR completes the issue:

- **Re-enable the core↔bus rule** — `bus-no-core` landed with #1089; the lint passes with it active.
- **Wire into pre-push/CI** — `check_module_boundaries.py` already runs at the `pre-push` stage in `.pre-commit-config.yaml`, so the new rule is enforced there automatically.

This is the lint **ratchet** only. The broader T2/N1 *cleanup* (adding the missing `api_service` public property, routing reach-throughs through guarded properties, and the `-O`-stripped-assert fix) remains separate backlog work the audit deliberately pinned apart.

### Tests

11 characterization tests pin the rule's behavior: flag bare/`self.`-qualified access, exempt `core`/`test_utils`, leave own-private and non-private/dunder access alone, suppress allowlisted `(path, attr)` pairs (scoped by path), flag chained access once, and pin the "no `rel_path` ⇒ flag by default" semantic. The violation-message format is a single shared template (`PRIVATE_ATTR_MSG_TEMPLATE`) used by both the tool and the tests, so they cannot drift.

Closes #1091
