### PR TITLE
refactor: name the missing service in wiring-guard errors

### DIFF
--- a/src/hassette/bus/bus.py
+++ b/src/hassette/bus/bus.py
@@ -138,8 +138,7 @@ class Bus(Resource):
     def __init__(self, hassette: "Hassette", *, priority: int = 0, parent: Resource | None = None) -> None:
         super().__init__(hassette, parent=parent)
         assert self.parent is not None, "Bus requires a parent Resource for telemetry identity (app_key/source_tier)"
-        assert self.hassette._bus_service is not None, "Bus service not initialized"
-        self.bus_service = self.hassette._bus_service
+        self.bus_service = self.hassette.bus_service
         self.priority = priority
         self._registered_listeners: dict[tuple[str, int, str, str], Listener] = {}
         self._error_handler: BusErrorHandlerType | None = None

--- a/src/hassette/core/bus_service.py
+++ b/src/hassette/core/bus_service.py
@@ -458,7 +458,7 @@ class BusService(Service):
         caller (DurationHoldManager) never needs to handle state-read failures.
         """
         try:
-            state_proxy = self.hassette._state_proxy
+            state_proxy = self.hassette.try_state_proxy()
             if state_proxy is None:
                 self.logger.debug("read_entity_state: StateProxy not available for entity %s, skipping", entity_id)
                 return None

--- a/src/hassette/core/core.py
+++ b/src/hassette/core/core.py
@@ -54,6 +54,18 @@ P = ParamSpec("P")
 R = TypeVar("R")
 
 
+def _service_not_wired_error(service: str) -> RuntimeError:
+    """Build the error raised when a service accessor is read before ``wire_services()`` ran.
+
+    Names the missing service and the startup-ordering fix, so a premature read during
+    construction (or a misordered embedding) is debuggable from the message alone.
+    """
+    return RuntimeError(
+        f"{service} is unavailable: wire_services() has not been called. "
+        "Construct Hassette(config), call wire_services(), then run_forever()."
+    )
+
+
 class Hassette(Resource):
     """Main class for the Hassette application.
 
@@ -245,7 +257,7 @@ class Hassette(Resource):
             RuntimeError: If no session has been created.
         """
         if self._session_manager is None:
-            raise RuntimeError("wire_services() has not been called")
+            raise _service_not_wired_error("SessionManager")
         return self._session_manager.session_id
 
     @property
@@ -273,6 +285,15 @@ class Hassette(Resource):
         return self._loop
 
     @property
+    def loop_thread_id(self) -> int | None:
+        """Thread id of the event-loop thread, or None before run_forever() captures it.
+
+        None is a valid return, not an error. Callers that compare a thread ident against
+        this value treat None as "the loop thread is not running yet".
+        """
+        return self._loop_thread_id
+
+    @property
     def sync_executor_service(self) -> SyncExecutorService:
         """The SyncExecutorService instance that owns the dedicated sync thread pool.
 
@@ -280,7 +301,7 @@ class Hassette(Resource):
         rate-limited pool-saturation warnings.
         """
         if self._sync_executor_service is None:
-            raise RuntimeError("wire_services() has not been called")
+            raise _service_not_wired_error("SyncExecutorService")
         return self._sync_executor_service
 
     @property
@@ -292,14 +313,14 @@ class Hassette(Resource):
         using the loop-default executor and are NOT routed through this property.
         """
         if self._sync_executor_service is None:
-            raise RuntimeError("wire_services() has not been called")
+            raise _service_not_wired_error("SyncExecutorService")
         return self._sync_executor_service.executor
 
     @property
     def command_executor(self) -> CommandExecutor:
         """CommandExecutor for telemetry recording."""
         if self._command_executor is None:
-            raise RuntimeError("wire_services() has not been called")
+            raise _service_not_wired_error("CommandExecutor")
         return self._command_executor
 
     def get_drop_counters(self) -> tuple[int, int, int]:
@@ -325,98 +346,107 @@ class Hassette(Resource):
     def database_service(self) -> DatabaseService:
         """DatabaseService instance for SQLite telemetry storage."""
         if self._database_service is None:
-            raise RuntimeError("wire_services() has not been called")
+            raise _service_not_wired_error("DatabaseService")
         return self._database_service
 
     @property
     def logging_service(self) -> LoggingService:
         """LoggingService instance for the async logging pipeline."""
         if self._logging_service is None:
-            raise RuntimeError("wire_services() has not been called")
+            raise _service_not_wired_error("LoggingService")
         return self._logging_service
 
     @property
     def runtime_query_service(self) -> RuntimeQueryService:
         """RuntimeQueryService instance for live in-memory state queries."""
         if self._runtime_query_service is None:
-            raise RuntimeError("wire_services() has not been called")
+            raise _service_not_wired_error("RuntimeQueryService")
         return self._runtime_query_service
 
     @property
     def telemetry_query_service(self) -> TelemetryQueryService:
         """TelemetryQueryService instance for historical DB-backed telemetry queries."""
         if self._telemetry_query_service is None:
-            raise RuntimeError("wire_services() has not been called")
+            raise _service_not_wired_error("TelemetryQueryService")
         return self._telemetry_query_service
 
     @property
     def app_handler(self) -> AppHandler:
         """AppHandler instance for app lifecycle management."""
         if self._app_handler is None:
-            raise RuntimeError("wire_services() has not been called")
+            raise _service_not_wired_error("AppHandler")
         return self._app_handler
 
     @property
     def websocket_service(self) -> WebsocketService:
         """WebsocketService instance for HA WebSocket connection."""
         if self._websocket_service is None:
-            raise RuntimeError("wire_services() has not been called")
+            raise _service_not_wired_error("WebsocketService")
         return self._websocket_service
 
     @property
     def bus_service(self) -> BusService:
         """BusService instance for event bus management."""
         if self._bus_service is None:
-            raise RuntimeError("wire_services() has not been called")
+            raise _service_not_wired_error("BusService")
         return self._bus_service
 
     @property
     def state_proxy(self) -> StateProxy:
         """StateProxy instance for entity state caching."""
         if self._state_proxy is None:
-            raise RuntimeError("wire_services() has not been called")
+            raise _service_not_wired_error("StateProxy")
+        return self._state_proxy
+
+    def try_state_proxy(self) -> StateProxy | None:
+        """Return the StateProxy if wired, else None — for callers that tolerate its absence.
+
+        Unlike the state_proxy property (which raises before wiring), this returns None so
+        hot paths like BusService.read_entity_state skip silently during early startup
+        instead of catching an exception.
+        """
         return self._state_proxy
 
     @property
     def api_service(self) -> ApiResource:
         """ApiResource instance for HA REST/WebSocket transport."""
         if self._api_service is None:
-            raise RuntimeError("wire_services() has not been called")
+            raise _service_not_wired_error("ApiResource")
         return self._api_service
 
     @property
     def scheduler_service(self) -> SchedulerService:
         """SchedulerService instance for job scheduling."""
         if self._scheduler_service is None:
-            raise RuntimeError("wire_services() has not been called")
+            raise _service_not_wired_error("SchedulerService")
         return self._scheduler_service
 
     @property
     def api(self) -> Api:
         """API service for handling HTTP requests."""
         if self._api is None:
-            raise RuntimeError("wire_services() has not been called")
+            raise _service_not_wired_error("Api")
         return self._api
 
     @property
     def states(self) -> StateManager:
         """States manager instance for accessing Home Assistant states."""
         if self._states is None:
-            raise RuntimeError("wire_services() has not been called")
+            raise _service_not_wired_error("StateManager")
         return self._states
 
     @property
     def state_registry(self) -> StateRegistry:
         """State registry for managing state class registrations and conversions."""
         if self._state_registry is None:
-            raise RuntimeError("wire_services() has not been called")
+            raise _service_not_wired_error("StateRegistry")
         return self._state_registry
 
     @property
     def type_registry(self) -> TypeRegistry:
         """Type registry for managing state value type conversions."""
         if self._type_registry is None:
-            raise RuntimeError("wire_services() has not been called")
+            raise _service_not_wired_error("TypeRegistry")
         return self._type_registry
 
     @property
@@ -447,7 +477,7 @@ class Hassette(Resource):
     async def send_event(self, event: "Event[Any]") -> None:
         """Send an event to the event bus."""
         if self._event_stream_service is None:
-            raise RuntimeError("wire_services() has not been called")
+            raise _service_not_wired_error("EventStreamService")
         if self.event_streams_closed:
             self.logger.debug("send_event dropped: streams closed (topic=%s)", event.topic)
             return
@@ -552,7 +582,7 @@ class Hassette(Resource):
         try:
             await self.wait_for_ready([self.database_service], timeout=self.config.lifecycle.startup_timeout_seconds)
             if self._session_manager is None:
-                raise RuntimeError("wire_services() has not been called")
+                raise _service_not_wired_error("SessionManager")
             await self._session_manager.mark_orphaned_sessions()
             await self._session_manager.create_session()
         except Exception:

--- a/src/hassette/scheduler/scheduler.py
+++ b/src/hassette/scheduler/scheduler.py
@@ -113,8 +113,7 @@ class Scheduler(Resource):
         assert self.parent is not None, (
             "Scheduler requires a parent Resource for telemetry identity (app_key/source_tier)"
         )
-        assert self.hassette._scheduler_service is not None, "Scheduler service not initialized"
-        self.scheduler_service = self.hassette._scheduler_service
+        self.scheduler_service = self.hassette.scheduler_service
         self._jobs_by_name = {}
         self._jobs_by_group: dict[str, set[ScheduledJob]] = {}
         self._error_handler: SchedulerErrorHandlerType | None = None

--- a/src/hassette/task_bucket/task_bucket.py
+++ b/src/hassette/task_bucket/task_bucket.py
@@ -139,7 +139,7 @@ class TaskBucket(Resource):
         self.logger.debug("Spawning task %s in bucket %s", name, self.unique_name)
         current_thread = threading.get_ident()
 
-        if current_thread == self.hassette._loop_thread_id:
+        if current_thread == self.hassette.loop_thread_id:
             # Fast path: already on loop thread
             with ctx.use_task_bucket(self):
                 return asyncio.create_task(coro, name=name)
@@ -150,7 +150,7 @@ class TaskBucket(Resource):
                     "Cross-thread spawn: %s from thread %s (loop thread %s)",
                     name,
                     current_thread,
-                    self.hassette._loop_thread_id,
+                    self.hassette.loop_thread_id,
                 )
             # Cross-thread: create the task on the real loop thread and wait for the handle
             result: Future[asyncio.Task[T]] = Future()

--- a/src/hassette/test_utils/harness.py
+++ b/src/hassette/test_utils/harness.py
@@ -535,6 +535,10 @@ class HassetteHarness:
     async def start(self) -> "HassetteHarness":
         self._resolve_dependencies()
 
+        # Emulate run_forever() on the real Hassette: populate the backing slots that the
+        # public loop / loop_thread_id accessors read. These are read-only properties with no
+        # setter, so the harness writes the private slots directly — the same way run_forever
+        # does — rather than reaching through a public accessor.
         self.hassette._loop = asyncio.get_running_loop()
         self._previous_task_factory = self.hassette._loop.get_task_factory()
         self.hassette._loop_thread_id = threading.get_ident()

--- a/src/hassette/test_utils/mock_hassette.py
+++ b/src/hassette/test_utils/mock_hassette.py
@@ -63,14 +63,14 @@ def make_mock_hassette(
         - ``.config``: real :class:`~hassette.config.config.HassetteConfig` instance
         - ``.ready_event``, ``.shutdown_event``: :class:`asyncio.Event` instances
         - ``.event_streams_closed``: ``False``
-        - ``._loop_thread_id``: current thread ident
+        - ``.loop_thread_id``: current thread ident
         - ``.loop``: running event loop (or ``None`` if ``set_loop=False``)
-        - ``._scheduler_service.register_removal_callback``: :class:`~unittest.mock.Mock`
-        - ``._scheduler_service.deregister_removal_callback``: :class:`~unittest.mock.Mock`
-        - ``._bus_service.remove_listeners_by_owner``: :class:`~unittest.mock.Mock`
-        - ``._bus_service.get_listeners_by_owner``: :class:`~unittest.mock.Mock` returning ``[]``
-        - ``._bus_service.register_removal_callback``: :class:`~unittest.mock.Mock`
-        - ``._bus_service.deregister_removal_callback``: :class:`~unittest.mock.Mock`
+        - ``.scheduler_service.register_removal_callback``: :class:`~unittest.mock.Mock`
+        - ``.scheduler_service.deregister_removal_callback``: :class:`~unittest.mock.Mock`
+        - ``.bus_service.remove_listeners_by_owner``: :class:`~unittest.mock.Mock`
+        - ``.bus_service.get_listeners_by_owner``: :class:`~unittest.mock.Mock` returning ``[]``
+        - ``.bus_service.register_removal_callback``: :class:`~unittest.mock.Mock`
+        - ``.bus_service.deregister_removal_callback``: :class:`~unittest.mock.Mock`
         - ``.app_handler.get``: :class:`~unittest.mock.Mock` returning ``None`` (no app running)
         - ``._runtime_query_service``: ``None`` (wired at runtime by the framework)
         - ``.session_id``: ``None``
@@ -118,8 +118,8 @@ def make_mock_hassette(
     # Event stream state
     hassette.event_streams_closed = False
 
-    # Thread / loop identity
-    hassette._loop_thread_id = threading.get_ident()
+    # Thread / loop identity — TaskBucket.spawn reads the public loop_thread_id accessor.
+    hassette.loop_thread_id = threading.get_ident()
     if set_loop:
         try:
             hassette.loop = asyncio.get_running_loop()
@@ -128,15 +128,15 @@ def make_mock_hassette(
     else:
         hassette.loop = None
 
-    # Scheduler service stubs
-    hassette._scheduler_service.register_removal_callback = Mock()
-    hassette._scheduler_service.deregister_removal_callback = Mock()
+    # Scheduler service stubs — production reads the public scheduler_service accessor.
+    hassette.scheduler_service.register_removal_callback = Mock()
+    hassette.scheduler_service.deregister_removal_callback = Mock()
 
-    # Bus service stubs
-    hassette._bus_service.remove_listeners_by_owner = Mock()
-    hassette._bus_service.get_listeners_by_owner = Mock(return_value=[])
-    hassette._bus_service.register_removal_callback = Mock()
-    hassette._bus_service.deregister_removal_callback = Mock()
+    # Bus service stubs — production reads the public bus_service accessor.
+    hassette.bus_service.remove_listeners_by_owner = Mock()
+    hassette.bus_service.get_listeners_by_owner = Mock(return_value=[])
+    hassette.bus_service.register_removal_callback = Mock()
+    hassette.bus_service.deregister_removal_callback = Mock()
 
     # App handler stubs — get() is synchronous; return None (no app running by default)
     hassette.app_handler.get = Mock(return_value=None)

--- a/tests/integration/test_state_proxy.py
+++ b/tests/integration/test_state_proxy.py
@@ -122,9 +122,9 @@ def state_proxy():
 
     # Bus.remove_all_listeners() delegates to bus_service.remove_listeners_by_owner()
     # which is now synchronous and returns None.
-    mock_hassette._bus_service.remove_listeners_by_owner.return_value = None
+    mock_hassette.bus_service.remove_listeners_by_owner.return_value = None
     # Bus registration awaits bus_service.add_listener() — must be AsyncMock.
-    mock_hassette._bus_service.add_listener = AsyncMock()
+    mock_hassette.bus_service.add_listener = AsyncMock()
 
     proxy = StateProxy(mock_hassette, parent=mock_hassette)
     proxy.mark_ready(reason="Test setup")

--- a/tests/unit/bus/test_bus.py
+++ b/tests/unit/bus/test_bus.py
@@ -125,7 +125,7 @@ async def test_framework_bus_inherits_framework_tier(hassette_with_bus: "Hassett
 def test_bus_requires_parent() -> None:
     """Bus.__init__ raises AssertionError when parent is None."""
     mock_hassette = Mock()
-    mock_hassette._bus_service = Mock()
+    mock_hassette.bus_service = Mock()
     with pytest.raises(AssertionError, match="Bus requires a parent"):
         Bus(mock_hassette, parent=None)
 

--- a/tests/unit/core/test_app_handler_readiness.py
+++ b/tests/unit/core/test_app_handler_readiness.py
@@ -22,7 +22,7 @@ def mock_hassette() -> AsyncMock:
         lifecycle={"app_startup_timeout_seconds": 30},
     )
     hassette.send_event = AsyncMock()
-    hassette._bus_service.router = MagicMock()
+    hassette.bus_service.router = MagicMock()
     hassette.session_id = 1
     return hassette
 

--- a/tests/unit/core/test_hassette_lifecycle.py
+++ b/tests/unit/core/test_hassette_lifecycle.py
@@ -22,3 +22,37 @@ class TestEventStreamsClosedBeforeWiring:
         """Bare Hassette(config) without wire_services() must report event streams as closed."""
         h = Hassette(test_config)
         assert h.event_streams_closed is True
+
+
+class TestServiceAccessorGuards:
+    """Service accessors raise a RuntimeError naming the missing service before wiring."""
+
+    @pytest.mark.parametrize(
+        ("accessor", "service"),
+        [
+            ("database_service", "DatabaseService"),
+            ("scheduler_service", "SchedulerService"),
+            ("bus_service", "BusService"),
+            ("state_proxy", "StateProxy"),
+            ("api", "Api"),
+            ("states", "StateManager"),
+        ],
+    )
+    def test_accessor_before_wiring_names_service(self, test_config, accessor: str, service: str) -> None:
+        """Reading a service accessor before wire_services() names the service and the startup fix."""
+        h = Hassette(test_config)
+        with pytest.raises(RuntimeError, match=service) as exc_info:
+            getattr(h, accessor)
+        assert "wire_services()" in str(exc_info.value)
+
+
+class TestNonRaisingAccessors:
+    """loop_thread_id and try_state_proxy() return None before wiring instead of raising."""
+
+    def test_loop_thread_id_is_none_before_run_forever(self, test_config) -> None:
+        """loop_thread_id is None until run_forever() captures the loop thread ident."""
+        assert Hassette(test_config).loop_thread_id is None
+
+    def test_try_state_proxy_is_none_before_wiring(self, test_config) -> None:
+        """try_state_proxy() returns None before wiring rather than raising."""
+        assert Hassette(test_config).try_state_proxy() is None

--- a/tests/unit/resources/lifecycle/test_force_terminal.py
+++ b/tests/unit/resources/lifecycle/test_force_terminal.py
@@ -62,7 +62,7 @@ async def test_scheduler_on_shutdown_dequeues_all_jobs():
     async def _add_job(job: ScheduledJob) -> None:
         job.mark_registered(1)
 
-    hassette._scheduler_service.add_job = AsyncMock(side_effect=_add_job)
+    hassette.scheduler_service.add_job = AsyncMock(side_effect=_add_job)
     scheduler = Scheduler(hassette, parent=hassette)
 
     await scheduler.initialize()
@@ -75,7 +75,7 @@ async def test_scheduler_on_shutdown_dequeues_all_jobs():
     await scheduler.shutdown()
 
     # remove_jobs_by_owner is called by remove_all_jobs, and it's on the mock service
-    hassette._scheduler_service.remove_jobs_by_owner.assert_awaited_once_with(scheduler.owner_id)
+    hassette.scheduler_service.remove_jobs_by_owner.assert_awaited_once_with(scheduler.owner_id)
 
 
 async def test_app_shutdown_propagates_to_bus_and_scheduler():

--- a/tests/unit/test_framework_injection_points.py
+++ b/tests/unit/test_framework_injection_points.py
@@ -438,7 +438,7 @@ def make_task_bucket() -> TaskBucket:
     hassette.config.logging.task_bucket = "DEBUG"
     hassette.config.logging.log_level = "DEBUG"
     hassette.config.dev_mode = False
-    hassette._loop_thread_id = None
+    hassette.loop_thread_id = None
 
     bucket = TaskBucket.__new__(TaskBucket)
     bucket._tasks = set()

--- a/tests/unit/test_scheduler_resource.py
+++ b/tests/unit/test_scheduler_resource.py
@@ -425,8 +425,8 @@ class TestCallbackRegistration:
         Regression guard for the removal of the legacy getattr/iscoroutinefunction guard.
         """
         mock_hassette = Mock()
-        mock_hassette._scheduler_service = Mock()
-        mock_hassette._scheduler_service.register_removal_callback = Mock()
+        mock_hassette.scheduler_service = Mock()
+        mock_hassette.scheduler_service.register_removal_callback = Mock()
 
         # Build a subclass that overrides owner_id/parent to avoid touching Resource state.
         mock_parent = make_mock_parent()
@@ -454,8 +454,8 @@ class TestCallbackRegistration:
             _TestScheduler.hassette = property(_hassette)  # pyright: ignore[reportAttributeAccessIssue]
             _TestScheduler(mock_hassette)
 
-        mock_hassette._scheduler_service.register_removal_callback.assert_called_once()
-        call_args = mock_hassette._scheduler_service.register_removal_callback.call_args
+        mock_hassette.scheduler_service.register_removal_callback.assert_called_once()
+        call_args = mock_hassette.scheduler_service.register_removal_callback.call_args
         assert call_args.args[0] == "test_owner"
         assert callable(call_args.args[1])
 
@@ -614,8 +614,8 @@ class TestIdentityPassThrough:
     def test_scheduler_requires_parent(self) -> None:
         """Scheduler.__init__ raises AssertionError when parent is None."""
         mock_hassette = Mock()
-        mock_hassette._scheduler_service = Mock()
-        mock_hassette._scheduler_service.register_removal_callback = Mock()
+        mock_hassette.scheduler_service = Mock()
+        mock_hassette.scheduler_service.register_removal_callback = Mock()
         with pytest.raises(AssertionError, match="Scheduler requires a parent"):
             Scheduler(mock_hassette, parent=None)
 

--- a/tests/unit/tools/test_check_module_boundaries.py
+++ b/tests/unit/tools/test_check_module_boundaries.py
@@ -224,14 +224,16 @@ def test_private_access_in_test_utils_exempt() -> None:
 
 
 def test_allowlisted_path_attr_suppressed() -> None:
-    src = "x = self.hassette._bus_service\n"
-    assert check_source(src, "bus", rel_path="bus/bus.py") == []
+    src = "x = self.hassette._should_skip_dependency_check()\n"
+    assert check_source(src, "resources", rel_path="resources/base.py") == []
 
 
 def test_allowlist_scoped_to_path() -> None:
     # The same attr in a different file is still flagged — the allowlist is (path, attr)-scoped.
-    src = "x = self.hassette._bus_service\n"
-    assert check_source(src, "bus", rel_path="bus/other.py") == [(1, reach_through_msg("_bus_service"))]
+    src = "x = self.hassette._should_skip_dependency_check()\n"
+    assert check_source(src, "resources", rel_path="resources/other.py") == [
+        (1, reach_through_msg("_should_skip_dependency_check"))
+    ]
 
 
 def test_allowlist_not_consulted_without_rel_path() -> None:

--- a/tools/check_module_boundaries.py
+++ b/tools/check_module_boundaries.py
@@ -34,10 +34,9 @@ and the ``test_utils/`` test harness (#1091). Subsystems should read public
 properties, not private slots: the audit found the reach-throughs guarded null
 state divergently and that ``python -O`` strips their ``assert`` guards. Unlike
 the import rules, the private-attr rule has an escape hatch — ``PRIVATE_ATTR_ALLOWLIST``
-— because a few framework internals (a hot-path loop-thread check, a test-harness
-bypass hook) legitimately read private state. Each allowlist entry is a conscious,
-auditable exception with a reason; entries tagged ``TODO`` are removed when the
-public-property fix lands.
+— because a few framework internals (a Resource/Hassette dependency-check bypass hook)
+legitimately read private state. Each allowlist entry is a conscious, auditable
+exception with a reason.
 
 Usage:
     python tools/check_module_boundaries.py
@@ -119,19 +118,15 @@ PRIVATE_ATTR_REASON = (
 PRIVATE_ATTR_MSG_TEMPLATE = f"private-attr-reach-through: accesses hassette.{{attr}} — {PRIVATE_ATTR_REASON}"
 
 #: (src-relative POSIX path, private attr name) pairs allowed to reach into ``hassette._foo``.
-#: Each is a conscious exception. ``TODO`` entries are removed once the corresponding
-#: public-property fix lands (the audit's N1 — service slots that should expose guarded
-#: properties), at which point the rule enforces the boundary on those sites.
+#: Each is a conscious exception for a genuine framework internal with no guarded public
+#: property to route through. The former service-slot entries (``_loop_thread_id``,
+#: ``_scheduler_service``, ``_bus_service``) were retired in #1092 once Hassette exposed
+#: public accessors for them.
 PRIVATE_ATTR_ALLOWLIST: frozenset[tuple[str, str]] = frozenset(
     {
-        # Hot-path loop-thread identity check — framework fast path, intentionally direct.
-        ("task_bucket/task_bucket.py", "_loop_thread_id"),
-        # Test-harness dependency-check bypass — internal coordination hook between Resource and Hassette.
+        # Dependency-check bypass — internal coordination hook between Resource and Hassette,
+        # not a service slot, so it has no guarded public property to route through.
         ("resources/base.py", "_should_skip_dependency_check"),
-        # TODO(#1091-followup): route through a guarded public property when the service-slot
-        # public-property fix (audit N1) lands; remove these two entries then.
-        ("scheduler/scheduler.py", "_scheduler_service"),
-        ("bus/bus.py", "_bus_service"),
     }
 )
 


### PR DESCRIPTION
## Summary

Reading a Hassette service accessor before `wire_services()` has run now raises an error that **names the missing service** and the startup-ordering fix, instead of a generic `wire_services() has not been called`. This is the follow-up to the #1091 boundary lint — it retires the last private-slot reach-throughs from production code (audit finding N1).

### Clearer wiring-guard errors

- Added a `_service_not_wired_error(service)` helper, used by every `~20` service-accessor guard in `Hassette`. The message names the service (e.g. `SchedulerService is unavailable: wire_services() has not been called. Construct Hassette(config), call wire_services(), then run_forever().`) so a premature read during construction or a misordered embedding is debuggable from the message alone.

### Public accessors replace private-slot reach-throughs

- Added two non-raising accessors on `Hassette`: `loop_thread_id` (`int | None`) and `try_state_proxy()` (`StateProxy | None`). The non-raising shape is needed where `None` is a valid pre-wiring state — `TaskBucket.spawn`'s loop-thread fast path and `BusService.read_entity_state`'s tolerant cache read — which the raising properties can't serve.
- Migrated the four remaining reach-throughs to public accessors: `BusService.read_entity_state` → `try_state_proxy()`; `Scheduler.__init__` and `Bus.__init__` → the public property (which also lets us drop the `assert hassette._x is not None` guards that `python -O` strips); `TaskBucket.spawn` → `loop_thread_id`.
- `try_state_proxy()` is intentionally a method (the try-get pattern) rather than a property, so it reads as the explicit non-raising sibling of the raising `state_proxy` property.

### Lint allowlist tightened

- `tools/check_module_boundaries.py`: removed the three now-resolved `PRIVATE_ATTR_ALLOWLIST` entries (`task_bucket/_loop_thread_id`, `scheduler/_scheduler_service`, `bus/_bus_service`). Only the `resources/base.py` `_should_skip_dependency_check` coordination hook remains — it's not a service slot and has no guarded property to route through. Docstrings refreshed accordingly.

### Tests

- New `TestServiceAccessorGuards` (parametrized) locks the "error names the service" contract; `TestNonRaisingAccessors` covers the `None`-before-wiring behavior of both new accessors.
- Test fixtures across 6 files now mock the **public** accessor names production reads (`bus_service`, `scheduler_service`, `loop_thread_id`) instead of the private slots — the mock boundary the migration shifted. The `HassetteHarness` continues to write the real backing slots directly (it emulates `run_forever`; the properties are read-only), with a comment marking that as deliberate.

## Verification

Full unit (6668) + integration (1075) + system + e2e suites pass; pyright, ruff, and the module-boundary lint are clean.

Closes #1092
