### PR TITLE
fix: force fresh module re-import on REST app reload

### DIFF
--- a/src/hassette/web/routes/apps.py
+++ b/src/hassette/web/routes/apps.py
@@ -97,7 +97,9 @@ async def reload_app(app_key: str, hassette: HassetteDep) -> ActionResponse:
     _validate_app_key(app_key)
     _require_known_app(app_key, hassette)
     try:
-        await hassette.app_handler.reload_app(app_key)
+        # Always re-import from disk so a previously-failed app recovers once its
+        # source is fixed -- without force_reload the cached failed class is reused (#1005).
+        await hassette.app_handler.reload_app(app_key, force_reload=True)
     except (ValueError, RuntimeError) as exc:
         LOGGER.warning("Failed to reload app %s", app_key, exc_info=True)
         raise HTTPException(status_code=500, detail="Failed to reload app") from exc

--- a/tests/integration/test_app_factory_lifecycle.py
+++ b/tests/integration/test_app_factory_lifecycle.py
@@ -235,16 +235,18 @@ class TestAppFactoryIntegration:
 
         # Simulate a prior failed load (e.g. a syntax error the user has since fixed).
         app_utils.FAILED_TO_LOAD_CLASSES[cache_key] = ImportError("boom")
+        try:
+            # Without force_reload the cached failure blocks loading — no instance is created.
+            app_factory.create_instances("my_app", manifest)
+            assert "my_app" not in app_registry.apps
+            assert cache_key in app_utils.FAILED_TO_LOAD_CLASSES
 
-        # Without force_reload the cached failure blocks loading — no instance is created.
-        app_factory.create_instances("my_app", manifest)
-        assert "my_app" not in app_registry.apps
-        assert cache_key in app_utils.FAILED_TO_LOAD_CLASSES
-
-        # With force_reload the failure is evicted and the app loads from disk.
-        app_factory.create_instances("my_app", manifest, force_reload=True)
-        assert "my_app" in app_registry.apps
-        assert cache_key not in app_utils.FAILED_TO_LOAD_CLASSES
+            # With force_reload the failure is evicted and the app loads from disk.
+            app_factory.create_instances("my_app", manifest, force_reload=True)
+            assert "my_app" in app_registry.apps
+            assert cache_key not in app_utils.FAILED_TO_LOAD_CLASSES
+        finally:
+            app_utils.FAILED_TO_LOAD_CLASSES.pop(cache_key, None)
 
 
 class TestAppLifecycleServiceIntegration:

--- a/tests/integration/test_app_factory_lifecycle.py
+++ b/tests/integration/test_app_factory_lifecycle.py
@@ -222,6 +222,30 @@ class TestAppFactoryIntegration:
         # After force reload, it should be a different class object
         assert first_class is not second_class
 
+    def test_factory_force_reload_recovers_previously_failed_class(
+        self, app_factory: AppFactory, app_registry: AppRegistry
+    ):
+        """force_reload=True evicts a cached load failure so a fixed app loads again.
+
+        Regression for #1005: a manual reload of a previously-failed app must re-import
+        from disk rather than re-raising the cached failure.
+        """
+        manifest = make_manifest("my_app", "my_app.py", "MyApp")
+        cache_key = app_utils.app_cache_key(manifest.full_path, manifest.class_name)
+
+        # Simulate a prior failed load (e.g. a syntax error the user has since fixed).
+        app_utils.FAILED_TO_LOAD_CLASSES[cache_key] = ImportError("boom")
+
+        # Without force_reload the cached failure blocks loading — no instance is created.
+        app_factory.create_instances("my_app", manifest)
+        assert "my_app" not in app_registry.apps
+        assert cache_key in app_utils.FAILED_TO_LOAD_CLASSES
+
+        # With force_reload the failure is evicted and the app loads from disk.
+        app_factory.create_instances("my_app", manifest, force_reload=True)
+        assert "my_app" in app_registry.apps
+        assert cache_key not in app_utils.FAILED_TO_LOAD_CLASSES
+
 
 class TestAppLifecycleServiceIntegration:
     """Integration tests for AppLifecycleService with real app instances."""

--- a/tests/integration/web_api/test_endpoints.py
+++ b/tests/integration/web_api/test_endpoints.py
@@ -129,7 +129,7 @@ class TestAppEndpoints:
         data = response.json()
         assert data["action"] == "stop"
 
-    async def test_reload_app(self, client: "AsyncClient", mock_hassette) -> None:
+    async def test_reload_app(self, client: "AsyncClient", mock_hassette: MagicMock) -> None:
         """Reload returns 202 and forces a fresh re-import from disk.
 
         The force_reload=True assertion guards #1005: without it the endpoint reused the

--- a/tests/integration/web_api/test_endpoints.py
+++ b/tests/integration/web_api/test_endpoints.py
@@ -129,11 +129,17 @@ class TestAppEndpoints:
         data = response.json()
         assert data["action"] == "stop"
 
-    async def test_reload_app(self, client: "AsyncClient") -> None:
+    async def test_reload_app(self, client: "AsyncClient", mock_hassette) -> None:
+        """Reload returns 202 and forces a fresh re-import from disk.
+
+        The force_reload=True assertion guards #1005: without it the endpoint reused the
+        cached (failed) class, so a fix on disk never took effect.
+        """
         response = await client.post("/api/apps/my_app/reload")
         assert response.status_code == 202
         data = response.json()
         assert data["action"] == "reload"
+        mock_hassette.app_handler.reload_app.assert_awaited_once_with("my_app", force_reload=True)
 
     async def test_app_management_works_without_dev_mode(self, client: "AsyncClient", mock_hassette) -> None:
         mock_hassette.config.dev_mode = False


### PR DESCRIPTION
## Summary

Fixes a confusing reload failure: when an app failed to start because of a bug in its source, fixing the file on disk and hitting **Reload** (in the UI or via `POST /api/apps/{app_key}/reload`) left the app failing with the *original* error — even though the traceback showed the corrected code.

The REST reload endpoint was the only `reload` caller that didn't pass `force_reload=True`, so it reused the cached failed class instead of re-importing from disk.

### The fix

- `src/hassette/web/routes/apps.py` — pass `force_reload=True` from the reload endpoint. The flag already threads cleanly through `app_handler.reload_app → lifecycle.reload_app → start_app → factory.create_instances → load_app_class`, which evicts both the loaded and failed class caches and calls `importlib.reload`. This matches what the file-watcher path already does on a file change, so a manual reload now behaves the same as an automatic one.

### Tests

- `tests/integration/web_api/test_endpoints.py` — `test_reload_app` now asserts the endpoint delegates with `force_reload=True` (the call-site regression anchor; RED before the fix, GREEN after).
- `tests/integration/test_app_factory_lifecycle.py` — `test_factory_force_reload_recovers_previously_failed_class` seeds a real load failure, confirms the no-force path stays blocked, then confirms `force_reload=True` evicts the failure and loads the class from disk — pinning the actual recovery behavior, not just the call site.

Closes #1005
