### PR TITLE
test: isolate destructive system tests and deflake bus lifecycle test

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -142,10 +142,13 @@ filterwarnings = [
     # Tests that assert the guard raises opt in locally via filterwarnings("error", ...).
     "default::hassette.exceptions.HassetteBlockingIOWarning",
     "default:.*does not declare restart_spec.*:UserWarning",
-    "default::ResourceWarning:anyio\\.streams\\.memory",
-    "default::ResourceWarning:aiohttp\\.client",
-    "default::ResourceWarning:aiosqlite\\.core",
-    "default::ResourceWarning:aiohttp\\.connector",
+    # ResourceWarning stays escalated to error (via the global "error" above). These were
+    # previously downgraded to mask a leak where a fatal-cascade system test orphaned service
+    # tasks onto the shared session-scoped event loop, leaving aiosqlite/aiohttp/anyio handles
+    # unclosed (issue #1101). The fix is structural — the destructive system tests now run on
+    # function-scoped loops (see the loop_scope markers in tests/system/test_shutdown.py and
+    # test_reconnection.py) so a crashed instance's tasks are reaped at loop teardown. Keeping
+    # ResourceWarning fatal ensures the leak can't return silently.
     "default:Top-level \\[apps\\.\\*\\]:DeprecationWarning:hassette\\.config\\.classes",
     # starlette 1.3.x's TestClient nudges toward the httpx2 fork; we still use httpx. Third-party
     # deprecation we can't act on without adopting the fork — don't let it fail the suite. Scope by

--- a/tests/integration/test_lifecycle_propagation.py
+++ b/tests/integration/test_lifecycle_propagation.py
@@ -46,6 +46,10 @@ class TestHassetteShutdownSinglePass:
             assert call_count == 1, f"on_shutdown should have been called exactly once, got {call_count}"
         finally:
             bus.on_shutdown = original_on_shutdown  # pyright: ignore[reportAttributeAccessIssue]
+            # Restore the shared module-scoped bus to RUNNING for the next test. Without this,
+            # a later bus test that assumes a running bus (e.g. test_children_stopped_*) finds
+            # shutdown_completed=True, so its bus.shutdown() no-ops and flakes (#1073).
+            await bus.initialize()
 
     async def test_shutdown_then_initialize_resets_flag(self, hassette_with_bus: "HassetteHarness") -> None:
         """After shutdown + initialize, the resource can be shut down again."""

--- a/tests/system/test_reconnection.py
+++ b/tests/system/test_reconnection.py
@@ -10,7 +10,9 @@ from hassette.test_utils import wait_for
 
 from .conftest import HA_CONTAINER_NAME, make_system_config, startup_context, toggle_and_capture, wait_for_ha_ready
 
-pytestmark = [pytest.mark.system_destructive]
+# These tests restart HA mid-run to exercise reconnection. Give each its own event loop so
+# residual tasks cannot bleed across tests on the shared session-scoped loop (see test_shutdown).
+pytestmark = [pytest.mark.system_destructive, pytest.mark.asyncio(loop_scope="function")]
 
 ENTITY = "light.kitchen_lights"
 

--- a/tests/system/test_shutdown.py
+++ b/tests/system/test_shutdown.py
@@ -13,7 +13,10 @@ from hassette.types.enums import ResourceStatus, RestartType
 
 from .conftest import make_system_config, startup_context
 
-pytestmark = [pytest.mark.system_destructive]
+# These tests deliberately crash Hassette into a fatal shutdown. Give each its own event
+# loop so a test that leaves residual tasks (e.g. a fatal-cascade teardown) cannot bleed
+# them into the next test on the shared session-scoped loop.
+pytestmark = [pytest.mark.system_destructive, pytest.mark.asyncio(loop_scope="function")]
 
 
 async def test_clean_shutdown(ha_container: str, tmp_path) -> None:


### PR DESCRIPTION
## Summary

Fixes the `ResourceWarning` leaks that appear on nearly every CI system-test run (#1101) and the parallel-load flake in `test_children_stopped_before_on_children_stopped_hook` (#1073). Both turned out to be **test-isolation** problems, proven with runtime evidence rather than the issues' original framing.

## #1101 — not a websocket-reconnect leak

The original title ("close connections on websocket reconnect") was misleading. Controlled experiments on the real Docker surface showed the reconnect path shuts down cleanly:

| Selection | Result |
|---|---|
| `test_reconnection.py` only | 3 passed, **0 ResourceWarnings** |
| `test_shutdown.py` only | 2 passed, **0 warnings** |
| full `system_destructive` (randomized) | **failure + 4 ResourceWarnings** |
| forced `cascade → clean_shutdown` | **deterministic failure** |

**Root cause:** the destructive system tests share one session-scoped asyncio event loop. `test_failed_service_cascade_triggers_fatal_shutdown` drives a `FatalError` whose `ServiceWatcher`-initiated shutdown self-cancels — it runs inside the `bus:dispatch_listener` task that the shutdown itself tears down — leaving ~11 orphaned service tasks (`DatabaseService`, `WebsocketService`, `db_write_worker`, the bus dispatch tasks, …) alive on the shared loop. They contaminate the next test: `test_clean_shutdown` is cancelled mid-lifecycle (a leftover `_AlwaysFailingService` crash bleeds into it), so its `ApiResource` REST session, `DatabaseService` connections, and `BusService` stream clone are orphaned and surface as `ResourceWarning`s at GC. tracemalloc confirmed the allocation sites (`api_resource.py:86`, the `receive_stream.clone()` at `core.py:194`, and `_db`/`_read_db`). In CI this hides as `RERUN → PASSED` while still emitting the warnings.

**Fix:** give the two destructive system-test files function-scoped event loops (`@pytest.mark.asyncio(loop_scope="function")`, an existing pattern in `tests/unit/core/test_loop_watchdog.py`) so each crashed instance's tasks are reaped at loop teardown. Re-promote `ResourceWarning` to error (drop the four `default::ResourceWarning:*` downgrades) so the leak can never return silently.

## #1073 — bus lifecycle flake

`test_child_on_shutdown_called_once` shuts down the shared **module-scoped** bus but — unlike the three sibling bus tests in the file — never re-initializes it in `finally`. Under random order + xdist distribution it leaves the bus `shutdown_completed=True`; `harness.reset()` only clears listeners, not lifecycle. The victim `test_children_stopped_before_on_children_stopped_hook` then finds a no-op `bus.shutdown()`, so `handle_stop` never fires and the assertion flakes. A DIAG capture confirmed the gate: `pre(shutdown_completed, shutting_down, status, streams_closed) = (True, False, 'stopped', False)`.

**Fix:** restore the bus with `await bus.initialize()` in the culprit's `finally`, honoring the contract the sibling tests already follow.

## Verification

- Forced `cascade → clean_shutdown`: passes, **0 ResourceWarnings**.
- Full `system_destructive` (randomized): **5/5 passed, 0 ResourceWarnings, exit 0**.
- **12/12 consecutive `-n2` integration runs green** (flaked 2/6 before — and reproduced at run 5/8 during diagnosis).
- **7,796 unit/integration tests pass** with `ResourceWarning` promoted to error (0 collateral).
- `code-reviewer`, `integration-reviewer`, `wtf-reviewer` all approve; `ruff` clean; `pyright` 0 errors.

Closes #1101
Closes #1073
