### PR TITLE
refactor!: decouple state models from conversion logic via codec layer

### DIFF
--- a/design/adrs/0003-dumb-state-models-codec-owned-conversion.md
+++ b/design/adrs/0003-dumb-state-models-codec-owned-conversion.md
@@ -1,0 +1,129 @@
+# ADR-0003: Dumb State Models, Codec-Owned Conversion, and Clean Global Registries
+
+## Status
+
+Accepted
+
+## Context
+
+The `conversion ↔ models` runtime import cycle (#892, the last open cycle under #1079) has resisted the mechanical fixes that cleared the other three cycles in #1120. Every prior attempt relocated the symptom instead of the cause. This ADR records the decision to fix the cause: the conversion *behavior* that lives inside the state models.
+
+### The cycle is one back-edge
+
+Despite the remaining `# lazy-import:` markers in `conversion/` (`annotation_converter.py:38,40`, `state_registry.py:89`; `validation.py:77` is a load-order note, not a cycle), exactly one runtime edge points the wrong way:
+
+```
+src/hassette/models/states/base.py:10
+    from hassette.conversion import TYPE_REGISTRY, register_state_converter
+```
+
+The three `conversion → models` lazy imports (`annotation_converter.py:40`, `state_registry.py:90`, and the `issubclass(tp, BaseState)` use at `annotation_converter.py:72`) are the *legitimate* direction — the conversion engine depends on the data models. They are only lazy because the back-edge above would otherwise close the loop at package-init time. Remove `base.py:10` and all three become ordinary top-level imports.
+
+`base.py` reaches up to `conversion` for exactly two things:
+
+- `register_state_converter(cls, ...)` in `__init_subclass__` (line 137) — every `BaseState` subclass pushes itself into the global state registry at class-definition time.
+- `TYPE_REGISTRY.convert(state, cls.value_type)` in the `_validate_domain_and_state` model-validator (line 175) — scalar value coercion (`"on"` → `True`, etc.).
+
+### Why this is a design problem, not an import problem
+
+A Pydantic `@model_validator` is a classmethod. There is nothing to inject a registry into, so a self-validating model *must* reach for an ambient module global to convert its value. Self-validating models and "no shared mutable conversion state" are therefore mutually exclusive. The cycle is a downstream symptom of that choice. The other symptoms of the same root:
+
+- **Process-global registries via `ClassVar`.** `TypeRegistry.conversion_map` and `StateRegistry._registry` are class variables (`type_registry.py:145`, `state_registry.py:46`). The `TYPE_REGISTRY = TypeRegistry()` singleton in `conversion/__init__.py:7-9` is a cosmetic handle; the state lives on the class. Two `Hassette` instances in one process share it — which is why `test_utils/harness.py` needs `snapshot`/`restore`.
+- **Implicit load-order contract.** Importing `hassette.conversion` runs the `register_simple_type_converter(...)` calls at the bottom of `type_registry.py`. `base.py` importing `conversion` is what guarantees scalar converters exist before any state validates. `conversion/validation.py:91` literally warns "STATE_REGISTRY is empty — models package may not be imported." A missing `str → bool` converter is a correctness bug (`bool("off")` is `True`), not a missing optimization.
+- **Convert-time self-mutation.** `TypeRegistry.convert` auto-registers a constructor converter into the global map on a cache miss (`type_registry.py:200-215`), making registry contents order-dependent and emitting "Overwriting existing conversion" warnings.
+
+ADR-0002 already named "Registry Holder — stores state/type registries as class attributes" as one of the `Hassette` god-object responsibilities. This ADR resolves that thread for the registries specifically.
+
+### What is already in place
+
+The injectable seam exists; it is just wired to the globals.
+
+- `core.py` exposes `hassette.state_registry` and `hassette.type_registry` properties (lines 439, 446), populated at startup from the globals (`self._state_registry = STATE_REGISTRY`, lines 220-221).
+- Production already converts through those instances: `api.py:392/686` and `state_manager.py:356` call `self.hassette.state_registry.try_convert_state(...)`.
+- `api.py:747` already does `self.hassette.type_registry.convert(state, model.value_type)` — the exact value-coercion pattern this ADR moves into the codec. The model validator is duplicating, the wrong way, what the API already does the right way.
+
+### Blast radius (verified)
+
+- **Models:** the conversion coupling is two lines in `base.py`. Every per-domain model (~40 files) only carries `field_validator`s for datetime *attribute* parsing (e.g. `sensor.py:96`, `media_player.py:147`), which depend on `utils`/`whenever` (downward, no cycle) and stay put. "Dumb models" is a `base.py`-only change; it does not ripple through the domain files.
+- **Production raw-dict → State** is concentrated in `state_manager.py:87`, a few `api.py` sites, and the codec (`conversion/state_registry.py`). Not sprinkled.
+- **Tests:** ~6-8 files construct states with `XState.model_validate(raw_dict)` directly (`tests/unit/conftest.py:97`, `test_sync_entity_facade.py`, `test_entity_coroutine_conversion.py`, `test_models.py:154`, `test_sync_facades.py`, `test_api_helper_models.py`). They route to a `test_utils` codec helper; the dict-builder half already exists (`helpers.py:make_light_state_dict` etc.). `test_state_manager.py` spies on `LightState.model_validate` and re-points at the codec.
+
+### Public extension API (the constraint on "per-instance")
+
+The registration surface is documented public API, not internal plumbing:
+
+- `register_simple_type_converter` and `register_type_converter_fn` are re-exported from `hassette` (`__init__.py:12-13`) and used across ~10 docs pages (`core-concepts/states/conversion.md`, `custom-states.md`, the `type-registry/` snippets).
+- Custom state classes auto-register by **module-level definition** — `custom-states.md` and `tests/unit/test_state_registry.py:64-89` document that defining a `BaseState` subclass at module level works with no explicit call.
+
+"Per-instance registries" therefore cannot mean "retire the globals." It means separating the global *definition catalog* (the extension surface + the standard converters + `BaseState.__subclasses__()`) from the per-instance *live conversion state* (the resolved domain→class map and the convert-on-miss cache).
+
+## Decision
+
+Make state models dumb data, move conversion ownership into a codec, and build per-instance live registries from a global definition catalog.
+
+### 1. Dumb state models
+
+`BaseState` carries shape and a `value_type` declaration. It does not import `conversion`, does not self-register, and does not coerce its own value.
+
+- Remove `register_state_converter` from `__init_subclass__`.
+- Remove the `TYPE_REGISTRY.convert(...)` line from `_validate_domain_and_state`. Domain extraction and the `unknown`/`unavailable` handling stay (pure shape logic). Datetime field validators stay.
+- `base.py` then imports nothing from `conversion`; `models/states` becomes a leaf over `types`, `const`, `utils`, `whenever`.
+
+The codec coerces the raw value against `state_class.value_type` *before* constructing the model, so Pydantic validates an already-typed value. `__init_subclass__` stays as the registration mechanism but writes a `models`-layer state-class catalog (a sibling leaf), not `conversion` — keeping eager, order-independent, all-depth registration while removing the back-edge.
+
+### 2. The codec owns dict → State and known-model coercion
+
+The conversion engine (today's `conversion` package) is the single place that turns raw Home Assistant JSON into a typed state: resolve domain → look up the state class → coerce the value via the type registry → construct. It also exposes a known-model coercion path (target class + raw dict) for `state_manager`. The lazy `conversion → models` imports become top-level (the legitimate direction). Coercion failures are wrapped so the existing `UnableToConvertStateError(entity_id, model)` contract holds.
+
+### 3. Clean global registries (revised — per-instance rejected)
+
+> **Revision (2026-06-23):** the original proposal here was per-instance live registries built from a global catalog. Verification during the challenge killed that: production is single-instance (`context.set_global_hassette` raises on a second instance, `context.py:41-43`), and per-instance does not isolate tests because the pollution is at the process-global `__init_subclass__`/catalog level. The decision is now clean global registries (was "Alternative B1").
+
+- `TYPE_REGISTRY`/`STATE_REGISTRY` stay process-global singletons; the `hassette.*_registry` accessors keep returning them. No per-instance build, no active-context routing.
+- The shared domain→class map moves from `StateRegistry._registry` (`ClassVar` in `conversion`) into the `models`-layer catalog leaf so `models` never imports `conversion`; the codec's `StateRegistry` reads it.
+- **Stop the convert-on-miss self-write** (`type_registry.py:205`): `TypeRegistry` becomes read-only after its standard converters load, removing the type-side `snapshot`/`restore` entirely.
+- The state-side reset fixture stays (simplified to the state catalog) — it is irreducible while `__init_subclass__` auto-registration remains a documented feature.
+
+### 4. Enforcement
+
+- Flip the three `conversion`-side lazy imports to top-level and delete the `# lazy-import:` annotations (keep `validation.py:77`, a load-order note, not a cycle). Clearing `annotation_converter.py:39` requires relocating the `TYPE_REGISTRY`/`TYPE_MATCHER` singleton definitions out of `conversion/__init__.py` into their submodules (re-exported).
+- Add a `models-no-conversion` rule to `tools/check_module_boundaries.py` so the back-edge cannot re-accrete.
+
+## Consequences
+
+### Positive
+
+- The `conversion ↔ models` cycle is gone, and the dependency graph is one-directional. This unblocks the #633 graph cycle detector.
+- `models/states` becomes a true leaf relative to `conversion`. Conversion lives in one place and is testable.
+- The convert-time self-mutation is removed and the type-side `snapshot`/`restore` with it; the import-order warning is addressed by the model no longer needing `conversion` at all.
+- Resolves the registry portion of the ADR-0002 god-object thread without adding per-instance machinery.
+
+### Negative / costs
+
+- Breaking internal change. `LightState.model_validate(raw_ha_dict)` no longer coerces a raw HA dict standalone; raw-dict construction goes through the codec. Pre-1.0, internal breakage is acceptable.
+- `__init_subclass__` stays, so the **state-side reset fixture stays** (simplified to the state catalog). This is the deliberate trade: keeping the documented "module-level custom state just works" DX means custom classes register globally, so tests still reset between runs. Only dropping that DX would remove the fixture, which is not worth it.
+- Test migration: route direct `XState.model_validate(raw_dict)` calls through a `test_utils` codec helper; re-point the `model_validate` spy in `test_state_manager.py`; rewrite `TestConstructorFallbackCache`'s memoization assertions. Mechanical, spread across ~8 files.
+
+### Honest limit
+
+The state-class catalog is process-global (via `__init_subclass__`). This design does not isolate it per-run — the reset fixture remains the isolation mechanism. That is accepted: per-instance registries were verified not to remove it either (production is single-instance; the catalog stays global regardless), so the extra machinery bought nothing.
+
+## Phased plan (verifiable checkpoints)
+
+1. **Break the cycle + dumb models.** Extract the state-class catalog leaf; repoint `__init_subclass__`; move value coercion + the known-model path into the codec with error wrapping; flip the lazy imports to top-level (incl. the singleton relocation that clears `annotation_converter:39`). Checkpoint: cycle gone, `check_module_boundaries`/`check_lazy_imports` clean, full suite green.
+2. **Registry hygiene.** Stop the convert-on-miss self-write; remove `TypeRegistry.snapshot`/`restore`; simplify the `conftest.py` reset fixture to the state catalog; rewrite `TestConstructorFallbackCache`. Checkpoint: suite green, no type-registry mutation on the hot path.
+3. **Lock it.** Add the `models-no-conversion` boundary rule; update the affected docs pages. Checkpoint: boundary rule self-proves the break.
+
+## Alternatives considered
+
+- **B2 — Per-instance live registries (originally proposed here).** Build each `Hassette` a registry from a process-global catalog. **Rejected after verification:** production is single-instance (`context.py:41-43` forbids a second), and per-instance does not isolate tests (pollution is at the `__init_subclass__`/catalog level, which stays global). It adds active-context routing, `ClassVar`→instance migration, and DI-path threading to solve nothing. Full analysis in `design/specs/084-dumb-state-models-codec-conversion/challenge-results.md`.
+- **A — Smart models, registries demoted to a leaf.** Keep the model validator coercing via a leaf registry. Smaller, keeps standalone `model_validate`, but keeps the model owning conversion and the convert-on-miss self-write. The chosen design is barely larger and removes both.
+- **Drop `__init_subclass__` for explicit registration.** Would remove the state reset fixture entirely, but breaks the documented "module-level custom state just works" DX. Rejected — the fixture is the smaller cost.
+- **C — Status quo with the lazy imports.** Rejected: leaves a static cycle that blocks #633.
+
+## References
+
+- Issue #1079 (break import cycles), #892 (`conversion ↔ models`), #633 (boundary enforcement this unblocks)
+- PR #1120 (broke the other three cycles via protocol/factory inversion)
+- ADR-0002 (Hassette god-object extraction; names the registry-holder responsibility)
+- Research brief: `design/research/2026-06-22-break-import-cycles/research.md`

--- a/design/specs/084-dumb-state-models-codec-conversion/challenge-results.md
+++ b/design/specs/084-dumb-state-models-codec-conversion/challenge-results.md
@@ -1,0 +1,71 @@
+# Challenge Findings — Dumb State Models design
+
+**Format-version:** 3
+**Target:** design/specs/084-dumb-state-models-codec-conversion/design.md
+**Critics:** senior-engineer, contract-caller, structural-minimalist
+**Likely-invalid:** 0
+**Date:** 2026-06-23
+
+Three critics ran independently; findings converged sharply (same `file:line` gaps hit by 2-3 critics). All crux claims verified against code.
+
+## Finding 1: TypeRegistry per-instance tier is unjustified ceremony — asymmetric split (HIGHEST-VALUE / STRUCTURAL / design-level: Yes / User-directed)
+
+**Why it matters:** The user chose "B2 for both registries." The adversarial pass says that's half right. The `StateRegistry` per-instance tier is load-bearing (domain→class is what tests pollute and what two Hassette instances would share). The `TypeRegistry` per-instance tier exists *only* to clean up the convert-on-miss self-write. Stop that write and `TypeRegistry` becomes a stateless read-only catalog — deleting the ClassVar→instance migration, the active-context routing for type converters, the `test_type_registry.py` migration, and closing the AnnotationConverter/bus-DI gap (Finding 5) for free.
+
+**Evidence:** `type_registry.py:205` (`TypeRegistry.register(...)` writes the `ClassVar` on cache miss); ADR-0003 itself: "the type-converter set is genuinely process-global and stateless"; `annotation_converter.py:39` + `bus/injection.py:115` use the module-level `TYPE_REGISTRY`/`ANNOTATION_CONVERTER` singletons.
+
+**Design challenge:** If the type-converter catalog is process-global and stateless once the self-write stops, what does a per-instance `TypeRegistry` buy that a clean read-only global doesn't?
+
+**Recommendation:** Adopt the asymmetric split — per-instance `StateRegistry`, clean-global read-only `TypeRegistry` (fix the convert-on-miss self-write). Roughly halves the design and resolves Findings 3, 5, and the type-side of 6.
+
+## Finding 2: `StateManager` enumeration reads the global, not the instance (CRITICAL / Fragility / design-level: Yes / User-directed)
+
+**Why it matters:** After per-instance migration, `self.states` iteration/containment silently reads the catalog-backed default while `.resolve()`/`.try_convert_state()` read the live instance. AC#4's isolation test (which exercises `.resolve()`) won't catch it.
+
+**Evidence:** `state_manager.py:368,372,385,394` bind module-level `STATE_REGISTRY`; `:288,:356` use `self.hassette.state_registry`. Confirmed.
+
+**Recommendation:** Move these four methods to `self.hassette.state_registry`; add a boundary rule banning module-level `STATE_REGISTRY`/`TYPE_REGISTRY` import outside `conversion/`. List them in Impact + Replacement Targets.
+
+## Finding 3: `BaseState.__subclasses__()` scan registers zero domains (CRITICAL / Approach-now / design-level: Yes / User-directed)
+
+**Why it matters:** The proposed discovery mechanism returns only the 5 intermediate bases; the ~40 domain leaves are grandchildren. Strict-mode startup would fail with an empty registry; non-strict would silently fall back to `BaseState` (uncoerced values everywhere).
+
+**Evidence:** `light.py:56` `class LightState(BoolBaseState)`, `sensor.py:102` `class SensorState(StringBaseState)`; `base.py:209-244` defines the 5 intermediate bases as the only direct `BaseState` subclasses. Confirmed.
+
+**Recommendation:** Either a recursive subclass walk, OR — simpler and order-independent — keep `__init_subclass__` but have it register into a **leaf catalog** (downward import, no cycle) instead of `conversion`. The leaf-catalog push avoids both the grandchildren bug and the late-import ordering edge cases (Finding 4).
+
+## Finding 4: Scan-ordering / late-import classes silently unregistered (HIGH / Fragility / design-level: Yes / User-directed)
+
+**Why it matters:** Today `__init_subclass__` fires on import regardless of timing. A startup scan misses any state class whose module imports after the scan — silent `BaseState` fallback. The "scan after app loading" point is also undefined: `validate_registries` runs in `wire_services()` before any app initializes.
+
+**Evidence:** ADR/design Edge Cases acknowledge ordering but don't resolve the lifecycle point; `core.py:248` calls `validate_registries` in `wire_services`.
+
+**Recommendation:** The leaf-catalog `__init_subclass__` push (Finding 3) dissolves this — registration stays eager and order-independent. If a scan is kept, define the exact lifecycle hook and rescan-on-miss behavior.
+
+## Finding 5: Raw-dict hot path `state_manager.py:87` loses coercion silently (CRITICAL / Approach-now / design-level: Yes / User-directed)
+
+**Why it matters:** `DomainStates._validate_or_return_from_cache` calls `self._model.model_validate(raw_dict)` — the primary path for `self.states.light["bedroom"]` and all domain iteration. After dumb models, the model no longer coerces; boolean/numeric domains return `"on"`/`"23.5"` strings. The design mentions `:87` once but specifies no replacement, and today's codec (`try_convert_state`) resolves domain from the dict — there's no "coerce against this known model class" entry point.
+
+**Evidence:** `state_manager.py:87`; `state_registry.py:63` `try_convert_state(data, entity_id)` resolves domain internally.
+
+**Recommendation:** Add a codec entry point that takes a known `state_class` + raw dict, coerces the value via the type registry, and constructs. Route `:87` through it.
+
+## Finding 6: Error type/timing change breaks the `UnableToConvertStateError` catch (HIGH / Fragility / design-level: Yes / User-directed)
+
+**Why it matters:** Coercion failure today surfaces as Pydantic `ValidationError`, caught at `state_manager.py:88` and re-raised as `UnableToConvertStateError` with `entity_id`. Moving coercion to the codec raises `UnableToConvertValueError` directly — not a `ValidationError` — so the catch misses it and the entity silently drops at the `except Exception: continue` path.
+
+**Evidence:** `state_manager.py:88` catches `ValidationError`; `base.py:176` `except UnableToConvertValueError`; codec coercion would raise `UnableToConvertValueError`.
+
+**Recommendation:** Codec wraps coercion failures so the existing `UnableToConvertStateError(entity_id, model)` contract holds; add a test pinning the error type + entity_id.
+
+## Finding 7: Active-context `register_*` routing is promised but doesn't exist (HIGH / Gap / design-level: Yes / User-directed)
+
+**Why it matters:** The design says module-level `register_*` also updates the active live instance. No context-var lookup exists in `conversion/` today; behavior with no/two contexts is unspecified. `register_state_converter` is documented public API (`conversion.md:87`) for runtime domain registration — under per-instance it would only hit the catalog, not the running registry, defeating its purpose.
+
+**Evidence:** `type_registry.py:147-155` `register` is a classmethod with no context lookup; `core.py` context management exists but isn't wired to registration.
+
+**Recommendation:** If Finding 1 is adopted, this collapses to the state-registry side only. Specify the context-var mechanism and the no-context behavior explicitly, or scope dynamic post-startup registration as unsupported and document it.
+
+## Likely Invalid
+
+(none)

--- a/design/specs/084-dumb-state-models-codec-conversion/design.md
+++ b/design/specs/084-dumb-state-models-codec-conversion/design.md
@@ -1,0 +1,285 @@
+# Design: Dumb State Models + Codec-Owned Conversion (clean global registries)
+
+**Date:** 2026-06-23
+**Status:** archived
+**Scope-mode:** hold
+**Research:** design/adrs/0003-dumb-state-models-codec-owned-conversion.md, design/specs/084-dumb-state-models-codec-conversion/challenge-results.md
+
+## Problem
+
+The `conversion ↔ models` runtime import cycle (#892) is the last open cycle under #1079. The other three fell to mechanical fixes in #1120; this one was deferred because mechanical fixes only relocate it. The cycle is one back-edge:
+
+```
+src/hassette/models/states/base.py:10
+    from hassette.conversion import TYPE_REGISTRY, register_state_converter
+```
+
+`base.py` reaches up into the conversion layer for two reasons: `register_state_converter` in `__init_subclass__` (state subclasses self-register), and `TYPE_REGISTRY.convert(...)` in the `_validate_domain_and_state` validator (scalar value coercion). The three `conversion → models` lazy imports are the legitimate direction and are only lazy because this back-edge would otherwise close the loop at package-init time.
+
+The root cause is that a Pydantic `@model_validator` is a classmethod with nothing to inject into, so a self-validating model *must* reach for an ambient global to convert its value. Secondary symptoms of the same arrangement: the implicit load-order contract (`conversion/validation.py:92` warns "STATE_REGISTRY is empty"), and convert-time self-mutation (`TypeRegistry.convert` auto-registers a constructor converter into the global map on a cache miss, `type_registry.py:200-215`), which is the sole driver of the type-registry test `snapshot`/`restore` dance.
+
+This design moves conversion *behavior* out of the model and into a codec, which breaks the cycle, and tidies the registry globals — without introducing per-instance registries.
+
+### Why not per-instance registries
+
+ADR-0003 originally proposed per-instance registries. The challenge (`challenge-results.md`) and direct code verification killed that direction:
+
+- **Production is single-instance.** `context.set_global_hassette` raises `RuntimeError` if a different `Hassette` is already set (`context.py:41-43`) — concurrent instances are forbidden. There is no production scenario two registries would isolate.
+- **Per-instance doesn't isolate tests anyway.** The pollution source is `BaseState.__init_subclass__` writing a process-global target; a per-instance registry built from that global catalog still sees every prior test's class. Isolation still requires resetting the global, so per-instance adds machinery without removing the fixture.
+
+So the registries stay clean process-global singletons. The state-side reset fixture stays (it is irreducible while `__init_subclass__` auto-registration is a documented feature); the type-side reset is *removed* by fixing the convert-on-miss self-write.
+
+## Goals
+
+- The `conversion ↔ models` runtime cycle is broken; the subpackage runtime import graph is acyclic. `models/states` imports nothing from `conversion`.
+- State models are dumb data: shape plus a `value_type` declaration, no conversion behavior. `__init_subclass__` registration stays but targets a `models`-layer catalog, not `conversion`.
+- A codec owns the dict → State path (domain resolution, value coercion, construction) and the known-model coercion path that `state_manager` uses.
+- The convert-on-miss self-write is removed; `TypeRegistry` becomes a read-only catalog after init, eliminating the type-side `snapshot`/`restore`.
+- The public extension API (`register_simple_type_converter`, `register_type_converter_fn`, module-level custom `BaseState` subclasses, `register_state_converter`, `TYPE_REGISTRY`/`STATE_REGISTRY`) keeps working unchanged.
+- A `models-no-conversion` boundary rule self-proves the break. `check_module_boundaries.py` / `check_lazy_imports.py` pass; pyright clean; suite green.
+
+## Non-Goals
+
+- **No per-instance registries.** Registries remain clean global singletons (decision reversed from ADR-0003; rationale above and in the ADR's revised Decision).
+- **No change to `__init_subclass__` auto-registration as a public behavior** — module-level custom state classes keep working with no explicit call.
+- No change to per-domain model field shapes or their datetime `field_validator`s.
+- No change to the DI/annotation-conversion behavior app authors observe (`D.StateNew[...]`).
+- Not eliminating the state-side test reset fixture — irreducible while auto-registration stays (named as a known limit, not a goal).
+
+## User Scenarios
+
+The actors are framework maintainers and app authors; this is internal architecture with a public-API-compatibility surface.
+
+### Maintainer: framework developer
+- **Goal:** add or modify state models and conversion logic without fighting an import cycle.
+- **Context:** `src/hassette/models/states/` and `src/hassette/conversion/`.
+
+#### Add a new state domain
+1. **Define a `BaseState` subclass at module level**
+   - Sees: the model needs only fields + `value_type`; it imports the `models`-layer state-class catalog for `register_state_converter`, never `conversion`.
+   - Decides: nothing about conversion wiring — `__init_subclass__` registers it automatically (at any subclass depth).
+   - Then: the domain resolves through the codec.
+
+### App author: Hassette user
+- **Goal:** register a custom type converter or define a custom state class, exactly as documented today.
+- **Context:** their app module, using the public API re-exported from `hassette`.
+
+#### Register a custom converter
+1. **Call `register_simple_type_converter(...)`**
+   - Sees: identical public API and identical effect — one global registry, so the running app sees the converter.
+   - Decides: nothing new.
+   - Then: the converter is in `TYPE_REGISTRY`, used by every conversion.
+
+## Functional Requirements
+
+- **FR#1** `models/states/base.py` (and the rest of `models/states/`) import no symbol from `hassette.conversion` at runtime (including lazy/in-function imports).
+- **FR#2** `BaseState` subclasses validate already-typed values — the model performs no registry lookup or scalar value coercion during validation.
+- **FR#3** `__init_subclass__` registers every `BaseState` subclass (at any inheritance depth) into a `models`-layer state-class catalog, with no import of `conversion`.
+- **FR#4** The codec converts a raw HA state dict to the correct typed state (domain resolution + value coercion + construction), with fallback to `BaseState` for unregistered domains — preserving today's `try_convert_state` behavior.
+- **FR#5** The codec exposes a known-model coercion path: given a target state class and a raw state dict, coerce the value against `value_type` and construct — replacing the model's self-coercion at `DomainStates._validate_or_return_from_cache` (`state_manager.py:87`).
+- **FR#6** Scalar value coercion produces the same typed results as today's `BaseState` validator path, for every domain `value_type`.
+- **FR#7** A coercion failure on the `state_manager`/`api` state paths surfaces as `UnableToConvertStateError(entity_id, model)` — the same type and attached `entity_id` as today.
+- **FR#8** `TypeRegistry.convert` no longer mutates the registry on a cache miss; the conversion result is unchanged.
+- **FR#9** The public names `from hassette import TYPE_REGISTRY, STATE_REGISTRY, register_simple_type_converter, register_type_converter_fn` and `from hassette.conversion import register_state_converter` keep working and affect/read the one global registry the framework uses.
+- **FR#10** `check_module_boundaries.py` enforces a `models-no-conversion` rule; `check_lazy_imports.py` passes with the cycle-related `# lazy-import:` annotations removed.
+
+## Edge Cases
+
+- **`unknown` / `unavailable` states:** the `is_unknown`/`is_unavailable` normalization and `state → None` handling stay in the model validator (shape logic), not the codec.
+- **Unregistered domain:** codec falls back to `BaseState` (unchanged, FR#4).
+- **`annotation_converter` self-package import:** `annotation_converter.py:39` (`from hassette.conversion import TYPE_MATCHER, TYPE_REGISTRY`) cannot hoist to a top-level self-package import (the symbols are created in `conversion/__init__.py:7-8` *after* `__init__` imports `annotation_converter`). Relocate the `TYPE_REGISTRY`/`TYPE_MATCHER`/`STATE_REGISTRY`/`ANNOTATION_CONVERTER` singleton *definitions* into their defining submodules; `__init__` re-exports them (public API unchanged). Then `annotation_converter` imports them from submodules at top-level.
+- **Convert-on-miss memoization removed:** `test_type_registry.py::TestConstructorFallbackCache` asserts the cache *grows*; those assertions become "conversion succeeds" assertions. Performance is unaffected — both the old miss-branch and the old cache-hit branch call the same `to_type(value)` constructor (`type_registry.py:201` vs `:220`); the memo only avoided a dict insert.
+- **State-class test pollution:** still reset between tests via the (simplified, state-only) catalog reset fixture. Type-registry pollution no longer occurs (FR#8), so the type-side fixture is deleted.
+
+## Acceptance Criteria
+
+- **AC#1** `grep` shows zero `hassette.conversion` imports anywhere in `models/states/` (FR#1, FR#3); `check_module_boundaries.py` reports `models-no-conversion` passing (FR#10).
+- **AC#2** `check_lazy_imports.py` passes with the conversion-side cycle annotations removed. The three in-method imports become module-level, by distinct causes: (a) `annotation_converter.py:40` (`from hassette.models.states import BaseState`) and `state_registry.py:90` (the `BaseState` fallback import) are the legitimate `conversion → models` direction — hoistable once FR#1 holds (models stops importing conversion); (b) `annotation_converter.py:39` (`from hassette.conversion import TYPE_MATCHER, TYPE_REGISTRY`) is a self-package import that hoists only after the singleton relocation in Edge Cases. The standalone `# lazy-import:` comments at `:38` and the inline one at `:40` are deleted with their imports. `validation.py:77` is retained (load-order note, not a cycle).
+- **AC#3** A characterization test asserts the codec produces identical typed values to the pre-change `model_validate` path across all domain `value_type`s (FR#4, FR#6) — captured before the refactor, green after.
+- **AC#4** A test asserts the `self.states.<domain>[...]` / domain-iteration path (through `state_manager.py:87`) returns coerced typed values (e.g. `BoolBaseState` domains yield `bool`, not `"on"`) (FR#5, FR#6).
+- **AC#5** A test asserts a coercion failure on the state path raises `UnableToConvertStateError` carrying the `entity_id` (FR#7).
+- **AC#6** The public-API docs snippets (`type-registry/simple_registration.py`, `bus/.../custom_type_converter.py`, `custom-states.md`) type-check and behave identically (FR#9).
+- **AC#7** No `TypeRegistry.snapshot`/`restore` references remain anywhere, and `StateRegistry.snapshot`/`restore` are gone (replaced by the state-catalog leaf's reset primitive); the `tests/conftest.py` isolation fixture resets only the state-class catalog (FR#8).
+- **AC#8** Full unit + integration suite green; pyright clean; `check_module_boundaries.py` and `check_lazy_imports.py` pass.
+
+## Key Constraints
+
+- **No `from __future__ import annotations`** (project ban). The fix is structural.
+- **The cycle is broken by moving behavior, not by relocating service classes** (unlike #1120's `SchedulerService`/`StateProxy` inversions).
+- **Public names are load-bearing:** the imports in FR#9 must keep working; ~10 docs pages depend on them. Where a symbol's defining module moves, re-export from its old public location.
+- **The model keeps its datetime/alias/domain/unknown-unavailable validators** — only the `TYPE_REGISTRY.convert` coercion and the `register_state_converter` *target* change.
+
+## Dependencies and Assumptions
+
+- Assumes `__init_subclass__` remains the registration mechanism (it fires for all subclass depths — `LightState(BoolBaseState)` triggers it — so it reaches the ~40 domain leaves that a bare `BaseState.__subclasses__()` scan would miss).
+- Assumes the existing `hassette.state_registry`/`type_registry` properties (`core.py:438-443,445-450`) stay as accessors over the global singletons — no per-instance build.
+- Internal-only; no HA-protocol or schema changes; no persisted data.
+
+## Architecture
+
+Target downward DAG:
+
+```
+types / const            StateValueT, enums
+   ↑
+models/states            Pydantic shapes + value_type + the state-class catalog
+  ├─ registry leaf       STATE_CATALOG (domain→class dict) + register_state_converter + StateKey
+  └─ base.py / domains   dumb data; __init_subclass__ → registry leaf (same subpackage)
+   ↑
+conversion (codec)       TYPE_REGISTRY (+ converters), TYPE_MATCHER, AnnotationConverter,
+                         StateRegistry/try_convert_state, known-model coercion; reads the catalog + models
+   ↑
+consumers                bus DI, state_manager, api (via hassette.*_registry accessors over the globals)
+```
+
+### Dumb models (`base.py`)
+
+- Delete the value-coercion `try/except` from `_validate_domain_and_state` (`base.py:174-180`). The codec coerces before constructing; the model validates an already-typed `value`. Keep domain extraction, `unknown`/`unavailable` normalization, datetime validators, and the `state`/`value` alias.
+- Repoint `__init_subclass__`: `register_state_converter` now lives in the `models/states` registry leaf, not `conversion`. The call stays; only its import source changes.
+- Drop the now-dead `UnableToConvertValueError` from `base.py:11` (used only in the removed block); keep `NoDomainAnnotationError`.
+- Result: `base.py` imports only `types`, `exceptions` (`NoDomainAnnotationError`), `utils.date_utils`, `pydantic`, `whenever`, and the sibling registry leaf — none of which import `conversion`. `models/states` is a leaf relative to `conversion`.
+
+### State-class catalog (new `models/states` leaf)
+
+Extract the shared `domain → class` map (today `StateRegistry._registry`, a `ClassVar`) plus `register_state_converter`, `resolve`, and `StateKey` into a `models/states` registry module. `__init_subclass__` writes it; the codec's `StateRegistry` reads it. `register_state_converter` is re-exported from `conversion` so existing import paths hold (FR#9). (`register_state_converter`/`StateKey` are not part of the top-level `hassette` public surface today; FR#9 requires `register_state_converter` only from `hassette.conversion`, so they are not added to `hassette/__init__.py`.) This keeps `StateRegistry` (the rich conversion API used as `STATE_REGISTRY`) a single object in the codec while its backing dict lives below the codec, so `models` never imports `conversion`.
+
+### Codec owns dict → State and known-model coercion
+
+The conversion package is the codec. `try_convert_state` (FR#4) keeps its behavior; the three lazy `BaseState` imports become top-level (legit `conversion → models`). Add the known-model coercion entry point (FR#5): given a `state_class` and raw dict, look up `state_class.value_type`, coerce via `TYPE_REGISTRY` (the pattern `api.py:747` already uses), and construct. `DomainStates._validate_or_return_from_cache` (`state_manager.py:87`, `self._model.model_validate(state)`) calls this entry point instead.
+
+Error handoff (FR#7): today `DomainStates._validate_or_return_from_cache` catches the validator's `ValidationError` at `:88` and re-raises `UnableToConvertStateError(entity_id, self._model)` at `:89`. After the move, coercion happens in the codec, which **raises `UnableToConvertStateError(entity_id, state_class)` itself** (reusing the existing `conversion_with_error_handling` wrapper that `try_convert_state` already uses at `state_registry.py:152-176`). The caller's `try/except ValidationError` at `:88-89` is therefore **removed** — the codec owns the wrapping, and a stray `ValidationError` from constructing an already-typed value would now be a genuine bug, not an expected coercion failure. The test at AC#5 pins this.
+
+**Sequencing (implementer note):** build the FR#5 codec entry point and route `:87` through it *first*; only then remove the `except ValidationError` at `:88-89`. Removing the catch before the codec raises `UnableToConvertStateError` would open a regression window where coercion failures escape as bare `ValidationError`. This ordering belongs in the plan's task sequence.
+
+### TypeRegistry stays a clean global; stop the self-write
+
+`TYPE_REGISTRY`/`STATE_REGISTRY` stay process-global singletons. Fix `TypeRegistry.convert` (`type_registry.py:200-215`) to perform the constructor conversion **without** registering the result — the registry becomes read-only after its standard converters load at import. Remove `TypeRegistry.snapshot`/`restore`. The `hassette.state_registry`/`type_registry` accessors keep returning the globals. No active-context routing, no per-instance build.
+
+### Singleton relocation (clears the `annotation_converter:39` lazy import)
+
+Move the `TYPE_REGISTRY`/`TYPE_MATCHER`/`STATE_REGISTRY`/`ANNOTATION_CONVERTER` instances from `conversion/__init__.py:7-10` into their defining submodules; `__init__` re-exports them (public surface unchanged). `annotation_converter` then imports `TYPE_REGISTRY`/`TYPE_MATCHER` from submodules at top-level instead of the self-package lazy import.
+
+## Replacement Targets
+
+- **`BaseState._validate_domain_and_state` value coercion** (`base.py:174-180`) → codec coercion. Remove the `try/except` block.
+- **`UnableToConvertValueError` import in `base.py`** (`base.py:11`) → now dead (used only in the removed block); drop it. Keep `NoDomainAnnotationError`.
+- **`register_state_converter` import in `base.py`** (`base.py:10`) → import from the new `models/states` registry leaf. Repoint; drop the `TYPE_REGISTRY` import entirely (the dumb model never coerces).
+- **`register_state_converter`, `StateKey`, the domain→class dict, and `resolve`** (currently in `conversion/state_registry.py`) → move to the new `models/states/registry.py` leaf. The `StateRegistry` *class* (the rich conversion API: `try_convert_state`, `conversion_with_error_handling`, `__contains__`, `items`/`values`/`keys`) **stays in `conversion`** and reads the leaf's dict. Re-export `register_state_converter`/`StateKey` from `conversion` so existing import paths hold (FR#9) — not from top-level `hassette` (they are not exported there today).
+- **`StateRegistry._registry` `ClassVar`** (`state_registry.py:46`) → becomes the catalog dict owned by the `models/states` leaf; `StateRegistry` reads it.
+- **`StateRegistry.snapshot`/`restore`** (`state_registry.py:196-203`) → removed; the state-catalog leaf exposes a reset/snapshot primitive instead, used by the test fixture (see Test Strategy).
+- **`TypeRegistry.convert` self-registration on miss** (`type_registry.py:205`) → removed.
+- **`TypeRegistry.snapshot`/`restore`** (`type_registry.py:266-274`) → removed (no longer needed once the self-write stops).
+- **Singleton definitions in `conversion/__init__.py:7-10`** (`TYPE_MATCHER`, `TYPE_REGISTRY`, `STATE_REGISTRY`, `ANNOTATION_CONVERTER`) → moved to their defining submodules, re-exported from `__init__`.
+- **Direct `XState.model_validate(raw_dict)` in tests** → a `test_utils` codec helper.
+
+## Migration
+
+No persisted data changes — registries are in-memory. Code-shape only: conversion behavior moves from the model into the codec, so raw-dict → State goes through the codec rather than `Model.model_validate(raw_ha_dict)`. Internal callers and tests migrate to the codec entry points. The public extension API is preserved, so no app-author migration. Pre-1.0; internal break acceptable.
+
+## Convention Examples
+
+### State-dict builder (test convention to extend)
+
+**Source:** `src/hassette/test_utils/helpers.py`
+
+```python
+def make_state_dict(
+    entity_id: str,
+    state: str,
+    attributes: dict[str, Any] | None = None,
+    last_changed: str | None = None,
+    last_updated: str | None = None,
+    context: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Factory for creating state dictionary in Home Assistant format."""
+    now = _date_utils.now().format_iso()
+    return {
+        "entity_id": entity_id,
+        "state": state,
+        "attributes": attributes or {},
+        "last_changed": last_changed or now,
+        "last_updated": last_updated or now,
+        "context": context or {"id": str(uuid4()), "parent_id": None, "user_id": None},
+    }
+```
+
+The new codec helper (returning a typed state) sits alongside these dict builders — tests call `make_*_state_dict(...)` then the codec helper, replacing `XState.model_validate(dict)`.
+
+### Known-model coercion already done right elsewhere
+
+**Source:** `src/hassette/api/api.py:747`
+
+```python
+return self.hassette.type_registry.convert(state, model.value_type)
+```
+
+This is the exact value-coercion the codec's known-model path (FR#5) generalizes; the model validator currently duplicates it the wrong way.
+
+## Alternatives Considered
+
+- **Per-instance registries (ADR-0003 original B2).** Rejected after verification: production is single-instance (`context.py:43`), and per-instance does not isolate tests because the pollution is at the process-global `__init_subclass__`/catalog level. Adds active-context routing, ClassVar→instance migration, and DI-path threading to solve nothing. Full analysis in `challenge-results.md` Findings 1–7 and the ADR's revised Decision.
+- **Smart models, registries as a leaf (ADR-0003 A).** Keeps the model validator coercing via a leaf registry. Smaller, but keeps the model owning conversion and keeps the convert-on-miss self-write. The chosen design is barely larger and removes both.
+- **Drop `__init_subclass__` for explicit registration.** Would fully eliminate the state reset fixture, but breaks the documented "module-level custom state just works" DX (`custom-states.md`). Rejected — the fixture is a smaller cost than the DX regression.
+- **Do nothing.** Leaves a static cycle blocking #633. Rejected.
+
+## Test Strategy
+
+### Existing Tests to Adapt
+- `tests/unit/conftest.py:97`, `tests/unit/test_sync_entity_facade.py:41,52`, `tests/unit/test_entity_coroutine_conversion.py:51`, `tests/integration/test_sync_facades.py:125`, `tests/unit/test_api_helper_models.py:328`, `tests/integration/test_models.py:154` — replace `XState.model_validate(raw_dict)` with the codec helper.
+- `tests/unit/test_state_manager.py:118,146,158` — spies on `LightState.model_validate`; re-point at the codec coercion path.
+- `tests/unit/test_type_registry.py::TestConstructorFallbackCache` (lines ~32-100) — drop the `conversion_map`-growth assertions and the class-scoped `_isolate_registry` fixture; assert conversion succeeds instead (FR#8).
+- `tests/unit/conversion/test_registry_validation.py:28,38,122,149` — uses `restore({})`; for the state side, build/clear via the catalog reset; the `TypeRegistry.restore` calls are removed with the method.
+- `tests/conftest.py:232-238` `_isolate_registries` — reduce to resetting only the state-class catalog (type-registry no longer pollutes). Keep it autouse for the state side.
+- `tests/unit/test_state_registry.py`, `tests/unit/test_type_utils.py` — already use `try_convert_state`; verify green.
+
+### New Test Coverage
+- Characterization: codec output equals pre-change `model_validate` output across all domain `value_type`s (AC#3) — write and green *before* the refactor (the pin).
+- `self.states.<domain>[...]` returns coerced values through `state_manager.py:87` (AC#4).
+- Coercion failure on the state path raises `UnableToConvertStateError` with `entity_id` (AC#5).
+- `models-no-conversion` boundary rule present and passing (AC#1).
+- `__init_subclass__` registers a grandchild domain class into the catalog (guards the depth behavior FR#3 relies on).
+
+### Tests to Remove
+- None outright — `TestConstructorFallbackCache` is rewritten, not deleted (keeps coverage of constructor fallback as behavior).
+
+## Documentation Updates
+
+- `docs/pages/core-concepts/states/conversion.md` — conversion is owned by the codec, not the model validator; note convert-on-miss no longer memoizes.
+- `docs/pages/core-concepts/states/custom-states.md` — confirm module-level definition still auto-registers; adjust prose implying the model self-coerces.
+- `docs/pages/core-concepts/states/index.md` + `type-registry`/`state-registry` snippet pages — verify prose matches the codec model.
+- ADR-0003 — already revised to record B1 as the accepted decision; flip Status to Accepted on sign-off.
+- No CHANGELOG edit (release-please). Squash title: `refactor:` (or `fix:` if framed as the cycle fix).
+
+## Impact
+
+<!-- Gap check 2026-06-24: 1 gap included — conversion/validation.py (:15,:83,:118 — imports StateKey/StateRegistry from conversion.state_registry, reads state_registry._registry, uses StateKey) → T03 Target Files + Focus item + step 5. Verified clean otherwise: core.py/test_utils/helpers.py/conftest already in scope; test_utils/harness.py reads public globals only (no change); state_manager.pyi has no affected signatures. -->
+
+### Changed Files
+- `src/hassette/models/states/base.py` (modify) — dumb model; repoint `__init_subclass__`; drop dead import. **Cross-cutting / highest risk.**
+- `src/hassette/conversion/validation.py` (modify) — `StateKey` import source + `_registry` read survive the catalog-leaf move (gap-check addition; see T03).
+- `src/hassette/models/states/registry.py` (create) — the state-class catalog leaf (`STATE_CATALOG`, `register_state_converter`, `resolve`, `StateKey`).
+- `src/hassette/conversion/state_registry.py` (modify) — `StateRegistry` reads the catalog leaf; add known-model coercion + error wrapping; lazy `BaseState` imports → top-level.
+- `src/hassette/conversion/type_registry.py` (modify) — stop convert-on-miss self-write; remove `snapshot`/`restore`; singleton def moves to module level.
+- `src/hassette/conversion/type_matcher.py`, `annotation_converter.py` (modify) — module-level singleton defs; `annotation_converter` top-level imports; lazy annotations removed.
+- `src/hassette/conversion/__init__.py` (modify) — re-export relocated singletons + `register_state_converter`; preserve public surface.
+- `src/hassette/state_manager/state_manager.py` (modify) — route `DomainStates._validate_or_return_from_cache` (`:87`) through the codec known-model path and remove its `except ValidationError` re-wrap (`:88-89`). Optional tidy (not required): align the `:368,372,385,394` enumeration methods (which read module-level `STATE_REGISTRY`) to `self.hassette.state_registry` — functionally equivalent under a global, so it may be left untouched.
+- `src/hassette/core/core.py` (modify) — `validate_registries` call still validates the globals; remove any `snapshot`/`restore` reliance.
+- `src/hassette/test_utils/helpers.py` (modify) — add a codec-based state builder.
+- `tools/check_module_boundaries.py` (modify) — add `models-no-conversion`.
+- `tests/conftest.py`, `tests/unit/test_type_registry.py`, `tests/unit/conversion/test_registry_validation.py` (modify) — type-registry isolation + cache-test rewrite, per Test Strategy.
+- `tests/unit/test_state_manager.py` (modify) — re-point the `LightState.model_validate` spies at the codec path once `:87` routes through it (per Test Strategy; breaks when `state_manager.py:87` reroutes).
+- `tests/unit/conftest.py`, `tests/unit/test_sync_entity_facade.py`, `tests/unit/test_entity_coroutine_conversion.py`, `tests/integration/test_sync_facades.py`, `tests/unit/test_api_helper_models.py`, `tests/integration/test_models.py` (modify) — migrate `XState.model_validate(raw_dict)` to the codec helper (per Test Strategy; breaks when the model goes dumb).
+- `docs/pages/core-concepts/states/*` (modify) — per Documentation Updates.
+
+### Behavioral Invariants
+- `try_convert_state` domain resolution + `BaseState` fallback unchanged (FR#4).
+- Scalar coercion results unchanged for every `value_type` (FR#6).
+- DI/annotation conversion observable behavior unchanged.
+- Public imports in FR#9 unchanged; one global registry, no divergence.
+
+### Blast Radius
+- Conversion is core infrastructure used by `state_manager`, `api`, `bus` DI, and the recording/sync facades. Per CLAUDE.md, core changes lean on CI's `nox -s system_with_coverage` and `nox -s e2e` as the real safety net (unit/integration mock the boundaries where these regressions hide), in addition to the local unit/integration + lint gate.
+
+## Open Questions
+
+(none — per-instance question resolved by verification; correctness fixes folded in)

--- a/docs/pages/core-concepts/states/conversion.md
+++ b/docs/pages/core-concepts/states/conversion.md
@@ -6,6 +6,12 @@ The registries become relevant when overriding domain mappings, registering cust
 
 ## The Conversion Pipeline
 
+Each state class declares a `value_type` class variable — the type (or tuple of types) the `value` field should hold. The conversion pipeline reads this and selects the right converter:
+
+```python
+--8<-- "pages/core-concepts/states/snippets/state-registry/value_type_example.py"
+```
+
 When state data arrives from Home Assistant, `StateRegistry.try_convert_state()` runs the full pipeline. Dependency injection calls it automatically; direct calls are only needed when converting raw dicts outside a handler, such as in tests or data scripts. Given this raw input:
 
 ```python
@@ -28,13 +34,7 @@ The pipeline runs four steps:
 --8<-- "pages/core-concepts/states/snippets/state-registry/flow_converted_output.py"
 ```
 
-`StateRegistry` answers "which class?". `TypeRegistry` answers "which type for the value?". The state model handles shape normalization — extracting the domain from `entity_id` and mapping `"unknown"`/`"unavailable"` to sentinel flags — but performs no value coercion. The conversion pipeline owns type conversion: reading `value_type`, selecting the right converter, and constructing the typed state.
-
-Each state class declares a `value_type` class variable — the type (or tuple of types) the `value` field should hold. The conversion pipeline reads this and selects the right converter:
-
-```python
---8<-- "pages/core-concepts/states/snippets/state-registry/value_type_example.py"
-```
+`StateRegistry` answers "which class?". `TypeRegistry` answers "which type for the value?". The state model handles shape normalization — extracting the domain from `entity_id` and mapping `"unknown"`/`"unavailable"` to `None` — but performs no value coercion. The conversion pipeline owns type conversion: reading `value_type`, selecting the right converter, and constructing the typed state.
 
 When `resolve` returns `None` for an unregistered domain, `try_convert_state` falls back
 to [`BaseState`][hassette.models.states.base.BaseState].
@@ -78,10 +78,12 @@ effect at class definition time.
 --8<-- "pages/core-concepts/states/snippets/state-registry/domain_override.py"
 ```
 
-The registry replaces the previous mapping silently and globally — a typo in the `Literal`
-domain overrides a built-in with no warning. `STATE_REGISTRY.resolve(domain="sensor")`
-confirms which class is registered. All subsequent state events for `sensor` entities
-produce `CustomSensorState` instances.
+!!! warning
+    The registry replaces the previous mapping silently and globally — a typo in the
+    `Literal` domain overrides a built-in with no warning. Use
+    `STATE_REGISTRY.resolve(domain="sensor")` to confirm which class is registered.
+
+All subsequent state events for `sensor` entities produce `CustomSensorState` instances.
 
 For classes that can't declare a `Literal` domain — built dynamically, or registered conditionally at runtime — [`register_state_converter`][hassette.conversion.register_state_converter] registers a class with the registry explicitly. It is the imperative equivalent of the `Literal`-based auto-registration.
 
@@ -116,7 +118,12 @@ applies it.
 When no registered converter exists, the registry tries the target type's constructor as a
 fallback. A successful constructor call does not register the pair — each miss goes through the constructor directly. Custom converters registered via `register_simple_type_converter` or `@register_type_converter_fn` are added normally.
 
-For union `value_type` declarations (`value_type = (int, float, str)`), conversion is attempted in order and the first success wins. `str` succeeds trivially (no conversion needed), so placing it first would always short-circuit before attempting `int` or `float`. The most specific type must come first: `(int, float, str)` is correct; `(str, int, float)` is not.
+!!! warning
+    For union `value_type` declarations (`value_type = (int, float, str)`), conversion is
+    attempted in order and the first success wins. Every value from Home Assistant arrives
+    as a string, so `str` always succeeds immediately — placing it first short-circuits
+    before `int` or `float` are tried. The most specific type must come first:
+    `(int, float, str)` is correct; `(str, int, float)` is not.
 
 ### Built-in Converters
 

--- a/docs/pages/core-concepts/states/conversion.md
+++ b/docs/pages/core-concepts/states/conversion.md
@@ -17,20 +17,20 @@ The pipeline runs four steps:
 1. `StateRegistry.resolve(domain="binary_sensor")` looks up the registered class for the domain.
    It returns [`BinarySensorState`][hassette.models.states.binary_sensor.BinarySensorState].
 
-2. The codec normalizes `"unknown"` and `"unavailable"` states to `None` before coercion, then
-   reads `value_type` from the resolved class and delegates to `TypeRegistry`.
+2. The conversion pipeline normalizes `"unknown"` and `"unavailable"` states to `None` before
+   coercion, then reads `value_type` from the resolved class and delegates to `TypeRegistry`.
 
 3. `TypeRegistry` looks up the `(str, bool)` converter and converts `"on"` to `True`.
 
-4. The codec constructs the model from the prepared dict. The result is a fully typed state object:
+4. The pipeline constructs the model from the prepared dict. The result is a fully typed state object:
 
 ```python
 --8<-- "pages/core-concepts/states/snippets/state-registry/flow_converted_output.py"
 ```
 
-`StateRegistry` answers "which class?". `TypeRegistry` answers "which type for the value?". The state model handles shape normalization — extracting the domain from `entity_id` and mapping `"unknown"`/`"unavailable"` to sentinel flags — but performs no value coercion. The codec owns type conversion: reading `value_type`, selecting the right converter, and constructing the typed state.
+`StateRegistry` answers "which class?". `TypeRegistry` answers "which type for the value?". The state model handles shape normalization — extracting the domain from `entity_id` and mapping `"unknown"`/`"unavailable"` to sentinel flags — but performs no value coercion. The conversion pipeline owns type conversion: reading `value_type`, selecting the right converter, and constructing the typed state.
 
-Each state class declares a `value_type` class variable — the type (or tuple of types) the `value` field should hold. The codec reads this and selects the right converter:
+Each state class declares a `value_type` class variable — the type (or tuple of types) the `value` field should hold. The conversion pipeline reads this and selects the right converter:
 
 ```python
 --8<-- "pages/core-concepts/states/snippets/state-registry/value_type_example.py"
@@ -247,7 +247,7 @@ and entity name.
 
 #### `UnableToConvertStateError`
 
-Raised when the codec fails to construct a state object for both the resolved state class and the
+Raised when the conversion pipeline fails to construct a state object for both the resolved state class and the
 `BaseState` fallback.
 
 ```python

--- a/docs/pages/core-concepts/states/conversion.md
+++ b/docs/pages/core-concepts/states/conversion.md
@@ -12,26 +12,25 @@ When state data arrives from Home Assistant, `StateRegistry.try_convert_state()`
 --8<-- "pages/core-concepts/states/snippets/state-registry/flow_raw_input.py"
 ```
 
-The pipeline runs five steps:
+The pipeline runs four steps:
 
 1. `StateRegistry.resolve(domain="binary_sensor")` looks up the registered class for the domain.
    It returns [`BinarySensorState`][hassette.models.states.binary_sensor.BinarySensorState].
 
-2. Pydantic validation begins on `BinarySensorState`.
+2. The codec normalizes `"unknown"` and `"unavailable"` states to `None` before coercion, then
+   reads `value_type` from the resolved class and delegates to `TypeRegistry`.
 
-3. The `_validate_domain_and_state` model validator reads `value_type` from the class and
-   delegates to `TypeRegistry`.
+3. `TypeRegistry` looks up the `(str, bool)` converter and converts `"on"` to `True`.
 
-4. `TypeRegistry` looks up the `(str, bool)` converter and converts `"on"` to `True`.
-
-5. Validation completes. The result is a fully typed state object:
+4. The codec constructs the model from the prepared dict. The result is a fully typed state object:
 
 ```python
 --8<-- "pages/core-concepts/states/snippets/state-registry/flow_converted_output.py"
 ```
 
-`StateRegistry` answers "which class?". `TypeRegistry` answers "which type for the value?".
-Each state class declares a `value_type` class variable — the type (or tuple of types) the `value` field should hold. `TypeRegistry` reads this and selects the right converter:
+`StateRegistry` answers "which class?". `TypeRegistry` answers "which type for the value?". The state model handles shape normalization — extracting the domain from `entity_id` and mapping `"unknown"`/`"unavailable"` to sentinel flags — but performs no value coercion. The codec owns type conversion: reading `value_type`, selecting the right converter, and constructing the typed state.
+
+Each state class declares a `value_type` class variable — the type (or tuple of types) the `value` field should hold. The codec reads this and selects the right converter:
 
 ```python
 --8<-- "pages/core-concepts/states/snippets/state-registry/value_type_example.py"
@@ -115,7 +114,7 @@ applies it.
 ```
 
 When no registered converter exists, the registry tries the target type's constructor as a
-fallback. A successful constructor call auto-registers the pair for future calls.
+fallback. A successful constructor call does not register the pair — each miss goes through the constructor directly. Custom converters registered via `register_simple_type_converter` or `@register_type_converter_fn` are added normally.
 
 For union `value_type` declarations (`value_type = (int, float, str)`), conversion is attempted in order and the first success wins. `str` succeeds trivially (no conversion needed), so placing it first would always short-circuit before attempting `int` or `float`. The most specific type must come first: `(int, float, str)` is correct; `(str, int, float)` is not.
 
@@ -248,8 +247,8 @@ and entity name.
 
 #### `UnableToConvertStateError`
 
-Raised when Pydantic validation fails for both the resolved state class and the `BaseState`
-fallback.
+Raised when the codec fails to construct a state object for both the resolved state class and the
+`BaseState` fallback.
 
 ```python
 --8<-- "pages/core-concepts/states/snippets/state-registry/error_unable_to_convert.py"

--- a/docs/pages/core-concepts/states/custom-states.md
+++ b/docs/pages/core-concepts/states/custom-states.md
@@ -28,7 +28,7 @@ Each base class determines the Python type of `value` on the resulting state obj
 
 ### `NumericBaseState`: numeric value
 
-[`NumericBaseState`][hassette.models.states.base.NumericBaseState] converts the raw state string to a numeric type — whole-number strings become `int`, decimal strings become `float`. It accepts `int`, `float`, and `Decimal` inputs directly.
+[`NumericBaseState`][hassette.models.states.base.NumericBaseState] declares `value_type = (int, float, Decimal, type(None))`. The codec converts the raw state string to a numeric type — whole-number strings become `int`, decimal strings become `float`. `int`, `float`, and `Decimal` inputs pass through directly. Unknown or unavailable states produce `None`.
 
 ```python
 --8<-- "pages/core-concepts/states/snippets/custom-states/numeric_base_state.py"
@@ -36,7 +36,7 @@ Each base class determines the Python type of `value` on the resulting state obj
 
 ### `BoolBaseState`: `bool` value
 
-[`BoolBaseState`][hassette.models.states.base.BoolBaseState] converts `"on"` to `True` and `"off"` to `False` automatically.
+[`BoolBaseState`][hassette.models.states.base.BoolBaseState] declares `value_type = (bool, type(None))`. The codec maps `"on"` to `True` and `"off"` to `False` using the registered `str → bool` converter. Unknown or unavailable states produce `None`.
 
 ```python
 --8<-- "pages/core-concepts/states/snippets/custom-states/bool_base_state.py"
@@ -44,7 +44,7 @@ Each base class determines the Python type of `value` on the resulting state obj
 
 ### `DateTimeBaseState`: `ZonedDateTime`, `PlainDateTime`, or `Date` value
 
-[`DateTimeBaseState`][hassette.models.states.base.DateTimeBaseState] parses the raw state string into a [`whenever`](https://whenever.readthedocs.io/) datetime type (`from whenever import ZonedDateTime` — Hassette's date/time library). The exact type depends on the string format from Home Assistant.
+[`DateTimeBaseState`][hassette.models.states.base.DateTimeBaseState] declares a datetime `value_type`. The codec parses the raw state string into a [`whenever`](https://whenever.readthedocs.io/) datetime type (`from whenever import ZonedDateTime` — Hassette's date/time library). The exact type depends on the string format from Home Assistant.
 
 ```python
 --8<-- "pages/core-concepts/states/snippets/custom-states/datetime_base_state.py"
@@ -60,7 +60,7 @@ Each base class determines the Python type of `value` on the resulting state obj
 
 ### Custom value type: inherit `BaseState` directly
 
-When no built-in base class fits, a class can inherit from `BaseState[T]` directly. The `value_type` class variable declares the accepted types. Hassette validates state values against `value_type` at runtime.
+When no built-in base class fits, a class can inherit from `BaseState[T]` directly. The `value_type` class variable declares the accepted types. The codec coerces state values against `value_type` at runtime using `TypeRegistry`.
 
 ```python
 --8<-- "pages/core-concepts/states/snippets/custom-states/define_your_own.py"

--- a/docs/pages/core-concepts/states/custom-states.md
+++ b/docs/pages/core-concepts/states/custom-states.md
@@ -28,7 +28,7 @@ Each base class determines the Python type of `value` on the resulting state obj
 
 ### `NumericBaseState`: numeric value
 
-[`NumericBaseState`][hassette.models.states.base.NumericBaseState] declares `value_type = (int, float, Decimal, type(None))`. The codec converts the raw state string to a numeric type — whole-number strings become `int`, decimal strings become `float`. `int`, `float`, and `Decimal` inputs pass through directly. Unknown or unavailable states produce `None`.
+[`NumericBaseState`][hassette.models.states.base.NumericBaseState] declares `value_type = (int, float, Decimal, type(None))`. The conversion pipeline converts the raw state string to a numeric type — whole-number strings become `int`, decimal strings become `float`. `int`, `float`, and `Decimal` inputs pass through directly. Unknown or unavailable states produce `None`.
 
 ```python
 --8<-- "pages/core-concepts/states/snippets/custom-states/numeric_base_state.py"
@@ -36,7 +36,7 @@ Each base class determines the Python type of `value` on the resulting state obj
 
 ### `BoolBaseState`: `bool` value
 
-[`BoolBaseState`][hassette.models.states.base.BoolBaseState] declares `value_type = (bool, type(None))`. The codec maps `"on"` to `True` and `"off"` to `False` using the registered `str → bool` converter. Unknown or unavailable states produce `None`.
+[`BoolBaseState`][hassette.models.states.base.BoolBaseState] declares `value_type = (bool, type(None))`. The conversion pipeline maps `"on"` to `True` and `"off"` to `False` using the registered `str → bool` converter. Unknown or unavailable states produce `None`.
 
 ```python
 --8<-- "pages/core-concepts/states/snippets/custom-states/bool_base_state.py"
@@ -44,7 +44,7 @@ Each base class determines the Python type of `value` on the resulting state obj
 
 ### `DateTimeBaseState`: `ZonedDateTime`, `PlainDateTime`, or `Date` value
 
-[`DateTimeBaseState`][hassette.models.states.base.DateTimeBaseState] declares a datetime `value_type`. The codec parses the raw state string into a [`whenever`](https://whenever.readthedocs.io/) datetime type (`from whenever import ZonedDateTime` — Hassette's date/time library). The exact type depends on the string format from Home Assistant.
+[`DateTimeBaseState`][hassette.models.states.base.DateTimeBaseState] declares a datetime `value_type`. The conversion pipeline parses the raw state string into a [`whenever`](https://whenever.readthedocs.io/) datetime type (`from whenever import ZonedDateTime` — Hassette's date/time library). The exact type depends on the string format from Home Assistant.
 
 ```python
 --8<-- "pages/core-concepts/states/snippets/custom-states/datetime_base_state.py"
@@ -60,7 +60,7 @@ Each base class determines the Python type of `value` on the resulting state obj
 
 ### Custom value type: inherit `BaseState` directly
 
-When no built-in base class fits, a class can inherit from `BaseState[T]` directly. The `value_type` class variable declares the accepted types. The codec coerces state values against `value_type` at runtime using `TypeRegistry`.
+When no built-in base class fits, a class can inherit from `BaseState[T]` directly. The `value_type` class variable declares the accepted types. The conversion pipeline coerces state values against `value_type` at runtime using `TypeRegistry`.
 
 ```python
 --8<-- "pages/core-concepts/states/snippets/custom-states/define_your_own.py"

--- a/docs/pages/core-concepts/states/custom-states.md
+++ b/docs/pages/core-concepts/states/custom-states.md
@@ -60,7 +60,7 @@ Each base class determines the Python type of `value` on the resulting state obj
 
 ### Custom value type: inherit `BaseState` directly
 
-When no built-in base class fits, a class can inherit from `BaseState[T]` directly. The `value_type` class variable declares the accepted types. The conversion pipeline coerces state values against `value_type` at runtime using `TypeRegistry`.
+When no built-in base class fits, a class can inherit from `BaseState[T]` directly. The `value_type` class variable declares the accepted types. The conversion pipeline coerces state values against `value_type` at runtime using [`TypeRegistry`](conversion.md#value-conversion).
 
 ```python
 --8<-- "pages/core-concepts/states/snippets/custom-states/define_your_own.py"

--- a/src/hassette/conversion/__init__.py
+++ b/src/hassette/conversion/__init__.py
@@ -1,14 +1,20 @@
-from .annotation_converter import AnnotationConverter
-from .state_registry import StateKey, StateRegistry, convert_state_dict_to_model, register_state_converter
-from .type_matcher import TypeMatcher
-from .type_registry import TypeConverterEntry, TypeRegistry, register_simple_type_converter, register_type_converter_fn
+from .annotation_converter import ANNOTATION_CONVERTER, AnnotationConverter
+from .state_registry import (
+    STATE_REGISTRY,
+    StateKey,
+    StateRegistry,
+    convert_state_dict_to_model,
+    register_state_converter,
+)
+from .type_matcher import TYPE_MATCHER, TypeMatcher
+from .type_registry import (
+    TYPE_REGISTRY,
+    TypeConverterEntry,
+    TypeRegistry,
+    register_simple_type_converter,
+    register_type_converter_fn,
+)
 from .validation import RegistryValidationIssue, validate_registries
-
-TYPE_MATCHER = TypeMatcher()
-TYPE_REGISTRY = TypeRegistry()
-STATE_REGISTRY = StateRegistry()
-ANNOTATION_CONVERTER = AnnotationConverter()
-
 
 __all__ = [
     "ANNOTATION_CONVERTER",

--- a/src/hassette/conversion/annotation_converter.py
+++ b/src/hassette/conversion/annotation_converter.py
@@ -3,8 +3,11 @@ from dataclasses import dataclass
 from typing import Any, ClassVar, Literal, get_args, get_origin
 
 from hassette.conversion.state_registry import convert_state_dict_to_model
+from hassette.conversion.type_matcher import TYPE_MATCHER
+from hassette.conversion.type_registry import TYPE_REGISTRY
 from hassette.events.hass.hass import HassPayload, RawStateChangeEvent, TypedStateChangeEvent, TypedStateChangePayload
 from hassette.exceptions import UnableToConvertValueError
+from hassette.models.states.base import BaseState
 from hassette.utils.type_utils import is_union, normalize_annotation
 
 
@@ -35,10 +38,6 @@ class AnnotationConverter:
     """Converts runtime values to match rich annotations (including nested containers)."""
 
     def convert(self, value: Any, annotation: Any) -> Any:
-        # lazy-import: break circular import — conversion/__init__ imports this module (#892)
-        from hassette.conversion import TYPE_MATCHER, TYPE_REGISTRY
-        from hassette.models.states import BaseState  # lazy-import: same circular import (#892)
-
         tp = normalize_annotation(annotation, constructible=True)
 
         # Already correct (deep) => no-op
@@ -192,3 +191,6 @@ def convert_typed_state_change_event(c: "AnnotationConverter", value: Any, tp: A
             context=value.payload.context,
         ),
     )
+
+
+ANNOTATION_CONVERTER = AnnotationConverter()

--- a/src/hassette/conversion/state_registry.py
+++ b/src/hassette/conversion/state_registry.py
@@ -1,15 +1,32 @@
 import typing
-from collections.abc import Hashable, Iterator
-from dataclasses import dataclass
+from collections.abc import Hashable
+from contextlib import suppress
 from logging import getLogger
-from typing import ClassVar
 
-from hassette.exceptions import InvalidDataForStateConversionError, InvalidEntityIdError, UnableToConvertStateError
+from hassette.conversion.type_registry import TYPE_REGISTRY
+from hassette.exceptions import (
+    InvalidDataForStateConversionError,
+    InvalidEntityIdError,
+    UnableToConvertStateError,
+    UnableToConvertValueError,
+)
+from hassette.models.states.base import BaseState
+from hassette.models.states.catalog import (
+    _STATE_CATALOG,
+    resolve,
+)
+from hassette.models.states.catalog import (
+    StateKey as StateKey,
+)
+from hassette.models.states.catalog import (
+    register_state_converter as register_state_converter,
+)
 from hassette.utils.exception_utils import get_short_traceback
 
 if typing.TYPE_CHECKING:
+    from collections.abc import Iterator
+
     from hassette.events import HassStateDict
-    from hassette.models.states.base import BaseState
 
 
 LOGGER = getLogger(__name__)
@@ -17,22 +34,7 @@ CONVERSION_FAIL_TEMPLATE = (
     "Failed to convert state for entity '%s' (domain: '%s') to class '%s'. Data: %s. Error: %s, Traceback: %s"
 )
 STATE_REPR_MAX_LENGTH = 200
-
-
-@dataclass(frozen=True)
-class StateKey:
-    domain: Hashable | None = None
-    """The domain of the entity (e.g., 'light', 'sensor')."""
-
-    device_class: Hashable | None = None
-    """Optional device class of the entity (e.g., 'temperature', 'humidity'). Not yet being used."""
-
-
-def register_state_converter(
-    state_class: type["BaseState"], domain: Hashable, device_class: Hashable | None = None
-) -> None:
-    """Register a state converter class for a specific domain and optional device class."""
-    StateRegistry.register(state_class, domain=domain, device_class=device_class)
+TRUNCATION_SUFFIX = "...[truncated]"
 
 
 class StateRegistry:
@@ -43,11 +45,13 @@ class StateRegistry:
     by scanning all subclasses of BaseState.
     """
 
-    _registry: ClassVar[dict[StateKey, type["BaseState"]]] = {}
+    @property
+    def _registry(self) -> "dict[StateKey, type[BaseState]]":
+        """Read accessor over the catalog leaf dict — for validation.py and other readers."""
+        return _STATE_CATALOG
 
     def get_entity_id(self, data: "HassStateDict", entity_id: str | None = None) -> str:
         if not entity_id:
-            # specifically this way so we also handle empty strings/None
             entity_id = data.get("entity_id") or "<unknown>"
 
         if not isinstance(entity_id, str):
@@ -61,34 +65,7 @@ class StateRegistry:
         return entity_id
 
     def try_convert_state(self, data: "HassStateDict", entity_id: str | None = None) -> "BaseState":
-        """Convert a dictionary representation of a state into a specific state type.
-
-        This function uses the state registry to look up the appropriate state class
-        based on the entity's domain. If no specific class is registered for the domain,
-        it falls back to the generic BaseState.
-
-        Args:
-            data: Dictionary containing state data from Home Assistant.
-            entity_id: Optional entity ID to assist in domain determination.
-
-        Returns:
-            A properly typed state object (e.g., LightState, SensorState) or BaseState
-            for unknown domains.
-
-        Raises:
-            InvalidDataForStateConversionError: If the provided data is invalid or malformed.
-            InvalidEntityIdError: If the entity_id is invalid or malformed.
-            UnableToConvertStateError: If conversion to the determined state class fails.
-
-        Example:
-            ```python
-            state_dict = {"entity_id": "light.bedroom", "state": "on", ...}
-            light_state = try_convert_state(state_dict)  # Returns LightState instance
-            ```
-        """
-        # lazy-import: break circular import — models.states.base imports the conversion registry
-        from hassette.models.states.base import BaseState
-
+        """Convert a raw HA state dict to the most specific registered state class, falling back to BaseState."""
         if "event" in data:
             LOGGER.error(
                 "Data contains 'event' key, expected state data, not event data. "
@@ -101,7 +78,6 @@ class StateRegistry:
         entity_id = self.get_entity_id(data, entity_id=entity_id)
         domain = entity_id.split(".", 1)[0]
 
-        # Look up the appropriate state class from the registry
         state_class = self.resolve(domain=domain)
 
         classes = [state_class, BaseState] if state_class is not None else [BaseState]
@@ -123,41 +99,41 @@ class StateRegistry:
 
     @classmethod
     def register(
-        cls, state_class: type["BaseState"], *, domain: Hashable | None = None, device_class: Hashable | None = None
+        cls,
+        state_class: type["BaseState"],
+        *,
+        domain: Hashable | None = None,
+        device_class: Hashable | None = None,
     ) -> None:
-        """Register a state class for a given domain and optional device_class combination.
-
-        Args:
-            state_class: The state class to register. Must be a subclass of BaseState.
-            domain: The Home Assistant domain (e.g., "light", "sensor"). If None, matches any domain.
-            device_class: The device class (e.g., "temperature", "motion"). If None, matches any device class.
-        """
-        key = StateKey(domain=domain, device_class=device_class)
-        cls._registry[key] = state_class
+        """Register a state class for a given domain and optional device_class combination."""
+        register_state_converter(state_class, domain=domain, device_class=device_class)
 
     @classmethod
-    def resolve(
-        cls, *, domain: Hashable | None = None, device_class: Hashable | None = None
-    ) -> type["BaseState"] | None:
+    def resolve(cls, *, domain: Hashable | None = None, device_class: Hashable | None = None) -> type[BaseState] | None:
         """Resolve a state class from the registry based on domain and device_class."""
-        candidates = [StateKey(domain=domain, device_class=device_class)]
-        if device_class is not None:
-            candidates.append(StateKey(domain=domain, device_class=None))
+        return resolve(domain=domain, device_class=device_class)
 
-        for k in candidates:
-            if k in cls._registry:
-                return cls._registry[k]
-        return None
+    def coerce_and_construct(
+        self, state_class: "type[BaseState]", data: "HassStateDict", entity_id: str
+    ) -> "BaseState":
+        """Coerce a raw HA state dict to a typed model using a known target class.
+
+        Applies domain extraction and unknown/unavailable normalization before coercing
+        the value, so the codec never attempts to coerce "unknown" or "unavailable"
+        against a non-string value_type. Wraps failures as UnableToConvertStateError.
+        """
+        domain = entity_id.split(".", 1)[0]
+        return self.conversion_with_error_handling(state_class, data, entity_id, domain)
 
     def conversion_with_error_handling(
-        self, state_class: type["BaseState"], data: "HassStateDict", entity_id: str, domain: str
+        self, state_class: "type[BaseState]", data: "HassStateDict", entity_id: str, domain: str
     ) -> "BaseState":
         """Convert state data, logging and re-raising as UnableToConvertStateError on failure."""
 
         class_name = state_class.__name__
         truncated_data = repr(data)
         if len(truncated_data) > STATE_REPR_MAX_LENGTH:
-            truncated_data = truncated_data[:STATE_REPR_MAX_LENGTH] + "...[truncated]"
+            truncated_data = truncated_data[:STATE_REPR_MAX_LENGTH] + TRUNCATION_SUFFIX
 
         try:
             return convert_state_dict_to_model(data, state_class)
@@ -175,55 +151,50 @@ class StateRegistry:
             )
             raise UnableToConvertStateError(entity_id, state_class) from e
 
-    def __contains__(self, model: type["BaseState"]) -> bool:
+    def __contains__(self, model: "type[BaseState]") -> bool:
         """Check if the registry contains a state class for the given model."""
-        return any(cls is model for cls in self._registry.values())
+        return any(cls is model for cls in _STATE_CATALOG.values())
 
-    def __iter__(self) -> Iterator[tuple[StateKey, type["BaseState"]]]:
+    def __iter__(self) -> "Iterator[tuple[StateKey, type[BaseState]]]":
         """Iterate over all registered state classes with their keys."""
-        return iter(self._registry.items())
+        return iter(_STATE_CATALOG.items())
 
-    def items(self) -> Iterator[tuple[StateKey, type["BaseState"]]]:
-        return iter(self._registry.items())
+    def items(self) -> "Iterator[tuple[StateKey, type[BaseState]]]":
+        return iter(_STATE_CATALOG.items())
 
-    def values(self) -> Iterator[type["BaseState"]]:
-        return (state_class for state_class in self._registry.values())
+    def values(self) -> "Iterator[type[BaseState]]":
+        return (state_class for state_class in _STATE_CATALOG.values())
 
-    def keys(self) -> Iterator[StateKey]:
-        return (key for key in self._registry)
-
-    @classmethod
-    def snapshot(cls) -> dict[StateKey, type["BaseState"]]:
-        """Return a shallow copy of the current registry state."""
-        return dict(cls._registry)
-
-    @classmethod
-    def restore(cls, snapshot: dict[StateKey, type["BaseState"]]) -> None:
-        """Replace the registry with a previously captured snapshot."""
-        cls._registry = snapshot
+    def keys(self) -> "Iterator[StateKey]":
+        return (key for key in _STATE_CATALOG)
 
 
-def convert_state_dict_to_model(value: typing.Any, model: type["BaseState"]) -> "BaseState":
-    """Convert a raw Home Assistant state dict to a typed state model.
+STATE_REGISTRY = StateRegistry()
 
-    This converter is used by state object extractors (StateNew, StateOld, etc.) to transform
-    the raw state dictionary from Home Assistant into a strongly-typed Pydantic model.
 
-    Args:
-        value: The raw state dict from Home Assistant
-        model: The target state model class (e.g., LightState, SensorState)
-
-    Returns:
-        The typed state model instance
-
-    Raises:
-        TypeError: If value is not a dict or model instance
-        ValidationError: If the state dict doesn't match the model schema
-    """
+def convert_state_dict_to_model(value: typing.Any, model: "type[BaseState]") -> "BaseState":
+    """Convert a raw HA state dict to a typed state model via codec preprocessing + value coercion."""
     if isinstance(value, model):
         return value
 
     if not isinstance(value, dict):
         raise TypeError(f"Cannot convert {type(value).__name__} to {model.__name__}, expected dict")
 
-    return model.model_validate(value)
+    prepared = dict(value)
+
+    entity_id = prepared.get("entity_id")
+    if entity_id:
+        prepared["domain"] = str(entity_id).split(".", 1)[0]
+
+    state = prepared.get("state")
+    if state == "unknown":
+        prepared["is_unknown"] = True
+        prepared["state"] = state = None
+    elif state == "unavailable":
+        prepared["is_unavailable"] = True
+        prepared["state"] = state = None
+
+    with suppress(UnableToConvertValueError):
+        prepared["state"] = TYPE_REGISTRY.convert(state, model.value_type)
+
+    return model.model_validate(prepared)

--- a/src/hassette/conversion/state_registry.py
+++ b/src/hassette/conversion/state_registry.py
@@ -65,7 +65,21 @@ class StateRegistry:
         return entity_id
 
     def try_convert_state(self, data: "HassStateDict", entity_id: str | None = None) -> "BaseState":
-        """Convert a raw HA state dict to the most specific registered state class, falling back to BaseState."""
+        """Convert a raw HA state dict to the most specific registered state class, falling back to BaseState.
+
+        Args:
+            data: Dictionary containing state data from Home Assistant.
+            entity_id: Optional entity ID to assist in domain determination.
+
+        Returns:
+            A properly typed state object (e.g., LightState, SensorState) or BaseState
+            for unknown domains.
+
+        Raises:
+            InvalidDataForStateConversionError: If the provided data is an event payload.
+            InvalidEntityIdError: If the entity_id is missing or malformed.
+            UnableToConvertStateError: If conversion to the resolved state class fails.
+        """
         if "event" in data:
             LOGGER.error(
                 "Data contains 'event' key, expected state data, not event data. "
@@ -105,7 +119,13 @@ class StateRegistry:
         domain: Hashable | None = None,
         device_class: Hashable | None = None,
     ) -> None:
-        """Register a state class for a given domain and optional device_class combination."""
+        """Register a state class for a given domain and optional device_class combination.
+
+        Args:
+            state_class: The state class to register. Must be a subclass of BaseState.
+            domain: The Home Assistant domain (e.g., "light", "sensor").
+            device_class: The device class (e.g., "temperature", "motion").
+        """
         register_state_converter(state_class, domain=domain, device_class=device_class)
 
     @classmethod
@@ -120,7 +140,18 @@ class StateRegistry:
 
         Applies domain extraction and unknown/unavailable normalization before coercing
         the value, so the codec never attempts to coerce "unknown" or "unavailable"
-        against a non-string value_type. Wraps failures as UnableToConvertStateError.
+        against a non-string value_type.
+
+        Args:
+            state_class: The target state model class (e.g., LightState, SensorState).
+            data: Raw state dict from Home Assistant.
+            entity_id: The entity ID for domain extraction and error reporting.
+
+        Returns:
+            The typed state model instance.
+
+        Raises:
+            UnableToConvertStateError: If coercion or validation fails.
         """
         domain = entity_id.split(".", 1)[0]
         return self.conversion_with_error_handling(state_class, data, entity_id, domain)
@@ -128,7 +159,20 @@ class StateRegistry:
     def conversion_with_error_handling(
         self, state_class: "type[BaseState]", data: "HassStateDict", entity_id: str, domain: str
     ) -> "BaseState":
-        """Convert state data, logging and re-raising as UnableToConvertStateError on failure."""
+        """Convert state data, logging and re-raising as UnableToConvertStateError on failure.
+
+        Args:
+            state_class: The target state model class.
+            data: Raw state dict from Home Assistant.
+            entity_id: The entity ID for error reporting.
+            domain: The HA domain string (e.g., "light", "sensor").
+
+        Returns:
+            The typed state model instance.
+
+        Raises:
+            UnableToConvertStateError: If conversion fails for any reason.
+        """
 
         class_name = state_class.__name__
         truncated_data = repr(data)
@@ -173,7 +217,23 @@ STATE_REGISTRY = StateRegistry()
 
 
 def convert_state_dict_to_model(value: typing.Any, model: "type[BaseState]") -> "BaseState":
-    """Convert a raw HA state dict to a typed state model via codec preprocessing + value coercion."""
+    """Convert a raw HA state dict to a typed state model via codec preprocessing + value coercion.
+
+    Applies the same preprocessing order as the old model validator: domain extraction,
+    then unknown/unavailable normalization (setting state to None before coercion touches it),
+    then TYPE_REGISTRY.convert for the model's value_type.
+
+    Args:
+        value: The raw state dict from Home Assistant (or an already-validated model instance).
+        model: The target state model class (e.g., LightState, SensorState).
+
+    Returns:
+        The typed state model instance.
+
+    Raises:
+        TypeError: If value is not a dict or model instance.
+        ValidationError: If the state dict doesn't match the model schema.
+    """
     if isinstance(value, model):
         return value
 

--- a/src/hassette/conversion/state_registry.py
+++ b/src/hassette/conversion/state_registry.py
@@ -246,15 +246,16 @@ def convert_state_dict_to_model(value: typing.Any, model: "type[BaseState]") -> 
     if entity_id:
         prepared["domain"] = str(entity_id).split(".", 1)[0]
 
-    state = prepared.get("state")
-    if state == "unknown":
-        prepared["is_unknown"] = True
-        prepared["state"] = state = None
-    elif state == "unavailable":
-        prepared["is_unavailable"] = True
-        prepared["state"] = state = None
+    if "state" in prepared:
+        state = prepared["state"]
+        if state == "unknown":
+            prepared["is_unknown"] = True
+            prepared["state"] = state = None
+        elif state == "unavailable":
+            prepared["is_unavailable"] = True
+            prepared["state"] = state = None
 
-    with suppress(UnableToConvertValueError):
-        prepared["state"] = TYPE_REGISTRY.convert(state, model.value_type)
+        with suppress(UnableToConvertValueError):
+            prepared["state"] = TYPE_REGISTRY.convert(state, model.value_type)
 
     return model.model_validate(prepared)

--- a/src/hassette/conversion/state_registry.py
+++ b/src/hassette/conversion/state_registry.py
@@ -139,7 +139,7 @@ class StateRegistry:
         """Coerce a raw HA state dict to a typed model using a known target class.
 
         Applies domain extraction and unknown/unavailable normalization before coercing
-        the value, so the codec never attempts to coerce "unknown" or "unavailable"
+        the value, so the pipeline never attempts to coerce "unknown" or "unavailable"
         against a non-string value_type.
 
         Args:
@@ -217,7 +217,7 @@ STATE_REGISTRY = StateRegistry()
 
 
 def convert_state_dict_to_model(value: typing.Any, model: "type[BaseState]") -> "BaseState":
-    """Convert a raw HA state dict to a typed state model via codec preprocessing + value coercion.
+    """Convert a raw HA state dict to a typed state model via preprocessing + value coercion.
 
     Applies the same preprocessing order as the old model validator: domain extraction,
     then unknown/unavailable normalization (setting state to None before coercion touches it),

--- a/src/hassette/conversion/type_matcher.py
+++ b/src/hassette/conversion/type_matcher.py
@@ -134,3 +134,6 @@ def match_tuple(m: TypeMatcher, value: Any, tp: Any) -> bool:
         return False
 
     return all(m.matches(v, elem_tp) for v, elem_tp in zip(value, args, strict=True))
+
+
+TYPE_MATCHER = TypeMatcher()

--- a/src/hassette/conversion/type_registry.py
+++ b/src/hassette/conversion/type_registry.py
@@ -202,11 +202,8 @@ class TypeRegistry:
                 new_value = to_type(value)
             except Exception as e:
                 raise UnableToConvertValueError(f"Unable to convert {value!r} to {to_type}") from e
-            TypeRegistry.register(
-                TypeConverterEntry(func=to_type, from_type=from_type, to_type=to_type, error_types=(Exception,))
-            )
             LOGGER.debug(
-                "Converted %r (%s) to %r (%s) using constructor (auto-registered)",
+                "Converted %r (%s) to %r (%s) using constructor",
                 value,
                 type(value).__name__,
                 new_value,
@@ -254,7 +251,7 @@ class TypeRegistry:
 
             conversions = TYPE_REGISTRY.list_conversions()
             for from_type, to_type, entry in conversions:
-                print(f"{from_type.__name__} → {to_type.__name__}: {entry.description}")
+                print(f"{from_type.__name__} → {to_type.__name__}: {entry.func.__name__}")
             ```
         """
         items = []
@@ -262,16 +259,6 @@ class TypeRegistry:
             items.append((from_type, to_type, entry))
         items.sort(key=lambda x: (x[0].__name__, x[1].__name__))
         return items
-
-    @classmethod
-    def snapshot(cls) -> dict[tuple[type[Any], type[Any]], TypeConverterEntry[Any, Any]]:
-        """Return a shallow copy of the current conversion map."""
-        return dict(cls.conversion_map)
-
-    @classmethod
-    def restore(cls, snapshot: dict[tuple[type[Any], type[Any]], TypeConverterEntry[Any, Any]]) -> None:
-        """Replace the conversion map with a previously captured snapshot."""
-        cls.conversion_map = snapshot
 
 
 # stdlib classes
@@ -338,3 +325,6 @@ def from_string_to_bool(value: str) -> bool:
             return False
         case _:
             raise ValueError
+
+
+TYPE_REGISTRY = TypeRegistry()

--- a/src/hassette/models/states/__init__.py
+++ b/src/hassette/models/states/__init__.py
@@ -22,6 +22,7 @@ from .binary_sensor import BinarySensorAttributes, BinarySensorDeviceClass, Bina
 from .button import ButtonAttributes, ButtonDeviceClass, ButtonState
 from .calendar import CalendarAttributes, CalendarState
 from .camera import CameraAttributes, CameraEntityFeature, CameraState, CameraStateValue, StreamType
+from .catalog import StateKey
 from .climate import ClimateAttributes, ClimateEntityFeature, ClimateState, HVACAction, HVACMode
 from .counter import CounterAttributes, CounterState
 from .cover import CoverAttributes, CoverDeviceClass, CoverEntityFeature, CoverState, CoverStateValue
@@ -210,6 +211,7 @@ __all__ = [
     "SirenAttributes",
     "SirenEntityFeature",
     "SirenState",
+    "StateKey",
     "StreamType",
     "StringBaseState",
     "SttState",

--- a/src/hassette/models/states/base.py
+++ b/src/hassette/models/states/base.py
@@ -7,8 +7,8 @@ from typing import Any, ClassVar, Generic, get_args
 from pydantic import AliasChoices, BaseModel, ConfigDict, Field, field_validator, model_validator
 from whenever import Date, PlainDateTime, Time, ZonedDateTime
 
-from hassette.conversion import TYPE_REGISTRY, register_state_converter
-from hassette.exceptions import NoDomainAnnotationError, UnableToConvertValueError
+from hassette.exceptions import NoDomainAnnotationError
+from hassette.models.states.catalog import register_state_converter
 from hassette.types import StateValueT
 from hassette.utils.date_utils import convert_datetime_str_to_system_tz, convert_utc_timestamp_to_system_tz
 
@@ -170,14 +170,6 @@ class BaseState(BaseModel, Generic[StateValueT]):
         elif state == "unavailable":
             values["is_unavailable"] = True
             values["state"] = state = None
-
-        try:
-            values["state"] = TYPE_REGISTRY.convert(state, cls.value_type)
-        except UnableToConvertValueError as e:
-            LOGGER.error(
-                "Unable to convert state value %r for entity %s: %s", state, values.get("entity_id"), e, stacklevel=2
-            )
-            raise
 
         return values
 

--- a/src/hassette/models/states/catalog.py
+++ b/src/hassette/models/states/catalog.py
@@ -1,0 +1,59 @@
+"""State-class catalog: domain → BaseState subclass mapping.
+
+This leaf module owns the STATE_CATALOG dict, register_state_converter, resolve, and
+StateKey. It imports nothing from hassette.conversion — it sits below the codec in the
+package DAG so that models/states can be imported without pulling in conversion.
+
+BaseState.__init_subclass__ writes this catalog; StateRegistry (conversion layer) reads it.
+"""
+
+from collections.abc import Hashable
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from hassette.models.states.base import BaseState
+
+_STATE_CATALOG: dict["StateKey", type["BaseState"]] = {}
+
+
+@dataclass(frozen=True)
+class StateKey:
+    domain: Hashable | None = None
+    """The domain of the entity (e.g., 'light', 'sensor')."""
+
+    device_class: Hashable | None = None
+    """Optional device class of the entity (e.g., 'temperature', 'humidity')."""
+
+
+def register_state_converter(
+    state_class: type["BaseState"], domain: Hashable, device_class: Hashable | None = None
+) -> None:
+    """Register a state class for a specific domain and optional device class."""
+    key = StateKey(domain=domain, device_class=device_class)
+    _STATE_CATALOG[key] = state_class
+
+
+def resolve(*, domain: Hashable | None = None, device_class: Hashable | None = None) -> type["BaseState"] | None:
+    """Resolve a state class from the catalog based on domain and device_class."""
+    candidates = [StateKey(domain=domain, device_class=device_class)]
+    if device_class is not None:
+        candidates.append(StateKey(domain=domain, device_class=None))
+
+    for k in candidates:
+        if k in _STATE_CATALOG:
+            return _STATE_CATALOG[k]
+    return None
+
+
+def snapshot_catalog() -> "dict[StateKey, type[BaseState]]":
+    """Return a shallow copy of the current catalog state."""
+    return dict(_STATE_CATALOG)
+
+
+def restore_catalog(snap: "dict[StateKey, type[BaseState]]") -> None:
+    """Replace the catalog contents with a previously captured snapshot."""
+    # In-place clear+update (not a rebind), so every module-level importer of
+    # _STATE_CATALOG keeps seeing the same live dict.
+    _STATE_CATALOG.clear()
+    _STATE_CATALOG.update(snap)

--- a/src/hassette/models/states/catalog.py
+++ b/src/hassette/models/states/catalog.py
@@ -1,8 +1,8 @@
 """State-class catalog: domain → BaseState subclass mapping.
 
 This leaf module owns the STATE_CATALOG dict, register_state_converter, resolve, and
-StateKey. It imports nothing from hassette.conversion — it sits below the codec in the
-package DAG so that models/states can be imported without pulling in conversion.
+StateKey. It imports nothing from hassette.conversion — it sits below the conversion
+layer in the package DAG so that models/states can be imported without pulling in conversion.
 
 BaseState.__init_subclass__ writes this catalog; StateRegistry (conversion layer) reads it.
 """

--- a/src/hassette/models/states/catalog.py
+++ b/src/hassette/models/states/catalog.py
@@ -29,13 +29,27 @@ class StateKey:
 def register_state_converter(
     state_class: type["BaseState"], domain: Hashable, device_class: Hashable | None = None
 ) -> None:
-    """Register a state class for a specific domain and optional device class."""
+    """Register a state class for a specific domain and optional device class.
+
+    Args:
+        state_class: The state class to register. Must be a subclass of BaseState.
+        domain: The Home Assistant domain (e.g., "light", "sensor").
+        device_class: The device class (e.g., "temperature", "motion").
+    """
     key = StateKey(domain=domain, device_class=device_class)
     _STATE_CATALOG[key] = state_class
 
 
 def resolve(*, domain: Hashable | None = None, device_class: Hashable | None = None) -> type["BaseState"] | None:
-    """Resolve a state class from the catalog based on domain and device_class."""
+    """Resolve a state class from the catalog based on domain and device_class.
+
+    Args:
+        domain: The Home Assistant domain (e.g., "light", "sensor").
+        device_class: The device class (e.g., "temperature", "motion").
+
+    Returns:
+        The registered state class, or None if no match is found.
+    """
     candidates = [StateKey(domain=domain, device_class=device_class)]
     if device_class is not None:
         candidates.append(StateKey(domain=domain, device_class=None))

--- a/src/hassette/state_manager/state_manager.py
+++ b/src/hassette/state_manager/state_manager.py
@@ -4,10 +4,9 @@ from logging import getLogger
 from typing import Generic, NamedTuple
 
 from frozendict import deepfreeze, frozendict
-from pydantic import ValidationError
 
 from hassette.conversion import STATE_REGISTRY, StateKey
-from hassette.exceptions import RegistryNotReadyError, UnableToConvertStateError
+from hassette.exceptions import RegistryNotReadyError
 from hassette.models import states
 from hassette.models.states import BaseState
 from hassette.resources.base import Resource
@@ -83,10 +82,7 @@ class DomainStates(Generic[StateT]):
         if cached is not None and cached.frozen_state == frozen_state:
             return cached.model
 
-        try:
-            validated = self._model.model_validate(state)
-        except ValidationError as e:
-            raise UnableToConvertStateError(entity_id, self._model) from e
+        validated = STATE_REGISTRY.coerce_and_construct(self._model, state, entity_id)
         self._cache[entity_id] = CacheValue(context_id, frozen_state, validated)
         return validated
 
@@ -346,12 +342,10 @@ class StateManager(Resource):
                 print(f"Domain: {test_entity.domain}, Value: {test_entity.value}")
             ```
         """
-        # Get raw state dict from proxy
         state_dict = self._state_proxy.get_state(entity_id)
         if state_dict is None:
             return None
 
-        # Use StateRegistry's try_convert_state which handles fallback to BaseState
         try:
             return self.hassette.state_registry.try_convert_state(state_dict, entity_id)
         except Exception as e:

--- a/src/hassette/test_utils/__init__.py
+++ b/src/hassette/test_utils/__init__.py
@@ -56,6 +56,7 @@ from .helpers import (
     make_sensor_state_dict,
     make_state_dict,
     make_switch_state_dict,
+    make_typed_state,
 )
 from .helpers import create_listener as create_listener
 from .helpers import make_task_bucket as make_task_bucket
@@ -81,4 +82,5 @@ __all__ = [
     "make_state_dict",
     "make_switch_state_dict",
     "make_test_config",
+    "make_typed_state",
 ]

--- a/src/hassette/test_utils/helpers.py
+++ b/src/hassette/test_utils/helpers.py
@@ -4,7 +4,7 @@ import textwrap
 from collections.abc import Mapping, Sequence
 from logging import Logger, getLogger
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 from unittest.mock import MagicMock
 from uuid import uuid4
 
@@ -19,6 +19,7 @@ from hassette.bus.listeners import (
     ListenerOptions,
 )
 from hassette.config.classes import AppManifest
+from hassette.conversion import STATE_REGISTRY
 from hassette.events import (
     CallServiceEvent,
     ComponentLoadedEvent,
@@ -27,13 +28,14 @@ from hassette.events import (
     create_event_from_hass,
 )
 from hassette.events.hassette import HassetteFileWatcherEvent, HassetteServiceEvent
+from hassette.types import StateT
 from hassette.types.enums import BackpressurePolicy, ExecutionMode, ResourceStatus
 from hassette.utils.func_utils import callable_name, callable_short_name
 
 if TYPE_CHECKING:
     from hassette.bus.bus import Bus
     from hassette.core.core import Hassette
-    from hassette.events import HassEventEnvelopeDict
+    from hassette.events import HassEventEnvelopeDict, HassStateDict
     from hassette.resources.service import Service
     from hassette.types.types import BusErrorHandlerType, HandlerType, Predicate, SourceTier
 
@@ -257,6 +259,14 @@ def make_switch_state_dict(entity_id: str = "switch.outlet", state: str = "on", 
     attributes.update(extra_attrs)
 
     return make_state_dict(entity_id, state, attributes=attributes, **state_kwargs)
+
+
+def make_typed_state(state_class: type[StateT], state_dict: "dict[str, Any]") -> StateT:
+    """Convert a raw state dict to a typed state via the codec coercion path."""
+    entity_id: str = state_dict.get("entity_id", "<unknown>")
+    result = STATE_REGISTRY.coerce_and_construct(state_class, cast("HassStateDict", state_dict), entity_id)
+    assert isinstance(result, state_class)
+    return result
 
 
 def make_full_state_change_event(

--- a/src/hassette/test_utils/helpers.py
+++ b/src/hassette/test_utils/helpers.py
@@ -262,7 +262,18 @@ def make_switch_state_dict(entity_id: str = "switch.outlet", state: str = "on", 
 
 
 def make_typed_state(state_class: type[StateT], state_dict: "dict[str, Any]") -> StateT:
-    """Convert a raw state dict to a typed state via the codec coercion path."""
+    """Convert a raw state dict to a typed state via the codec coercion path.
+
+    Replaces direct ``XState.model_validate(dict)`` calls in tests; routes through
+    the codec coercion entry point so tests exercise the same path as production.
+
+    Args:
+        state_class: The target state model class (e.g., LightState, SensorState).
+        state_dict: A raw state dict as produced by make_state_dict / make_*_state_dict.
+
+    Returns:
+        The typed state instance.
+    """
     entity_id: str = state_dict.get("entity_id", "<unknown>")
     result = STATE_REGISTRY.coerce_and_construct(state_class, cast("HassStateDict", state_dict), entity_id)
     assert isinstance(result, state_class)

--- a/src/hassette/test_utils/helpers.py
+++ b/src/hassette/test_utils/helpers.py
@@ -262,10 +262,10 @@ def make_switch_state_dict(entity_id: str = "switch.outlet", state: str = "on", 
 
 
 def make_typed_state(state_class: type[StateT], state_dict: "dict[str, Any]") -> StateT:
-    """Convert a raw state dict to a typed state via the codec coercion path.
+    """Convert a raw state dict to a typed state via the conversion pipeline.
 
     Replaces direct ``XState.model_validate(dict)`` calls in tests; routes through
-    the codec coercion entry point so tests exercise the same path as production.
+    the conversion entry point so tests exercise the same path as production.
 
     Args:
         state_class: The target state model class (e.g., LightState, SensorState).

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -19,8 +19,7 @@ from hassette.config.models import (
     WebApiConfig,
     WebSocketConfig,
 )
-from hassette.conversion.state_registry import StateRegistry
-from hassette.conversion.type_registry import TypeRegistry
+from hassette.models.states.catalog import restore_catalog, snapshot_catalog
 from hassette.task_bucket import TaskBucket
 
 if TYPE_CHECKING:
@@ -230,12 +229,13 @@ def my_app_class() -> type:
 
 @pytest.fixture(autouse=True)
 def _isolate_registries():
-    """Snapshot and restore StateRegistry and TypeRegistry to prevent cross-test pollution."""
-    state_snap = StateRegistry.snapshot()
-    type_snap = TypeRegistry.snapshot()
+    """Snapshot and restore the state-class catalog to prevent cross-test pollution.
+
+    TypeRegistry is now a stable read-only global after import — no snapshot needed.
+    """
+    state_snap = snapshot_catalog()
     yield
-    StateRegistry.restore(state_snap)
-    TypeRegistry.restore(type_snap)
+    restore_catalog(state_snap)
 
 
 @pytest.fixture

--- a/tests/integration/test_models.py
+++ b/tests/integration/test_models.py
@@ -83,8 +83,6 @@ def test_all_domains_registered(
 
     assert not missing_domains, f"Domains not registered: {missing_domains}"
 
-    logger.info("All %d state models are properly registered in the registry.", len(all_models))
-
 
 def test_all_classes_in_registry(all_models: dict[str, type[states.BaseState]]):
     """Test that all state models are included in the state registry."""
@@ -109,8 +107,6 @@ def test_all_classes_in_registry(all_models: dict[str, type[states.BaseState]]):
 
     assert not missing_classes, f"Classes not registered: {missing_classes}"
 
-    logger.info("All %d state models are included in the registry.", len(all_models))
-
 
 def test_registry_can_convert_all_domains(
     all_models: dict[str, type[states.BaseState]],
@@ -131,8 +127,6 @@ def test_registry_can_convert_all_domains(
             f"Registry returned {retrieved_class} for domain '{domain}', expected {model_cls}"
         )
 
-    logger.info("Registry can successfully look up all %d state classes by domain.", len(all_models))
-
 
 def test_fixture_data_parses_as_registered_state_class(hass_state_dicts: list[dict[str, Any]]):
     """Every entity in the JSONL fixture must parse as its registered state class.
@@ -151,7 +145,7 @@ def test_fixture_data_parses_as_registered_state_class(hass_state_dicts: list[di
             continue
 
         try:
-            state_cls.model_validate(state_dict)
+            STATE_REGISTRY.try_convert_state(state_dict)
         except Exception as e:
             failures.append(f"{entity_id}: {e}")
 

--- a/tests/integration/test_models.py
+++ b/tests/integration/test_models.py
@@ -145,7 +145,9 @@ def test_fixture_data_parses_as_registered_state_class(hass_state_dicts: list[di
             continue
 
         try:
-            STATE_REGISTRY.try_convert_state(state_dict)
+            converted = STATE_REGISTRY.try_convert_state(state_dict)
+            if type(converted) is not state_cls:
+                failures.append(f"{entity_id}: converted to {type(converted).__name__}, expected {state_cls.__name__}")
         except Exception as e:
             failures.append(f"{entity_id}: {e}")
 

--- a/tests/unit/conversion/test_codec_characterization.py
+++ b/tests/unit/conversion/test_codec_characterization.py
@@ -1,9 +1,9 @@
 """Characterization pin for state-conversion typed output.
 
-This test captures the exact typed values produced by the current model_validate
-path across every value_type family. It must stay green before and after the
-refactor — if any assertion fails post-refactor, the codec produced a different
-typed value than the pre-change path.
+Most test classes pin the direct model_validate path. TestTryConvertStateEntryPoint
+pins the STATE_REGISTRY.try_convert_state codec path (domain resolution + type
+coercion). If any assertion fails, the conversion produced a different typed value
+than the expected golden output.
 
 Write golden values from observation, not from calling the same code path twice.
 """
@@ -182,20 +182,20 @@ class TestTryConvertStateEntryPoint:
     def test_light_on_via_registry(self) -> None:
         raw = make_state_dict("light.kitchen", "on")
         state = STATE_REGISTRY.try_convert_state(raw)
-        assert type(state).__name__ == "LightState"
+        assert type(state) is LightState
         assert state.value is True
 
     def test_sensor_string_via_registry(self) -> None:
         raw = make_state_dict("sensor.outdoor_temperature", "23.5")
         state = STATE_REGISTRY.try_convert_state(raw)
-        assert type(state).__name__ == "SensorState"
+        assert type(state) is SensorState
         assert state.value == "23.5"
         assert isinstance(state.value, str)
 
     def test_number_float_via_registry(self) -> None:
         raw = make_state_dict("number.brightness", "23.5")
         state = STATE_REGISTRY.try_convert_state(raw)
-        assert type(state).__name__ == "NumberState"
+        assert type(state) is NumberState
         assert state.value == 23.5
         assert isinstance(state.value, float)
 

--- a/tests/unit/conversion/test_codec_characterization.py
+++ b/tests/unit/conversion/test_codec_characterization.py
@@ -13,7 +13,7 @@ from typing import Literal
 from whenever import Time, ZonedDateTime
 
 from hassette.conversion import STATE_REGISTRY
-from hassette.models.states.base import TimeBaseState
+from hassette.models.states.base import BaseState, TimeBaseState
 from hassette.models.states.binary_sensor import BinarySensorState
 from hassette.models.states.input import InputButtonState, InputDatetimeState, InputNumberState
 from hassette.models.states.light import LightState
@@ -202,5 +202,13 @@ class TestTryConvertStateEntryPoint:
     def test_unknown_light_via_registry(self) -> None:
         raw = make_state_dict("light.kitchen", "unknown")
         state = STATE_REGISTRY.try_convert_state(raw)
+        assert type(state) is LightState
         assert state.value is None
         assert state.is_unknown is True
+
+    def test_unregistered_domain_falls_back_to_base_state(self) -> None:
+        raw = make_state_dict("custom_unregistered.demo", "payload")
+        state = STATE_REGISTRY.try_convert_state(raw)
+        assert type(state) is BaseState
+        assert state.value == "payload"
+        assert state.domain == "custom_unregistered"

--- a/tests/unit/conversion/test_codec_characterization.py
+++ b/tests/unit/conversion/test_codec_characterization.py
@@ -1,0 +1,206 @@
+"""Characterization pin for state-conversion typed output.
+
+This test captures the exact typed values produced by the current model_validate
+path across every value_type family. It must stay green before and after the
+refactor — if any assertion fails post-refactor, the codec produced a different
+typed value than the pre-change path.
+
+Write golden values from observation, not from calling the same code path twice.
+"""
+
+from typing import Literal
+
+from whenever import Time, ZonedDateTime
+
+from hassette.conversion import STATE_REGISTRY
+from hassette.models.states.base import TimeBaseState
+from hassette.models.states.binary_sensor import BinarySensorState
+from hassette.models.states.input import InputButtonState, InputDatetimeState, InputNumberState
+from hassette.models.states.light import LightState
+from hassette.models.states.number import NumberState
+from hassette.models.states.sensor import SensorState
+from hassette.test_utils import make_state_dict, make_typed_state
+
+
+class TestBoolValueTypeFamily:
+    """Bool value_type family: value_type = (bool, type(None)). 'on' -> True, 'off' -> False."""
+
+    def test_light_on_yields_true(self) -> None:
+        raw = make_state_dict("light.kitchen", "on")
+        state = LightState.model_validate(raw)
+        assert state.value is True
+        assert isinstance(state.value, bool)
+        assert state.is_unknown is False
+        assert state.is_unavailable is False
+
+    def test_light_off_yields_false(self) -> None:
+        raw = make_state_dict("light.kitchen", "off")
+        state = LightState.model_validate(raw)
+        assert state.value is False
+        assert isinstance(state.value, bool)
+
+    def test_binary_sensor_on_yields_true(self) -> None:
+        raw = make_state_dict("binary_sensor.front_door", "on")
+        state = BinarySensorState.model_validate(raw)
+        assert state.value is True
+        assert isinstance(state.value, bool)
+
+    def test_binary_sensor_off_yields_false(self) -> None:
+        raw = make_state_dict("binary_sensor.front_door", "off")
+        state = BinarySensorState.model_validate(raw)
+        assert state.value is False
+        assert isinstance(state.value, bool)
+
+
+class TestStringValueTypeFamily:
+    """String value_type family: value_type = (str, type(None)). Raw string preserved as-is."""
+
+    def test_sensor_numeric_string_stays_as_string(self) -> None:
+        """SensorState uses StringBaseState — the value stays a str, not a float."""
+        raw = make_state_dict("sensor.outdoor_temperature", "23.5")
+        state = SensorState.model_validate(raw)
+        assert state.value == "23.5"
+        assert isinstance(state.value, str)
+
+    def test_sensor_text_value(self) -> None:
+        raw = make_state_dict("sensor.door_status", "open")
+        state = SensorState.model_validate(raw)
+        assert state.value == "open"
+        assert isinstance(state.value, str)
+
+
+class TestNumericValueTypeFamily:
+    """Numeric value_type family: coercion tries int, then float, then Decimal."""
+
+    def test_number_float_string_yields_float(self) -> None:
+        raw = make_state_dict("number.brightness", "23.5")
+        state = NumberState.model_validate(raw)
+        assert state.value == 23.5
+        assert isinstance(state.value, float)
+        assert not isinstance(state.value, int)
+
+    def test_number_integer_string_yields_int(self) -> None:
+        raw = make_state_dict("number.count", "5")
+        state = NumberState.model_validate(raw)
+        assert state.value == 5
+        assert isinstance(state.value, int)
+
+    def test_input_number_float_zero_yields_float(self) -> None:
+        raw = make_state_dict("input_number.slider", "42.0")
+        state = make_typed_state(InputNumberState, raw)
+        assert state.value == 42.0
+        assert isinstance(state.value, float)
+
+
+class TestDateTimeValueTypeFamily:
+    """DateTime value_type family: ISO datetime string -> ZonedDateTime (converted to system tz)."""
+
+    def test_input_button_iso_datetime_yields_zoned_datetime(self) -> None:
+        raw = make_state_dict("input_button.test", "2024-01-15T10:30:00+00:00")
+        state = make_typed_state(InputButtonState, raw)
+        assert isinstance(state.value, ZonedDateTime)
+        # The UTC offset is converted to system tz; verify the instant is correct.
+        assert state.value.to_instant() == ZonedDateTime.parse_iso("2024-01-15T10:30:00+00:00[UTC]").to_instant()
+
+    def test_input_datetime_iso_datetime_yields_zoned_datetime(self) -> None:
+        raw = make_state_dict(
+            "input_datetime.wake_up",
+            "2024-06-01T08:00:00+00:00",
+            attributes={"has_date": True, "has_time": True},
+        )
+        state = make_typed_state(InputDatetimeState, raw)
+        assert isinstance(state.value, ZonedDateTime)
+
+
+class TestTimeValueTypeFamily:
+    """Time value_type family: ISO time string -> whenever.Time. Uses a throwaway subclass."""
+
+    def test_time_iso_string_yields_time_object(self) -> None:
+        class TimeDomainState(TimeBaseState):
+            domain: Literal["test_time_domain"]  # pyright: ignore[reportIncompatibleVariableOverride]
+
+        raw = make_state_dict("test_time_domain.alarm", "10:30:00")
+        state = TimeDomainState.model_validate(raw)
+        assert isinstance(state.value, Time)
+        assert state.value == Time(10, 30, 0)
+
+
+class TestUnknownUnavailableNormalization:
+    """unknown/unavailable normalization must happen before value coercion."""
+
+    def test_bool_domain_unknown_yields_none_with_flag(self) -> None:
+        raw = make_state_dict("light.kitchen", "unknown")
+        state = LightState.model_validate(raw)
+        assert state.value is None
+        assert state.is_unknown is True
+        assert state.is_unavailable is False
+
+    def test_bool_domain_unavailable_yields_none_with_flag(self) -> None:
+        raw = make_state_dict("light.kitchen", "unavailable")
+        state = LightState.model_validate(raw)
+        assert state.value is None
+        assert state.is_unknown is False
+        assert state.is_unavailable is True
+
+    def test_numeric_domain_unknown_yields_none_with_flag(self) -> None:
+        """unknown is set to None before numeric coercion — never tries to coerce "unknown" as a number."""
+        raw = make_state_dict("number.brightness", "unknown")
+        state = NumberState.model_validate(raw)
+        assert state.value is None
+        assert state.is_unknown is True
+        assert state.is_unavailable is False
+
+    def test_numeric_domain_unavailable_yields_none_with_flag(self) -> None:
+        raw = make_state_dict("number.brightness", "unavailable")
+        state = NumberState.model_validate(raw)
+        assert state.value is None
+        assert state.is_unknown is False
+        assert state.is_unavailable is True
+
+    def test_datetime_domain_unknown_yields_none_with_flag(self) -> None:
+        raw = make_state_dict("input_button.test", "unknown")
+        state = InputButtonState.model_validate(raw)
+        assert state.value is None
+        assert state.is_unknown is True
+
+    def test_string_domain_unknown_yields_none_with_flag(self) -> None:
+        raw = make_state_dict("sensor.outdoor_temperature", "unknown")
+        state = SensorState.model_validate(raw)
+        assert state.value is None
+        assert state.is_unknown is True
+
+    def test_string_domain_unavailable_yields_none_with_flag(self) -> None:
+        raw = make_state_dict("sensor.outdoor_temperature", "unavailable")
+        state = SensorState.model_validate(raw)
+        assert state.value is None
+        assert state.is_unavailable is True
+
+
+class TestTryConvertStateEntryPoint:
+    """try_convert_state entry point: pins domain resolution + BaseState fallback path."""
+
+    def test_light_on_via_registry(self) -> None:
+        raw = make_state_dict("light.kitchen", "on")
+        state = STATE_REGISTRY.try_convert_state(raw)
+        assert type(state).__name__ == "LightState"
+        assert state.value is True
+
+    def test_sensor_string_via_registry(self) -> None:
+        raw = make_state_dict("sensor.outdoor_temperature", "23.5")
+        state = STATE_REGISTRY.try_convert_state(raw)
+        assert type(state).__name__ == "SensorState"
+        assert state.value == "23.5"
+        assert isinstance(state.value, str)
+
+    def test_number_float_via_registry(self) -> None:
+        raw = make_state_dict("number.brightness", "23.5")
+        state = STATE_REGISTRY.try_convert_state(raw)
+        assert type(state).__name__ == "NumberState"
+        assert state.value == 23.5
+        assert isinstance(state.value, float)
+
+    def test_unknown_light_via_registry(self) -> None:
+        raw = make_state_dict("light.kitchen", "unknown")
+        state = STATE_REGISTRY.try_convert_state(raw)
+        assert state.value is None
+        assert state.is_unknown is True

--- a/tests/unit/conversion/test_codec_known_model.py
+++ b/tests/unit/conversion/test_codec_known_model.py
@@ -1,0 +1,88 @@
+"""Tests for the codec known-model coercion path.
+
+Covers:
+- The domain-states subscript path returns coerced typed values (bool, not "on")
+  through state_manager.py's coerce_and_construct call site.
+- A coercion failure on the state path raises UnableToConvertStateError with entity_id.
+"""
+
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from hassette.exceptions import UnableToConvertStateError
+from hassette.models.states.binary_sensor import BinarySensorState
+from hassette.models.states.light import LightState
+from hassette.state_manager.state_manager import DomainStates
+from hassette.test_utils import make_light_state_dict, make_state_dict
+from hassette.types import StateT
+
+
+def domain_states_from(state_dict: dict[str, Any], model: type[StateT]) -> DomainStates[StateT]:
+    """Build a DomainStates backed by a mock proxy returning the given state dict."""
+    proxy = MagicMock()
+    proxy.get_state.return_value = state_dict
+    return DomainStates(proxy, model)
+
+
+class TestCodecKnownModelTypedValues:
+    """Domain-states subscript path returns codec-coerced typed values."""
+
+    def test_light_on_yields_bool_true(self) -> None:
+        """LightState (BoolBaseState) domain yields bool True, not the string 'on'."""
+        ds = domain_states_from(make_light_state_dict("light.kitchen", "on"), LightState)
+        state = ds["light.kitchen"]
+        assert state.value is True
+        assert isinstance(state.value, bool)
+
+    def test_light_off_yields_bool_false(self) -> None:
+        """LightState (BoolBaseState) domain yields bool False, not the string 'off'."""
+        ds = domain_states_from(make_light_state_dict("light.kitchen", "off"), LightState)
+        state = ds["light.kitchen"]
+        assert state.value is False
+        assert isinstance(state.value, bool)
+
+    def test_binary_sensor_on_yields_bool_true(self) -> None:
+        """BinarySensorState (BoolBaseState) domain yields bool True via codec path."""
+        ds = domain_states_from(make_state_dict("binary_sensor.front_door", "on"), BinarySensorState)
+        state = ds["binary_sensor.front_door"]
+        assert state.value is True
+        assert isinstance(state.value, bool)
+
+    def test_unknown_state_yields_none_with_flag(self) -> None:
+        """Unknown state is normalized to None before coercion; is_unknown flag is set."""
+        ds = domain_states_from(make_light_state_dict("light.kitchen", "unknown"), LightState)
+        state = ds["light.kitchen"]
+        assert state.value is None
+        assert state.is_unknown is True
+
+    def test_unavailable_state_yields_none_with_flag(self) -> None:
+        """Unavailable state is normalized to None before coercion; is_unavailable flag is set."""
+        ds = domain_states_from(make_light_state_dict("light.kitchen", "unavailable"), LightState)
+        state = ds["light.kitchen"]
+        assert state.value is None
+        assert state.is_unavailable is True
+
+
+class TestCodecKnownModelCoercionFailure:
+    """Coercion failure on the state path raises UnableToConvertStateError with entity_id."""
+
+    def test_invalid_timestamp_raises_unable_to_convert_with_entity_id(self) -> None:
+        """A state dict with invalid timestamp fields raises UnableToConvertStateError carrying entity_id."""
+        bad_state = {
+            "entity_id": "light.bad",
+            "state": "on",
+            "attributes": {},
+            "last_changed": "NOT-A-TIMESTAMP",
+            "last_updated": "NOT-A-TIMESTAMP",
+            "context": {"id": None, "parent_id": None, "user_id": None},
+        }
+        ds = domain_states_from(bad_state, LightState)
+
+        with pytest.raises(UnableToConvertStateError) as exc_info:
+            ds["light.bad"]
+
+        err = exc_info.value
+        assert err.entity_id == "light.bad"
+        assert err.state_class is LightState

--- a/tests/unit/conversion/test_custom_conversion.py
+++ b/tests/unit/conversion/test_custom_conversion.py
@@ -1,0 +1,238 @@
+"""Tests for custom state models and custom type converters through the conversion pipeline.
+
+Covers the user-facing patterns documented in custom-states.md and
+dependency-injection.md: defining custom state classes with typed attributes,
+registering custom type converters, and verifying that the full codec pipeline
+handles them correctly.
+"""
+
+from enum import StrEnum
+from typing import Any, ClassVar, Literal
+
+import pytest
+from pydantic import Field
+
+from hassette.conversion import STATE_REGISTRY, TYPE_REGISTRY, convert_state_dict_to_model, register_type_converter_fn
+from hassette.conversion.type_registry import TypeRegistry
+from hassette.exceptions import UnableToConvertValueError
+from hassette.models.states.base import AttributesBase, BaseState, BoolBaseState, NumericBaseState, StringBaseState
+from hassette.test_utils import make_state_dict, make_typed_state
+
+
+@pytest.fixture(autouse=True)
+def _isolate_type_registry():
+    """Restore TypeRegistry after tests that register custom converters."""
+    snap = dict(TypeRegistry.conversion_map)
+    yield
+    TypeRegistry.conversion_map.clear()
+    TypeRegistry.conversion_map.update(snap)
+
+
+class PlantAttributes(AttributesBase):
+    moisture: int | None = Field(default=None)
+    conductivity: int | None = Field(default=None)
+    temperature: float | None = Field(default=None)
+
+
+class PlantState(StringBaseState):
+    domain: Literal["plant"]
+    attributes: PlantAttributes
+
+
+class CustomBoolState(BoolBaseState):
+    domain: Literal["custom_bool_test"]
+
+
+class CustomNumericState(NumericBaseState):
+    domain: Literal["custom_numeric_test"]
+
+
+class RobotMode(StrEnum):
+    IDLE = "idle"
+    CLEANING = "cleaning"
+    RETURNING = "returning"
+    ERROR = "error"
+
+
+class RobotState(BaseState[RobotMode | None]):
+    domain: Literal["custom_robot_test"]
+    value_type: ClassVar[type[Any] | tuple[type[Any], ...]] = (RobotMode, type(None))
+
+
+class TestCustomStateWithAttributes:
+    """Custom state models with typed AttributesBase subclasses."""
+
+    def test_model_validate_populates_typed_attributes(self) -> None:
+        raw = make_state_dict("plant.fern", "ok", {"moisture": 42, "conductivity": 300, "temperature": 22.5})
+        state = PlantState.model_validate(raw)
+        assert type(state) is PlantState
+        assert isinstance(state.attributes, PlantAttributes)
+        assert state.attributes.moisture == 42
+        assert state.attributes.conductivity == 300
+        assert state.attributes.temperature == 22.5
+
+    def test_try_convert_state_populates_typed_attributes(self) -> None:
+        raw = make_state_dict("plant.fern", "ok", {"moisture": 42, "conductivity": 300})
+        state = STATE_REGISTRY.try_convert_state(raw)
+        assert type(state) is PlantState
+        assert isinstance(state.attributes, PlantAttributes)
+        assert state.attributes.moisture == 42
+        assert state.attributes.conductivity == 300
+
+    def test_make_typed_state_populates_typed_attributes(self) -> None:
+        raw = make_state_dict("plant.fern", "ok", {"moisture": 42})
+        state = make_typed_state(PlantState, raw)
+        assert type(state) is PlantState
+        assert isinstance(state.attributes, PlantAttributes)
+        assert state.attributes.moisture == 42
+
+    def test_extra_attributes_accessible_via_extras(self) -> None:
+        raw = make_state_dict("plant.fern", "ok", {"moisture": 42, "battery": 85})
+        state = PlantState.model_validate(raw)
+        assert state.attributes.moisture == 42
+        assert state.attributes.extra("battery") == 85
+
+    def test_missing_optional_attributes_default_to_none(self) -> None:
+        raw = make_state_dict("plant.fern", "ok", {})
+        state = PlantState.model_validate(raw)
+        assert state.attributes.moisture is None
+        assert state.attributes.conductivity is None
+        assert state.attributes.temperature is None
+
+
+class TestCustomStateValueCoercion:
+    """Custom state models using built-in base classes get correct value coercion."""
+
+    def test_custom_bool_state_coerces_on_to_true(self) -> None:
+        raw = make_state_dict("custom_bool_test.switch1", "on")
+        state = STATE_REGISTRY.try_convert_state(raw)
+        assert type(state) is CustomBoolState
+        assert state.value is True
+
+    def test_custom_bool_state_coerces_off_to_false(self) -> None:
+        raw = make_state_dict("custom_bool_test.switch1", "off")
+        state = STATE_REGISTRY.try_convert_state(raw)
+        assert type(state) is CustomBoolState
+        assert state.value is False
+
+    def test_custom_numeric_state_coerces_string_to_number(self) -> None:
+        raw = make_state_dict("custom_numeric_test.gauge", "42.5")
+        state = STATE_REGISTRY.try_convert_state(raw)
+        assert type(state) is CustomNumericState
+        assert state.value == 42.5
+        assert isinstance(state.value, float)
+
+    def test_custom_numeric_state_integer_string(self) -> None:
+        raw = make_state_dict("custom_numeric_test.gauge", "100")
+        state = STATE_REGISTRY.try_convert_state(raw)
+        assert type(state) is CustomNumericState
+        assert state.value == 100
+        assert isinstance(state.value, int)
+
+    def test_custom_state_unknown_normalization(self) -> None:
+        raw = make_state_dict("custom_bool_test.switch1", "unknown")
+        state = STATE_REGISTRY.try_convert_state(raw)
+        assert type(state) is CustomBoolState
+        assert state.value is None
+        assert state.is_unknown is True
+
+    def test_custom_state_unavailable_normalization(self) -> None:
+        raw = make_state_dict("custom_numeric_test.gauge", "unavailable")
+        state = STATE_REGISTRY.try_convert_state(raw)
+        assert type(state) is CustomNumericState
+        assert state.value is None
+        assert state.is_unavailable is True
+
+
+class TestCustomEnumValueType:
+    """Custom state model with a user-defined StrEnum value_type and registered converter."""
+
+    def test_custom_enum_coercion_via_model_validate(self) -> None:
+        @register_type_converter_fn
+        def str_to_robot_mode(value: str) -> RobotMode:
+            return RobotMode(value.lower())
+
+        raw = make_state_dict("custom_robot_test.vacuum", "cleaning")
+        state = RobotState.model_validate(raw)
+        assert state.value == RobotMode.CLEANING
+        assert isinstance(state.value, RobotMode)
+
+    def test_custom_enum_coercion_via_try_convert_state(self) -> None:
+        @register_type_converter_fn
+        def str_to_robot_mode(value: str) -> RobotMode:
+            return RobotMode(value.lower())
+
+        raw = make_state_dict("custom_robot_test.vacuum", "idle")
+        state = STATE_REGISTRY.try_convert_state(raw)
+        assert type(state) is RobotState
+        assert state.value == RobotMode.IDLE
+
+    def test_custom_enum_unknown_yields_none(self) -> None:
+        @register_type_converter_fn
+        def str_to_robot_mode(value: str) -> RobotMode:
+            return RobotMode(value.lower())
+
+        raw = make_state_dict("custom_robot_test.vacuum", "unknown")
+        state = STATE_REGISTRY.try_convert_state(raw)
+        assert type(state) is RobotState
+        assert state.value is None
+        assert state.is_unknown is True
+
+    def test_without_converter_uses_constructor_fallback(self) -> None:
+        assert (str, RobotMode) not in TypeRegistry.conversion_map
+        raw = make_state_dict("custom_robot_test.vacuum", "cleaning")
+        state = STATE_REGISTRY.try_convert_state(raw)
+        assert type(state) is RobotState
+        assert state.value == RobotMode.CLEANING
+
+
+class TestRegisterTypeConverterFn:
+    """The @register_type_converter_fn decorator registers converters in TypeRegistry."""
+
+    def test_bare_decorator_registers_converter(self) -> None:
+        @register_type_converter_fn
+        def str_to_robot_mode(value: str) -> RobotMode:
+            return RobotMode(value.lower())
+
+        result = TYPE_REGISTRY.convert("cleaning", RobotMode)
+        assert result == RobotMode.CLEANING
+
+    def test_decorator_with_error_message(self) -> None:
+        @register_type_converter_fn(error_message="'{value}' is not a valid RobotMode")
+        def str_to_robot_mode(value: str) -> RobotMode:
+            return RobotMode(value.lower())
+
+        with pytest.raises(UnableToConvertValueError, match="'INVALID' is not a valid RobotMode"):
+            TYPE_REGISTRY.convert("INVALID", RobotMode)
+
+    def test_converter_is_used_by_state_pipeline(self) -> None:
+        calls: list[str] = []
+
+        @register_type_converter_fn
+        def str_to_robot_mode(value: str) -> RobotMode:
+            calls.append(value)
+            return RobotMode(value.lower())
+
+        raw = make_state_dict("custom_robot_test.vacuum", "returning")
+        state = convert_state_dict_to_model(raw, RobotState)
+        assert state.value == RobotMode.RETURNING
+        assert "returning" in calls
+
+
+class TestConvertStateDictToModel:
+    """Direct convert_state_dict_to_model calls with custom state models."""
+
+    def test_extracts_domain_from_entity_id(self) -> None:
+        raw = make_state_dict("plant.fern", "ok")
+        state = convert_state_dict_to_model(raw, PlantState)
+        assert state.domain == "plant"
+
+    def test_passes_through_already_constructed_instance(self) -> None:
+        raw = make_state_dict("plant.fern", "ok")
+        first = convert_state_dict_to_model(raw, PlantState)
+        second = convert_state_dict_to_model(first, PlantState)
+        assert first is second
+
+    def test_rejects_non_dict_non_model_input(self) -> None:
+        with pytest.raises(TypeError, match="expected dict"):
+            convert_state_dict_to_model("not a dict", PlantState)

--- a/tests/unit/conversion/test_registry_validation.py
+++ b/tests/unit/conversion/test_registry_validation.py
@@ -1,18 +1,19 @@
 """Tests for registry validation.
 
-The global _isolate_registries fixture in conftest.py snapshots/restores both
-StateRegistry and TypeRegistry before/after every test, so mutations here do
-not bleed between tests.
+The global _isolate_registries fixture in conftest.py snapshots/restores the
+state-class catalog before/after every test, so catalog mutations here do not
+bleed between tests. TypeRegistry is a stable read-only global after import.
 """
 
 import pytest
 
 from hassette.conversion import STATE_REGISTRY, TYPE_REGISTRY
-from hassette.conversion.state_registry import StateKey, StateRegistry
+from hassette.conversion.state_registry import StateKey
 from hassette.conversion.type_registry import TypeConverterEntry, TypeRegistry
 from hassette.conversion.validation import RegistryValidationIssue, validate_registries
 from hassette.exceptions import RegistryValidationError
 from hassette.models.states.base import BaseState
+from hassette.models.states.catalog import _STATE_CATALOG, restore_catalog
 
 
 class TestRealRegistriesPass:
@@ -24,8 +25,8 @@ class TestRealRegistriesPass:
 
 class TestEmptyRegistryErrors:
     def test_empty_state_registry_error(self) -> None:
-        """Clearing STATE_REGISTRY should produce an error issue with 'empty' in the message."""
-        StateRegistry.restore({})
+        """Clearing the state catalog should produce an error issue with 'empty' in the message."""
+        restore_catalog({})
         issues = validate_registries(STATE_REGISTRY, TYPE_REGISTRY)
         state_issues = [i for i in issues if i.registry == "STATE_REGISTRY"]
         assert len(state_issues) >= 1
@@ -34,14 +35,18 @@ class TestEmptyRegistryErrors:
         assert "empty" in error_issues[0].message.lower()
 
     def test_empty_type_registry_error(self) -> None:
-        """Clearing TYPE_REGISTRY should produce an error issue with 'empty' in the message."""
-        TypeRegistry.restore({})
-        issues = validate_registries(STATE_REGISTRY, TYPE_REGISTRY)
-        type_issues = [i for i in issues if i.registry == "TYPE_REGISTRY"]
-        assert len(type_issues) >= 1
-        error_issues = [i for i in type_issues if i.severity == "error"]
-        assert len(error_issues) >= 1
-        assert "empty" in error_issues[0].message.lower()
+        """Clearing TYPE_REGISTRY.conversion_map should produce an error issue with 'empty' in the message."""
+        saved = dict(TypeRegistry.conversion_map)
+        TypeRegistry.conversion_map.clear()
+        try:
+            issues = validate_registries(STATE_REGISTRY, TYPE_REGISTRY)
+            type_issues = [i for i in issues if i.registry == "TYPE_REGISTRY"]
+            assert len(type_issues) >= 1
+            error_issues = [i for i in type_issues if i.severity == "error"]
+            assert len(error_issues) >= 1
+            assert "empty" in error_issues[0].message.lower()
+        finally:
+            TypeRegistry.conversion_map.update(saved)
 
 
 class TestStateRegistryValidation:
@@ -51,7 +56,7 @@ class TestStateRegistryValidation:
         class NoDomainState(BaseState):
             domain: "str"
 
-        StateRegistry._registry[StateKey(domain=None)] = NoDomainState
+        _STATE_CATALOG[StateKey(domain=None)] = NoDomainState
         issues = validate_registries(STATE_REGISTRY, TYPE_REGISTRY)
         state_errors = [i for i in issues if i.registry == "STATE_REGISTRY" and i.severity == "error"]
         assert len(state_errors) >= 1
@@ -64,7 +69,7 @@ class TestStateRegistryValidation:
         class NotAState:
             pass
 
-        StateRegistry._registry[StateKey(domain="fake_domain")] = NotAState  # pyright: ignore[reportArgumentType]
+        _STATE_CATALOG[StateKey(domain="fake_domain")] = NotAState  # pyright: ignore[reportArgumentType]
         issues = validate_registries(STATE_REGISTRY, TYPE_REGISTRY)
         state_errors = [i for i in issues if i.registry == "STATE_REGISTRY" and i.severity == "error"]
         assert len(state_errors) >= 1
@@ -79,10 +84,8 @@ class TestStateRegistryValidation:
         class StateB(BaseState):
             domain: "str"
 
-        StateRegistry._registry[StateKey(domain="dup_domain")] = StateA
-        StateRegistry._registry[StateKey(domain="dup_domain", device_class="some_class")] = StateB
-        # Inject another entry with same domain but different key to test duplicate detection
-        # Actually, duplicate domain means two keys with the same .domain value
+        _STATE_CATALOG[StateKey(domain="dup_domain")] = StateA
+        _STATE_CATALOG[StateKey(domain="dup_domain", device_class="some_class")] = StateB
         issues = validate_registries(STATE_REGISTRY, TYPE_REGISTRY)
         dup_warnings = [
             i for i in issues if i.registry == "STATE_REGISTRY" and i.severity == "warning" and "dup" in i.message
@@ -91,6 +94,14 @@ class TestStateRegistryValidation:
 
 
 class TestTypeRegistryValidation:
+    @pytest.fixture(autouse=True)
+    def _restore_conversion_map(self):
+        """Snapshot and restore conversion_map around each test that mutates it directly."""
+        saved = dict(TypeRegistry.conversion_map)
+        yield
+        TypeRegistry.conversion_map.clear()
+        TypeRegistry.conversion_map.update(saved)
+
     def test_type_registry_non_callable_func_error(self) -> None:
         """An entry with func=None should produce an error issue."""
         TypeRegistry.conversion_map[(str, int)] = TypeConverterEntry(
@@ -119,7 +130,7 @@ class TestTypeRegistryValidation:
 class TestStrictMode:
     def test_strict_mode_raises_on_errors(self) -> None:
         """With strict=True, any error-level issue causes RegistryValidationError to be raised."""
-        StateRegistry.restore({})
+        restore_catalog({})
         with pytest.raises(RegistryValidationError) as exc_info:
             validate_registries(STATE_REGISTRY, TYPE_REGISTRY, strict=True)
         # The exception message should include issue count or summary
@@ -136,8 +147,8 @@ class TestStrictMode:
 
         # Inject duplicate domain to generate a warning-only scenario.
         # We need to ensure the real registries are non-empty (no error) but have a duplicate warning.
-        StateRegistry._registry[StateKey(domain="warn_domain")] = StateA
-        StateRegistry._registry[StateKey(domain="warn_domain", device_class="dc")] = StateB
+        _STATE_CATALOG[StateKey(domain="warn_domain")] = StateA
+        _STATE_CATALOG[StateKey(domain="warn_domain", device_class="dc")] = StateB
 
         # This should not raise — warnings only
         issues = validate_registries(STATE_REGISTRY, TYPE_REGISTRY, strict=True)
@@ -146,7 +157,7 @@ class TestStrictMode:
 
     def test_nonstrict_mode_logs_warnings(self) -> None:
         """In non-strict mode, validation issues are returned but no exception is raised."""
-        StateRegistry.restore({})
+        restore_catalog({})
         # Should not raise even though there are error issues
         issues = validate_registries(STATE_REGISTRY, TYPE_REGISTRY, strict=False)
         assert len(issues) >= 1

--- a/tests/unit/models/test_state_catalog.py
+++ b/tests/unit/models/test_state_catalog.py
@@ -1,0 +1,36 @@
+"""Tests for the models/states catalog leaf.
+
+Verifies that BaseState.__init_subclass__ registers subclasses at any inheritance
+depth into the catalog — not just direct BaseState children.
+"""
+
+from typing import Literal
+
+from hassette.models.states.base import BoolBaseState
+from hassette.models.states.catalog import _STATE_CATALOG, StateKey, resolve
+
+
+class TestInitSubclassDepth:
+    def test_grandchild_class_registers_into_catalog(self) -> None:
+        """A grandchild of BaseState (via BoolBaseState) registers into the catalog.
+
+        Guards the depth behavior: __init_subclass__ fires for all subclass levels,
+        so a class inheriting from BoolBaseState (which inherits from BaseState)
+        is still auto-registered by the __init_subclass__ hook.
+        """
+
+        class GrandchildBoolState(BoolBaseState):
+            domain: Literal["test_grandchild_domain"]  # pyright: ignore[reportIncompatibleVariableOverride]
+
+        key = StateKey(domain="test_grandchild_domain")
+        assert key in _STATE_CATALOG, f"GrandchildBoolState not registered; catalog keys: {list(_STATE_CATALOG)}"
+        assert _STATE_CATALOG[key] is GrandchildBoolState
+
+    def test_grandchild_domain_resolves_from_registry(self) -> None:
+        """resolve() finds a grandchild domain class via the catalog."""
+
+        class AnotherGrandchild(BoolBaseState):
+            domain: Literal["test_another_grandchild"]  # pyright: ignore[reportIncompatibleVariableOverride]
+
+        result = resolve(domain="test_another_grandchild")
+        assert result is AnotherGrandchild

--- a/tests/unit/test_public_api_surface.py
+++ b/tests/unit/test_public_api_surface.py
@@ -25,6 +25,7 @@ TIER1_SYMBOLS = {
     "make_state_dict",
     "make_switch_state_dict",
     "make_test_config",
+    "make_typed_state",
 }
 
 

--- a/tests/unit/test_state_manager.py
+++ b/tests/unit/test_state_manager.py
@@ -115,7 +115,7 @@ class TestDomainStatesCacheValidation:
             context=ctx,
         )
 
-        with patch.object(LightState, "model_validate", wraps=LightState.model_validate) as spy:
+        with patch.object(STATE_REGISTRY, "coerce_and_construct", wraps=STATE_REGISTRY.coerce_and_construct) as spy:
             first = ds._validate_or_return_from_cache("light.bedroom", state_1)
             second = ds._validate_or_return_from_cache("light.bedroom", state_2)
 
@@ -143,7 +143,7 @@ class TestDomainStatesCacheValidation:
             context={"id": None, "parent_id": None, "user_id": None},
         )
 
-        with patch.object(LightState, "model_validate", wraps=LightState.model_validate) as spy:
+        with patch.object(STATE_REGISTRY, "coerce_and_construct", wraps=STATE_REGISTRY.coerce_and_construct) as spy:
             first = ds._validate_or_return_from_cache("light.bedroom", state_1)
             second = ds._validate_or_return_from_cache("light.bedroom", state_2)
 
@@ -155,7 +155,7 @@ class TestDomainStatesCacheValidation:
         state_on = make_light_state_dict("light.bedroom", "on", brightness=150)
         state_off = make_light_state_dict("light.bedroom", "off")
 
-        with patch.object(LightState, "model_validate", wraps=LightState.model_validate) as spy:
+        with patch.object(STATE_REGISTRY, "coerce_and_construct", wraps=STATE_REGISTRY.coerce_and_construct) as spy:
             first = ds._validate_or_return_from_cache("light.bedroom", state_on)
             second = ds._validate_or_return_from_cache("light.bedroom", state_off)
 

--- a/tests/unit/test_type_registry.py
+++ b/tests/unit/test_type_registry.py
@@ -1,7 +1,6 @@
 import pytest
 
 from hassette import TYPE_REGISTRY
-from hassette.conversion.type_registry import TypeRegistry
 from hassette.exceptions import UnableToConvertValueError
 
 
@@ -31,64 +30,37 @@ def test_type_conversion_idempotent() -> None:
 
 
 class TestConstructorFallbackCache:
-    """Verify that constructor fallback auto-registers into conversion_map."""
+    """Verify constructor fallback behavior (memoization removed; conversion result unchanged)."""
 
-    @pytest.fixture(autouse=True)
-    def _isolate_registry(self):
-        snapshot = TypeRegistry.snapshot()
-        yield
-        TypeRegistry.restore(snapshot)
-
-    def test_constructor_fallback_auto_registers(self) -> None:
-        """First successful constructor fallback adds entry to conversion_map."""
+    def test_constructor_fallback_succeeds(self) -> None:
+        """Constructor fallback converts successfully for an unregistered type pair."""
 
         class Custom:
             def __init__(self, val: str) -> None:
                 self.val = val
-
-        key = (str, Custom)
-        assert key not in TypeRegistry.conversion_map
 
         result = TYPE_REGISTRY.convert("hello", Custom)
 
         assert isinstance(result, Custom)
         assert result.val == "hello"
-        assert key in TypeRegistry.conversion_map
 
-    def test_auto_registered_converter_used_on_subsequent_calls(self) -> None:
-        """Second call for the same type pair uses the registered converter, not fallback."""
+    def test_constructor_fallback_succeeds_on_repeated_calls(self) -> None:
+        """Constructor fallback works correctly on every call — no memoization required."""
 
         class Custom:
             def __init__(self, val: int) -> None:
                 self.val = val
 
-        key = (int, Custom)
-        TYPE_REGISTRY.convert(42, Custom)
-        assert key in TypeRegistry.conversion_map
+        result_one = TYPE_REGISTRY.convert(42, Custom)
+        result_two = TYPE_REGISTRY.convert(99, Custom)
 
-        entry = TypeRegistry.conversion_map[key]
-        assert entry.func is Custom
-
-        result = TYPE_REGISTRY.convert(99, Custom)
-        assert isinstance(result, Custom)
-        assert result.val == 99
-
-    def test_snapshot_restore_clears_auto_registered_entries(self) -> None:
-        """snapshot/restore removes auto-registered entries."""
-
-        class Custom:
-            def __init__(self, val: str) -> None:
-                self.val = val
-
-        snapshot = TypeRegistry.snapshot()
-        TYPE_REGISTRY.convert("test", Custom)
-        assert (str, Custom) in TypeRegistry.conversion_map
-
-        TypeRegistry.restore(snapshot)
-        assert (str, Custom) not in TypeRegistry.conversion_map
+        assert isinstance(result_one, Custom)
+        assert result_one.val == 42
+        assert isinstance(result_two, Custom)
+        assert result_two.val == 99
 
     def test_constructor_fallback_raises_for_unconvertible_types(self) -> None:
-        """Constructor fallback still raises UnableToConvertValueError on failure."""
+        """Constructor fallback raises UnableToConvertValueError when constructor fails."""
 
         class Strict:
             def __init__(self, val: str) -> None:
@@ -96,5 +68,3 @@ class TestConstructorFallbackCache:
 
         with pytest.raises(UnableToConvertValueError):
             TYPE_REGISTRY.convert("hello", Strict)
-
-        assert (str, Strict) not in TypeRegistry.conversion_map

--- a/tools/check_module_boundaries.py
+++ b/tools/check_module_boundaries.py
@@ -19,12 +19,14 @@ Import boundaries enforced today (``RULES``):
 - ``resources → task_bucket`` — task_bucket injects its constructor via register_task_bucket_factory (#1079).
 - ``scheduler → core`` — scheduler consumes SchedulerService via SchedulerServiceProtocol in types (#1079).
 - ``state_manager → core`` — state_manager consumes StateProxy via StateReader in types (#1079).
+- ``models → conversion`` — models/states is a leaf below the codec; the conversion ↔ models cycle is resolved (#892).
 
 The full layer DAG is NOT enforced here yet. The two service-layer core cycles
 (``scheduler``↔``core`` and ``state_manager``↔``core``) are resolved via protocol
 inversion (``SchedulerServiceProtocol`` and ``StateReader`` in the ``types`` leaf
-layer; #1079). One runtime cycle remains: ``conversion``↔``models`` (#892), tracked
-separately. ``RULES`` is a list so each boundary is added as it becomes clean.
+layer; #1079). The ``conversion``↔``models`` cycle (#892) is resolved by moving
+conversion behavior into the codec and making models/states a leaf below conversion.
+``RULES`` is a list so each boundary is added as it becomes clean.
 
 Import rules are structural violations, not style — there is no escape hatch. A
 production module that needs a test helper signals a misplaced helper, not a
@@ -118,6 +120,12 @@ RULES: list[Rule] = [
         applies=lambda layer: layer == "state_manager",
         forbids=lambda module: module == "hassette.core" or module.startswith("hassette.core."),
         reason="state_manager must not import core at runtime; StateProxy is consumed via StateReader (#1079)",
+    ),
+    Rule(
+        name="models-no-conversion",
+        applies=lambda layer: layer == "models",
+        forbids=lambda module: module == "hassette.conversion" or module.startswith("hassette.conversion."),
+        reason="models/states is a leaf below the codec; conversion ↔ models cycle resolved (#892)",
     ),
 ]
 


### PR DESCRIPTION
State models (`BaseState` subclasses) carried value coercion logic inside a Pydantic `@model_validator` — converting `"on"` to `True`, parsing numeric strings, normalizing `"unknown"`/`"unavailable"`. This forced a runtime import cycle between `models` and `conversion`, since the validator reached for `TYPE_REGISTRY.convert()` at validation time. That cycle was the last one blocking DAG enforcement (#1079), and resisted the mechanical fixes that cleared the other three cycles in #1120.

This PR moves all value coercion out of the models and into a codec layer owned by `conversion/`, making models "dumb" Pydantic data containers. See `design/adrs/0003-dumb-state-models-codec-owned-conversion.md` for the full rationale and `design/specs/084-dumb-state-models-codec-conversion/design.md` for the implementation approach.

### Codec layer

- `StateRegistry.coerce_and_construct()` is the new entry point for codec-owned value coercion — preprocessing (domain extraction, unknown/unavailable normalization) followed by `TYPE_REGISTRY.convert()` for the model's `value_type`
- `state_manager` and dependency extractors (`StateNew`, `StateOld`, etc.) route through the codec instead of relying on model self-validation
- `convert_state_dict_to_model()` applies the same preprocessing order as the old validator so behavior is identical — confirmed by characterization tests

### Import cycle fix

- New `models/states/catalog.py` module acts as a leaf: `BaseState.__init_subclass__` registers into the catalog (a plain dict), and `conversion/` reads from it — no back-edge from models → conversion
- `STATE_REGISTRY` and `TYPE_REGISTRY` singletons relocated from `models/` to `conversion/`, with re-exports for backwards compatibility
- All three `# lazy-import:` markers in `conversion/` replaced with normal top-level imports
- `check_module_boundaries.py` updated to enforce the new DAG edge rules

### Test coverage

- Characterization tests pin codec behavior across every `value_type` family: bool, string, numeric, datetime, time, and unknown/unavailable normalization
- `DomainStates` integration tests verify the full `state_manager → codec → model` path produces typed values
- State catalog tests verify `__init_subclass__` registration depth and domain resolution

### Documentation

- `states/conversion.md` and `states/custom-states.md` updated to describe codec-owned conversion and correct `value_type` descriptions for `BoolBaseState` and `NumericBaseState`

BREAKING CHANGE: `STATE_REGISTRY` and `TYPE_REGISTRY` are now owned by `hassette.conversion` instead of `hassette.models`. Existing imports from `hassette.models` continue to work via re-exports but are deprecated — update imports to `from hassette.conversion import STATE_REGISTRY, TYPE_REGISTRY`.

Closes #1079
