### PR TITLE
chore: exclude docs snippets from ruff to match CI

### DIFF
--- a/ruff.toml
+++ b/ruff.toml
@@ -28,6 +28,19 @@ exclude = [
     "venv",
 ]
 
+# Exclude docs snippets from linting. These are intentional anti-pattern teaching
+# examples (S610, S113, S108) and bare-fragment snippets (F704 await outside a
+# function) that are not real code. CI already excludes them via the ruff-check
+# hook's `exclude: ^docs/.*\.(py|rst)$` in .pre-commit-config.yaml; this keeps a
+# direct `ruff check .` in agreement with CI. Snippets keep Pyright coverage
+# separately via `pyright --project docs` (docs.yml).
+extend-exclude = ["docs/**/*.py"]
+
+# Honor excludes even when a file is passed explicitly (editor "lint this file",
+# explicit paths). Matches the `--force-exclude` the ruff-check hook already uses,
+# so every ruff invocation agrees with CI rather than just directory walks.
+force-exclude = true
+
 # Same as Black.
 line-length = 120
 indent-width = 4
@@ -117,7 +130,6 @@ dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
 "tools/*.py" = ["S603", "S607"]
 "scripts/*.py" = ["S105", "S310", "S603", "S607"]
 "codegen/**/*.py" = ["S108", "S603", "S607", "S701"]
-"docs/**/*.py" = ["S101", "S105", "S106", "S311", "ASYNC110"]
 "src/hassette/core/database_service.py" = ["S608"]
 "src/hassette/core/telemetry_query_service.py" = ["S608"]
 "src/hassette/core/telemetry/*.py" = ["S608"]


### PR DESCRIPTION
## Summary

`ruff.toml` carried no docs exclusion, but CI runs ruff through pre-commit, where the `ruff-check`/`ruff-format` hooks exclude docs (`exclude: ^docs/.*\.(py|rst)$`). The two disagreed:

- **CI** never linted `docs/pages/**/snippets/*.py` → green.
- **Direct `ruff check .`** (editors, agent lint gates) *did* lint them → 6 errors (`S610`, `ASYNC210`, `F704`×2, `S113`, `S108`).

Those 6 are intentional anti-pattern teaching snippets (and bare `await` fragments that can't be valid standalone), not bugs — so the fix is to teach `ruff.toml` the same exclusion CI already applies, not to "fix" the snippets.

### The fix (`ruff.toml` only)

- **`extend-exclude = ["docs/**/*.py"]`** — brings the directory-walk `ruff check .` into agreement with CI's pre-commit exclude.
- **`force-exclude = true`** — closes the residual gap. Without it, ruff still lints files passed *explicitly* (an editor's "lint this file") even when excluded. The pre-commit hook already passes `--force-exclude`, so this makes every invocation — directory walk, explicit path, editor — agree with CI rather than just `ruff check .`.
- **Removed the now-dead `"docs/**/*.py"` per-file-ignores entry** — once docs are fully excluded from ruff, linting-them-with-exceptions is meaningless config.

No lint coverage is lost: docs snippets are still Pyright-checked via `pyright --project docs` (`docs.yml`), which this PR doesn't touch.

### Verification

| Check | Result |
|---|---|
| `ruff check .` (repo-wide) | All checks passed |
| `ruff format --check .` | 725 files already formatted |
| Explicit docs snippet path | now excluded |
| Real `src` file still linted (F401 probe) | still fires |
| `prek run ruff-check` / `ruff-format` (CI's path) | both passed |
