### PR TITLE
fix(cli): show app config values instead of the inlined schema blob

### DIFF
--- a/src/hassette/cli/commands/app.py
+++ b/src/hassette/cli/commands/app.py
@@ -119,8 +119,7 @@ def cmd_app_config(
     result = client.get(f"/api/apps/{key}/config", AppConfigResponse)
     # Render every field except config_schema, the large machine-oriented blob. Dumping the
     # model (rather than naming fields) keeps new AppConfigResponse fields visible automatically.
-    detail = result.model_dump(mode="json")
-    detail.pop("config_schema", None)
+    detail = {field: value for field, value in result.model_dump(mode="json").items() if field != "config_schema"}
     render_detail_dict(detail, "App Config", json_mode=ctx.json_mode)
 
 

--- a/src/hassette/cli/commands/app.py
+++ b/src/hassette/cli/commands/app.py
@@ -4,7 +4,14 @@ from typing import Any
 
 from hassette.cli.client import make_client
 from hassette.cli.context import DEFAULT_CLI_CONTEXT, CLIContextParam
-from hassette.cli.output import Column, fmt_duration_ms, fmt_relative_time, render_detail, render_table
+from hassette.cli.output import (
+    Column,
+    fmt_duration_ms,
+    fmt_relative_time,
+    render_detail,
+    render_detail_dict,
+    render_table,
+)
 from hassette.cli.types import InstanceArg, LimitArg, SinceArg, SourceTierArg
 from hassette.schemas.telemetry_models import ActivityFeedEntry
 from hassette.web.models import AppConfigResponse, AppHealthResponse, AppManifestListResponse, AppSourceResponse
@@ -102,10 +109,19 @@ def cmd_app_config(
     *,
     ctx: CLIContextParam = DEFAULT_CLI_CONTEXT,
 ) -> None:
-    """Show app configuration (GET /api/apps/{key}/config)."""
+    """Show app configuration (GET /api/apps/{key}/config).
+
+    Renders the app's metadata and masked config values. The fully-inlined
+    ``config_schema`` is part of the response but is intentionally not shown — it is a
+    large machine-oriented blob, not something a CLI reader needs.
+    """
     client = make_client(ctx)
     result = client.get(f"/api/apps/{key}/config", AppConfigResponse)
-    render_detail(result, json_mode=ctx.json_mode)
+    # Render every field except config_schema, the large machine-oriented blob. Dumping the
+    # model (rather than naming fields) keeps new AppConfigResponse fields visible automatically.
+    detail = result.model_dump(mode="json")
+    detail.pop("config_schema", None)
+    render_detail_dict(detail, "App Config", json_mode=ctx.json_mode)
 
 
 def cmd_app_source(

--- a/src/hassette/test_utils/web_helpers.py
+++ b/src/hassette/test_utils/web_helpers.py
@@ -470,7 +470,7 @@ def make_app_config_response(
     filename: str = "my_app.py",
     class_name: str = "MyApp",
     enabled: bool = True,
-    app_config: dict | None = None,
+    app_config: dict | list[dict] | None = None,
     config_schema: dict | None = None,
 ) -> AppConfigResponse:
     """Build an AppConfigResponse with sensible defaults."""
@@ -479,7 +479,7 @@ def make_app_config_response(
         filename=filename,
         class_name=class_name,
         enabled=enabled,
-        app_config=app_config or {"setting_name": "default"},
+        app_config=app_config if app_config is not None else {"setting_name": "default"},
         config_schema=config_schema,
     )
 

--- a/src/hassette/web/config_view.py
+++ b/src/hassette/web/config_view.py
@@ -1,7 +1,9 @@
 """Shared view builder for config endpoints: schema deref and type-driven value masking.
 
-Both the global config endpoint and the per-app config endpoint call ``build_config_view``
-to produce a ``{config_schema, config_values}`` pair where:
+The global config endpoint calls ``build_config_view`` to produce a
+``{config_schema, config_values}`` pair. The per-app endpoint calls ``deref_schema`` and
+``mask_values`` directly so a multi-instance config derefs its schema once and masks each
+instance against it. Both paths produce a pair where:
 
 - ``config_schema`` is the JSON schema with all ``$ref``/``$defs`` resolved inline so the
   frontend never needs to walk a reference.
@@ -59,7 +61,7 @@ def _object_properties(node: dict[str, Any]) -> dict[str, Any] | None:
     return None
 
 
-def _mask_values(schema_props: dict[str, Any], values: dict[str, Any]) -> dict[str, Any]:
+def mask_values(schema_props: dict[str, Any], values: dict[str, Any]) -> dict[str, Any]:
     """Return a copy of ``values`` with secret fields replaced by ``MASK_SENTINEL``.
 
     Walks ``schema_props`` (the ``properties`` dict of a deref'd schema node).
@@ -82,7 +84,7 @@ def _mask_values(schema_props: dict[str, Any], values: dict[str, Any]) -> dict[s
             continue
         nested_props = _object_properties(node)
         if nested_props is not None and isinstance(result.get(key), dict):
-            result[key] = _mask_values(nested_props, result[key])
+            result[key] = mask_values(nested_props, result[key])
     return result
 
 
@@ -133,6 +135,23 @@ def mask_all_values(values: dict[str, Any]) -> dict[str, Any]:
     return {k: _mask_leaf(v) for k, v in values.items()}
 
 
+def deref_schema(schema: dict[str, Any]) -> dict[str, Any]:
+    """Resolve every ``$ref``/``$defs`` in a JSON schema inline and return a plain dict.
+
+    ``jsonref.replace_refs`` returns lazy proxy objects; ``_materialize`` converts them to
+    concrete dicts/lists so FastAPI and ``json.dumps`` can serialize them. The ``$defs``
+    store is dropped because every reference is now inlined.
+
+    Split out of ``build_config_view`` so the multi-instance app path can deref a schema
+    once and reuse it across instances, rather than re-running the deref per instance.
+    """
+    plain_schema = _materialize(jsonref.replace_refs(schema))
+    if not isinstance(plain_schema, dict):
+        return {}
+    plain_schema.pop("$defs", None)
+    return plain_schema
+
+
 def build_config_view(schema: dict[str, Any], values: dict[str, Any]) -> dict[str, Any]:
     """Build the unified config view payload from a JSON schema and a values dict.
 
@@ -150,13 +169,6 @@ def build_config_view(schema: dict[str, Any], values: dict[str, Any]) -> dict[st
         ``config_values`` has any field marked ``writeOnly: true`` or ``format: "password"``
         replaced with ``MASK_SENTINEL`` when set, left ``None``/absent when unset.
     """
-    deref_result = jsonref.replace_refs(schema)
-    plain_schema = _materialize(deref_result)
-    # Drop $defs — all references are now inlined; the definition store is redundant.
-    if isinstance(plain_schema, dict):
-        plain_schema.pop("$defs", None)
-
-    props = plain_schema.get("properties", {}) if isinstance(plain_schema, dict) else {}
-    masked_values = _mask_values(props, values)
-
+    plain_schema = deref_schema(schema)
+    masked_values = mask_values(plain_schema.get("properties", {}), values)
     return {"config_schema": plain_schema, "config_values": masked_values}

--- a/src/hassette/web/routes/apps.py
+++ b/src/hassette/web/routes/apps.py
@@ -10,7 +10,7 @@ from hassette.app.app_config import AppConfig
 from hassette.config.classes import AppManifest
 from hassette.exceptions import TelemetryUnavailableError
 from hassette.utils.app_utils import class_already_loaded, get_loaded_class
-from hassette.web.config_view import build_config_view, mask_all_values
+from hassette.web.config_view import deref_schema, mask_all_values, mask_values
 from hassette.web.dependencies import HassetteDep, RuntimeDep, TelemetryDep
 from hassette.web.mappers import app_manifest_list_response_from, app_status_response_from
 from hassette.web.models import (
@@ -169,14 +169,16 @@ def _resolve_app_config_cls(hassette: "Hassette", app_key: str, manifest: AppMan
 def _build_app_config_view(
     schema: dict[str, Any], app_config: dict[str, Any] | list[dict[str, Any]]
 ) -> tuple[dict[str, Any], dict[str, Any] | list[dict[str, Any]]]:
-    """Build the deref'd schema and masked values for a single- or multi-instance app config."""
+    """Build the deref'd schema and masked values for a single- or multi-instance app config.
+
+    The schema is dereferenced once and reused across every instance; only the per-instance
+    masking differs. An empty instance list returns the deref'd schema with no masking run.
+    """
+    plain_schema = deref_schema(schema)
+    props = plain_schema.get("properties", {})
     if isinstance(app_config, list):
-        if not app_config:
-            return build_config_view(schema, {})["config_schema"], []
-        views = [build_config_view(schema, inst) for inst in app_config]
-        return views[0]["config_schema"], [v["config_values"] for v in views]
-    view = build_config_view(schema, app_config)
-    return view["config_schema"], view["config_values"]
+        return plain_schema, [mask_values(props, inst) for inst in app_config]
+    return plain_schema, mask_values(props, app_config)
 
 
 def _mask_floor(app_config: dict[str, Any] | list[dict[str, Any]]) -> dict[str, Any] | list[dict[str, Any]]:

--- a/tests/system/test_web_api.py
+++ b/tests/system/test_web_api.py
@@ -71,10 +71,24 @@ async def test_config_endpoint(ha_container: str, tmp_path) -> None:
         assert config_values["web_api"]["run"] is True
         assert config_values["web_api"]["port"] > 0
 
-        # Token-masking invariant on a live response: the plaintext SecretStr must never
-        # appear in GET /api/config. Unit and integration tests mock this serialization
-        # boundary, so a regression (e.g. model_dump() instead of model_dump(mode="json"))
-        # would pass them and still leak the token from a real running instance.
+
+async def test_config_endpoint_masks_token(ha_container: str, tmp_path) -> None:
+    """GET /api/config never leaks the plaintext HA token on a live response.
+
+    The plaintext SecretStr must never appear in the body, and the token field must
+    render as the mask sentinel. Unit and integration tests mock this serialization
+    boundary, so a regression (e.g. model_dump() instead of model_dump(mode="json"))
+    would pass them and still leak the token from a real running instance.
+    """
+    config, base_url = make_web_system_config(ha_container, tmp_path)
+    async with startup_context(config) as _hassette:
+        await wait_for_web_server(base_url)
+
+        async with httpx.AsyncClient() as client:
+            r = await client.get(f"{base_url}/api/config", timeout=10.0)
+
+        assert r.status_code == 200
+        config_values: dict[str, Any] = r.json()["config_values"]
         assert HA_TOKEN not in r.text
         assert config_values["token"] == MASK_SENTINEL
 

--- a/tests/system/test_web_api.py
+++ b/tests/system/test_web_api.py
@@ -10,8 +10,9 @@ import pytest
 from websockets import connect as ws_connect
 
 from hassette.test_utils import wait_for
+from hassette.web.config_view import MASK_SENTINEL
 
-from .conftest import make_web_system_config, startup_context, toggle_and_capture, wait_for_web_server
+from .conftest import HA_TOKEN, make_web_system_config, startup_context, toggle_and_capture, wait_for_web_server
 
 pytestmark = [pytest.mark.system]
 
@@ -69,6 +70,13 @@ async def test_config_endpoint(ha_container: str, tmp_path) -> None:
         assert "logging" in config_values
         assert config_values["web_api"]["run"] is True
         assert config_values["web_api"]["port"] > 0
+
+        # Token-masking invariant on a live response: the plaintext SecretStr must never
+        # appear in GET /api/config. Unit and integration tests mock this serialization
+        # boundary, so a regression (e.g. model_dump() instead of model_dump(mode="json"))
+        # would pass them and still leak the token from a real running instance.
+        assert HA_TOKEN not in r.text
+        assert config_values["token"] == MASK_SENTINEL
 
 
 async def test_telemetry_after_activity(ha_container: str, tmp_path) -> None:

--- a/tests/unit/cli/test_commands_app.py
+++ b/tests/unit/cli/test_commands_app.py
@@ -474,6 +474,31 @@ class TestCmdAppConfig:
         assert parsed["app_config"] == {"setting_name": "visible_value"}
         assert "config_schema" not in parsed
 
+    def test_json_mode_handles_multi_instance_app_config(self, cli_client_factory: CLIClientFactory) -> None:
+        """app config --json renders a list-shaped (multi-instance) app_config without the schema blob."""
+        cfg = make_app_config_response(
+            app_key="my-app",
+            app_config=[
+                {"setting_name": "first"},
+                {"setting_name": "second"},
+            ],
+            config_schema={"properties": {"setting_name": {"SCHEMA_BLOB_MARKER": True}}},
+        )
+        client, _ = cli_client_factory.build_with_routes([("GET", "/api/apps/my-app/config", 200, cfg.model_dump())])
+        captured: list[str] = []
+        with (
+            patch("hassette.cli.commands.app.make_client", return_value=client),
+            patch("sys.stdout.write", side_effect=lambda s: captured.append(s) or len(s)),
+        ):
+            cmd_app_config("my-app", ctx=CLIContext(json_mode=True))
+
+        parsed = json.loads("".join(captured))
+        assert parsed["app_config"] == [
+            {"setting_name": "first"},
+            {"setting_name": "second"},
+        ]
+        assert "config_schema" not in parsed
+
 
 # cmd_app_source
 

--- a/tests/unit/cli/test_commands_app.py
+++ b/tests/unit/cli/test_commands_app.py
@@ -499,6 +499,25 @@ class TestCmdAppConfig:
         ]
         assert "config_schema" not in parsed
 
+    def test_json_mode_preserves_empty_multi_instance_app_config(self, cli_client_factory: CLIClientFactory) -> None:
+        """app config --json keeps an empty list as [], not the default dict, when there are no instances."""
+        cfg = make_app_config_response(
+            app_key="my-app",
+            app_config=[],
+            config_schema={"properties": {"setting_name": {"SCHEMA_BLOB_MARKER": True}}},
+        )
+        client, _ = cli_client_factory.build_with_routes([("GET", "/api/apps/my-app/config", 200, cfg.model_dump())])
+        captured: list[str] = []
+        with (
+            patch("hassette.cli.commands.app.make_client", return_value=client),
+            patch("sys.stdout.write", side_effect=lambda s: captured.append(s) or len(s)),
+        ):
+            cmd_app_config("my-app", ctx=CLIContext(json_mode=True))
+
+        parsed = json.loads("".join(captured))
+        assert parsed["app_config"] == []
+        assert "config_schema" not in parsed
+
 
 # cmd_app_source
 

--- a/tests/unit/cli/test_commands_app.py
+++ b/tests/unit/cli/test_commands_app.py
@@ -438,6 +438,42 @@ class TestCmdAppConfig:
         assert parsed["app_key"] == "my-app"
         assert parsed["enabled"] is True
 
+    def test_renders_config_values_not_schema_blob(self, cli_client_factory: CLIClientFactory) -> None:
+        """app config shows masked config values but never dumps the inlined config_schema."""
+        cfg = make_app_config_response(
+            app_key="my-app",
+            app_config={"setting_name": "visible_value"},
+            config_schema={"properties": {"setting_name": {"SCHEMA_BLOB_MARKER": True}}},
+        )
+        client, _ = cli_client_factory.build_with_routes([("GET", "/api/apps/my-app/config", 200, cfg.model_dump())])
+        with (
+            capture_stdout() as buf,
+            patch("hassette.cli.commands.app.make_client", return_value=client),
+        ):
+            cmd_app_config("my-app")
+        output = buf.getvalue()
+        assert "visible_value" in output
+        assert "SCHEMA_BLOB_MARKER" not in output
+
+    def test_json_mode_omits_schema_blob(self, cli_client_factory: CLIClientFactory) -> None:
+        """app config --json emits values and metadata, not the config_schema envelope."""
+        cfg = make_app_config_response(
+            app_key="my-app",
+            app_config={"setting_name": "visible_value"},
+            config_schema={"properties": {"setting_name": {"SCHEMA_BLOB_MARKER": True}}},
+        )
+        client, _ = cli_client_factory.build_with_routes([("GET", "/api/apps/my-app/config", 200, cfg.model_dump())])
+        captured: list[str] = []
+        with (
+            patch("hassette.cli.commands.app.make_client", return_value=client),
+            patch("sys.stdout.write", side_effect=lambda s: captured.append(s) or len(s)),
+        ):
+            cmd_app_config("my-app", ctx=CLIContext(json_mode=True))
+
+        parsed = json.loads("".join(captured))
+        assert parsed["app_config"] == {"setting_name": "visible_value"}
+        assert "config_schema" not in parsed
+
 
 # cmd_app_source
 

--- a/tests/unit/web/test_config_view.py
+++ b/tests/unit/web/test_config_view.py
@@ -4,7 +4,7 @@ import json
 
 from pydantic import BaseModel, SecretStr
 
-from hassette.web.config_view import MASK_SENTINEL, build_config_view, mask_all_values
+from hassette.web.config_view import MASK_SENTINEL, build_config_view, deref_schema, mask_all_values, mask_values
 
 
 class _PlainConfig(BaseModel):
@@ -230,6 +230,38 @@ class TestDeref:
         # Should have inlined Inner's properties, not a $ref
         assert "properties" in inner_prop
         assert "nested_secret" in inner_prop["properties"]
+
+
+class TestDerefSchema:
+    """deref_schema is the standalone deref step; build_config_view delegates to it."""
+
+    def test_inlines_refs_and_drops_defs(self) -> None:
+        """deref_schema resolves $ref nodes inline and removes the $defs store."""
+        schema = _OuterConfig.model_json_schema()
+        assert "$ref" in str(schema)
+        assert "$defs" in schema
+
+        result = deref_schema(schema)
+        assert "$ref" not in json.dumps(result)
+        assert "$defs" not in result
+        assert "nested_secret" in result["properties"]["inner"]["properties"]
+
+    def test_build_config_view_delegates_to_deref_schema(self) -> None:
+        """build_config_view's config_schema is exactly what deref_schema produces."""
+        schema = _OuterConfig.model_json_schema()
+        values = {"name": "x", "inner": {}, "top_secret": None}
+        assert build_config_view(schema, values)["config_schema"] == deref_schema(schema)
+
+    def test_deref_once_then_mask_per_instance(self) -> None:
+        """A schema deref'd once can mask multiple instances — the multi-instance app path."""
+        deref = deref_schema(_PlainConfig.model_json_schema())
+        props = deref["properties"]
+        first = mask_values(props, {"real_secret": "a", "plain_field": "one"})
+        second = mask_values(props, {"real_secret": "b", "plain_field": "two"})
+        assert first["real_secret"] == MASK_SENTINEL
+        assert second["real_secret"] == MASK_SENTINEL
+        assert first["plain_field"] == "one"
+        assert second["plain_field"] == "two"
 
 
 class TestCyclicSchema:


### PR DESCRIPTION
## Summary

Three small follow-ups surfaced during review of #1131 (unified config UI). All touch
the config-view layer and are independent of each other.

- **Closes #1132** — Extract `deref_schema()` out of `build_config_view()` and rename the
  cross-module helper `_mask_values` → `mask_values`. The multi-instance app config path
  now derefs the schema **once** and masks each instance against it, rather than re-running
  the full deref+materialize per instance. The empty-instance branch no longer runs the
  masking pipeline against a dummy dict just to extract the schema. Pure refactor —
  behavior unchanged, pinned by existing config-view tests plus new delegation /
  deref-once tests.

- **Closes #1134** — `hassette app config <key>` no longer dumps the large inlined
  `config_schema` blob into the terminal (a regression from #1131, which started inlining
  the schema). `cmd_app_config` now renders the masked `app_config` values plus metadata,
  mirroring how `cmd_config` renders `config_values`. JSON mode drops the schema envelope
  too.

- **Closes #1133** — Add a live token-masking assertion to
  `tests/system/test_web_api.py::test_config_endpoint`. The masking invariant is covered by
  unit/integration tests, but those mock the serialization boundary — a regression there
  (e.g. `model_dump()` instead of `model_dump(mode="json")`) would pass them and still leak
  the plaintext token from a running instance. The system test now asserts on the live
  `/api/config` response that the configured token is absent and the `token` field equals
  the mask sentinel.

## Verification

- `pytest tests/unit/web tests/unit/cli tests/integration/web_api` — 603 passed
- New tests: `deref_schema` delegation + deref-once-mask-per-instance; CLI schema-blob
  exclusion (human + JSON modes)
- `pyright` clean, `ruff check`/`format` clean
- System test (#1133) verified to collect; assertion grounded with a probe confirming
  `config_values["token"] == MASK_SENTINEL` and no plaintext leak. Runs under `nox -s system`
  in CI.

The `ui.tier` / show-advanced follow-up (#1135) is intentionally left out — it's a
medium feature (~90 per-field judgment calls + a frontend affordance + docs) and gets its
own PR.
