### PR TITLE
chore: run lint checks at pre-commit; harden release-please lock sync

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -236,6 +236,31 @@ jobs:
                   uvx pip-audit@2.10.0 -r requirements.txt \
                     --ignore-vuln CVE-2025-69872  # diskcache — no fix available yet (#861)
 
+    lockfile-fresh:
+        needs: changes
+        if: needs.changes.outputs.python == 'true' || github.event_name == 'workflow_dispatch'
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout code
+              uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+              with:
+                persist-credentials: false
+
+            - name: Install uv
+              uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8
+              with:
+                  python-version: "3.13"
+
+            # uv.lock pins the project's own version, so a pyproject version bump leaves it
+            # stale until re-locked. CI installs with a plain `uv sync`, which silently re-resolves
+            # and hides the drift — this gate makes a stale lock a loud, fixable red check instead.
+            - name: Verify uv.lock is in sync with pyproject.toml
+              run: |
+                  if ! uv lock --check; then
+                      echo "::error::uv.lock is out of sync with pyproject.toml — run 'uv lock' and commit the result"
+                      exit 1
+                  fi
+
     slotscheck:
         needs: changes
         if: needs.changes.outputs.python == 'true' || github.event_name == 'workflow_dispatch'
@@ -274,7 +299,7 @@ jobs:
                   fail: true
 
     lint-complete:
-        needs: [python, frontend, codegen-freshness, security, slotscheck, link-check]
+        needs: [python, frontend, codegen-freshness, security, lockfile-fresh, slotscheck, link-check]
         if: always()
         runs-on: ubuntu-latest
         steps:

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -70,17 +70,44 @@ jobs:
                   APP_TOKEN: ${{ steps.app-token.outputs.token }}
               run: |
                   set -euo pipefail
-                  uv lock
+
+                  # Re-lock, retrying the package-index resolve — the one network-flaky step.
+                  for attempt in 1 2 3; do
+                      uv lock && break
+                      if [ "$attempt" = 3 ]; then
+                          echo "::error::uv lock failed after 3 attempts"
+                          exit 1
+                      fi
+                      echo "::warning::uv lock attempt ${attempt} failed; retrying in $((attempt * 5))s"
+                      sleep $((attempt * 5))
+                  done
+
                   if git diff --quiet uv.lock; then
-                      echo "uv.lock is already up to date"
-                  else
-                      git config user.name "github-actions[bot]"
-                      git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-                      git remote set-url origin "https://x-access-token:${APP_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
-                      git add uv.lock
-                      git commit -m "chore: sync uv.lock with version bump"
-                      git push origin HEAD
+                      echo "uv.lock already matches the version bump — nothing to push"
+                      exit 0
                   fi
+
+                  git config user.name "github-actions[bot]"
+                  git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+                  git remote set-url origin "https://x-access-token:${APP_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+                  git add uv.lock
+                  git commit -m "chore: sync uv.lock with version bump"
+
+                  # Push with a retry for transient failures. The workflow-level concurrency
+                  # group serializes release-please runs, so the branch tip won't move under
+                  # us mid-run — a rejected push here is almost always transient. The one case
+                  # retries can't fix is a human pushing to the release branch mid-run (a genuine
+                  # non-fast-forward); that exhausts the attempts and fails loudly, which is the
+                  # signal to investigate rather than silently overwrite their commit.
+                  for attempt in 1 2 3; do
+                      git push origin HEAD && break
+                      if [ "$attempt" = 3 ]; then
+                          echo "::error::failed to push uv.lock sync after 3 attempts"
+                          exit 1
+                      fi
+                      echo "::warning::push attempt ${attempt} failed; retrying in $((attempt * 3))s"
+                      sleep $((attempt * 3))
+                  done
 
     build-pypi:
         needs: release-please

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -169,36 +169,28 @@ repos:
         language: system
         entry: ./tools/check_lazy_imports.py
         files: ^(src|tests|scripts|tools|codegen|docs|examples)/.*\.py$
-        stages:
-          - pre-commit
-          - pre-push
+        stages: [pre-commit, pre-push]
 
       - id: check-spec-tokens
         name: Ban leaked spec-artifact tokens (AC#/FR#/T##/WP#)
         language: system
         entry: ./tools/check_spec_tokens.py
         files: ^(src|tests|scripts|tools|codegen|docs|examples)/.*\.py$
-        stages:
-          - pre-commit
-          - pre-push
+        stages: [pre-commit, pre-push]
 
       - id: check-llm-cruft
         name: Ban AI-writing tells (section dividers, filler phrases)
         language: system
         entry: ./tools/check_llm_cruft.py
         files: ^(src|tests|scripts|tools|codegen|docs|examples)/.*\.py$
-        stages:
-          - pre-commit
-          - pre-push
+        stages: [pre-commit, pre-push]
 
       - id: check-module-boundaries
         name: Enforce import boundaries (test_utils isolation) in src
         language: system
         entry: ./tools/check_module_boundaries.py
         files: ^src/.*\.py$
-        stages:
-          - pre-commit
-          - pre-push
+        stages: [pre-commit, pre-push]
 
   - repo: https://github.com/RobertCraigie/pyright-python
     rev: v1.1.408

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -168,36 +168,36 @@ repos:
         name: Ban lazy imports (use '# lazy-import:' to defend circular-import cases)
         language: system
         entry: ./tools/check_lazy_imports.py
-        pass_filenames: false
         files: ^(src|tests|scripts|tools|codegen|docs|examples)/.*\.py$
         stages:
+          - pre-commit
           - pre-push
 
       - id: check-spec-tokens
         name: Ban leaked spec-artifact tokens (AC#/FR#/T##/WP#)
         language: system
         entry: ./tools/check_spec_tokens.py
-        pass_filenames: false
         files: ^(src|tests|scripts|tools|codegen|docs|examples)/.*\.py$
         stages:
+          - pre-commit
           - pre-push
 
       - id: check-llm-cruft
         name: Ban AI-writing tells (section dividers, filler phrases)
         language: system
         entry: ./tools/check_llm_cruft.py
-        pass_filenames: false
         files: ^(src|tests|scripts|tools|codegen|docs|examples)/.*\.py$
         stages:
+          - pre-commit
           - pre-push
 
       - id: check-module-boundaries
         name: Enforce import boundaries (test_utils isolation) in src
         language: system
         entry: ./tools/check_module_boundaries.py
-        pass_filenames: false
         files: ^src/.*\.py$
         stages:
+          - pre-commit
           - pre-push
 
   - repo: https://github.com/RobertCraigie/pyright-python

--- a/tests/unit/tools/test_lint_helpers.py
+++ b/tests/unit/tools/test_lint_helpers.py
@@ -1,0 +1,72 @@
+"""Tests for the shared lint-script helpers, focused on ``resolve_paths``.
+
+``resolve_paths`` is what lets the checkers run as pre-commit hooks: pre-commit
+passes the staged files as arguments, so a checker scans only what changed instead
+of re-walking the whole tree. With no arguments it falls back to a full scan — the
+behaviour CI (``prek run --all-files``) and a manual full sweep rely on.
+"""
+
+from pathlib import Path
+
+from lint_helpers import resolve_paths
+
+
+def _make_repo(root: Path) -> None:
+    """Lay down a small repo: src/a.py, tests/b.py, an out-of-scope file, and a .venv file."""
+    (root / "src").mkdir()
+    (root / "tests").mkdir()
+    (root / "other").mkdir()
+    (root / "src" / ".venv").mkdir()
+    (root / "src" / "a.py").write_text("x = 1\n")
+    (root / "tests" / "b.py").write_text("y = 2\n")
+    (root / "other" / "c.py").write_text("z = 3\n")
+    (root / "src" / ".venv" / "vendored.py").write_text("w = 4\n")
+
+
+def test_no_args_scans_the_full_tree(tmp_path: Path) -> None:
+    _make_repo(tmp_path)
+    # No argv → full scan: every in-scope .py, with the out-of-scope and .venv files dropped.
+    expected = [tmp_path / "src" / "a.py", tmp_path / "tests" / "b.py"]
+    assert resolve_paths([], tmp_path, ["src", "tests"]) == expected
+
+
+def test_single_in_scope_file_returns_only_that_file(tmp_path: Path) -> None:
+    _make_repo(tmp_path)
+    target = tmp_path / "src" / "a.py"
+    assert resolve_paths([str(target)], tmp_path, ["src", "tests"]) == [target]
+
+
+def test_relative_arg_resolves_against_repo_root(tmp_path: Path) -> None:
+    _make_repo(tmp_path)
+    assert resolve_paths(["src/a.py"], tmp_path, ["src", "tests"]) == [tmp_path / "src" / "a.py"]
+
+
+def test_out_of_scope_file_is_ignored(tmp_path: Path) -> None:
+    _make_repo(tmp_path)
+    # other/c.py is a real .py file but lives outside the scan dirs — dropped, not crashed.
+    assert resolve_paths([str(tmp_path / "other" / "c.py")], tmp_path, ["src", "tests"]) == []
+
+
+def test_excluded_venv_file_is_ignored(tmp_path: Path) -> None:
+    _make_repo(tmp_path)
+    # Under a scan dir, but inside a .venv — EXCLUDED_PARTS keeps vendored code out.
+    assert resolve_paths([str(tmp_path / "src" / ".venv" / "vendored.py")], tmp_path, ["src"]) == []
+
+
+def test_non_py_and_missing_args_are_ignored(tmp_path: Path) -> None:
+    _make_repo(tmp_path)
+    (tmp_path / "src" / "readme.md").write_text("# not python\n")
+    args = [
+        str(tmp_path / "src" / "readme.md"),  # wrong suffix
+        str(tmp_path / "src" / "missing.py"),  # does not exist
+        str(tmp_path / "src"),  # a directory, not a file
+    ]
+    assert resolve_paths(args, tmp_path, ["src"]) == []
+
+
+def test_result_is_sorted_and_deduplicated(tmp_path: Path) -> None:
+    _make_repo(tmp_path)
+    a = tmp_path / "src" / "a.py"
+    b = tmp_path / "tests" / "b.py"
+    # Pass b before a, and a twice — output is sorted and carries no duplicate.
+    assert resolve_paths([str(b), str(a), "src/a.py"], tmp_path, ["src", "tests"]) == [a, b]

--- a/tests/unit/tools/test_lint_helpers.py
+++ b/tests/unit/tools/test_lint_helpers.py
@@ -66,7 +66,7 @@ def test_non_py_and_missing_args_are_ignored(tmp_path: Path) -> None:
 
 def test_result_is_sorted_and_deduplicated(tmp_path: Path) -> None:
     _make_repo(tmp_path)
-    a = tmp_path / "src" / "a.py"
-    b = tmp_path / "tests" / "b.py"
-    # Pass b before a, and a twice — output is sorted and carries no duplicate.
-    assert resolve_paths([str(b), str(a), "src/a.py"], tmp_path, ["src", "tests"]) == [a, b]
+    src_py = tmp_path / "src" / "a.py"
+    tests_py = tmp_path / "tests" / "b.py"
+    # Pass tests_py before src_py, and src_py twice — output is sorted and carries no duplicate.
+    assert resolve_paths([str(tests_py), str(src_py), "src/a.py"], tmp_path, ["src", "tests"]) == [src_py, tests_py]

--- a/tests/unit/tools/test_lint_helpers.py
+++ b/tests/unit/tools/test_lint_helpers.py
@@ -8,6 +8,7 @@ behaviour CI (``prek run --all-files``) and a manual full sweep rely on.
 
 from pathlib import Path
 
+import pytest
 from lint_helpers import resolve_paths
 
 
@@ -53,15 +54,16 @@ def test_excluded_venv_file_is_ignored(tmp_path: Path) -> None:
     assert resolve_paths([str(tmp_path / "src" / ".venv" / "vendored.py")], tmp_path, ["src"]) == []
 
 
-def test_non_py_and_missing_args_are_ignored(tmp_path: Path) -> None:
+@pytest.mark.parametrize(
+    "rel_arg",
+    ["src/readme.md", "src/missing.py", "src"],
+    ids=["wrong-suffix", "missing-file", "directory"],
+)
+def test_non_qualifying_arg_is_ignored(tmp_path: Path, rel_arg: str) -> None:
     _make_repo(tmp_path)
-    (tmp_path / "src" / "readme.md").write_text("# not python\n")
-    args = [
-        str(tmp_path / "src" / "readme.md"),  # wrong suffix
-        str(tmp_path / "src" / "missing.py"),  # does not exist
-        str(tmp_path / "src"),  # a directory, not a file
-    ]
-    assert resolve_paths(args, tmp_path, ["src"]) == []
+    (tmp_path / "src" / "readme.md").write_text("# not python\n")  # wrong suffix, exists
+    # Each case is a distinct reason to skip: wrong suffix, missing file, or a directory.
+    assert resolve_paths([str(tmp_path / rel_arg)], tmp_path, ["src"]) == []
 
 
 def test_result_is_sorted_and_deduplicated(tmp_path: Path) -> None:

--- a/tools/check_lazy_imports.py
+++ b/tools/check_lazy_imports.py
@@ -26,7 +26,11 @@ accepted:
 Canonical annotation form: ``# lazy-import: break circular import with <module>``
 
 Usage:
-    python tools/check_lazy_imports.py
+    python tools/check_lazy_imports.py [FILE ...]
+
+With no arguments, scans every file under src/, tests/, scripts/, tools/, codegen/,
+docs/, and examples/. Given file paths (as pre-commit passes the staged files), scans
+only those — out-of-scope or non-Python paths are ignored.
 """
 
 import ast
@@ -34,7 +38,7 @@ import re
 import sys
 from pathlib import Path
 
-from lint_helpers import iter_py_files, run_check
+from lint_helpers import resolve_paths, run_check
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 
@@ -111,13 +115,18 @@ def check_file(path: Path) -> list[tuple[int, str]]:
 
 
 def iter_paths() -> list[Path]:
-    """Return every .py file under the scanned directories, sorted for stable output."""
-    return iter_py_files(REPO_ROOT, SCAN_DIRS)
+    """Return every .py file under the scanned directories, sorted for stable output.
+
+    The full-scan entry point the characterization tests parametrize over; ``main`` calls
+    ``resolve_paths`` directly so a pre-commit run can scan just the staged files. Both go
+    through ``resolve_paths``, so the full-scan path can't drift from the per-file path.
+    """
+    return resolve_paths([], REPO_ROOT, SCAN_DIRS)
 
 
 def main() -> int:
     return run_check(
-        iter_paths(),
+        resolve_paths(sys.argv[1:], REPO_ROOT, SCAN_DIRS),
         REPO_ROOT,
         check_file,
         summary="lazy import(s) found inside function bodies",

--- a/tools/check_llm_cruft.py
+++ b/tools/check_llm_cruft.py
@@ -20,7 +20,11 @@ AST line spans). Arbitrary string literals are not scanned. There is no escape
 hatch — these are always cruft. If a pattern misfires, tighten the pattern.
 
 Usage:
-    python tools/check_llm_cruft.py
+    python tools/check_llm_cruft.py [FILE ...]
+
+With no arguments, scans every file under src/, tests/, scripts/, tools/, codegen/,
+docs/, and examples/. Given file paths (as pre-commit passes the staged files), scans
+only those — out-of-scope or non-Python paths are ignored.
 """
 
 import ast
@@ -30,7 +34,7 @@ import sys
 import tokenize
 from pathlib import Path
 
-from lint_helpers import docstring_spans, iter_py_files, run_check
+from lint_helpers import docstring_spans, resolve_paths, run_check
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 
@@ -99,13 +103,18 @@ def check_file(path: Path) -> list[tuple[int, str]]:
 
 
 def iter_paths() -> list[Path]:
-    """Return every .py file under the scanned directories, sorted for stable output."""
-    return iter_py_files(REPO_ROOT, SCAN_DIRS)
+    """Return every .py file under the scanned directories, sorted for stable output.
+
+    The full-scan entry point the characterization tests parametrize over; ``main`` calls
+    ``resolve_paths`` directly so a pre-commit run can scan just the staged files. Both go
+    through ``resolve_paths``, so the full-scan path can't drift from the per-file path.
+    """
+    return resolve_paths([], REPO_ROOT, SCAN_DIRS)
 
 
 def main() -> int:
     return run_check(
-        iter_paths(),
+        resolve_paths(sys.argv[1:], REPO_ROOT, SCAN_DIRS),
         REPO_ROOT,
         check_file,
         summary="AI-writing tell(s) found:",

--- a/tools/check_module_boundaries.py
+++ b/tools/check_module_boundaries.py
@@ -43,7 +43,11 @@ legitimately read private state. Each allowlist entry is a conscious, auditable
 exception with a reason.
 
 Usage:
-    python tools/check_module_boundaries.py
+    python tools/check_module_boundaries.py [FILE ...]
+
+With no arguments, scans every file under src/hassette. Given file paths (as
+pre-commit passes the staged files), scans only those — paths outside
+src/hassette or non-Python paths are ignored.
 """
 
 import ast
@@ -52,10 +56,13 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
 
-from lint_helpers import iter_py_files, run_check
+from lint_helpers import resolve_paths, run_check
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 SRC = REPO_ROOT / "src" / "hassette"
+
+# Directory scanned for boundary violations, derived from SRC so the two can't drift.
+SCAN_DIRS: list[str] = [SRC.relative_to(REPO_ROOT).as_posix()]
 
 
 @dataclass(frozen=True)
@@ -319,13 +326,18 @@ def check_file(path: Path) -> list[tuple[int, str]]:
 
 
 def iter_paths() -> list[Path]:
-    """Return every .py file under src/hassette, sorted for stable output."""
-    return iter_py_files(REPO_ROOT, ["src/hassette"])
+    """Return every .py file under src/hassette, sorted for stable output.
+
+    The full-scan entry point the characterization tests parametrize over; ``main`` calls
+    ``resolve_paths`` directly so a pre-commit run can scan just the staged files. Both go
+    through ``resolve_paths``, so the full-scan path can't drift from the per-file path.
+    """
+    return resolve_paths([], REPO_ROOT, SCAN_DIRS)
 
 
 def main() -> int:
     return run_check(
-        iter_paths(),
+        resolve_paths(sys.argv[1:], REPO_ROOT, SCAN_DIRS),
         REPO_ROOT,
         check_file,
         summary="module-boundary violation(s)",

--- a/tools/check_spec_tokens.py
+++ b/tools/check_spec_tokens.py
@@ -27,7 +27,11 @@ itself produces a false positive, tighten the pattern rather than adding an
 exemption.
 
 Usage:
-    python tools/check_spec_tokens.py
+    python tools/check_spec_tokens.py [FILE ...]
+
+With no arguments, scans every file under src/, tests/, scripts/, tools/, codegen/,
+docs/, and examples/. Given file paths (as pre-commit passes the staged files), scans
+only those — out-of-scope or non-Python paths are ignored.
 """
 
 import ast
@@ -37,7 +41,7 @@ import sys
 import tokenize
 from pathlib import Path
 
-from lint_helpers import docstring_spans, iter_py_files
+from lint_helpers import docstring_spans, resolve_paths
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 
@@ -91,8 +95,13 @@ def check_file(path: Path) -> list[tuple[int, str]]:
 
 
 def iter_paths() -> list[Path]:
-    """Return every .py file under the scanned directories, sorted for stable output."""
-    return iter_py_files(REPO_ROOT, SCAN_DIRS)
+    """Return every .py file under the scanned directories, sorted for stable output.
+
+    The full-scan entry point the characterization tests parametrize over; ``main`` calls
+    ``resolve_paths`` directly so a pre-commit run can scan just the staged files. Both go
+    through ``resolve_paths``, so the full-scan path can't drift from the per-file path.
+    """
+    return resolve_paths([], REPO_ROOT, SCAN_DIRS)
 
 
 def check_filename(path: Path) -> list[str]:
@@ -106,7 +115,7 @@ def main() -> int:
     content_violations: list[tuple[Path, int, str]] = []
     name_violations: list[tuple[Path, str]] = []
 
-    for path in iter_paths():
+    for path in resolve_paths(sys.argv[1:], REPO_ROOT, SCAN_DIRS):
         rel = path.relative_to(REPO_ROOT)
         for lineno, token in check_file(path):
             content_violations.append((rel, lineno, token))

--- a/tools/lint_helpers.py
+++ b/tools/lint_helpers.py
@@ -86,3 +86,34 @@ def iter_py_files(repo_root: Path, scan_dirs: list[str]) -> list[Path]:
         for path in (repo_root / scan_dir).rglob("*.py")
         if EXCLUDED_PARTS.isdisjoint(path.relative_to(repo_root).parts)
     )
+
+
+def resolve_paths(argv: list[str], repo_root: Path, scan_dirs: list[str]) -> list[Path]:
+    """Resolve CLI file arguments to first-party .py paths, or scan ``scan_dirs`` when none given.
+
+    Pre-commit passes the staged files as arguments, so the hook checks only what changed
+    instead of re-scanning the whole tree on every commit. Running with no arguments falls
+    back to a full scan of ``scan_dirs`` — the behaviour CI and a manual full sweep rely on.
+
+    Arguments are kept only when they are existing ``.py`` files under one of ``scan_dirs``
+    and clear of EXCLUDED_PARTS, so a stray non-source path is ignored rather than crashing
+    a checker that assumes its inputs live in scope.
+    """
+    if not argv:
+        return iter_py_files(repo_root, scan_dirs)
+
+    scan_roots = [(repo_root / scan_dir).resolve() for scan_dir in scan_dirs]
+    selected: set[Path] = set()
+    for arg in argv:
+        path = Path(arg)
+        if not path.is_absolute():
+            path = repo_root / path
+        path = path.resolve()
+        if path.suffix != ".py" or not path.is_file():
+            continue
+        if not any(root in path.parents for root in scan_roots):
+            continue
+        if not EXCLUDED_PARTS.isdisjoint(path.relative_to(repo_root).parts):
+            continue
+        selected.add(path)
+    return sorted(selected)


### PR DESCRIPTION
## Summary

Two independent improvements to the local/CI quality loop: the hand-written lint checkers now run at **pre-commit** on staged files, and the release-please `uv.lock` sync is hardened so the manual `uv lock` + force-push dance is no longer needed.

### Lint checks run at pre-commit

The four hand-written checkers (lazy imports, spec tokens, llm cruft, module boundaries) moved from `pre-push` to `[pre-commit, pre-push]` and now receive the staged filenames instead of always full-scanning. The point is to catch violations on each commit rather than in one pre-push sweep at the end.

- A shared `resolve_paths()` helper in `tools/lint_helpers.py` scans only the passed files when pre-commit supplies them, and falls back to a full directory scan with no args (CI's `prek run --all-files` and manual sweeps). Out-of-scope, non-Python, and excluded (`.venv`) paths are dropped rather than crashing a checker.
- `iter_paths()` now delegates to `resolve_paths([])` so the full-scan and per-file code paths can't drift — the same helper backs both.
- Staying at `[pre-commit, pre-push]` (rather than pre-commit only) keeps the checkers in the CI `--hook-stage pre-push` sweep; dropping pre-push would have silently removed them from CI.
- New `tests/unit/tools/test_lint_helpers.py` pins `resolve_paths` (scope filtering, `.venv` exclusion, relative-path resolution, dedup/sort).

### release-please uv.lock hardening

release-please can't own the `uv.lock` version bump itself — `uv.lock` carries no comments (so the annotation updater can't survive) and the TOML jsonpath array-filter needed to target the project among 131 packages is a [confirmed open bug](https://github.com/googleapis/release-please/issues/2455). So the existing `sync-lockfile` job stays, but is now reliable, and staleness is made loud:

- `sync-lockfile` retries `uv lock` and `git push` (3 attempts each), so a transient failure no longer leaves the release PR with a stale lock.
- New `lockfile-fresh` job runs `uv lock --check`, gated on the existing `python` path-filter and wired into the `lint-complete` aggregate. Any PR whose `uv.lock` drifts from `pyproject.toml` now fails with a clear red check instead of being silently re-resolved by `uv sync`.

### Housekeeping

- Flow-style `stages:` on the four new hooks to match the existing hooks in the file, and descriptive Path locals in the dedup test (clean-code pass).

## Notes

#1146 tracks consolidating the per-checker `SCAN_DIRS` / `REPO_ROOT` / `iter_paths()` duplication into `lint_helpers.py` — deliberately left out of this PR since it predates these changes and is coupled to the per-module characterization tests.

All changes are `chore`/`ci` — none appear in the changelog. Verified: ruff + pyright clean, 3399 tools tests pass, both workflows valid (`bash -n` + YAML), checkers work in both scan modes.
