### PR TITLE
fix: mask app secret fields in global GET /config manifest data

### DIFF
--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -714,7 +714,7 @@
           "config"
         ],
         "summary": "Get Config",
-        "description": "Return the complete Hassette configuration as a JSON schema plus current values.\n\n``config_schema`` is the fully-inlined JSON schema derived from the\n``HassetteConfig`` class (all ``$ref``/``$defs`` resolved server-side).\n``config_values`` is the current configuration serialized to JSON with\nany ``SecretStr`` field replaced by a masked placeholder \u2014 the plaintext\nvalue is never sent over the wire.  Every field and nested group is present;\nnothing is omitted.",
+        "description": "Return the complete Hassette configuration as a JSON schema plus current values.\n\n``config_schema`` is the fully-inlined JSON schema derived from the\n``HassetteConfig`` class (all ``$ref``/``$defs`` resolved server-side).\n``config_values`` is the current configuration serialized to JSON with\nany ``SecretStr`` field replaced by a masked placeholder \u2014 the plaintext\nvalue is never sent over the wire. Every field and nested group is present;\nnothing is omitted.",
         "operationId": "get_config_api_config_get",
         "responses": {
           "200": {

--- a/frontend/src/api/generated-types.ts
+++ b/frontend/src/api/generated-types.ts
@@ -314,7 +314,7 @@ export interface paths {
          *     ``HassetteConfig`` class (all ``$ref``/``$defs`` resolved server-side).
          *     ``config_values`` is the current configuration serialized to JSON with
          *     any ``SecretStr`` field replaced by a masked placeholder — the plaintext
-         *     value is never sent over the wire.  Every field and nested group is present;
+         *     value is never sent over the wire. Every field and nested group is present;
          *     nothing is omitted.
          */
         get: operations["get_config_api_config_get"];

--- a/src/hassette/web/config_view.py
+++ b/src/hassette/web/config_view.py
@@ -22,9 +22,19 @@ Note: the OpenAPI freshness check does not cover ``ui`` annotation content (it r
 ``ui``-shape drift.
 """
 
-from typing import Any
+from logging import getLogger
+from typing import TYPE_CHECKING, Any
 
 import jsonref
+
+from hassette.app.app_config import AppConfig
+from hassette.utils.app_utils import class_already_loaded, get_loaded_class
+
+LOGGER = getLogger(__name__)
+
+if TYPE_CHECKING:
+    from hassette import Hassette
+    from hassette.config.classes import AppManifest
 
 MASK_SENTINEL = "••••••••"
 """Placeholder shown in the UI when a secret field is set but not revealed."""
@@ -172,3 +182,45 @@ def build_config_view(schema: dict[str, Any], values: dict[str, Any]) -> dict[st
     plain_schema = deref_schema(schema)
     masked_values = mask_values(plain_schema.get("properties", {}), values)
     return {"config_schema": plain_schema, "config_values": masked_values}
+
+
+def resolve_app_config_cls(
+    hassette: "Hassette", app_key: str, manifest: "AppManifest | None" = None
+) -> type[AppConfig] | None:
+    """Resolve an app's ``AppConfig`` class from the running instance or the loaded module.
+
+    Returns ``None`` when the app has no running instance and its class is not already
+    loaded (e.g. a disabled app that never started).  Does not import the app module — a
+    config request must not trigger loading of arbitrary app code on the unauthenticated API.
+    """
+    instance = hassette.app_handler.registry.get(app_key)
+    if instance is not None:
+        return getattr(type(instance), "app_config_cls", None)
+    if manifest is None:
+        manifest = hassette.config.apps.manifests.get(app_key)
+    if manifest is not None and class_already_loaded(manifest.full_path, manifest.class_name):
+        return get_loaded_class(manifest.full_path, manifest.class_name).app_config_cls
+    return None
+
+
+def mask_app_config(
+    config_cls: type[AppConfig] | None,
+    app_config: dict[str, Any] | list[dict[str, Any]],
+) -> dict[str, Any] | list[dict[str, Any]]:
+    """Mask an app's config values using its real schema when available, else mask all strings.
+
+    When ``config_cls`` is provided, uses schema-driven masking (only fields marked
+    ``writeOnly``/``format: password``, i.e. ``SecretStr``-typed, are masked).  When
+    ``None`` or schema generation fails, every string value is masked as a safe floor.
+    """
+    if config_cls is not None:
+        try:
+            schema_props = deref_schema(config_cls.model_json_schema()).get("properties", {})
+            if isinstance(app_config, list):
+                return [mask_values(schema_props, inst) for inst in app_config]
+            return mask_values(schema_props, app_config)
+        except Exception:
+            LOGGER.warning("Schema generation failed for %s; falling back to safe-floor masking", config_cls)
+    if isinstance(app_config, list):
+        return [mask_all_values(inst) for inst in app_config]
+    return mask_all_values(app_config)

--- a/src/hassette/web/config_view.py
+++ b/src/hassette/web/config_view.py
@@ -30,11 +30,11 @@ import jsonref
 from hassette.app.app_config import AppConfig
 from hassette.utils.app_utils import class_already_loaded, get_loaded_class
 
-LOGGER = getLogger(__name__)
-
 if TYPE_CHECKING:
     from hassette import Hassette
     from hassette.config.classes import AppManifest
+
+LOGGER = getLogger(__name__)
 
 MASK_SENTINEL = "••••••••"
 """Placeholder shown in the UI when a secret field is set but not revealed."""
@@ -190,7 +190,7 @@ def resolve_app_config_cls(
     """Resolve an app's ``AppConfig`` class from the running instance or the loaded module.
 
     Returns ``None`` when the app has no running instance and its class is not already
-    loaded (e.g. a disabled app that never started).  Does not import the app module — a
+    loaded (e.g. a disabled app that never started). Does not import the app module — a
     config request must not trigger loading of arbitrary app code on the unauthenticated API.
     """
     instance = hassette.app_handler.registry.get(app_key)
@@ -204,23 +204,23 @@ def resolve_app_config_cls(
 
 
 def mask_app_config(
-    config_cls: type[AppConfig] | None,
+    app_config_cls: type[AppConfig] | None,
     app_config: dict[str, Any] | list[dict[str, Any]],
 ) -> dict[str, Any] | list[dict[str, Any]]:
     """Mask an app's config values using its real schema when available, else mask all strings.
 
-    When ``config_cls`` is provided, uses schema-driven masking (only fields marked
-    ``writeOnly``/``format: password``, i.e. ``SecretStr``-typed, are masked).  When
+    When ``app_config_cls`` is provided, uses schema-driven masking (only fields marked
+    ``writeOnly``/``format: password``, i.e. ``SecretStr``-typed, are masked). When
     ``None`` or schema generation fails, every string value is masked as a safe floor.
     """
-    if config_cls is not None:
+    if app_config_cls is not None:
         try:
-            schema_props = deref_schema(config_cls.model_json_schema()).get("properties", {})
+            schema_props = deref_schema(app_config_cls.model_json_schema()).get("properties", {})
             if isinstance(app_config, list):
                 return [mask_values(schema_props, inst) for inst in app_config]
             return mask_values(schema_props, app_config)
         except Exception:
-            LOGGER.warning("Schema generation failed for %s; falling back to safe-floor masking", config_cls)
+            LOGGER.warning("Schema generation failed for %s; falling back to safe-floor masking", app_config_cls)
     if isinstance(app_config, list):
         return [mask_all_values(inst) for inst in app_config]
     return mask_all_values(app_config)

--- a/src/hassette/web/config_view.py
+++ b/src/hassette/web/config_view.py
@@ -199,7 +199,7 @@ def resolve_app_config_cls(
     if manifest is None:
         manifest = hassette.config.apps.manifests.get(app_key)
     if manifest is not None and class_already_loaded(manifest.full_path, manifest.class_name):
-        return get_loaded_class(manifest.full_path, manifest.class_name).app_config_cls
+        return getattr(get_loaded_class(manifest.full_path, manifest.class_name), "app_config_cls", None)
     return None
 
 
@@ -220,7 +220,9 @@ def mask_app_config(
                 return [mask_values(schema_props, inst) for inst in app_config]
             return mask_values(schema_props, app_config)
         except Exception:
-            LOGGER.warning("Schema generation failed for %s; falling back to safe-floor masking", app_config_cls)
+            LOGGER.warning(
+                "Schema generation failed for %s; falling back to safe-floor masking", app_config_cls, exc_info=True
+            )
     if isinstance(app_config, list):
         return [mask_all_values(inst) for inst in app_config]
     return mask_all_values(app_config)

--- a/src/hassette/web/routes/apps.py
+++ b/src/hassette/web/routes/apps.py
@@ -2,15 +2,13 @@
 
 import re
 from logging import getLogger
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
 from fastapi import APIRouter, HTTPException
 
 from hassette.app.app_config import AppConfig
-from hassette.config.classes import AppManifest
 from hassette.exceptions import TelemetryUnavailableError
-from hassette.utils.app_utils import class_already_loaded, get_loaded_class
-from hassette.web.config_view import deref_schema, mask_all_values, mask_values
+from hassette.web.config_view import deref_schema, mask_app_config, mask_values, resolve_app_config_cls
 from hassette.web.dependencies import HassetteDep, RuntimeDep, TelemetryDep
 from hassette.web.mappers import app_manifest_list_response_from, app_status_response_from
 from hassette.web.models import (
@@ -20,9 +18,6 @@ from hassette.web.models import (
     AppSourceResponse,
     AppStatusResponse,
 )
-
-if TYPE_CHECKING:
-    from hassette import Hassette
 
 LOGGER = getLogger(__name__)
 
@@ -142,10 +137,10 @@ async def get_app_config(app_key: str, hassette: HassetteDep) -> AppConfigRespon
     if manifest is None:
         raise HTTPException(status_code=404, detail=f"App {app_key!r} not found")
 
-    app_config_cls = _resolve_app_config_cls(hassette, app_key, manifest)
-    if app_config_cls is not None:
+    config_cls = resolve_app_config_cls(hassette, app_key, manifest)
+    if config_cls is not None:
         try:
-            raw_schema = app_config_cls.model_json_schema()
+            raw_schema = config_cls.model_json_schema()
             if not isinstance(raw_schema, dict):
                 raise TypeError(f"model_json_schema() returned {type(raw_schema).__name__}, expected dict")
             config_schema, masked_config = _build_app_config_view(raw_schema, manifest.app_config)
@@ -162,32 +157,16 @@ async def get_app_config(app_key: str, hassette: HassetteDep) -> AppConfigRespon
         except Exception:
             LOGGER.warning("Failed to generate config schema for %s", app_key, exc_info=True)
 
-    # No schema available — uniformly mask every string value so a secret never leaks.
     return AppConfigResponse(
         app_key=app_key,
         filename=manifest.filename,
         class_name=manifest.class_name,
         enabled=manifest.enabled,
         autostart=manifest.autostart,
-        app_config=_mask_floor(manifest.app_config),
+        app_config=mask_app_config(None, manifest.app_config),
         config_schema=None,
         framework_fields=_FRAMEWORK_FIELDS,
     )
-
-
-def _resolve_app_config_cls(hassette: "Hassette", app_key: str, manifest: AppManifest) -> type[AppConfig] | None:
-    """Resolve the app's ``AppConfig`` class: from the running instance, else the loaded class.
-
-    Returns ``None`` when the app has no running instance and its class is not already
-    loaded (e.g. a disabled app that never started). Does not import the app module — a
-    config request must not trigger loading of arbitrary app code on the unauthenticated API.
-    """
-    instance = hassette.app_handler.registry.get(app_key)
-    if instance is not None:
-        return getattr(type(instance), "app_config_cls", None)
-    if class_already_loaded(manifest.full_path, manifest.class_name):
-        return get_loaded_class(manifest.full_path, manifest.class_name).app_config_cls
-    return None
 
 
 def _build_app_config_view(
@@ -196,12 +175,8 @@ def _build_app_config_view(
     """Build the deref'd schema and masked values for a single- or multi-instance app config.
 
     The schema is dereferenced once and reused across every instance; only the per-instance
-    masking differs. An empty instance list returns the deref'd schema with no masking run.
-
-    Manifest-level fields (enabled, autostart) are injected into the schema so the
-    frontend can render them alongside config fields in the framework section. Their
-    values live on AppConfigResponse (not in app_config); the frontend merges them
-    into the display values before passing to ConfigSchemaView.
+    masking differs.  Manifest-level fields (enabled, autostart) are injected into the schema
+    so the frontend can render them alongside config fields in the framework section.
     """
     plain_schema = deref_schema(schema)
     config_props = plain_schema.get("properties", {})
@@ -209,13 +184,6 @@ def _build_app_config_view(
     if isinstance(app_config, list):
         return enriched_schema, [mask_values(config_props, inst) for inst in app_config]
     return enriched_schema, mask_values(config_props, app_config)
-
-
-def _mask_floor(app_config: dict[str, Any] | list[dict[str, Any]]) -> dict[str, Any] | list[dict[str, Any]]:
-    """Apply the schema-less safe-floor mask to a single- or multi-instance app config."""
-    if isinstance(app_config, list):
-        return [mask_all_values(inst) for inst in app_config]
-    return mask_all_values(app_config)
 
 
 @router.get("/apps/{app_key}/source", response_model=AppSourceResponse)

--- a/src/hassette/web/routes/apps.py
+++ b/src/hassette/web/routes/apps.py
@@ -137,10 +137,10 @@ async def get_app_config(app_key: str, hassette: HassetteDep) -> AppConfigRespon
     if manifest is None:
         raise HTTPException(status_code=404, detail=f"App {app_key!r} not found")
 
-    config_cls = resolve_app_config_cls(hassette, app_key, manifest)
-    if config_cls is not None:
+    app_config_cls = resolve_app_config_cls(hassette, app_key, manifest)
+    if app_config_cls is not None:
         try:
-            raw_schema = config_cls.model_json_schema()
+            raw_schema = app_config_cls.model_json_schema()
             if not isinstance(raw_schema, dict):
                 raise TypeError(f"model_json_schema() returned {type(raw_schema).__name__}, expected dict")
             config_schema, masked_config = _build_app_config_view(raw_schema, manifest.app_config)
@@ -175,7 +175,7 @@ def _build_app_config_view(
     """Build the deref'd schema and masked values for a single- or multi-instance app config.
 
     The schema is dereferenced once and reused across every instance; only the per-instance
-    masking differs.  Manifest-level fields (enabled, autostart) are injected into the schema
+    masking differs. Manifest-level fields (enabled, autostart) are injected into the schema
     so the frontend can render them alongside config fields in the framework section.
     """
     plain_schema = deref_schema(schema)

--- a/src/hassette/web/routes/config.py
+++ b/src/hassette/web/routes/config.py
@@ -1,11 +1,16 @@
 """Configuration endpoint."""
 
+from typing import TYPE_CHECKING, Any
+
 from fastapi import APIRouter
 
 from hassette.config import HassetteConfig
-from hassette.web.config_view import build_config_view
+from hassette.web.config_view import build_config_view, mask_app_config, resolve_app_config_cls
 from hassette.web.dependencies import HassetteDep
 from hassette.web.models import ConfigSchemaResponse
+
+if TYPE_CHECKING:
+    from hassette import Hassette
 
 router = APIRouter(tags=["config"])
 
@@ -24,4 +29,30 @@ async def get_config(hassette: HassetteDep) -> ConfigSchemaResponse:
     schema = HassetteConfig.model_json_schema()
     values = hassette.config.model_dump(mode="json")
     view = build_config_view(schema, values)
+    view["config_values"] = _mask_manifest_configs(hassette, view["config_values"])
     return ConfigSchemaResponse(**view)
+
+
+def _mask_manifest_configs(hassette: "Hassette", config_values: dict[str, Any]) -> dict[str, Any]:
+    """Mask ``app_config`` inside each manifest so secrets never leak via the global endpoint.
+
+    ``HassetteConfig`` types ``app_config`` as ``dict[str, Any]``, so the schema-driven
+    masking in ``build_config_view`` has no ``writeOnly``/``format: password`` markers to
+    act on.  This post-processing step resolves each app's real config class via
+    ``resolve_app_config_cls`` and re-masks with the type-accurate schema.  When no schema
+    is available, every string value is masked as a safe floor.
+    """
+    manifests = config_values.get("apps", {}).get("manifests")
+    if not manifests:
+        return config_values
+
+    masked_manifests = {}
+    for app_key, manifest_dict in manifests.items():
+        raw_config = manifest_dict.get("app_config")
+        if raw_config is None:
+            masked_manifests[app_key] = manifest_dict
+            continue
+        config_cls = resolve_app_config_cls(hassette, app_key)
+        masked_manifests[app_key] = {**manifest_dict, "app_config": mask_app_config(config_cls, raw_config)}
+
+    return {**config_values, "apps": {**config_values["apps"], "manifests": masked_manifests}}

--- a/src/hassette/web/routes/config.py
+++ b/src/hassette/web/routes/config.py
@@ -23,7 +23,7 @@ async def get_config(hassette: HassetteDep) -> ConfigSchemaResponse:
     ``HassetteConfig`` class (all ``$ref``/``$defs`` resolved server-side).
     ``config_values`` is the current configuration serialized to JSON with
     any ``SecretStr`` field replaced by a masked placeholder — the plaintext
-    value is never sent over the wire.  Every field and nested group is present;
+    value is never sent over the wire. Every field and nested group is present;
     nothing is omitted.
     """
     schema = HassetteConfig.model_json_schema()
@@ -38,8 +38,8 @@ def _mask_manifest_configs(hassette: "Hassette", config_values: dict[str, Any]) 
 
     ``HassetteConfig`` types ``app_config`` as ``dict[str, Any]``, so the schema-driven
     masking in ``build_config_view`` has no ``writeOnly``/``format: password`` markers to
-    act on.  This post-processing step resolves each app's real config class via
-    ``resolve_app_config_cls`` and re-masks with the type-accurate schema.  When no schema
+    act on. This post-processing step resolves each app's real config class via
+    ``resolve_app_config_cls`` and re-masks with the type-accurate schema. When no schema
     is available, every string value is masked as a safe floor.
     """
     manifests = config_values.get("apps", {}).get("manifests")
@@ -52,7 +52,7 @@ def _mask_manifest_configs(hassette: "Hassette", config_values: dict[str, Any]) 
         if raw_config is None:
             masked_manifests[app_key] = manifest_dict
             continue
-        config_cls = resolve_app_config_cls(hassette, app_key)
-        masked_manifests[app_key] = {**manifest_dict, "app_config": mask_app_config(config_cls, raw_config)}
+        app_config_cls = resolve_app_config_cls(hassette, app_key)
+        masked_manifests[app_key] = {**manifest_dict, "app_config": mask_app_config(app_config_cls, raw_config)}
 
     return {**config_values, "apps": {**config_values["apps"], "manifests": masked_manifests}}

--- a/tests/integration/web_api/test_api_app_config.py
+++ b/tests/integration/web_api/test_api_app_config.py
@@ -324,6 +324,99 @@ class TestSchemaDeref:
         schema = data["config_schema"]
         assert schema is not None
         conn_prop = schema.get("properties", {}).get("connection", {})
-        # Nested group must be inlined: it should have properties, not a $ref
         assert "properties" in conn_prop, f"connection schema not inlined: {conn_prop}"
         assert "host" in conn_prop["properties"]
+
+
+class TestGlobalConfigManifestMasking:
+    """Secret fields inside manifests' ``app_config`` are masked in the global config endpoint."""
+
+    async def test_secret_str_masked_in_manifest(self, client, mock_hassette) -> None:
+        """A SecretStr field in a manifest's app_config is replaced by the mask sentinel."""
+        mock_hassette.config.model_dump.return_value["apps"]["manifests"] = {
+            "my_app": {
+                "app_key": "my_app",
+                "app_config": {"api_key": "plaintext-secret"},
+            },
+        }
+        mock_hassette._app_handler.registry.get.return_value = _AppWithMaskedKey()
+
+        response = await client.get("/api/config")
+
+        manifests = response.json()["config_values"]["apps"]["manifests"]
+        assert manifests["my_app"]["app_config"]["api_key"] == MASK_SENTINEL
+
+    async def test_plain_str_not_masked_in_manifest(self, client, mock_hassette) -> None:
+        """A plain str field is NOT masked — masking is schema-driven, not name-driven."""
+        mock_hassette.config.model_dump.return_value["apps"]["manifests"] = {
+            "my_app": {
+                "app_key": "my_app",
+                "app_config": {"api_key": "my-real-value"},
+            },
+        }
+        mock_hassette._app_handler.registry.get.return_value = _AppWithUnmaskedKey()
+
+        response = await client.get("/api/config")
+
+        manifests = response.json()["config_values"]["apps"]["manifests"]
+        assert manifests["my_app"]["app_config"]["api_key"] == "my-real-value"
+
+    async def test_safe_floor_when_no_schema(self, client, mock_hassette) -> None:
+        """When no app class is available, every string value is masked as a safe floor."""
+        mock_hassette.config.model_dump.return_value["apps"]["manifests"] = {
+            "disabled_app": {
+                "app_key": "disabled_app",
+                "app_config": {"password": "hunter2", "retries": 3},
+            },
+        }
+        mock_hassette._app_handler.registry.get.return_value = None
+        mock_hassette.config.apps.manifests = {}
+
+        response = await client.get("/api/config")
+
+        app_config = response.json()["config_values"]["apps"]["manifests"]["disabled_app"]["app_config"]
+        assert app_config["password"] == MASK_SENTINEL
+        assert app_config["retries"] == 3
+
+    async def test_plaintext_never_in_response_body(self, client, mock_hassette) -> None:
+        """Plaintext of a SecretStr field must not appear anywhere in the response body."""
+        mock_hassette.config.model_dump.return_value["apps"]["manifests"] = {
+            "my_app": {
+                "app_key": "my_app",
+                "app_config": {"api_key": "super-secret-value-12345"},
+            },
+        }
+        mock_hassette._app_handler.registry.get.return_value = _AppWithMaskedKey()
+
+        response = await client.get("/api/config")
+
+        assert "super-secret-value-12345" not in response.text
+
+    async def test_multi_instance_manifest_masked(self, client, mock_hassette) -> None:
+        """Each instance in a multi-instance manifest has its secrets masked."""
+        mock_hassette.config.model_dump.return_value["apps"]["manifests"] = {
+            "my_app": {
+                "app_key": "my_app",
+                "app_config": [
+                    {"instance_name": "MyApp.0", "api_key": "secret-0"},
+                    {"instance_name": "MyApp.1", "api_key": "secret-1"},
+                ],
+            },
+        }
+        mock_hassette._app_handler.registry.get.return_value = _AppWithMaskedKey()
+
+        response = await client.get("/api/config")
+
+        app_config = response.json()["config_values"]["apps"]["manifests"]["my_app"]["app_config"]
+        assert isinstance(app_config, list)
+        assert app_config[0]["api_key"] == MASK_SENTINEL
+        assert app_config[1]["api_key"] == MASK_SENTINEL
+        assert app_config[0]["instance_name"] == "MyApp.0"
+
+    async def test_no_manifests_passes_through(self, client) -> None:
+        """When no manifests exist in config values, the response is unchanged."""
+        response = await client.get("/api/config")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert "config_values" in data

--- a/tests/integration/web_api/test_api_app_config.py
+++ b/tests/integration/web_api/test_api_app_config.py
@@ -331,7 +331,7 @@ class TestSchemaDeref:
 class TestGlobalConfigManifestMasking:
     """Secret fields inside manifests' ``app_config`` are masked in the global config endpoint."""
 
-    async def test_secret_str_masked_in_manifest(self, client, mock_hassette) -> None:
+    async def test_secret_str_field_renders_masked_in_manifest(self, client, mock_hassette) -> None:
         """A SecretStr field in a manifest's app_config is replaced by the mask sentinel."""
         mock_hassette.config.model_dump.return_value["apps"]["manifests"] = {
             "my_app": {
@@ -346,7 +346,7 @@ class TestGlobalConfigManifestMasking:
         manifests = response.json()["config_values"]["apps"]["manifests"]
         assert manifests["my_app"]["app_config"]["api_key"] == MASK_SENTINEL
 
-    async def test_plain_str_not_masked_in_manifest(self, client, mock_hassette) -> None:
+    async def test_plain_str_field_renders_unmasked_in_manifest(self, client, mock_hassette) -> None:
         """A plain str field is NOT masked — masking is schema-driven, not name-driven."""
         mock_hassette.config.model_dump.return_value["apps"]["manifests"] = {
             "my_app": {
@@ -378,7 +378,7 @@ class TestGlobalConfigManifestMasking:
         assert app_config["password"] == MASK_SENTINEL
         assert app_config["retries"] == 3
 
-    async def test_plaintext_never_in_response_body(self, client, mock_hassette) -> None:
+    async def test_plaintext_never_appears_in_response_body(self, client, mock_hassette) -> None:
         """Plaintext of a SecretStr field must not appear anywhere in the response body."""
         mock_hassette.config.model_dump.return_value["apps"]["manifests"] = {
             "my_app": {


### PR DESCRIPTION
### Bug Fix

- The global `GET /config` endpoint returned each app's `app_config` fields unmasked inside `apps.manifests`, because `AppManifest.app_config` is typed `dict[str, Any]` — there's no `writeOnly`/`format: password` marker for the existing schema-driven masking in `build_config_view` to act on. Secret values (API keys, passwords, etc.) were leaking in plaintext over the wire.
- Fixed by post-processing each manifest's `app_config` after `build_config_view` runs: resolve the app's real `AppConfig` class (when available) and re-mask with its type-accurate schema. When no class is available (e.g. a disabled app that never started), every string value is masked as a safe floor instead of leaking unmasked.

### Refactor

- Extracted `resolve_app_config_cls` and `mask_app_config` into `config_view.py` as shared helpers, and migrated the per-app `GET /apps/{key}/config` endpoint onto them — removing the duplicate `_resolve_app_config_cls` and `_mask_floor` functions that previously lived in `apps.py`. Both endpoints now share one masking implementation instead of two copies that could drift apart.

Closes #1139
