### PR TITLE
fix: propagate contextvars to worker threads in run_in_thread

### DIFF
--- a/src/hassette/task_bucket/task_bucket.py
+++ b/src/hassette/task_bucket/task_bucket.py
@@ -190,7 +190,7 @@ class TaskBucket(Resource):
             **kwargs: Keyword arguments to pass to the function.
 
         Returns:
-            A coroutine that resolves to the return value of *fn*.
+            An :class:`asyncio.Future` that resolves to the return value of *fn*.
         """
         parent_ctx = copy_context()
         cell: list[threading.Thread | None] = [None]

--- a/src/hassette/task_bucket/task_bucket.py
+++ b/src/hassette/task_bucket/task_bucket.py
@@ -1,5 +1,6 @@
 import asyncio
 import contextlib
+import contextvars
 import functools
 import threading
 import typing
@@ -22,13 +23,10 @@ itself is a ``list[threading.Thread | None]`` whose first element is set by the 
 when ``_call`` starts executing.  ``_execute`` (same asyncio task, same context snapshot) reads
 this ContextVar to reach ``cell[0]`` at the timeout site.
 
-Why a ContextVar carrying the cell *reference* works (unlike writing from the worker):
-``loop.run_in_executor`` copies the loop thread's context one-way into the worker; the worker
-gets a private snapshot.  Only the loop thread writes to this ContextVar (setting the cell
-reference); the worker writes only to ``cell[0]`` (the list contents).  Because the cell is a
-plain mutable list created on the loop thread and captured by both sides, the worker's mutation
-to ``cell[0]`` is immediately visible to the loop thread when it reads ``cell[0]`` via
-``SYNC_WORKER_CELL.get()``.
+The worker accesses the cell via closure, not via this ContextVar.  The ContextVar exists so
+that ``_execute`` (running on the loop thread, in the same asyncio task) can read back the cell
+reference.  The worker mutates ``cell[0]`` (a plain list element), which is immediately visible
+to the loop thread because both sides share the same list object.
 """
 
 if typing.TYPE_CHECKING:
@@ -178,24 +176,24 @@ class TaskBucket(Resource):
         ``asyncio.to_thread`` calls (logging, database), which continue using the
         loop-default executor.
 
-        A shared mutable cell (``list[threading.Thread | None]``) captures the
-        worker thread immediately when ``_call`` starts executing.  The loop
-        thread reads ``cell[0]`` at the timeout site to check whether the thread
-        outlived its timeout::
+        **Context propagation:** ``loop.run_in_executor`` does NOT copy the calling
+        thread's contextvars into the worker (unlike ``asyncio.to_thread``).  This
+        method captures a full snapshot via ``contextvars.copy_context()`` and runs
+        *fn* inside it so that all contextvars set on the loop thread are visible to
+        sync user code.
+
+        **Thread cell:** A shared mutable cell (``list[threading.Thread | None]``)
+        captures the worker thread when ``_call`` starts executing.  The loop thread
+        reads ``cell[0]`` at the timeout site::
 
             cell: list[threading.Thread | None] = [None]
             # _call (worker):  cell[0] = threading.current_thread()  <- set on worker
             # timeout (loop):  cell[0].is_alive()                    <- read on loop
 
-        A ContextVar is NOT used here: ``loop.run_in_executor`` copies the loop
-        thread's context one-way into the worker callable, so any write the worker
-        makes to a ContextVar mutates the worker's private copy and the loop thread
-        reads back ``None``.  The cell sidesteps this by being a plain list created
-        on the loop thread and closed over by both the loop thread and the worker.
-
-        If the timeout fires before the worker has dequeued ``_call``, ``cell[0]``
-        remains ``None`` — a "not-started" timeout, not a thread leak.  The timeout
-        site relies on this sentinel to distinguish the two cases.
+        The cell is a plain list closed over by both sides — mutations to ``cell[0]``
+        are immediately visible across threads.  If the timeout fires before the
+        worker has dequeued ``_call``, ``cell[0]`` remains ``None`` (not-started
+        timeout, not a thread leak).
 
         Args:
             fn: The synchronous function to run.
@@ -205,24 +203,13 @@ class TaskBucket(Resource):
         Returns:
             A coroutine that resolves to the return value of *fn*.
         """
-        current_bucket = ctx.CURRENT_BUCKET.get()
-        # Shared mutable cell: set by the worker, read on the loop thread at the timeout site.
-        # The cell is created and owned here (loop thread); the worker mutates cell[0].
+        parent_ctx = contextvars.copy_context()
         cell: list[threading.Thread | None] = [None]
-        # Expose the cell to _execute via a ContextVar set on the loop thread.
-        # _execute runs in the same asyncio task (same context), so it reads back
-        # the same cell reference.  See SYNC_WORKER_CELL docstring for why this
-        # works when setting from the loop thread but not from the worker.
         SYNC_WORKER_CELL.set(cell)
 
         def _call() -> R:
-            # Record which worker thread picked up this callable — read at the timeout site.
             cell[0] = threading.current_thread()
-            if current_bucket is not None:
-                with ctx.use_task_bucket(current_bucket):
-                    return fn(*args, **kwargs)
-            else:
-                return fn(*args, **kwargs)
+            return parent_ctx.run(fn, *args, **kwargs)
 
         # Submit to the dedicated executor so sync user code is isolated from
         # framework-internal asyncio.to_thread calls (logging, database).

--- a/src/hassette/task_bucket/task_bucket.py
+++ b/src/hassette/task_bucket/task_bucket.py
@@ -1,13 +1,12 @@
 import asyncio
 import contextlib
-import contextvars
 import functools
 import threading
 import typing
 from collections.abc import Awaitable, Callable, Coroutine
 from concurrent.futures import Future
 from concurrent.futures import TimeoutError as CfTimeoutError  # aliased to distinguish from builtin TimeoutError
-from contextvars import ContextVar
+from contextvars import ContextVar, copy_context
 from typing import Any, ParamSpec, TypeVar, cast, overload
 
 from hassette import context as ctx
@@ -182,18 +181,8 @@ class TaskBucket(Resource):
         *fn* inside it so that all contextvars set on the loop thread are visible to
         sync user code.
 
-        **Thread cell:** A shared mutable cell (``list[threading.Thread | None]``)
-        captures the worker thread when ``_call`` starts executing.  The loop thread
-        reads ``cell[0]`` at the timeout site::
-
-            cell: list[threading.Thread | None] = [None]
-            # _call (worker):  cell[0] = threading.current_thread()  <- set on worker
-            # timeout (loop):  cell[0].is_alive()                    <- read on loop
-
-        The cell is a plain list closed over by both sides — mutations to ``cell[0]``
-        are immediately visible across threads.  If the timeout fires before the
-        worker has dequeued ``_call``, ``cell[0]`` remains ``None`` (not-started
-        timeout, not a thread leak).
+        **Thread cell:** see :data:`SYNC_WORKER_CELL` module docstring for the
+        shared-mutable-cell mechanism used by the timeout site.
 
         Args:
             fn: The synchronous function to run.
@@ -203,7 +192,7 @@ class TaskBucket(Resource):
         Returns:
             A coroutine that resolves to the return value of *fn*.
         """
-        parent_ctx = contextvars.copy_context()
+        parent_ctx = copy_context()
         cell: list[threading.Thread | None] = [None]
         SYNC_WORKER_CELL.set(cell)
 

--- a/tests/unit/task_bucket/test_run_in_thread_context_propagation.py
+++ b/tests/unit/task_bucket/test_run_in_thread_context_propagation.py
@@ -1,0 +1,122 @@
+"""Tests for contextvar propagation through TaskBucket.run_in_thread.
+
+Covers:
+- HASSETTE_INSTANCE is visible in the worker thread.
+- HASSETTE_CONFIG is visible in the worker thread.
+- CURRENT_BUCKET is visible in the worker thread.
+- CURRENT_EXECUTION_ID is visible in the worker thread.
+- SYNC_WORKER_CELL still works after the context-propagation change.
+"""
+
+import threading
+from collections.abc import Iterator
+from unittest.mock import AsyncMock
+
+import pytest
+
+from hassette import context as ctx
+from hassette.task_bucket.task_bucket import SYNC_WORKER_CELL, TaskBucket
+from hassette.test_utils import make_mock_hassette
+
+
+@pytest.fixture
+def hassette_mock() -> Iterator[AsyncMock]:
+    hassette = make_mock_hassette()
+    token = ctx.HASSETTE_INSTANCE.set(hassette)
+    config_token = ctx.HASSETTE_CONFIG.set(hassette.config)
+    try:
+        yield hassette
+    finally:
+        ctx.HASSETTE_CONFIG.reset(config_token)
+        ctx.HASSETTE_INSTANCE.reset(token)
+        hassette.sync_executor.shutdown(join_threads_or_timeout=True)
+
+
+@pytest.fixture
+def bucket(hassette_mock: AsyncMock) -> TaskBucket:
+    return TaskBucket(hassette_mock)
+
+
+async def test_hassette_instance_visible_in_worker(hassette_mock: AsyncMock, bucket: TaskBucket) -> None:
+    """get_hassette() returns the correct instance inside run_in_thread."""
+    captured: list[object] = []
+
+    def read_hassette() -> None:
+        captured.append(ctx.get_hassette())
+
+    await bucket.run_in_thread(read_hassette)
+
+    assert len(captured) == 1
+    assert captured[0] is hassette_mock
+
+
+async def test_hassette_config_visible_in_worker(hassette_mock: AsyncMock, bucket: TaskBucket) -> None:
+    """get_hassette_config() returns the correct config inside run_in_thread."""
+    captured: list[object] = []
+
+    def read_config() -> None:
+        captured.append(ctx.get_hassette_config())
+
+    await bucket.run_in_thread(read_config)
+
+    assert len(captured) == 1
+    assert captured[0] is hassette_mock.config
+
+
+async def test_current_bucket_visible_in_worker(bucket: TaskBucket) -> None:
+    """CURRENT_BUCKET is propagated so spawned sub-tasks route to the correct bucket."""
+    captured: list[object] = []
+
+    with ctx.use_task_bucket(bucket):
+
+        def read_bucket() -> None:
+            captured.append(ctx.CURRENT_BUCKET.get())
+
+        await bucket.run_in_thread(read_bucket)
+
+    assert len(captured) == 1
+    assert captured[0] is bucket
+
+
+async def test_execution_id_visible_in_worker(bucket: TaskBucket) -> None:
+    """CURRENT_EXECUTION_ID is propagated to the worker thread."""
+    captured: list[str | None] = []
+    test_id = "exec-1145-test"
+
+    with ctx.use(ctx.CURRENT_EXECUTION_ID, test_id):
+
+        def read_execution_id() -> None:
+            captured.append(ctx.CURRENT_EXECUTION_ID.get())
+
+        await bucket.run_in_thread(read_execution_id)
+
+    assert len(captured) == 1
+    assert captured[0] == test_id
+
+
+async def test_worker_contextvar_writes_do_not_leak_back(bucket: TaskBucket) -> None:
+    """ContextVar mutations inside the worker stay in the worker's copy."""
+    original_id = ctx.CURRENT_EXECUTION_ID.get(None)
+
+    def mutate_execution_id() -> None:
+        ctx.CURRENT_EXECUTION_ID.set("mutated-in-worker")
+
+    await bucket.run_in_thread(mutate_execution_id)
+
+    assert ctx.CURRENT_EXECUTION_ID.get(None) == original_id
+
+
+async def test_sync_worker_cell_still_works(bucket: TaskBucket) -> None:
+    """The SYNC_WORKER_CELL thread-capture mechanism is unaffected by context propagation."""
+
+    def sync_fn() -> str:
+        return "ok"
+
+    future = bucket.run_in_thread(sync_fn)
+    cell = SYNC_WORKER_CELL.get()
+    assert cell is not None
+
+    result = await future
+    assert result == "ok"
+    assert cell[0] is not None
+    assert isinstance(cell[0], threading.Thread)

--- a/tests/unit/task_bucket/test_run_in_thread_context_propagation.py
+++ b/tests/unit/task_bucket/test_run_in_thread_context_propagation.py
@@ -81,7 +81,7 @@ async def test_current_bucket_visible_in_worker(bucket: TaskBucket) -> None:
 async def test_execution_id_visible_in_worker(bucket: TaskBucket) -> None:
     """CURRENT_EXECUTION_ID is propagated to the worker thread."""
     captured: list[str | None] = []
-    test_id = "exec-1145-test"
+    test_id = "test-execution-id"
 
     with ctx.use(ctx.CURRENT_EXECUTION_ID, test_id):
 


### PR DESCRIPTION
### Bug Fixes

- **Sync handlers run via `run_in_thread` now see contextvars set on the loop thread** — `loop.run_in_executor` does *not* copy the calling thread's contextvars into the worker (unlike `asyncio.to_thread`), so sync handlers silently lost access to `HASSETTE_INSTANCE`, `HASSETTE_CONFIG`, `CURRENT_BUCKET`, and `CURRENT_EXECUTION_ID`. This surfaced as `HassetteNotInitializedError` that appeared intermittent, because a memoization race in the getter masked the missing context most of the time. The fix captures a full context snapshot with `contextvars.copy_context()` and runs the callable inside it via `parent_ctx.run(...)`, which also let the explicit `CURRENT_BUCKET` restoration in the `_call` closure be removed as redundant.
- Corrected the module and method docstrings, which incorrectly claimed `run_in_executor` propagates context one-way — it doesn't propagate context at all, only the thread-cell mechanism used for timeout detection crosses the thread boundary via a shared mutable list.

### Housekeeping

- Deduplicated the shared-mutable-cell explanation between the module docstring and the `run_in_thread` docstring — the method docstring now points to the module docstring instead of repeating it.
- Minor cleanup from clean-code review: import `copy_context` directly instead of via the `contextvars` module alias, and use a non-issue-numbered test id in the new regression test.

Closes #1145
