### PR TITLE
chore: enforce 80% coverage threshold for backend and frontend

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,8 +18,11 @@ uv run nox -s dev
 # Run tests via nox (CI — tests across Python 3.11, 3.12, 3.13)
 uv run nox -s tests
 
-# Run tests with coverage
+# Run tests with coverage (see ## Coverage section below for why NOT pytest --cov)
 uv run nox -s tests_with_coverage
+
+# Run tests with coverage (frontend)
+cd frontend && npm run test:coverage
 
 # Run a single test file
 uv run pytest tests/integration/test_api.py
@@ -140,6 +143,12 @@ assert result > 0                                  # confirms registration succe
 **Sentinel filtering** — verify that records with unregistered IDs (listener_id=0, job_id=0, session_id=0) are silently dropped and not written to the database.
 
 **Error isolation** — confirm that exceptions raised inside `execute()` do not propagate out of the method; the caller (TaskBucket) must not crash.
+
+## Coverage
+
+Do **not** use `pytest --cov` for backend coverage — it under-reports by 15-40 percentage points. See `tests/TESTING.md` (Coverage Measurement) for the full explanation. Use the nox coverage sessions instead (see Common Commands above).
+
+Both backend and frontend enforce an 80% floor — backend via `fail_under` in `pyproject.toml`, frontend via `thresholds` in `vitest.config.ts`. Codecov's `target: auto` additionally catches per-PR regressions.
 
 ## Test Infrastructure
 

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -13,6 +13,12 @@ export default defineConfig({
       reportsDirectory: "./coverage",
       include: ["src/**/*.{ts,tsx}"],
       exclude: ["src/test/**", "src/test-setup.ts", "src/**/*.test.{ts,tsx}"],
+      thresholds: {
+        statements: 80,
+        branches: 80,
+        functions: 80,
+        lines: 80,
+      },
     },
   },
 });

--- a/noxfile.py
+++ b/noxfile.py
@@ -147,7 +147,9 @@ def system_with_coverage(session: "Session"):
     _run_system_tests(session, marker="system and not system_destructive")
     _run_system_tests(session, marker="system_destructive")
     session.run("uv", "run", "--active", "coverage", "combine", external=True)
-    session.run("uv", "run", "--active", "coverage", "xml", "-o", "coverage.system.xml", external=True)
+    session.run(
+        "uv", "run", "--active", "coverage", "xml", "--fail-under=0", "-o", "coverage.system.xml", external=True
+    )
 
 
 def _install_coverage_pth(session: "Session") -> None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -196,7 +196,7 @@ omit = [
 [tool.coverage.report]
 show_missing = true
 skip_covered = true
-# fail_under = 85 # local default; CI can override
+fail_under = 80
 exclude_lines = [
     "pragma: no cover",
     "if (typing\\.)?TYPE_CHECKING:",


### PR DESCRIPTION
### Coverage enforcement

- Enable `fail_under = 80` in `pyproject.toml` for backend coverage — it had been commented out at 85, so the floor wasn't actually enforced locally or in CI.
- Add `thresholds` (statements/branches/functions/lines at 80%) to `frontend/vitest.config.ts` so frontend coverage has the same floor as the backend.
- Document both coverage commands in `CLAUDE.md`, plus a note on why `pytest --cov` under-reports backend coverage by 15-40 points (see `tests/TESTING.md` for the full explanation) — the nox coverage sessions are the accurate measurement.
