### PR TITLE
refactor: inject HA event operations into bus kernel via DI

### DIFF
--- a/src/hassette/bus/duration_hold.py
+++ b/src/hassette/bus/duration_hold.py
@@ -91,8 +91,9 @@ class DurationHoldManager:
     async def immediate_fire_task(self, listener: Listener) -> None:
         """Fire a handler immediately with the current entity state.
 
-        Implements ``immediate=True``: fires once with a synthetic ``RawStateChangeEvent``
-        (``old_state=None``) if the entity is in the cache.
+        Implements ``immediate=True``: fires once with a synthetic event built
+        by the injected ``make_synthetic_event`` factory if the entity is in
+        the cache.
 
         Error contract: any exception → log at WARNING; immediate fire becomes a no-op.
         ``state_reader`` handles state-read errors; the outer try/except catches

--- a/src/hassette/bus/duration_hold.py
+++ b/src/hassette/bus/duration_hold.py
@@ -2,15 +2,11 @@
 
 from collections.abc import Awaitable, Callable
 from typing import TYPE_CHECKING, Any
-from uuid import uuid4
 
-import hassette.utils.date_utils as _date_utils
 from hassette.bus.invocation import build_tracked_invoke_fn
 from hassette.bus.listeners import DurationConfig, Listener, Subscription
 from hassette.bus.router import Router
-from hassette.events import HassPayload
-from hassette.events.base import Event, HassContext
-from hassette.events.hass.hass import RawStateChangeEvent, RawStateChangePayload
+from hassette.events.base import Event
 from hassette.types import Topic
 
 if TYPE_CHECKING:
@@ -38,6 +34,8 @@ class DurationHoldManager:
         router: Router,
         task_bucket: "TaskBucket",
         logger: "logging.Logger",
+        make_synthetic_event: "Callable[[str, HassStateDict], Event[Any]]",
+        compute_elapsed: "Callable[[HassStateDict, DurationConfig], float]",
     ) -> None:
         """Initialize the DurationHoldManager.
 
@@ -52,6 +50,12 @@ class DurationHoldManager:
             router: Router for synchronous cancel-listener route insertion.
             task_bucket: TaskBucket for spawning background tasks.
             logger: Logger for structured logging.
+            make_synthetic_event: Builds a synthetic state-change event with old_state=None
+                from an entity_id and its current state dict. Injected from core so the bus
+                kernel does not import HA event types.
+            compute_elapsed: Computes how long an entity has been in its current state,
+                reading HA-specific fields from the state dict. Injected from core so the
+                bus kernel does not import HA event types.
         """
         self.executor = executor
         self.config_resolver = config_resolver
@@ -60,6 +64,8 @@ class DurationHoldManager:
         self.router = router
         self.task_bucket = task_bucket
         self.logger = logger
+        self.make_synthetic_event = make_synthetic_event
+        self.compute_elapsed = compute_elapsed
         self._duration_timers_active: int = 0
 
     @property
@@ -71,23 +77,6 @@ class DurationHoldManager:
         """Decrement the active timer counter on cancellation."""
         if self._duration_timers_active > 0:
             self._duration_timers_active -= 1
-
-    def make_synthetic_state_event(self, entity_id: str, current_state: "HassStateDict") -> RawStateChangeEvent:
-        """Build a synthetic RawStateChangeEvent with old_state=None."""
-        return RawStateChangeEvent(
-            topic=f"{Topic.HASS_EVENT_STATE_CHANGED!s}.{entity_id}",
-            payload=HassPayload(
-                event_type="state_changed",
-                data=RawStateChangePayload(
-                    entity_id=entity_id,
-                    old_state=None,
-                    new_state=current_state,
-                ),
-                origin="LOCAL",
-                time_fired=_date_utils.now(),
-                context=HassContext(id=str(uuid4()), parent_id=None, user_id=None),
-            ),
-        )
 
     def hold_matches(self, listener: Listener, event: Any) -> bool:
         """Check hold predicates (state-value only) against an event.
@@ -124,7 +113,7 @@ class DurationHoldManager:
             return
 
         try:
-            synthetic_event = self.make_synthetic_state_event(entity_id, current_state)
+            synthetic_event = self.make_synthetic_event(entity_id, current_state)
             if not listener.matches(synthetic_event):
                 return
 
@@ -138,7 +127,7 @@ class DurationHoldManager:
             )
 
             if duration_config is not None and duration_config.duration is not None:
-                elapsed = compute_elapsed(current_state, duration_config)
+                elapsed = self.compute_elapsed(current_state, duration_config)
                 if elapsed >= duration_config.duration:
                     try:
                         await listener.invoker.dispatch(invoke_fn)
@@ -214,7 +203,7 @@ class DurationHoldManager:
                         entity_id,
                     )
                     return
-                recheck_event = self.make_synthetic_state_event(entity_id, current_state)
+                recheck_event = self.make_synthetic_event(entity_id, current_state)
                 if not self.hold_matches(listener, recheck_event):
                     self.logger.debug(
                         "duration_fire: entity %s predicate no longer matches, dropping fire",
@@ -278,27 +267,3 @@ class DurationHoldManager:
             self.router.remove_listener_by_id(cancel_listener.topic, cancel_listener.listener_id)
 
         return Subscription(cancel_listener, unsubscribe)
-
-
-def compute_elapsed(current_state: "HassStateDict", duration_config: DurationConfig) -> float:
-    """Compute how long an entity has been in its current state.
-
-    For attribute listeners, returns 0.0 (elapsed time is not tracked the same way).
-    Returns a value clamped to [0.0, duration_config.duration].
-    Caller must ensure duration_config.duration is not None.
-    """
-    duration = duration_config.duration
-    if duration is None:
-        return 0.0
-
-    if duration_config.is_attribute_listener:
-        return 0.0
-
-    last_changed_raw = current_state.get("last_changed")
-    if not isinstance(last_changed_raw, str):
-        return 0.0
-
-    last_changed = _date_utils.convert_datetime_str_to_system_tz(last_changed_raw)
-    now_dt = _date_utils.now()
-    raw_elapsed = (now_dt - last_changed).total("seconds")
-    return max(0.0, min(raw_elapsed, duration))

--- a/src/hassette/bus/duration_timer.py
+++ b/src/hassette/bus/duration_timer.py
@@ -10,9 +10,6 @@ import asyncio
 import typing
 from logging import getLogger
 
-from hassette.events import HassPayload
-from hassette.events.hass.hass import RawStateChangeEvent, RawStateChangePayload
-
 if typing.TYPE_CHECKING:
     from collections.abc import Awaitable, Callable
     from typing import Any
@@ -56,6 +53,7 @@ class DurationTimer:
         owner_id: str,
         create_cancel_sub: "Callable[[], Subscription]",
         on_cancel: "Callable[[], None] | None" = None,
+        normalize_cancel_event: "Callable[[Event[Any]], Event[Any]] | None" = None,
     ) -> None:
         """Initialize the DurationTimer.
 
@@ -72,6 +70,9 @@ class DurationTimer:
                 mock that returns a ``MagicMock()`` acting as a ``Subscription``.
             on_cancel: Optional callback invoked when an active timer is cancelled
                 (not fired).  Used by BusService to decrement the active timer counter.
+            normalize_cancel_event: Strips HA-specific transition state (e.g. old_state)
+                from an event before cancel predicate evaluation. When None, the event
+                is passed through unchanged.
         """
         self.task_bucket = task_bucket
         self.duration = duration
@@ -80,6 +81,7 @@ class DurationTimer:
         self.owner_id = owner_id
         self._create_cancel_sub = create_cancel_sub
         self._on_cancel = on_cancel
+        self._normalize_cancel_event = normalize_cancel_event
 
         self._task: asyncio.Task[None] | None = None
         self._cancel_sub: Subscription | None = None
@@ -199,22 +201,7 @@ class DurationTimer:
         if self._cancelled:
             return
 
-        eval_event = event
-        if isinstance(event, RawStateChangeEvent) and event.payload.data.old_state is not None:
-            eval_event = RawStateChangeEvent(
-                topic=event.topic,
-                payload=HassPayload(
-                    event_type=event.payload.event_type,
-                    data=RawStateChangePayload(
-                        entity_id=event.payload.data.entity_id,
-                        old_state=None,
-                        new_state=event.payload.data.new_state,
-                    ),
-                    origin=event.payload.origin,
-                    time_fired=event.payload.time_fired,
-                    context=event.payload.context,
-                ),
-            )
+        eval_event = self._normalize_cancel_event(event) if self._normalize_cancel_event is not None else event
 
         if self.predicates is not None and not self.predicates(eval_event):
             LOGGER.debug(

--- a/src/hassette/bus/duration_timer.py
+++ b/src/hassette/bus/duration_timer.py
@@ -189,9 +189,11 @@ class DurationTimer:
         against the new event.  If the predicates no longer match, the entity has
         left the target state and the timer is cancelled.
 
-        For ``RawStateChangeEvent`` with a non-None ``old_state``, strips
-        ``old_state`` to None before evaluation so that transition predicates
-        (if any leak through) and "did it change?" predicates do not falsely cancel.
+        When a ``normalize_cancel_event`` callable was injected at construction,
+        it transforms the event before predicate evaluation — e.g. stripping
+        ``old_state`` so that transition predicates do not falsely cancel.
+        Without the callable the event is evaluated as-is.
+
         The semantics: "is the entity STILL in the target state?" — not "did it
         change TO the target state?".
 

--- a/src/hassette/bus/listeners.py
+++ b/src/hassette/bus/listeners.py
@@ -389,6 +389,7 @@ class DurationConfig:
         owner_id: str,
         create_cancel_sub: "Callable[[], Subscription]",
         on_cancel: Callable[[], None] | None = None,
+        normalize_cancel_event: "Callable[[Event[Any]], Event[Any]] | None" = None,
     ) -> None:
         """Construct a DurationTimer and store it.
 
@@ -406,6 +407,7 @@ class DurationConfig:
             owner_id=owner_id,
             create_cancel_sub=create_cancel_sub,
             on_cancel=on_cancel,
+            normalize_cancel_event=normalize_cancel_event,
         )
 
 

--- a/src/hassette/core/bus_service.py
+++ b/src/hassette/core/bus_service.py
@@ -45,6 +45,7 @@ _DISPATCH_SATURATION_WARN_RATE_LIMIT_SECS = 30.0
 
 _HASS_TOPIC_PREFIX = "hass."
 _HASSETTE_TOPIC_PREFIX = "hassette."
+_HASS_EVENT_STATE_CHANGED = "state_changed"
 
 
 class BusService(Service):
@@ -443,7 +444,7 @@ class BusService(Service):
         if not isinstance(payload, HassPayload):
             return [topic]
 
-        if payload.event_type != "state_changed":
+        if payload.event_type != _HASS_EVENT_STATE_CHANGED:
             return [topic]
 
         entity_id = payload.entity_id
@@ -605,7 +606,7 @@ def make_synthetic_state_event(entity_id: str, current_state: "HassStateDict") -
     return RawStateChangeEvent(
         topic=f"{Topic.HASS_EVENT_STATE_CHANGED!s}.{entity_id}",
         payload=HassPayload(
-            event_type="state_changed",
+            event_type=_HASS_EVENT_STATE_CHANGED,
             data=RawStateChangePayload(
                 entity_id=entity_id,
                 old_state=None,

--- a/src/hassette/core/bus_service.py
+++ b/src/hassette/core/bus_service.py
@@ -3,10 +3,12 @@ import time
 import typing
 from collections import defaultdict
 from typing import Any, ClassVar
+from uuid import uuid4
 
+import hassette.utils.date_utils as _date_utils
 from hassette.bus.duration_hold import DurationHoldManager
 from hassette.bus.invocation import build_tracked_invoke_fn
-from hassette.bus.listeners import Listener, Subscription
+from hassette.bus.listeners import DurationConfig, Listener, Subscription
 from hassette.bus.router import Router
 from hassette.core.database_service import DatabaseService
 from hassette.core.event_filter import EventFilter
@@ -14,11 +16,13 @@ from hassette.core.registration import ListenerRegistration
 from hassette.core.sync_executor_service import SyncExecutorService
 from hassette.event_handling.predicates import summarize_top_level
 from hassette.events import Event, HassPayload
+from hassette.events.base import HassContext
+from hassette.events.hass.hass import RawStateChangeEvent, RawStateChangePayload
 from hassette.exceptions import ResourceNotReadyError
 from hassette.resources.restart import RestartSpec
 from hassette.resources.service import Service
 from hassette.schemas.live_counts import LiveCounts
-from hassette.types.enums import BackpressurePolicy, RestartType
+from hassette.types.enums import BackpressurePolicy, RestartType, Topic
 from hassette.types.types import LOG_LEVEL_TYPE
 from hassette.utils.hass_utils import split_entity_id, valid_entity_id
 
@@ -106,6 +110,8 @@ class BusService(Service):
             router=self.router,
             task_bucket=self.task_bucket,
             logger=self.logger,
+            make_synthetic_event=make_synthetic_state_event,
+            compute_elapsed=compute_elapsed,
         )
 
         self._removal_callbacks = {}
@@ -187,6 +193,7 @@ class BusService(Service):
                 owner_id=listener.identity.owner_id,
                 create_cancel_sub=make_cancel_sub,
                 on_cancel=on_timer_cancel,
+                normalize_cancel_event=strip_old_state,
             )
 
         # Await DB registration inline — db_id is set before route insertion.
@@ -588,3 +595,76 @@ class BusService(Service):
                     await self.dispatch(str(event.topic), event)
                 except Exception as e:
                     self.logger.exception("Error processing event: %s", e)
+
+
+def make_synthetic_state_event(entity_id: str, current_state: "HassStateDict") -> RawStateChangeEvent:
+    """Build a synthetic RawStateChangeEvent with old_state=None.
+
+    Injected into the bus kernel so it stays free of HA event type imports.
+    """
+    return RawStateChangeEvent(
+        topic=f"{Topic.HASS_EVENT_STATE_CHANGED!s}.{entity_id}",
+        payload=HassPayload(
+            event_type="state_changed",
+            data=RawStateChangePayload(
+                entity_id=entity_id,
+                old_state=None,
+                new_state=current_state,
+            ),
+            origin="LOCAL",
+            time_fired=_date_utils.now(),
+            context=HassContext(id=str(uuid4()), parent_id=None, user_id=None),
+        ),
+    )
+
+
+def compute_elapsed(current_state: "HassStateDict", duration_config: DurationConfig) -> float:
+    """Compute how long an entity has been in its current state.
+
+    Reads the HA-specific ``last_changed`` field from the state dict. Injected
+    into the bus kernel so it stays free of HA event type imports.
+
+    For attribute listeners, returns 0.0 (elapsed time is not tracked the same way).
+    Returns a value clamped to [0.0, duration_config.duration].
+    """
+    duration = duration_config.duration
+    if duration is None:
+        return 0.0
+
+    if duration_config.is_attribute_listener:
+        return 0.0
+
+    last_changed_raw = current_state.get("last_changed")
+    if not isinstance(last_changed_raw, str):
+        return 0.0
+
+    last_changed = _date_utils.convert_datetime_str_to_system_tz(last_changed_raw)
+    now_dt = _date_utils.now()
+    raw_elapsed = (now_dt - last_changed).total("seconds")
+    return max(0.0, min(raw_elapsed, duration))
+
+
+def strip_old_state(event: Event[Any]) -> Event[Any]:
+    """Strip old_state from a RawStateChangeEvent for cancel-predicate evaluation.
+
+    For ``RawStateChangeEvent`` with a non-None ``old_state``, returns a copy with
+    ``old_state=None`` so that transition predicates (``StateFrom``, ``StateDidChange``)
+    do not falsely cancel a duration timer. For all other events, returns the event
+    unchanged.
+    """
+    if isinstance(event, RawStateChangeEvent) and event.payload.data.old_state is not None:
+        return RawStateChangeEvent(
+            topic=event.topic,
+            payload=HassPayload(
+                event_type=event.payload.event_type,
+                data=RawStateChangePayload(
+                    entity_id=event.payload.data.entity_id,
+                    old_state=None,
+                    new_state=event.payload.data.new_state,
+                ),
+                origin=event.payload.origin,
+                time_fired=event.payload.time_fired,
+                context=event.payload.context,
+            ),
+        )
+    return event

--- a/tests/unit/bus/test_duration_hold.py
+++ b/tests/unit/bus/test_duration_hold.py
@@ -64,18 +64,24 @@ def make_manager(
     state: dict[str, Any] | None = None,
     remove_listener: Callable[[Listener], None] | None = None,
     task_bucket: Any = None,
+    executor: Any = None,
+    router: Router | None = None,
 ) -> DurationHoldManager:
     """Build a DurationHoldManager with default mocks."""
     if remove_listener is None:
         remove_listener = make_remove_listener()
     if task_bucket is None:
         task_bucket = make_task_bucket_with_spawn()
+    if executor is None:
+        executor = make_executor()
+    if router is None:
+        router = Router()
     return DurationHoldManager(
-        executor=make_executor(),
+        executor=executor,
         config_resolver=make_config_resolver(),
         state_reader=make_state_reader(state),
         remove_listener=remove_listener,
-        router=Router(),
+        router=router,
         task_bucket=task_bucket,
         logger=logging.getLogger("test"),
         make_synthetic_event=make_synthetic_state_event,
@@ -100,17 +106,7 @@ class TestImmediateFireTask:
     async def test_returns_early_when_state_reader_returns_none(self) -> None:
         """immediate_fire_task returns early (no dispatch) when state_reader returns None."""
         executor = make_executor()
-        manager = DurationHoldManager(
-            executor=executor,
-            config_resolver=make_config_resolver(),
-            state_reader=make_state_reader(None),
-            remove_listener=make_remove_listener(),
-            router=Router(),
-            task_bucket=make_task_bucket_with_spawn(),
-            logger=logging.getLogger("test"),
-            make_synthetic_event=make_synthetic_state_event,
-            compute_elapsed=compute_elapsed,
-        )
+        manager = make_manager(executor=executor)
         listener = create_listener(
             topic="hass.event.state_changed.light.kitchen",
             entity_id="light.kitchen",
@@ -125,17 +121,7 @@ class TestImmediateFireTask:
         """immediate_fire_task calls state_reader and dispatches when state exists and predicate matches."""
         executor = make_executor()
         state = make_state_dict("light.kitchen", "on")
-        manager = DurationHoldManager(
-            executor=executor,
-            config_resolver=make_config_resolver(),
-            state_reader=make_state_reader(state),
-            remove_listener=make_remove_listener(),
-            router=Router(),
-            task_bucket=make_task_bucket_with_spawn(),
-            logger=logging.getLogger("test"),
-            make_synthetic_event=make_synthetic_state_event,
-            compute_elapsed=compute_elapsed,
-        )
+        manager = make_manager(state=state, executor=executor)
         listener = create_listener(
             topic="hass.event.state_changed.light.kitchen",
             entity_id="light.kitchen",
@@ -149,17 +135,7 @@ class TestImmediateFireTask:
     async def test_logs_error_and_returns_when_no_entity_id(self) -> None:
         """immediate_fire_task logs error and returns early when listener has no entity_id."""
         executor = make_executor()
-        manager = DurationHoldManager(
-            executor=executor,
-            config_resolver=make_config_resolver(),
-            state_reader=make_state_reader(make_state_dict("light.kitchen", "on")),
-            remove_listener=make_remove_listener(),
-            router=Router(),
-            task_bucket=make_task_bucket_with_spawn(),
-            logger=logging.getLogger("test"),
-            make_synthetic_event=make_synthetic_state_event,
-            compute_elapsed=compute_elapsed,
-        )
+        manager = make_manager(state=make_state_dict("light.kitchen", "on"), executor=executor)
         # Listener without entity_id (no duration_config)
         listener = create_listener(
             topic="hass.event.state_changed.light.kitchen",
@@ -176,17 +152,7 @@ class TestImmediateFireTask:
         executor = make_executor()
         state = make_state_dict("light.kitchen", "on")
         remove_listener = make_remove_listener()
-        manager = DurationHoldManager(
-            executor=executor,
-            config_resolver=make_config_resolver(),
-            state_reader=make_state_reader(state),
-            remove_listener=remove_listener,
-            router=Router(),
-            task_bucket=make_task_bucket_with_spawn(),
-            logger=logging.getLogger("test"),
-            make_synthetic_event=make_synthetic_state_event,
-            compute_elapsed=compute_elapsed,
-        )
+        manager = make_manager(state=state, executor=executor, remove_listener=remove_listener)
         listener = create_listener(
             topic="hass.event.state_changed.light.kitchen",
             entity_id="light.kitchen",
@@ -206,17 +172,7 @@ class TestImmediateFireTask:
         # Predicate that never matches
         never_match = MagicMock(return_value=False)
 
-        manager = DurationHoldManager(
-            executor=executor,
-            config_resolver=make_config_resolver(),
-            state_reader=make_state_reader(state),
-            remove_listener=make_remove_listener(),
-            router=Router(),
-            task_bucket=make_task_bucket_with_spawn(),
-            logger=logging.getLogger("test"),
-            make_synthetic_event=make_synthetic_state_event,
-            compute_elapsed=compute_elapsed,
-        )
+        manager = make_manager(state=state, executor=executor)
         listener = create_listener(
             topic="hass.event.state_changed.light.kitchen",
             entity_id="light.kitchen",
@@ -449,17 +405,7 @@ class TestCreateCancelListener:
         """create_cancel_listener inserts a route and returns a Subscription."""
         router = Router()
         task_bucket = make_task_bucket_with_spawn()
-        manager = DurationHoldManager(
-            executor=make_executor(),
-            config_resolver=make_config_resolver(),
-            state_reader=make_state_reader(),
-            remove_listener=make_remove_listener(),
-            router=router,
-            task_bucket=task_bucket,
-            logger=logging.getLogger("test"),
-            make_synthetic_event=make_synthetic_state_event,
-            compute_elapsed=compute_elapsed,
-        )
+        manager = make_manager(router=router, task_bucket=task_bucket)
 
         # Build a listener with a duration timer attached
         listener = create_listener(
@@ -489,17 +435,7 @@ class TestCreateCancelListener:
         """Calling sub.cancel() removes the cancel listener from the router."""
         router = Router()
         task_bucket = make_task_bucket_with_spawn()
-        manager = DurationHoldManager(
-            executor=make_executor(),
-            config_resolver=make_config_resolver(),
-            state_reader=make_state_reader(),
-            remove_listener=make_remove_listener(),
-            router=router,
-            task_bucket=task_bucket,
-            logger=logging.getLogger("test"),
-            make_synthetic_event=make_synthetic_state_event,
-            compute_elapsed=compute_elapsed,
-        )
+        manager = make_manager(router=router, task_bucket=task_bucket)
 
         listener = create_listener(
             topic="hass.event.state_changed.light.kitchen",
@@ -527,17 +463,7 @@ class TestCreateCancelListener:
         Cancel-listeners bypass DB registration entirely; no registration_task field.
         """
         task_bucket = make_task_bucket_with_spawn()
-        manager = DurationHoldManager(
-            executor=make_executor(),
-            config_resolver=make_config_resolver(),
-            state_reader=make_state_reader(),
-            remove_listener=make_remove_listener(),
-            router=Router(),
-            task_bucket=task_bucket,
-            logger=logging.getLogger("test"),
-            make_synthetic_event=make_synthetic_state_event,
-            compute_elapsed=compute_elapsed,
-        )
+        manager = make_manager(task_bucket=task_bucket)
         listener = create_listener(
             topic="hass.event.state_changed.light.kitchen",
             entity_id="light.kitchen",

--- a/tests/unit/bus/test_duration_hold.py
+++ b/tests/unit/bus/test_duration_hold.py
@@ -17,9 +17,10 @@ from typing import Any
 from unittest.mock import AsyncMock, MagicMock
 
 import hassette.utils.date_utils as _date_utils
-from hassette.bus.duration_hold import DurationHoldManager, compute_elapsed
+from hassette.bus.duration_hold import DurationHoldManager
 from hassette.bus.listeners import DurationConfig, Listener, Subscription
 from hassette.bus.router import Router
+from hassette.core.bus_service import compute_elapsed, make_synthetic_state_event
 from hassette.test_utils.helpers import create_listener, make_state_dict
 
 
@@ -77,6 +78,8 @@ def make_manager(
         router=Router(),
         task_bucket=task_bucket,
         logger=logging.getLogger("test"),
+        make_synthetic_event=make_synthetic_state_event,
+        compute_elapsed=compute_elapsed,
     )
 
 
@@ -105,6 +108,8 @@ class TestImmediateFireTask:
             router=Router(),
             task_bucket=make_task_bucket_with_spawn(),
             logger=logging.getLogger("test"),
+            make_synthetic_event=make_synthetic_state_event,
+            compute_elapsed=compute_elapsed,
         )
         listener = create_listener(
             topic="hass.event.state_changed.light.kitchen",
@@ -128,6 +133,8 @@ class TestImmediateFireTask:
             router=Router(),
             task_bucket=make_task_bucket_with_spawn(),
             logger=logging.getLogger("test"),
+            make_synthetic_event=make_synthetic_state_event,
+            compute_elapsed=compute_elapsed,
         )
         listener = create_listener(
             topic="hass.event.state_changed.light.kitchen",
@@ -150,6 +157,8 @@ class TestImmediateFireTask:
             router=Router(),
             task_bucket=make_task_bucket_with_spawn(),
             logger=logging.getLogger("test"),
+            make_synthetic_event=make_synthetic_state_event,
+            compute_elapsed=compute_elapsed,
         )
         # Listener without entity_id (no duration_config)
         listener = create_listener(
@@ -175,6 +184,8 @@ class TestImmediateFireTask:
             router=Router(),
             task_bucket=make_task_bucket_with_spawn(),
             logger=logging.getLogger("test"),
+            make_synthetic_event=make_synthetic_state_event,
+            compute_elapsed=compute_elapsed,
         )
         listener = create_listener(
             topic="hass.event.state_changed.light.kitchen",
@@ -203,6 +214,8 @@ class TestImmediateFireTask:
             router=Router(),
             task_bucket=make_task_bucket_with_spawn(),
             logger=logging.getLogger("test"),
+            make_synthetic_event=make_synthetic_state_event,
+            compute_elapsed=compute_elapsed,
         )
         listener = create_listener(
             topic="hass.event.state_changed.light.kitchen",
@@ -444,6 +457,8 @@ class TestCreateCancelListener:
             router=router,
             task_bucket=task_bucket,
             logger=logging.getLogger("test"),
+            make_synthetic_event=make_synthetic_state_event,
+            compute_elapsed=compute_elapsed,
         )
 
         # Build a listener with a duration timer attached
@@ -482,6 +497,8 @@ class TestCreateCancelListener:
             router=router,
             task_bucket=task_bucket,
             logger=logging.getLogger("test"),
+            make_synthetic_event=make_synthetic_state_event,
+            compute_elapsed=compute_elapsed,
         )
 
         listener = create_listener(
@@ -518,6 +535,8 @@ class TestCreateCancelListener:
             router=Router(),
             task_bucket=task_bucket,
             logger=logging.getLogger("test"),
+            make_synthetic_event=make_synthetic_state_event,
+            compute_elapsed=compute_elapsed,
         )
         listener = create_listener(
             topic="hass.event.state_changed.light.kitchen",

--- a/tests/unit/bus/test_duration_timer.py
+++ b/tests/unit/bus/test_duration_timer.py
@@ -25,6 +25,7 @@ def make_timer(
     predicates=None,
     entity_id: str = "light.kitchen",
     owner_id: str = "test_owner",
+    normalize_cancel_event=None,
 ) -> tuple[DurationTimer, MagicMock, MagicMock]:
     """Create a DurationTimer with a real task_bucket (using asyncio directly for spawning)
     and mock cancellation subscription.
@@ -51,6 +52,7 @@ def make_timer(
         entity_id=entity_id,
         owner_id=owner_id,
         create_cancel_sub=create_cancel_sub,
+        normalize_cancel_event=normalize_cancel_event,
     )
     return timer, task_bucket_mock, cancel_sub_mock
 

--- a/tests/unit/core/conftest.py
+++ b/tests/unit/core/conftest.py
@@ -10,7 +10,7 @@ import pytest
 from hassette.bus.duration_hold import DurationHoldManager
 from hassette.bus.router import Router
 from hassette.core.app_lifecycle_service import AppLifecycleService
-from hassette.core.bus_service import BusService
+from hassette.core.bus_service import BusService, compute_elapsed, make_synthetic_state_event
 from hassette.core.command_executor import CommandExecutor
 from hassette.core.event_filter import EventFilter
 from hassette.core.service_watcher import ServiceWatcher
@@ -342,6 +342,8 @@ def make_bus_service(*, config_timeout: float | None = 600.0, max_concurrent_dis
         router=svc.router,
         task_bucket=task_bucket,
         logger=svc.logger,
+        make_synthetic_event=make_synthetic_state_event,
+        compute_elapsed=compute_elapsed,
     )
     svc._dispatch_pending = 0
     svc._dispatch_idle_event = asyncio.Event()

--- a/tests/unit/tools/test_check_module_boundaries.py
+++ b/tests/unit/tools/test_check_module_boundaries.py
@@ -2,7 +2,7 @@
 
 Pin the boundary rules in ``RULES`` (test_utils-isolation, api-no-core,
 utils-no-events, web-no-core, bus-no-core, resources-no-task_bucket,
-scheduler-no-core, state_manager-no-core): the governed layer must not import
+scheduler-no-core, state_manager-no-core, bus-no-ha-events): the governed layer must not import
 the forbidden package at runtime, while type-only imports under ``TYPE_CHECKING``
 and a layer importing itself are exempt.
 
@@ -343,6 +343,46 @@ def test_scheduler_type_checking_core_import_exempt() -> None:
         """
     )
     assert check_source(src, "scheduler") == []
+
+
+def test_bus_import_of_ha_events_flagged() -> None:
+    src = "from hassette.events.hass.hass import RawStateChangeEvent\n"
+    assert check_source(src, "bus") == [
+        (
+            1,
+            "bus-no-ha-events: imports hassette.events.hass.hass — "
+            "bus is a generic pub/sub kernel; HA event types are injected from core (#1136)",
+        )
+    ]
+
+
+def test_bus_import_of_ha_events_submodule_flagged() -> None:
+    src = "from hassette.events.hass.raw import HassStateDict\n"
+    assert check_source(src, "bus") == [
+        (
+            1,
+            "bus-no-ha-events: imports hassette.events.hass.raw — "
+            "bus is a generic pub/sub kernel; HA event types are injected from core (#1136)",
+        )
+    ]
+
+
+def test_bus_type_checking_ha_events_import_exempt() -> None:
+    src = textwrap.dedent(
+        """\
+        from typing import TYPE_CHECKING
+
+        if TYPE_CHECKING:
+            from hassette.events.hass.raw import HassStateDict
+        """
+    )
+    assert check_source(src, "bus") == []
+
+
+def test_bus_import_of_base_events_not_flagged() -> None:
+    """Bus may import generic event types from hassette.events and hassette.events.base."""
+    src = "from hassette.events.base import Event\n"
+    assert check_source(src, "bus") == []
 
 
 @pytest.mark.parametrize("path", iter_paths(), ids=lambda p: str(p))

--- a/tools/check_module_boundaries.py
+++ b/tools/check_module_boundaries.py
@@ -16,11 +16,11 @@ Import boundaries enforced today (``RULES``):
 - ``utils → events`` — utils sits below events; ``is_event_type`` has moved to events/.
 - ``web → core`` — web-facing data types live in hassette.schemas, not core.
 - ``bus → core`` — bus is a service layer and must not import core at runtime (#1089).
+- ``bus → events.hass`` — bus is a generic pub/sub kernel; HA event types are injected from core (#1136).
 - ``resources → task_bucket`` — task_bucket injects its constructor via register_task_bucket_factory (#1079).
 - ``scheduler → core`` — scheduler consumes SchedulerService via SchedulerServiceProtocol in types (#1079).
 - ``state_manager → core`` — state_manager consumes StateProxy via StateReader in types (#1079).
 - ``models → conversion`` — models/states is a leaf below the codec; the conversion ↔ models cycle is resolved (#892).
-- ``bus → events.hass`` — bus is a generic pub/sub kernel; HA event types are injected from core (#1136).
 
 The full layer DAG is NOT enforced here yet. The two service-layer core cycles
 (``scheduler``↔``core`` and ``state_manager``↔``core``) are resolved via protocol
@@ -112,6 +112,12 @@ RULES: list[Rule] = [
         reason="bus must not import core at runtime; core sits above the service layer (#1089)",
     ),
     Rule(
+        name="bus-no-ha-events",
+        applies=lambda layer: layer == "bus",
+        forbids=lambda module: module == "hassette.events.hass" or module.startswith("hassette.events.hass."),
+        reason="bus is a generic pub/sub kernel; HA event types are injected from core (#1136)",
+    ),
+    Rule(
         name="resources-no-task_bucket",
         applies=lambda layer: layer == "resources",
         forbids=lambda module: module == "hassette.task_bucket" or module.startswith("hassette.task_bucket."),
@@ -134,12 +140,6 @@ RULES: list[Rule] = [
         applies=lambda layer: layer == "models",
         forbids=lambda module: module == "hassette.conversion" or module.startswith("hassette.conversion."),
         reason="models/states is a leaf below the codec; conversion ↔ models cycle resolved (#892)",
-    ),
-    Rule(
-        name="bus-no-ha-events",
-        applies=lambda layer: layer == "bus",
-        forbids=lambda module: module == "hassette.events.hass" or module.startswith("hassette.events.hass."),
-        reason="bus is a generic pub/sub kernel; HA event types are injected from core (#1136)",
     ),
 ]
 

--- a/tools/check_module_boundaries.py
+++ b/tools/check_module_boundaries.py
@@ -20,6 +20,7 @@ Import boundaries enforced today (``RULES``):
 - ``scheduler → core`` — scheduler consumes SchedulerService via SchedulerServiceProtocol in types (#1079).
 - ``state_manager → core`` — state_manager consumes StateProxy via StateReader in types (#1079).
 - ``models → conversion`` — models/states is a leaf below the codec; the conversion ↔ models cycle is resolved (#892).
+- ``bus → events.hass`` — bus is a generic pub/sub kernel; HA event types are injected from core (#1136).
 
 The full layer DAG is NOT enforced here yet. The two service-layer core cycles
 (``scheduler``↔``core`` and ``state_manager``↔``core``) are resolved via protocol
@@ -133,6 +134,12 @@ RULES: list[Rule] = [
         applies=lambda layer: layer == "models",
         forbids=lambda module: module == "hassette.conversion" or module.startswith("hassette.conversion."),
         reason="models/states is a leaf below the codec; conversion ↔ models cycle resolved (#892)",
+    ),
+    Rule(
+        name="bus-no-ha-events",
+        applies=lambda layer: layer == "bus",
+        forbids=lambda module: module == "hassette.events.hass" or module.startswith("hassette.events.hass."),
+        reason="bus is a generic pub/sub kernel; HA event types are injected from core (#1136)",
     ),
 ]
 


### PR DESCRIPTION
### Bus kernel no longer imports HA event types

- `duration_hold.py` and `duration_timer.py` previously imported `RawStateChangeEvent` / `RawStateChangePayload` directly from `hassette.events.hass.hass`, coupling the generic pub/sub kernel to Home Assistant's event schema.
- Three HA-specific operations are now injected as callables from `core/bus_service.py` instead of being defined or imported in the bus layer:
  - `make_synthetic_event` — builds a synthetic state-change event with `old_state=None`
  - `compute_elapsed` — reads the HA-specific `last_changed` field to compute how long an entity has held its current state
  - `normalize_cancel_event` (`strip_old_state`) — strips `old_state` from a cancel event before predicate evaluation, so transition predicates don't falsely cancel a duration timer
- `DurationHoldManager`, `DurationTimer`, and `DurationConfig` now take these as constructor parameters, and `BusService` wires the concrete HA implementations at construction time.

### Structural lock on the boundary

- Added a `bus-no-ha-events` rule to `tools/check_module_boundaries.py` that forbids any `bus` module from importing `hassette.events.hass` (or submodules). This makes the boundary a CI-enforced invariant rather than a convention that can silently erode on the next change.

Closes #1136
