### PR TITLE
refactor: replace SYNC_WORKER_CELL list-cell with named SyncWorkerHandle

### DIFF
--- a/src/hassette/core/command_executor.py
+++ b/src/hassette/core/command_executor.py
@@ -32,7 +32,7 @@ from hassette.resources.restart import RestartSpec
 from hassette.resources.service import Service
 from hassette.scheduler.error_context import SchedulerErrorContext
 from hassette.schemas.telemetry_models import BlockingEvent
-from hassette.task_bucket.task_bucket import SYNC_WORKER_CELL
+from hassette.task_bucket.task_bucket import SYNC_WORKER_HANDLE
 from hassette.types.enums import RestartType
 from hassette.types.types import LOG_LEVEL_TYPE
 from hassette.utils.execution import ExecutionResult, track_execution
@@ -324,23 +324,23 @@ class CommandExecutor(Service):
         # result is available for both success and error paths
         if result.is_timed_out:
             # Check whether the sync worker thread is still alive after the timeout.
-            # The cell was set by run_in_thread on this same asyncio task (same context),
-            # so SYNC_WORKER_CELL.get() returns the same list object the worker mutates.
-            # cell[0] is None when: (a) the handler is async (no worker), or (b) the
+            # The handle was set by run_in_thread on this same asyncio task (same context),
+            # so SYNC_WORKER_HANDLE.get() returns the same SyncWorkerHandle the worker mutates.
+            # handle.thread is None when: (a) the handler is async (no worker), or (b) the
             # timeout fired before the worker dequeued _call (not-started timeout).
-            # Neither case is a leak; only a live cell[0] after the await is cancelled is.
-            cell = SYNC_WORKER_CELL.get()
-            if cell is not None and cell[0] is not None and cell[0].is_alive():
+            # Neither case is a leak; only a live thread after the await is cancelled is.
+            handle = SYNC_WORKER_HANDLE.get()
+            if handle is not None and handle.thread is not None and handle.thread.is_alive():
                 result.thread_leaked = True
                 self.logger.warning(
                     "Sync worker thread still alive after timeout (%.1fms elapsed, thread=%s) — "
                     "worker will run to completion on the dedicated executor",
                     result.duration_ms,
-                    cell[0].name,
+                    handle.thread.name,
                 )
-            # Clear the cell so a future invocation that reuses this asyncio context cannot
+            # Clear the handle so a future invocation that reuses this asyncio context cannot
             # read a stale worker reference and report a false thread_leaked.
-            SYNC_WORKER_CELL.set(None)
+            SYNC_WORKER_HANDLE.set(None)
             if cmd.effective_timeout is not None:
                 self.log_timeout_rate_limited(cmd, result)
             else:

--- a/src/hassette/core/command_executor.py
+++ b/src/hassette/core/command_executor.py
@@ -338,9 +338,6 @@ class CommandExecutor(Service):
                     result.duration_ms,
                     handle.thread.name,
                 )
-            # Clear the handle so a future invocation that reuses this asyncio context cannot
-            # read a stale worker reference and report a false thread_leaked.
-            SYNC_WORKER_HANDLE.set(None)
             if cmd.effective_timeout is not None:
                 self.log_timeout_rate_limited(cmd, result)
             else:
@@ -349,6 +346,9 @@ class CommandExecutor(Service):
                     "exception originated from user code)",
                     result.duration_ms,
                 )
+        # Clear the handle unconditionally so a future invocation that reuses this asyncio
+        # context cannot read a stale worker reference and report a false thread_leaked.
+        SYNC_WORKER_HANDLE.set(None)
         if result.is_error:
             log_error(result)
         self.enqueue_record(self.build_record(cmd, result, execution_start_ts, execution_id))

--- a/src/hassette/task_bucket/task_bucket.py
+++ b/src/hassette/task_bucket/task_bucket.py
@@ -7,6 +7,7 @@ from collections.abc import Awaitable, Callable, Coroutine
 from concurrent.futures import Future
 from concurrent.futures import TimeoutError as CfTimeoutError  # aliased to distinguish from builtin TimeoutError
 from contextvars import ContextVar, copy_context
+from dataclasses import dataclass
 from typing import Any, ParamSpec, TypeVar, cast, overload
 
 from hassette import context as ctx
@@ -14,18 +15,29 @@ from hassette.resources.base import Resource
 from hassette.types.types import LOG_LEVEL_TYPE, CoroLikeT
 from hassette.utils.func_utils import is_async_callable
 
-SYNC_WORKER_CELL: ContextVar[list[threading.Thread | None] | None] = ContextVar("sync_worker_cell", default=None)
-"""Carries the shared mutable cell for the current sync submission from the loop thread to _execute.
 
-Set on the loop thread in ``run_in_thread`` immediately after creating the cell.  The cell
-itself is a ``list[threading.Thread | None]`` whose first element is set by the worker thread
-when ``_call`` starts executing.  ``_execute`` (same asyncio task, same context snapshot) reads
-this ContextVar to reach ``cell[0]`` at the timeout site.
+@dataclass
+class SyncWorkerHandle:
+    """Shared handle between the loop thread and a sync worker for thread-identity tracking.
 
-The worker accesses the cell via closure, not via this ContextVar.  The ContextVar exists so
-that ``_execute`` (running on the loop thread, in the same asyncio task) can read back the cell
-reference.  The worker mutates ``cell[0]`` (a plain list element), which is immediately visible
-to the loop thread because both sides share the same list object.
+    Created by ``run_in_thread`` on the loop thread and stored in ``SYNC_WORKER_HANDLE``.
+    The worker thread sets ``handle.thread`` via closure; ``_execute`` reads it at the
+    timeout site to check liveness.
+    """
+
+    thread: threading.Thread | None = None
+
+
+SYNC_WORKER_HANDLE: ContextVar[SyncWorkerHandle | None] = ContextVar("sync_worker_handle", default=None)
+"""Carries the worker handle for the current sync submission from the loop thread to _execute.
+
+Set on the loop thread in ``run_in_thread`` immediately after creating the handle.
+``_execute`` (same asyncio task, same context snapshot) reads this ContextVar to check
+``handle.thread.is_alive()`` at the timeout site.
+
+The worker accesses the handle via closure, not via this ContextVar.  The ContextVar exists so
+that ``_execute`` (running on the loop thread, in the same asyncio task) can read back the
+handle reference.
 """
 
 if typing.TYPE_CHECKING:
@@ -181,8 +193,8 @@ class TaskBucket(Resource):
         *fn* inside it so that all contextvars set on the loop thread are visible to
         sync user code.
 
-        **Thread cell:** see :data:`SYNC_WORKER_CELL` module docstring for the
-        shared-mutable-cell mechanism used by the timeout site.
+        **Thread handle:** see :class:`SyncWorkerHandle` and :data:`SYNC_WORKER_HANDLE`
+        for the shared-handle mechanism used by the timeout site.
 
         Args:
             fn: The synchronous function to run.
@@ -193,11 +205,11 @@ class TaskBucket(Resource):
             An :class:`asyncio.Future` that resolves to the return value of *fn*.
         """
         parent_ctx = copy_context()
-        cell: list[threading.Thread | None] = [None]
-        SYNC_WORKER_CELL.set(cell)
+        handle = SyncWorkerHandle()
+        SYNC_WORKER_HANDLE.set(handle)
 
         def _call() -> R:
-            cell[0] = threading.current_thread()
+            handle.thread = threading.current_thread()
             return parent_ctx.run(fn, *args, **kwargs)
 
         # Submit to the dedicated executor so sync user code is isolated from

--- a/src/hassette/utils/execution.py
+++ b/src/hassette/utils/execution.py
@@ -38,9 +38,9 @@ class ExecutionResult:
     thread_leaked: bool = False
     """True when the execution timed out and the sync worker thread was still alive after the timeout.
 
-    Set by ``CommandExecutor._execute`` at the timeout site after reading the shared mutable cell
-    (``list[threading.Thread | None]``) exposed by ``TaskBucket.run_in_thread``.  False for async
-    handlers, not-started timeouts (``cell[0]`` is ``None``), and all non-timed-out executions.
+    Set by ``CommandExecutor._execute`` at the timeout site after reading the
+    ``SyncWorkerHandle`` exposed by ``TaskBucket.run_in_thread``.  False for async handlers,
+    not-started timeouts (``handle.thread`` is ``None``), and all non-timed-out executions.
 
     Subject to a small race window: if the worker finishes between the timeout cancellation and the
     liveness check, this flag reads False even though the thread outlived the asyncio deadline.

--- a/tests/integration/test_thread_leaked_observability.py
+++ b/tests/integration/test_thread_leaked_observability.py
@@ -43,7 +43,7 @@ async def executor(
         await exc.on_shutdown()
 
 
-# Not-started sync timeout → thread_leaked=False (cell[0] still None)
+# Not-started sync timeout → thread_leaked=False (handle.thread still None)
 
 
 async def test_not_started_sync_timeout_no_false_positive(
@@ -52,9 +52,9 @@ async def test_not_started_sync_timeout_no_false_positive(
     """run_in_thread is called but worker hasn't dequeued before timeout → thread_leaked=False.
 
     Saturates the pool (max_workers=2) with two long-running blockers so that the
-    third submission sits in the queue.  When the asyncio timeout fires, cell[0] is
+    third submission sits in the queue.  When the asyncio timeout fires, handle.thread is
     still None (the worker never called _call), so the liveness guard must not flag
-    thread_leaked.  Exercises the ``cell[0] is not None`` branch in _execute.
+    thread_leaked.  Exercises the ``handle.thread is not None`` branch in _execute.
     """
     # Gate for the two pool-filling blockers.  We release it after the test assertion
     # so they exit cleanly before the test tears down.
@@ -72,7 +72,7 @@ async def test_not_started_sync_timeout_no_false_positive(
         pool_gate.wait(timeout=10.0)
 
     # Submit two jobs to saturate both workers (max_workers=2 in make_mock_hassette).
-    # Use the underlying sync_executor directly so these don't touch SYNC_WORKER_CELL.
+    # Use the underlying sync_executor directly so these don't touch SYNC_WORKER_HANDLE.
     loop = asyncio.get_running_loop()
     filler_f1 = loop.run_in_executor(hassette_mock.sync_executor, pool_filler)
     filler_f2 = loop.run_in_executor(hassette_mock.sync_executor, pool_filler)
@@ -114,7 +114,9 @@ async def test_not_started_sync_timeout_no_false_positive(
     record = executor._write_queue.get_nowait()
     assert isinstance(record, ExecutionRecord)
     assert record.status == "timed_out"
-    assert record.thread_leaked is False, "thread_leaked must be False when worker never dequeued (cell[0] is None)"
+    assert record.thread_leaked is False, (
+        "thread_leaked must be False when worker never dequeued (handle.thread is None)"
+    )
 
 
 # Blocked sync handler past timeout → thread_leaked=True
@@ -213,8 +215,8 @@ async def test_pure_async_timeout_no_cell_no_thread_leaked(
 ) -> None:
     """A pure async handler that times out (no run_in_thread) sets thread_leaked=False.
 
-    SYNC_WORKER_CELL is never set because no run_in_thread call occurs, so the
-    liveness guard sees cell=None and does not flag the execution.  This is the
+    SYNC_WORKER_HANDLE is never set because no run_in_thread call occurs, so the
+    liveness guard sees handle=None and does not flag the execution.  This is the
     primary "not-started" / "no worker" gate.
     """
 

--- a/tests/integration/test_thread_leaked_observability.py
+++ b/tests/integration/test_thread_leaked_observability.py
@@ -210,7 +210,7 @@ async def test_async_handler_timeout_does_not_set_thread_leaked(
 # Thread-leaked distinguishable from clean timeout (thread finishes before check)
 
 
-async def test_pure_async_timeout_no_cell_no_thread_leaked(
+async def test_pure_async_timeout_no_handle_no_thread_leaked(
     executor: CommandExecutor,
 ) -> None:
     """A pure async handler that times out (no run_in_thread) sets thread_leaked=False.
@@ -244,7 +244,7 @@ async def test_pure_async_timeout_no_cell_no_thread_leaked(
     record = executor._write_queue.get_nowait()
     assert isinstance(record, ExecutionRecord)
     assert record.status == "timed_out"
-    # No worker thread — cell is None, so thread_leaked must be False
+    # No worker thread — handle is None, so thread_leaked must be False
     assert record.thread_leaked is False
 
 

--- a/tests/unit/task_bucket/test_run_in_thread_context_propagation.py
+++ b/tests/unit/task_bucket/test_run_in_thread_context_propagation.py
@@ -106,7 +106,7 @@ async def test_worker_contextvar_writes_do_not_leak_back(bucket: TaskBucket) -> 
     assert ctx.CURRENT_EXECUTION_ID.get(None) == original_id
 
 
-async def test_sync_worker_cell_still_works(bucket: TaskBucket) -> None:
+async def test_sync_worker_handle_still_works(bucket: TaskBucket) -> None:
     """The SYNC_WORKER_HANDLE thread-capture mechanism is unaffected by context propagation."""
 
     def sync_fn() -> str:

--- a/tests/unit/task_bucket/test_run_in_thread_context_propagation.py
+++ b/tests/unit/task_bucket/test_run_in_thread_context_propagation.py
@@ -5,7 +5,7 @@ Covers:
 - HASSETTE_CONFIG is visible in the worker thread.
 - CURRENT_BUCKET is visible in the worker thread.
 - CURRENT_EXECUTION_ID is visible in the worker thread.
-- SYNC_WORKER_CELL still works after the context-propagation change.
+- SYNC_WORKER_HANDLE still works after the context-propagation change.
 """
 
 import threading
@@ -15,7 +15,7 @@ from unittest.mock import AsyncMock
 import pytest
 
 from hassette import context as ctx
-from hassette.task_bucket.task_bucket import SYNC_WORKER_CELL, TaskBucket
+from hassette.task_bucket.task_bucket import SYNC_WORKER_HANDLE, TaskBucket
 from hassette.test_utils import make_mock_hassette
 
 
@@ -107,16 +107,16 @@ async def test_worker_contextvar_writes_do_not_leak_back(bucket: TaskBucket) -> 
 
 
 async def test_sync_worker_cell_still_works(bucket: TaskBucket) -> None:
-    """The SYNC_WORKER_CELL thread-capture mechanism is unaffected by context propagation."""
+    """The SYNC_WORKER_HANDLE thread-capture mechanism is unaffected by context propagation."""
 
     def sync_fn() -> str:
         return "ok"
 
     future = bucket.run_in_thread(sync_fn)
-    cell = SYNC_WORKER_CELL.get()
-    assert cell is not None
+    handle = SYNC_WORKER_HANDLE.get()
+    assert handle is not None
 
     result = await future
     assert result == "ok"
-    assert cell[0] is not None
-    assert isinstance(cell[0], threading.Thread)
+    assert handle.thread is not None
+    assert isinstance(handle.thread, threading.Thread)

--- a/tests/unit/task_bucket/test_run_in_thread_executor_routing.py
+++ b/tests/unit/task_bucket/test_run_in_thread_executor_routing.py
@@ -7,7 +7,7 @@ Covers:
   "hassette-sync" prefix).
 - A slow sync handler under a short asyncio.timeout still surfaces
   TimeoutError to the caller — the timeout signal is unchanged.
-- Thread cell capture: cell[0] is set to the worker thread before _call returns.
+- SyncWorkerHandle capture: handle.thread is set to the worker thread before _call returns.
 """
 
 import asyncio
@@ -18,7 +18,7 @@ from unittest.mock import AsyncMock
 
 import pytest
 
-from hassette.task_bucket.task_bucket import SYNC_WORKER_CELL, TaskBucket
+from hassette.task_bucket.task_bucket import SYNC_WORKER_HANDLE, TaskBucket
 from hassette.test_utils import make_mock_hassette
 
 # Shared fixture
@@ -64,11 +64,11 @@ async def test_run_in_thread_uses_dedicated_executor(bucket: TaskBucket) -> None
     assert worker_name[0].startswith("hassette-sync"), f"expected 'hassette-sync' prefix, got '{worker_name[0]}'"
 
 
-async def test_run_in_thread_cell_captures_worker_thread(bucket: TaskBucket) -> None:
-    """SYNC_WORKER_CELL holds the worker Thread after run_in_thread completes.
+async def test_run_in_thread_handle_captures_worker_thread(bucket: TaskBucket) -> None:
+    """SYNC_WORKER_HANDLE holds the worker Thread after run_in_thread completes.
 
-    The timeout site reads cell[0].is_alive() — this test confirms the cell
-    is populated via SYNC_WORKER_CELL and points at a Thread object (not still None).
+    The timeout site reads handle.thread.is_alive() — this test confirms the handle
+    is populated via SYNC_WORKER_HANDLE and points at a Thread object (not still None).
     """
 
     def slow_fn() -> str:
@@ -76,16 +76,15 @@ async def test_run_in_thread_cell_captures_worker_thread(bucket: TaskBucket) -> 
         return "done"
 
     future = bucket.run_in_thread(slow_fn)
-    # Capture the cell reference immediately after run_in_thread sets SYNC_WORKER_CELL.
-    cell = SYNC_WORKER_CELL.get()
-    assert cell is not None, "SYNC_WORKER_CELL should be set after run_in_thread"
+    handle = SYNC_WORKER_HANDLE.get()
+    assert handle is not None, "SYNC_WORKER_HANDLE should be set after run_in_thread"
 
-    # Before the future resolves, cell[0] may or may not be set yet (race) — but after
-    # awaiting, it must be a Thread.
+    # Before the future resolves, handle.thread may or may not be set yet (race) — but
+    # after awaiting, it must be a Thread.
     result = await future
     assert result == "done"
-    assert cell[0] is not None, "cell[0] should be a Thread after completion"
-    assert isinstance(cell[0], threading.Thread)
+    assert handle.thread is not None, "handle.thread should be a Thread after completion"
+    assert isinstance(handle.thread, threading.Thread)
 
 
 # Framework asyncio.to_thread still uses the default pool


### PR DESCRIPTION
### Refactor: named `SyncWorkerHandle` replaces the list-cell pattern

- `TaskBucket.run_in_thread` used a `list[threading.Thread | None]` as a shared mutable cell to pass the worker thread's identity from the loop thread to the timeout check in `CommandExecutor._execute`. The list-cell idiom worked (mutation through a shared list is visible across threads) but forced every reader to decode why a one-element list existed and what `cell[0]` meant.
- Replaced it with a small `SyncWorkerHandle` dataclass (`thread: threading.Thread | None = None`) that names the same relationship directly: `handle.thread` instead of `cell[0]`.
- Renamed the backing `ContextVar` from `SYNC_WORKER_CELL` to `SYNC_WORKER_HANDLE` to match, and updated every read/write site (`task_bucket.py`, `command_executor.py`, `execution.py`) plus the docstrings that explained the old mechanism.
- No behavioral change — same semantics, same race-window caveat on `thread_leaked`, just a self-documenting shape instead of an opaque list.

### Housekeeping

- Updated test names, comments, and assertions across `test_thread_leaked_observability.py`, `test_run_in_thread_context_propagation.py`, and `test_run_in_thread_executor_routing.py` to use `handle`/`SYNC_WORKER_HANDLE` terminology instead of `cell`/`SYNC_WORKER_CELL`.

Closes #1170
