### PR TITLE
feat: add single-app manifest endpoint for app detail page

### DIFF
--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -122,6 +122,48 @@
         }
       }
     },
+    "/api/apps/{app_key}/manifest": {
+      "get": {
+        "tags": [
+          "apps"
+        ],
+        "summary": "Get App Manifest",
+        "operationId": "get_app_manifest_api_apps__app_key__manifest_get",
+        "parameters": [
+          {
+            "name": "app_key",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "App Key"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AppManifestResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/apps/{app_key}/start": {
       "post": {
         "tags": [

--- a/frontend/src/api/endpoints.ts
+++ b/frontend/src/api/endpoints.ts
@@ -43,6 +43,8 @@ function buildUrl(path: string, params: Record<string, string | number | null | 
 
 export const getManifests = () => apiFetch<ManifestListResponse>("/apps/manifests");
 
+export const getManifest = (appKey: string) => apiFetch<AppManifest>(`/apps/${encodeURIComponent(appKey)}/manifest`);
+
 export const startApp = (appKey: string) => apiPost<{ status: string }>(`/apps/${encodeURIComponent(appKey)}/start`);
 export const stopApp = (appKey: string) => apiPost<{ status: string }>(`/apps/${encodeURIComponent(appKey)}/stop`);
 export const reloadApp = (appKey: string) => apiPost<{ status: string }>(`/apps/${encodeURIComponent(appKey)}/reload`);

--- a/frontend/src/api/endpoints.ts
+++ b/frontend/src/api/endpoints.ts
@@ -41,9 +41,9 @@ function buildUrl(path: string, params: Record<string, string | number | null | 
 
 // ---- App management ----
 
-export const getManifests = () => apiFetch<ManifestListResponse>("/apps/manifests");
+export const getAppManifests = () => apiFetch<ManifestListResponse>("/apps/manifests");
 
-export const getManifest = (appKey: string) => apiFetch<AppManifest>(`/apps/${encodeURIComponent(appKey)}/manifest`);
+export const getAppManifest = (appKey: string) => apiFetch<AppManifest>(`/apps/${encodeURIComponent(appKey)}/manifest`);
 
 export const startApp = (appKey: string) => apiPost<{ status: string }>(`/apps/${encodeURIComponent(appKey)}/start`);
 export const stopApp = (appKey: string) => apiPost<{ status: string }>(`/apps/${encodeURIComponent(appKey)}/stop`);

--- a/frontend/src/api/generated-types.ts
+++ b/frontend/src/api/generated-types.ts
@@ -95,6 +95,23 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/apps/{app_key}/manifest": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get App Manifest */
+        get: operations["get_app_manifest_api_apps__app_key__manifest_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/apps/{app_key}/start": {
         parameters: {
             query?: never;
@@ -1510,6 +1527,37 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["AppManifestListResponse"];
+                };
+            };
+        };
+    };
+    get_app_manifest_api_apps__app_key__manifest_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                app_key: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AppManifestResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
                 };
             };
         };

--- a/frontend/src/hooks/use-manifest.ts
+++ b/frontend/src/hooks/use-manifest.ts
@@ -1,0 +1,11 @@
+import { useQuery } from "@tanstack/preact-query";
+
+import { getManifest } from "../api/endpoints";
+import { queryKeys } from "../lib/query-keys";
+
+export function useManifest(appKey: string) {
+  return useQuery({
+    queryKey: queryKeys.manifest(appKey),
+    queryFn: () => getManifest(appKey),
+  });
+}

--- a/frontend/src/hooks/use-manifest.ts
+++ b/frontend/src/hooks/use-manifest.ts
@@ -1,11 +1,11 @@
 import { useQuery } from "@tanstack/preact-query";
 
-import { getManifest } from "../api/endpoints";
+import { getAppManifest } from "../api/endpoints";
 import { queryKeys } from "../lib/query-keys";
 
 export function useManifest(appKey: string) {
   return useQuery({
     queryKey: queryKeys.manifest(appKey),
-    queryFn: () => getManifest(appKey),
+    queryFn: () => getAppManifest(appKey),
   });
 }

--- a/frontend/src/hooks/use-manifests.test.ts
+++ b/frontend/src/hooks/use-manifests.test.ts
@@ -1,7 +1,7 @@
 /**
  * Tests for useManifests hook.
  *
- * Uses vi.fn() mocks for getManifests (matching the established pattern for
+ * Uses vi.fn() mocks for getAppManifests (matching the established pattern for
  * renderHook tests in this codebase) and renderHookWithProviders to ensure
  * the hook runs inside QueryClientProvider + AppStateContext.
  */
@@ -35,7 +35,7 @@ describe("useManifests", () => {
       createManifest({ app_key: "app_a", display_name: "App A" }),
       createManifest({ app_key: "app_b", display_name: "App B" }),
     ];
-    vi.spyOn(endpoints, "getManifests").mockResolvedValue(makeManifestResponse({ total: 2, running: 2, manifests }));
+    vi.spyOn(endpoints, "getAppManifests").mockResolvedValue(makeManifestResponse({ total: 2, running: 2, manifests }));
 
     const { result } = renderHookWithProviders(() => useManifests());
 
@@ -56,7 +56,7 @@ describe("useManifests", () => {
 
   it("data is undefined when query is pending (no data yet)", () => {
     // Create a promise that never resolves to keep the query in pending state
-    vi.spyOn(endpoints, "getManifests").mockReturnValue(new Promise(() => {}));
+    vi.spyOn(endpoints, "getAppManifests").mockReturnValue(new Promise(() => {}));
 
     const { result } = renderHookWithProviders(() => useManifests());
 
@@ -67,7 +67,7 @@ describe("useManifests", () => {
 
   it("multiple components calling useManifests share one network request (deduplication)", async () => {
     let callCount = 0;
-    vi.spyOn(endpoints, "getManifests").mockImplementation(() => {
+    vi.spyOn(endpoints, "getAppManifests").mockImplementation(() => {
       callCount++;
       return Promise.resolve(
         makeManifestResponse({

--- a/frontend/src/hooks/use-manifests.ts
+++ b/frontend/src/hooks/use-manifests.ts
@@ -1,6 +1,6 @@
 import { useQuery } from "@tanstack/preact-query";
 
-import { type AppManifest, getManifests } from "../api/endpoints";
+import { type AppManifest, getAppManifests } from "../api/endpoints";
 import { queryKeys } from "../lib/query-keys";
 
 /**
@@ -16,7 +16,7 @@ import { queryKeys } from "../lib/query-keys";
 export function useManifests() {
   return useQuery({
     queryKey: queryKeys.manifests(),
-    queryFn: getManifests,
+    queryFn: getAppManifests,
     select: (data): AppManifest[] => data.manifests,
   });
 }

--- a/frontend/src/lib/query-keys.ts
+++ b/frontend/src/lib/query-keys.ts
@@ -2,6 +2,7 @@ export const queryKeys = {
   config: () => ["config"] as const,
   systemStatus: () => ["system-status"] as const,
   manifests: () => ["manifests"] as const,
+  manifest: (appKey: string) => ["manifest", appKey] as const,
   allListenersPalette: () => ["all-listeners-palette"] as const,
   recentLogs: (appKey?: string, executionId?: string | null) =>
     ["recent-logs", appKey ?? null, executionId ?? null] as const,

--- a/frontend/src/pages/app-detail.test.tsx
+++ b/frontend/src/pages/app-detail.test.tsx
@@ -133,18 +133,7 @@ function createWrapper(state: AppState) {
 
 function setupApi(manifest: AppManifest, listeners: ListenerData[] = [], jobs: JobData[] = []) {
   server.use(
-    http.get("/api/apps/manifests", () =>
-      HttpResponse.json({
-        total: 1,
-        running: 1,
-        failed: 0,
-        stopped: 0,
-        disabled: 0,
-        blocked: 0,
-        manifests: [manifest],
-        only_app: null,
-      }),
-    ),
+    http.get("/api/apps/:app_key/manifest", () => HttpResponse.json(manifest)),
     http.get("/api/telemetry/app/:app_key/listeners", () => HttpResponse.json(listeners)),
     http.get("/api/telemetry/app/:app_key/jobs", () => HttpResponse.json(jobs)),
   );

--- a/frontend/src/pages/app-detail.tsx
+++ b/frontend/src/pages/app-detail.tsx
@@ -14,7 +14,7 @@ import { OverviewTab } from "../components/app-detail/overview-tab";
 import { Spinner } from "../components/shared/spinner";
 import { useCorrectUrl } from "../hooks/use-correct-url";
 import { useDocumentTitle } from "../hooks/use-document-title";
-import { useManifests } from "../hooks/use-manifests";
+import { useManifest } from "../hooks/use-manifest";
 import { useQueryInvalidator } from "../hooks/use-query-invalidator";
 import { useQueryParams } from "../hooks/use-query-params";
 import { useScopedQuery } from "../hooks/use-scoped-query";
@@ -65,7 +65,7 @@ export function AppDetailPage({ params }: Props) {
   const appKey = params.key;
   const activeTab: TabId = params.tab ?? "overview";
   const { appStatus, executionCompleted } = useAppState();
-  const { data: manifests = [], isPending: manifestsLoading } = useManifests();
+  const { data: manifest, isPending: manifestLoading, error: manifestError } = useManifest(appKey);
   const [, navigate] = useLocation();
   const queryParams = useQueryParams();
   const correctUrl = useCorrectUrl();
@@ -109,7 +109,6 @@ export function AppDetailPage({ params }: Props) {
   const displayListeners = listenersData ?? [];
   const displayJobs = jobsData ?? [];
 
-  const manifest = manifests.find((m) => m.app_key === appKey);
   useDocumentTitle(manifest?.display_name ?? "App");
 
   const isMultiInstance = (manifest?.instance_count ?? 0) > 1;
@@ -122,8 +121,8 @@ export function AppDetailPage({ params }: Props) {
   const instanceStatus = wsStatus ?? currentInstance?.status ?? manifest?.status ?? "unknown";
   const liveStatus = showParentOverview ? (manifest?.status ?? "unknown") : instanceStatus;
 
-  const hasData = !manifestsLoading && listenersData !== undefined && jobsData !== undefined;
-  const initialLoading = !hasData && (listenersLoading || jobsLoading || manifestsLoading);
+  const hasData = !manifestLoading && listenersData !== undefined && jobsData !== undefined;
+  const initialLoading = !hasData && (listenersLoading || jobsLoading || manifestLoading);
 
   useEffect(() => {
     if (initialLoading) return;
@@ -140,10 +139,10 @@ export function AppDetailPage({ params }: Props) {
 
   if (initialLoading) return <Spinner />;
 
-  if (listenersError || jobsError) {
+  if (manifestError || listenersError || jobsError) {
     return (
       <div class="ht-alert ht-alert--danger" role="alert">
-        {(listenersError ?? jobsError)!.message}
+        {(manifestError ?? listenersError ?? jobsError)!.message}
       </div>
     );
   }

--- a/src/hassette/core/app_registry.py
+++ b/src/hassette/core/app_registry.py
@@ -171,7 +171,7 @@ class AppRegistry:
         manifest = self._manifests.get(app_key)
         if manifest is None:
             return None
-        return self._build_manifest_info(app_key, manifest)
+        return self.build_manifest_info(app_key, manifest)
 
     def get_full_snapshot(self) -> AppFullSnapshot:
         """Generate manifest-based snapshot including all configured apps."""
@@ -179,7 +179,7 @@ class AppRegistry:
         counts = {"running": 0, "failed": 0, "stopped": 0, "disabled": 0, "blocked": 0}
 
         for app_key, manifest in self._manifests.items():
-            info = self._build_manifest_info(app_key, manifest)
+            info = self.build_manifest_info(app_key, manifest)
             counts[info.status] += 1
             manifests.append(info)
 
@@ -190,7 +190,7 @@ class AppRegistry:
             **counts,
         )
 
-    def _build_manifest_info(self, app_key: str, manifest: "AppManifest") -> AppManifestInfo:
+    def build_manifest_info(self, app_key: str, manifest: "AppManifest") -> AppManifestInfo:
         if not manifest.enabled:
             status = "disabled"
         elif app_key in self._blocked_apps:

--- a/src/hassette/core/app_registry.py
+++ b/src/hassette/core/app_registry.py
@@ -166,67 +166,74 @@ class AppRegistry:
             only_app=self._only_app,
         )
 
+    def get_manifest_snapshot(self, app_key: str) -> AppManifestInfo | None:
+        """Generate a snapshot for a single app manifest, or None if not found."""
+        manifest = self._manifests.get(app_key)
+        if manifest is None:
+            return None
+        return self._build_manifest_info(app_key, manifest)
+
     def get_full_snapshot(self) -> AppFullSnapshot:
         """Generate manifest-based snapshot including all configured apps."""
         manifests: list[AppManifestInfo] = []
         counts = {"running": 0, "failed": 0, "stopped": 0, "disabled": 0, "blocked": 0}
 
         for app_key, manifest in self._manifests.items():
-            if not manifest.enabled:
-                status = "disabled"
-            elif app_key in self._blocked_apps:
-                status = "blocked"
-            elif self._apps.get(app_key):
-                status = "running"
-            elif self._failed_apps.get(app_key):
-                status = "failed"
-            else:
-                status = "stopped"
-
-            counts[status] += 1
-
-            instances: list[AppInstanceInfo] = []
-            error_message: str | None = None
-
-            if app_key in self._apps:
-                for index, app in self._apps[app_key].items():
-                    instances.append(self.info_from_running(app_key, index, app))
-
-            error_traceback: str | None = None
-
-            if app_key in self._failed_apps:
-                for index, error in self._failed_apps[app_key]:
-                    info = self.info_from_failure(app_key, index, error, manifest.class_name)
-                    instances.append(info)
-                    if error_message is None:
-                        error_message = info.error_message
-                        error_traceback = info.error_traceback
-
-            block_reason = self._blocked_apps.get(app_key)
-
-            manifests.append(
-                AppManifestInfo(
-                    app_key=app_key,
-                    class_name=manifest.class_name,
-                    display_name=manifest.display_name,
-                    filename=manifest.filename,
-                    enabled=manifest.enabled,
-                    auto_loaded=manifest.auto_loaded,
-                    status=status,
-                    autostart=manifest.autostart,
-                    block_reason=block_reason.value if block_reason else None,
-                    instance_count=len(instances),
-                    instances=instances,
-                    error_message=error_message,
-                    error_traceback=error_traceback,
-                )
-            )
+            info = self._build_manifest_info(app_key, manifest)
+            counts[info.status] += 1
+            manifests.append(info)
 
         return AppFullSnapshot(
             manifests=manifests,
             only_app=self._only_app,
             total=len(manifests),
             **counts,
+        )
+
+    def _build_manifest_info(self, app_key: str, manifest: "AppManifest") -> AppManifestInfo:
+        if not manifest.enabled:
+            status = "disabled"
+        elif app_key in self._blocked_apps:
+            status = "blocked"
+        elif self._apps.get(app_key):
+            status = "running"
+        elif self._failed_apps.get(app_key):
+            status = "failed"
+        else:
+            status = "stopped"
+
+        instances: list[AppInstanceInfo] = []
+        error_message: str | None = None
+        error_traceback: str | None = None
+
+        if app_key in self._apps:
+            for index, app in self._apps[app_key].items():
+                instances.append(self.info_from_running(app_key, index, app))
+
+        if app_key in self._failed_apps:
+            for index, error in self._failed_apps[app_key]:
+                info = self.info_from_failure(app_key, index, error, manifest.class_name)
+                instances.append(info)
+                if error_message is None:
+                    error_message = info.error_message
+                    error_traceback = info.error_traceback
+
+        block_reason = self._blocked_apps.get(app_key)
+
+        return AppManifestInfo(
+            app_key=app_key,
+            class_name=manifest.class_name,
+            display_name=manifest.display_name,
+            filename=manifest.filename,
+            enabled=manifest.enabled,
+            auto_loaded=manifest.auto_loaded,
+            status=status,
+            autostart=manifest.autostart,
+            block_reason=block_reason.value if block_reason else None,
+            instance_count=len(instances),
+            instances=instances,
+            error_message=error_message,
+            error_traceback=error_traceback,
         )
 
     @property

--- a/src/hassette/web/mappers.py
+++ b/src/hassette/web/mappers.py
@@ -15,7 +15,7 @@ coerces it directly — pass the enum value as-is. ``AppManifestInfo.status`` is
 
 from typing import cast
 
-from hassette.schemas.app_snapshots import AppFullSnapshot, AppInstanceInfo, AppStatusSnapshot
+from hassette.schemas.app_snapshots import AppFullSnapshot, AppInstanceInfo, AppManifestInfo, AppStatusSnapshot
 from hassette.schemas.domain_models import SystemStatus
 from hassette.schemas.live_counts import LiveCounts
 from hassette.schemas.telemetry_models import ListenerSummary
@@ -63,34 +63,28 @@ def app_status_response_from(snapshot: AppStatusSnapshot) -> AppStatusResponse:
     )
 
 
-def app_manifest_list_response_from(full: AppFullSnapshot) -> AppManifestListResponse:
-    """Convert an ``AppFullSnapshot`` to ``AppManifestListResponse``.
+def app_manifest_response_from(m: AppManifestInfo) -> AppManifestResponse:
+    """Convert an ``AppManifestInfo`` snapshot to ``AppManifestResponse``."""
+    instances = [instance_response_from(inst) for inst in m.instances]
+    return AppManifestResponse(
+        app_key=m.app_key,
+        class_name=m.class_name,
+        display_name=m.display_name,
+        filename=m.filename,
+        enabled=m.enabled,
+        auto_loaded=m.auto_loaded,
+        autostart=m.autostart,
+        status=cast("ManifestStatus", m.status),  # AppManifestInfo.status is str
+        block_reason=m.block_reason,
+        instance_count=m.instance_count,
+        instances=instances,
+        error_message=m.error_message,
+        error_traceback=m.error_traceback,
+    )
 
-    Builds nested ``AppInstanceResponse`` objects from each manifest's
-    ``instances`` list. ``AppInstanceInfo.status`` is a ``ResourceStatus``
-    enum and requires ``.value``; ``AppManifestInfo.status`` is already a
-    plain ``str``.
-    """
-    manifests = []
-    for m in full.manifests:
-        instances = [instance_response_from(inst) for inst in m.instances]
-        manifests.append(
-            AppManifestResponse(
-                app_key=m.app_key,
-                class_name=m.class_name,
-                display_name=m.display_name,
-                filename=m.filename,
-                enabled=m.enabled,
-                auto_loaded=m.auto_loaded,
-                autostart=m.autostart,
-                status=cast("ManifestStatus", m.status),  # AppManifestInfo.status is str
-                block_reason=m.block_reason,
-                instance_count=m.instance_count,
-                instances=instances,
-                error_message=m.error_message,
-                error_traceback=m.error_traceback,
-            )
-        )
+
+def app_manifest_list_response_from(full: AppFullSnapshot) -> AppManifestListResponse:
+    """Convert an ``AppFullSnapshot`` to ``AppManifestListResponse``."""
     return AppManifestListResponse(
         total=full.total,
         running=full.running,
@@ -98,7 +92,7 @@ def app_manifest_list_response_from(full: AppFullSnapshot) -> AppManifestListRes
         stopped=full.stopped,
         disabled=full.disabled,
         blocked=full.blocked,
-        manifests=manifests,
+        manifests=[app_manifest_response_from(m) for m in full.manifests],
         only_app=full.only_app,
     )
 

--- a/src/hassette/web/routes/apps.py
+++ b/src/hassette/web/routes/apps.py
@@ -10,11 +10,12 @@ from hassette.app.app_config import AppConfig
 from hassette.exceptions import TelemetryUnavailableError
 from hassette.web.config_view import deref_schema, mask_app_config, mask_values, resolve_app_config_cls
 from hassette.web.dependencies import HassetteDep, RuntimeDep, TelemetryDep
-from hassette.web.mappers import app_manifest_list_response_from, app_status_response_from
+from hassette.web.mappers import app_manifest_list_response_from, app_manifest_response_from, app_status_response_from
 from hassette.web.models import (
     ActionResponse,
     AppConfigResponse,
     AppManifestListResponse,
+    AppManifestResponse,
     AppSourceResponse,
     AppStatusResponse,
 )
@@ -78,6 +79,25 @@ async def get_app_manifests(runtime: RuntimeDep, telemetry: TelemetryDep) -> App
         for m in manifest_list.manifests
     ]
     return manifest_list.model_copy(update={"manifests": enriched_manifests})
+
+
+@router.get("/apps/{app_key}/manifest", response_model=AppManifestResponse)
+async def get_app_manifest(app_key: str, hassette: HassetteDep, telemetry: TelemetryDep) -> AppManifestResponse:
+    _validate_app_key(app_key)
+    manifest_info = hassette.app_handler.registry.get_manifest_snapshot(app_key)
+    if manifest_info is None:
+        raise HTTPException(status_code=404, detail=f"App {app_key!r} not found")
+
+    response = app_manifest_response_from(manifest_info)
+
+    invocations = 0
+    try:
+        invocations_by_key = await telemetry.get_recent_invocations_1h_all_apps()
+        invocations = invocations_by_key.get(app_key, 0)
+    except TelemetryUnavailableError:
+        LOGGER.warning("Failed to fetch recent_invocations_1h for app %s manifest", app_key, exc_info=True)
+
+    return response.model_copy(update={"recent_invocations_1h": invocations})
 
 
 @router.post("/apps/{app_key}/start", status_code=202, response_model=ActionResponse)

--- a/tests/e2e/mock_fixtures.py
+++ b/tests/e2e/mock_fixtures.py
@@ -793,6 +793,11 @@ def wire_app_manifest_lookups(hassette, manifests: list[AppManifestInfo]) -> Non
 
     hassette._app_handler.registry.get_manifest.side_effect = lambda app_key: _stubs.get(app_key)
 
+    _manifest_info_by_key = {m.app_key: m for m in manifests}
+    hassette._app_handler.registry.get_manifest_snapshot.side_effect = lambda app_key: _manifest_info_by_key.get(
+        app_key
+    )
+
 
 def wire_owner_resolution(hassette) -> None:
     """Wire app instance owner resolution onto the mock app handler."""

--- a/tests/integration/web_api/test_endpoints.py
+++ b/tests/integration/web_api/test_endpoints.py
@@ -9,6 +9,7 @@ import pytest
 from hassette.core.runtime_query_service import RuntimeQueryService
 from hassette.exceptions import TelemetryUnavailableError
 from hassette.schemas.telemetry_models import ListenerSummary
+from hassette.test_utils.web_helpers import make_manifest
 from hassette.web.config_view import MASK_SENTINEL
 
 if TYPE_CHECKING:
@@ -148,6 +149,44 @@ class TestAppEndpoints:
         assert (await client.post("/api/apps/my_app/start")).status_code == 202
         assert (await client.post("/api/apps/my_app/stop")).status_code == 202
         assert (await client.post("/api/apps/my_app/reload")).status_code == 202
+
+
+class TestAppManifestEndpoint:
+    async def test_get_manifest_returns_single_manifest(self, client: "AsyncClient", mock_hassette) -> None:
+        manifest = make_manifest(app_key="my_app", display_name="My App", status="running")
+        mock_hassette.app_handler.registry.get_manifest_snapshot.return_value = manifest
+        mock_hassette.telemetry_query_service.get_recent_invocations_1h_all_apps.return_value = {"my_app": 5}
+
+        response = await client.get("/api/apps/my_app/manifest")
+        assert response.status_code == 200
+        data = response.json()
+        assert data["app_key"] == "my_app"
+        assert data["display_name"] == "My App"
+        assert data["status"] == "running"
+        assert data["recent_invocations_1h"] == 5
+
+    async def test_get_manifest_returns_404_for_unknown_app(self, client: "AsyncClient", mock_hassette) -> None:
+        mock_hassette.app_handler.registry.get_manifest_snapshot.return_value = None
+
+        response = await client.get("/api/apps/unknown_app/manifest")
+        assert response.status_code == 404
+
+    async def test_get_manifest_returns_400_for_invalid_key(self, client: "AsyncClient") -> None:
+        response = await client.get("/api/apps/!!invalid/manifest")
+        assert response.status_code == 400
+
+    async def test_get_manifest_degrades_gracefully_on_telemetry_failure(
+        self, client: "AsyncClient", mock_hassette
+    ) -> None:
+        manifest = make_manifest(app_key="my_app")
+        mock_hassette.app_handler.registry.get_manifest_snapshot.return_value = manifest
+        mock_hassette.telemetry_query_service.get_recent_invocations_1h_all_apps = AsyncMock(
+            side_effect=TelemetryUnavailableError("db down")
+        )
+
+        response = await client.get("/api/apps/my_app/manifest")
+        assert response.status_code == 200
+        assert response.json()["recent_invocations_1h"] == 0
 
 
 class TestEventsEndpoint:


### PR DESCRIPTION
Add GET /api/apps/{app_key}/manifest that returns a single
AppManifestResponse directly, replacing the O(N) pattern where the
detail page fetched all manifests and filtered client-side.

Backend:
- Extract _build_manifest_info from get_full_snapshot loop
- Add get_manifest_snapshot(app_key) to AppRegistry
- Extract app_manifest_response_from single-item mapper
- New endpoint with validation, 404, telemetry enrichment

Frontend:
- Add getManifest(appKey) endpoint function
- Add useManifest(appKey) hook with dedicated query key
- Switch app-detail page from useManifests + .find() to useManifest
- Surface manifest fetch errors in error banner

Closes #368