### PR TITLE
feat(ui): add roving tabindex to interactive tables

### DIFF
--- a/frontend/src/components/app-detail/handler-health-card.test.tsx
+++ b/frontend/src/components/app-detail/handler-health-card.test.tsx
@@ -24,7 +24,7 @@ function makeJobItem(overrides: Parameters<typeof createJob>[0] = {}) {
 }
 
 function renderCard(item: ReturnType<typeof buildItems>[number], { appKey = "test_app", instanceQs = "" } = {}) {
-  return renderWithAppState(<HandlerHealthCard item={item} appKey={appKey} instanceQs={instanceQs} />);
+  return renderWithAppState(<HandlerHealthCard item={item} appKey={appKey} instanceQs={instanceQs} tabIndex={0} />);
 }
 
 // ──────────────────────────────────────────────────────────────────────────────
@@ -294,6 +294,20 @@ describe("HandlerHealthCard — accessibility", () => {
     const { getByRole } = renderCard(item);
     const card = getByRole("button", { name: "on_motion handler details" });
     expect(card).toBeDefined();
+  });
+
+  it("renders the provided tabIndex", () => {
+    const item = makeListenerItem({ listener_id: 1 });
+    const { getByTestId } = renderWithAppState(
+      <HandlerHealthCard item={item} appKey="test_app" instanceQs="" tabIndex={-1} />,
+    );
+    expect(getByTestId("overview-health-card-listener-1").getAttribute("tabindex")).toBe("-1");
+  });
+
+  it("has data-roving-item attribute", () => {
+    const item = makeListenerItem({ listener_id: 1 });
+    const { getByTestId } = renderCard(item);
+    expect(getByTestId("overview-health-card-listener-1").hasAttribute("data-roving-item")).toBe(true);
   });
 });
 

--- a/frontend/src/components/app-detail/handler-health-card.tsx
+++ b/frontend/src/components/app-detail/handler-health-card.tsx
@@ -23,9 +23,10 @@ interface HandlerHealthCardProps {
   item: UnifiedItem;
   appKey: string;
   instanceQs: string;
+  tabIndex: 0 | -1;
 }
 
-export function HandlerHealthCard({ item, appKey, instanceQs }: HandlerHealthCardProps) {
+export function HandlerHealthCard({ item, appKey, instanceQs, tabIndex }: HandlerHealthCardProps) {
   const [, navigate] = useLocation();
   const href = handlerPath(appKey, item, instanceQs);
   const failing = isFailing(item);
@@ -52,7 +53,8 @@ export function HandlerHealthCard({ item, appKey, instanceQs }: HandlerHealthCar
       data-testid={`overview-health-card-${item.kind}-${item.id}`}
       role="button"
       aria-label={`${item.name} handler details`}
-      tabIndex={0}
+      tabIndex={tabIndex}
+      data-roving-item
       onClick={() => navigate(href)}
       onKeyDown={handleKeyDown}
     >

--- a/frontend/src/components/app-detail/handler-health-grid.tsx
+++ b/frontend/src/components/app-detail/handler-health-grid.tsx
@@ -1,5 +1,6 @@
 import { useMemo } from "preact/hooks";
 
+import { useRovingTabIndex } from "../../hooks/use-roving-tab-index";
 import { EmptyState } from "../shared/empty-state";
 import { HandlerHealthCard } from "./handler-health-card";
 // Grid layout classes live in overview-tab's stylesheet — this component is only rendered within OverviewTab
@@ -17,6 +18,8 @@ export function HandlerHealthGrid({
   instanceQs: string;
 }) {
   const sorted = useMemo(() => sortedByFailingFirst(items), [items]);
+  // setActiveIndex omitted — clicking a card navigates away, unmounting the grid.
+  const { containerRef, onContainerKeyDown, getTabIndex } = useRovingTabIndex<HTMLDivElement>(sorted.length, "both");
 
   if (items.length === 0) {
     return (
@@ -35,9 +38,15 @@ export function HandlerHealthGrid({
     <section class={styles.section} data-testid="overview-health-grid">
       <h3 class="ht-section-label">handler health</h3>
       <div class={styles.healthGridScroll}>
-        <div class={styles.healthGrid}>
-          {sorted.map((item) => (
-            <HandlerHealthCard key={`${item.kind}-${item.id}`} item={item} appKey={appKey} instanceQs={instanceQs} />
+        <div class={styles.healthGrid} ref={containerRef} onKeyDown={onContainerKeyDown}>
+          {sorted.map((item, i) => (
+            <HandlerHealthCard
+              key={`${item.kind}-${item.id}`}
+              item={item}
+              appKey={appKey}
+              instanceQs={instanceQs}
+              tabIndex={getTabIndex(i)}
+            />
           ))}
         </div>
       </div>

--- a/frontend/src/components/shared/execution-table.tsx
+++ b/frontend/src/components/shared/execution-table.tsx
@@ -1,5 +1,6 @@
 import clsx from "clsx";
 
+import { useRovingTabIndex } from "../../hooks/use-roving-tab-index";
 import { useSignal } from "../../hooks/use-signal";
 import { STATUS_DOT_SIZE } from "../../utils/constants";
 import { formatDuration, formatTimestamp, truncateId } from "../../utils/format";
@@ -36,6 +37,10 @@ interface Props {
 export function ExecutionTable({ records, kind, tableId }: Props) {
   const showAll = useSignal(false);
   const openRow = useSignal<number | null>(null);
+  const visible = showAll.value ? records : records.slice(0, INITIAL_ROWS);
+  const { containerRef, onContainerKeyDown, getTabIndex, setActiveIndex } = useRovingTabIndex<HTMLTableSectionElement>(
+    visible.length,
+  );
 
   if (records.length === 0) {
     return kind === "handler" ? (
@@ -49,7 +54,6 @@ export function ExecutionTable({ records, kind, tableId }: Props) {
     );
   }
 
-  const visible = showAll.value ? records : records.slice(0, INITIAL_ROWS);
   const hasMore = records.length > INITIAL_ROWS;
 
   return (
@@ -74,7 +78,7 @@ export function ExecutionTable({ records, kind, tableId }: Props) {
             </th>
           </tr>
         </thead>
-        <tbody>
+        <tbody ref={containerRef} onKeyDown={onContainerKeyDown}>
           {visible.map((record, i) => {
             const isOpen = openRow.value === i;
             const rowKey = record.execution_id ?? `${kind}-${i}`;
@@ -88,10 +92,14 @@ export function ExecutionTable({ records, kind, tableId }: Props) {
                 key={rowKey}
                 class={clsx(styles.row, isOpen && styles.rowOpen)}
                 data-testid={kind === "handler" ? "invocation-row" : "execution-row"}
-                tabIndex={0}
+                tabIndex={getTabIndex(i)}
                 role="row"
                 aria-expanded={isOpen}
-                onClick={() => (openRow.value = isOpen ? null : i)}
+                data-roving-item
+                onClick={() => {
+                  setActiveIndex(i);
+                  openRow.value = isOpen ? null : i;
+                }}
                 onKeyDown={(e: KeyboardEvent) => {
                   if (e.key === "Enter" || e.key === " ") {
                     e.preventDefault();

--- a/frontend/src/components/shared/log-table/log-table-row.test.tsx
+++ b/frontend/src/components/shared/log-table/log-table-row.test.tsx
@@ -35,6 +35,7 @@ function renderRow(props: Partial<Parameters<typeof LogTableRow>[0]> = {}) {
     visibleColumns: ["level", "timestamp", "app", "message"] as ColumnId[],
     isSelected: false,
     onClick: vi.fn(),
+    tabIndex: 0 as const,
   };
   return render(
     <table>
@@ -51,12 +52,24 @@ function renderRow(props: Partial<Parameters<typeof LogTableRow>[0]> = {}) {
 
 describe("LogTableRow", () => {
   describe("row element", () => {
-    it("renders a <tr> with role='button' and tabIndex=0", () => {
-      const { container } = renderRow();
+    it("renders a <tr> with role='button' and the provided tabIndex", () => {
+      const { container } = renderRow({ tabIndex: 0 });
       const tr = container.querySelector("tr");
       expect(tr).not.toBeNull();
       expect(tr!.getAttribute("role")).toBe("button");
       expect(tr!.getAttribute("tabindex")).toBe("0");
+    });
+
+    it("renders tabIndex=-1 when passed", () => {
+      const { container } = renderRow({ tabIndex: -1 });
+      const tr = container.querySelector("tr");
+      expect(tr!.getAttribute("tabindex")).toBe("-1");
+    });
+
+    it("has data-roving-item attribute", () => {
+      const { container } = renderRow();
+      const tr = container.querySelector("tr");
+      expect(tr!.hasAttribute("data-roving-item")).toBe(true);
     });
 
     it("does not have aria-current when not selected", () => {

--- a/frontend/src/components/shared/log-table/log-table-row.tsx
+++ b/frontend/src/components/shared/log-table/log-table-row.tsx
@@ -16,9 +16,10 @@ interface LogTableRowProps {
   visibleColumns: ColumnId[];
   isSelected: boolean;
   onClick: () => void;
+  tabIndex: 0 | -1;
 }
 
-export function LogTableRow({ entry, rowKey, visibleColumns, isSelected, onClick }: LogTableRowProps) {
+export function LogTableRow({ entry, rowKey, visibleColumns, isSelected, onClick, tabIndex }: LogTableRowProps) {
   const isMobile = useMediaQuery(BREAKPOINT_MOBILE);
   const relativeTime = useRelativeTime(entry.timestamp);
 
@@ -37,8 +38,9 @@ export function LogTableRow({ entry, rowKey, visibleColumns, isSelected, onClick
           onClick();
         }
       }}
-      tabIndex={0}
+      tabIndex={tabIndex}
       role="button"
+      data-roving-item
       aria-current={isSelected ? "true" : undefined}
     >
       {isColumnVisible("level") && (

--- a/frontend/src/components/shared/log-table/log-table-view.tsx
+++ b/frontend/src/components/shared/log-table/log-table-view.tsx
@@ -1,3 +1,4 @@
+import { useRovingTabIndex } from "../../../hooks/use-roving-tab-index";
 import { COLUMN_MAP } from "./constants";
 import { LogTableHeader } from "./log-table-header";
 import { LogTableRow } from "./log-table-row";
@@ -14,6 +15,10 @@ export function LogTableView({
   onRowClick,
   isMobile,
 }: LogTableViewProps) {
+  const { containerRef, onContainerKeyDown, getTabIndex, setActiveIndex } = useRovingTabIndex<HTMLTableSectionElement>(
+    entries.length,
+  );
+
   return (
     <table class="ht-table ht-table--fixed" data-testid="log-table">
       <colgroup>
@@ -24,8 +29,8 @@ export function LogTableView({
         })}
       </colgroup>
       <LogTableHeader visibleColumns={visibleColumns} sort={sort} onSort={onSort} columnFilters={columnFilters} />
-      <tbody>
-        {entries.map((entry) => {
+      <tbody ref={containerRef} onKeyDown={onContainerKeyDown}>
+        {entries.map((entry, i) => {
           const key = rowKey(entry);
           return (
             <LogTableRow
@@ -34,7 +39,11 @@ export function LogTableView({
               rowKey={key}
               visibleColumns={visibleColumns}
               isSelected={selectedKey === key}
-              onClick={() => onRowClick(entry)}
+              onClick={() => {
+                setActiveIndex(i);
+                onRowClick(entry);
+              }}
+              tabIndex={getTabIndex(i)}
             />
           );
         })}

--- a/frontend/src/hooks/use-roving-tab-index.test.ts
+++ b/frontend/src/hooks/use-roving-tab-index.test.ts
@@ -1,0 +1,131 @@
+import { act, renderHook } from "@testing-library/preact";
+import { describe, expect, it } from "vitest";
+
+import { useRovingTabIndex } from "./use-roving-tab-index";
+
+function keyEvent(key: string): KeyboardEvent {
+  return new KeyboardEvent("keydown", { key, bubbles: true, cancelable: true });
+}
+
+describe("useRovingTabIndex", () => {
+  it("initially focuses the first item", () => {
+    const { result } = renderHook(() => useRovingTabIndex(5));
+    expect(result.current.getTabIndex(0)).toBe(0);
+    expect(result.current.getTabIndex(1)).toBe(-1);
+    expect(result.current.getTabIndex(4)).toBe(-1);
+  });
+
+  it("ArrowDown moves focus forward", () => {
+    const { result } = renderHook(() => useRovingTabIndex(5));
+    act(() => result.current.onContainerKeyDown(keyEvent("ArrowDown")));
+    expect(result.current.getTabIndex(0)).toBe(-1);
+    expect(result.current.getTabIndex(1)).toBe(0);
+  });
+
+  it("ArrowUp moves focus backward", () => {
+    const { result } = renderHook(() => useRovingTabIndex(5));
+    act(() => result.current.onContainerKeyDown(keyEvent("ArrowDown")));
+    act(() => result.current.onContainerKeyDown(keyEvent("ArrowDown")));
+    act(() => result.current.onContainerKeyDown(keyEvent("ArrowUp")));
+    expect(result.current.getTabIndex(1)).toBe(0);
+  });
+
+  it("does not go below zero", () => {
+    const { result } = renderHook(() => useRovingTabIndex(5));
+    act(() => result.current.onContainerKeyDown(keyEvent("ArrowUp")));
+    expect(result.current.getTabIndex(0)).toBe(0);
+  });
+
+  it("does not go above count - 1", () => {
+    const { result } = renderHook(() => useRovingTabIndex(3));
+    act(() => result.current.onContainerKeyDown(keyEvent("End")));
+    act(() => result.current.onContainerKeyDown(keyEvent("ArrowDown")));
+    expect(result.current.getTabIndex(2)).toBe(0);
+  });
+
+  it("Home jumps to first item", () => {
+    const { result } = renderHook(() => useRovingTabIndex(5));
+    act(() => result.current.onContainerKeyDown(keyEvent("End")));
+    act(() => result.current.onContainerKeyDown(keyEvent("Home")));
+    expect(result.current.getTabIndex(0)).toBe(0);
+  });
+
+  it("End jumps to last item", () => {
+    const { result } = renderHook(() => useRovingTabIndex(5));
+    act(() => result.current.onContainerKeyDown(keyEvent("End")));
+    expect(result.current.getTabIndex(4)).toBe(0);
+  });
+
+  it("setActiveIndex updates the focused item", () => {
+    const { result } = renderHook(() => useRovingTabIndex(5));
+    act(() => result.current.setActiveIndex(3));
+    expect(result.current.getTabIndex(3)).toBe(0);
+  });
+
+  it("clamps when count shrinks", () => {
+    let count = 5;
+    const { result, rerender } = renderHook(() => useRovingTabIndex(count));
+    act(() => result.current.onContainerKeyDown(keyEvent("End")));
+    expect(result.current.getTabIndex(4)).toBe(0);
+
+    count = 3;
+    rerender();
+    expect(result.current.getTabIndex(2)).toBe(0);
+  });
+
+  it("ignores unrelated keys", () => {
+    const { result } = renderHook(() => useRovingTabIndex(5));
+    act(() => result.current.onContainerKeyDown(keyEvent("Tab")));
+    expect(result.current.getTabIndex(0)).toBe(0);
+  });
+
+  it("does nothing when count is zero", () => {
+    const { result } = renderHook(() => useRovingTabIndex(0));
+    const event = keyEvent("ArrowDown");
+    act(() => result.current.onContainerKeyDown(event));
+    expect(event.defaultPrevented).toBe(false);
+  });
+
+  it("prevents default on handled keys", () => {
+    const { result } = renderHook(() => useRovingTabIndex(5));
+    const event = keyEvent("ArrowDown");
+    act(() => result.current.onContainerKeyDown(event));
+    expect(event.defaultPrevented).toBe(true);
+  });
+
+  it("does not prevent default on unhandled keys", () => {
+    const { result } = renderHook(() => useRovingTabIndex(5));
+    const event = keyEvent("Tab");
+    act(() => result.current.onContainerKeyDown(event));
+    expect(event.defaultPrevented).toBe(false);
+  });
+
+  describe("direction: both", () => {
+    it("ArrowRight moves forward", () => {
+      const { result } = renderHook(() => useRovingTabIndex(5, "both"));
+      act(() => result.current.onContainerKeyDown(keyEvent("ArrowRight")));
+      expect(result.current.getTabIndex(1)).toBe(0);
+    });
+
+    it("ArrowLeft moves backward", () => {
+      const { result } = renderHook(() => useRovingTabIndex(5, "both"));
+      act(() => result.current.onContainerKeyDown(keyEvent("ArrowRight")));
+      act(() => result.current.onContainerKeyDown(keyEvent("ArrowLeft")));
+      expect(result.current.getTabIndex(0)).toBe(0);
+    });
+  });
+
+  describe("direction: vertical (default)", () => {
+    it("ignores ArrowRight", () => {
+      const { result } = renderHook(() => useRovingTabIndex(5));
+      act(() => result.current.onContainerKeyDown(keyEvent("ArrowRight")));
+      expect(result.current.getTabIndex(0)).toBe(0);
+    });
+
+    it("ignores ArrowLeft", () => {
+      const { result } = renderHook(() => useRovingTabIndex(5));
+      act(() => result.current.onContainerKeyDown(keyEvent("ArrowLeft")));
+      expect(result.current.getTabIndex(0)).toBe(0);
+    });
+  });
+});

--- a/frontend/src/hooks/use-roving-tab-index.ts
+++ b/frontend/src/hooks/use-roving-tab-index.ts
@@ -1,0 +1,56 @@
+import { useEffect, useRef, useState } from "preact/hooks";
+
+// Items participating in roving tabindex must have the `data-roving-item` attribute.
+const ROVING_SELECTOR = "[data-roving-item]";
+
+type Direction = "vertical" | "both";
+
+export function useRovingTabIndex<T extends HTMLElement = HTMLElement>(
+  itemCount: number,
+  direction: Direction = "vertical",
+) {
+  const [activeIndex, setActiveIndex] = useState(0);
+  const containerRef = useRef<T>(null);
+  // Only move DOM focus after keyboard navigation, not on click or initial render.
+  const focusViaKeyboard = useRef(false);
+
+  const clampedIndex = itemCount > 0 ? Math.min(activeIndex, itemCount - 1) : 0;
+
+  function onContainerKeyDown(e: KeyboardEvent) {
+    if (itemCount === 0) return;
+
+    let next: number;
+    if (e.key === "ArrowDown" || (direction === "both" && e.key === "ArrowRight")) {
+      next = Math.min(clampedIndex + 1, itemCount - 1);
+    } else if (e.key === "ArrowUp" || (direction === "both" && e.key === "ArrowLeft")) {
+      next = Math.max(clampedIndex - 1, 0);
+    } else if (e.key === "Home") {
+      next = 0;
+    } else if (e.key === "End") {
+      next = itemCount - 1;
+    } else {
+      return;
+    }
+
+    if (next === clampedIndex) return;
+    e.preventDefault();
+    focusViaKeyboard.current = true;
+    setActiveIndex(next);
+  }
+
+  useEffect(() => {
+    if (!focusViaKeyboard.current) return;
+    focusViaKeyboard.current = false;
+    const el = containerRef.current;
+    if (!el) return;
+    const items = el.querySelectorAll<HTMLElement>(ROVING_SELECTOR);
+    items[clampedIndex]?.focus();
+  }, [clampedIndex]);
+
+  return {
+    containerRef,
+    onContainerKeyDown,
+    getTabIndex: (i: number): 0 | -1 => (i === clampedIndex ? 0 : -1),
+    setActiveIndex,
+  };
+}


### PR DESCRIPTION
### Roving tabindex for interactive tables

- Adds a `useRovingTabIndex` hook (`frontend/src/hooks/use-roving-tab-index.ts`) that manages a single active index per container: the active item gets `tabIndex=0`, everything else gets `tabIndex=-1`. Arrow keys (and Left/Right in `"both"` mode) move the active index, `Home`/`End` jump to the boundaries, and `Tab` exits the container entirely instead of tabbing through every row — this was the core WCAG keyboard-navigation gap in #750, where every row/card was independently focusable and tabbing through a long table meant one Tab press per row.
- Integrates the hook into the three interactive table/grid components: `LogTableView`/`LogTableRow`, `ExecutionTable`, and `HandlerHealthGrid`/`HandlerHealthCard`. Each container wires `onKeyDown` to the hook and marks its items with `data-roving-item` so the hook can find and focus them.
- `HandlerHealthGrid` omits `setActiveIndex` — clicking a card navigates away and unmounts the grid, so there's no post-click active-index state to track. `ExecutionTable` and `LogTableView` do call `setActiveIndex` on click, since clicking a row keeps it selected in place (expanding it or marking it selected) rather than navigating away.
- Filed two follow-ups discovered while working on this: #1187 (a pre-existing missing `:focus-visible` style on execution table rows) and #1189 (pre-existing style cleanup) — both are pre-existing issues unrelated to the roving-tabindex behavior, so they're scoped separately rather than folded into this PR.

Closes #750
