### PR TITLE
docs: add IDE support section to configuration page

### DIFF
--- a/docs/pages/core-concepts/configuration/index.md
+++ b/docs/pages/core-concepts/configuration/index.md
@@ -30,6 +30,12 @@ When the same setting appears in multiple sources, the higher-precedence source 
 !!! tip "Docker"
     In Docker, the configuration volume mounts to `/config`. Hassette checks `/config/hassette.toml` first.
 
+## IDE Support {#ide-support}
+
+`hassette.toml` has a [JSON Schema](https://json-schema.org/) listed on [SchemaStore](https://www.schemastore.org/). Editors with TOML language support — VS Code ([Even Better TOML](https://marketplace.visualstudio.com/items?itemName=tamasfe.even-better-toml)), JetBrains IDEs, and Neovim with [Taplo](https://taplo.tamasfe.dev/) — discover the schema by filename and provide autocomplete, inline validation, and hover documentation for every field.
+
+No editor configuration is needed. The schema is generated from [`HassetteConfig`][hassette.config.HassetteConfig] and stays current with each release.
+
 ## Authentication
 
 The `token` field accepts four aliases: `token`, `hassette__token`, `ha_token`, and `home_assistant_token`. This means the same token can be supplied under any of those names in any source.

--- a/hassette.schema.json
+++ b/hassette.schema.json
@@ -1146,12 +1146,6 @@
             "label": "CORS Origins"
           }
         },
-        "event_buffer_size": {
-          "default": 500,
-          "description": "Maximum number of recent events to keep in the RuntimeQueryService ring buffer.",
-          "title": "Event Buffer Size",
-          "type": "integer"
-        },
         "log_buffer_size": {
           "default": 2000,
           "description": "Maximum number of log entries to keep in the LogCaptureHandler ring buffer.",


### PR DESCRIPTION
Add an "IDE Support" section to the configuration docs page, documenting that `hassette.toml` has a JSON Schema listed on SchemaStore.

Editors with TOML language support (VS Code with Even Better TOML, JetBrains IDEs, Neovim with Taplo) discover the schema by filename and provide autocomplete, inline validation, and hover documentation -- no editor configuration needed. The schema is generated from `HassetteConfig` and stays current with each release.

This is the hassette-side documentation. The SchemaStore catalog entry is submitted separately (SchemaStore PR).

Closes #1188