### PR TITLE
refactor(ui): clean up pre-existing style debt in table/grid and config components

### DIFF
--- a/.claude/rules/clean-code-findings.md
+++ b/.claude/rules/clean-code-findings.md
@@ -1,0 +1,52 @@
+# Clean Code Findings
+
+How to file issues for pre-existing code quality findings surfaced during `/mine-clean-code`, `/mine-review`, or `/mine-ship`.
+
+## When to File
+
+File an issue when a clean-code or nitpicker review surfaces a pre-existing finding (not introduced by the current branch) that:
+
+1. Passed the validity protocol (not filtered as likely-invalid)
+2. Is independently actionable — someone can fix it without understanding the current PR's context
+3. Is not already tracked by an existing issue
+
+Do not file findings introduced by the current branch — fix those in the current PR.
+
+## Issue Shape
+
+**Title:** `Clean up <what> in <where>` — imperative, specific to the affected files or component area. Not the checker name or finding ID.
+
+**Labels (all required):**
+
+- `type:enhancement`
+- `topic:code-quality`
+- `size:small` (most findings are; use `size:medium` only for multi-file structural changes)
+- One or more `area:` labels matching the affected code
+
+**Milestone:** `Code Quality`
+
+**Body structure:**
+
+```markdown
+## Description
+
+<One sentence: what review surfaced this, during which PR, and that it predates the current work.>
+
+## Key Items
+
+<Bulleted list of specific findings with file:line references. Group tightly related findings.>
+
+## Acceptance Criteria
+
+<Checklist of concrete done conditions — one per finding or per tightly-related cluster.>
+```
+
+## Grouping
+
+One issue per component area or tightly-related cluster of findings. A nitpicker run that flags 3 issues in `execution-table.tsx` and 2 in `handler-health-card.tsx` from the same component family becomes one issue. Unrelated findings in different subsystems become separate issues.
+
+Do not create one mega-issue for an entire review run. Do not create one issue per individual finding when they share a file.
+
+## Filing Mechanics
+
+Use `/mine-create-issue` to file. After filing, confirm the milestone and labels are set (the create-issue skill handles labels but may not set the milestone automatically).

--- a/frontend/src/components/app-detail/config-tab.tsx
+++ b/frontend/src/components/app-detail/config-tab.tsx
@@ -16,14 +16,14 @@ interface Props {
 }
 
 /** True when the value is a plain (non-array) object usable as a ConfigRecord. */
-function isConfigRecord(val: unknown): val is ConfigRecord {
-  return val !== null && typeof val === "object" && !Array.isArray(val);
+function isConfigRecord(value: unknown): value is ConfigRecord {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
 }
 
-function ConfigValue({ val }: { val: unknown }) {
-  if (val === null || val === undefined) return <>—</>;
-  if (typeof val === "object") return <ExpandableValue value={val} />;
-  return <>{String(val)}</>;
+function ConfigValue({ value }: { value: unknown }) {
+  if (value === null || value === undefined) return <>—</>;
+  if (typeof value === "object") return <ExpandableValue value={value} />;
+  return <>{String(value)}</>;
 }
 
 function SimpleConfigTable({ config }: { config: ConfigRecord }) {
@@ -52,7 +52,7 @@ function SimpleConfigTable({ config }: { config: ConfigRecord }) {
             </td>
             <td class={styles.value} data-testid={`config-value-${key}`}>
               <code class="ht-text-mono ht-text-sm">
-                <ConfigValue val={val} />
+                <ConfigValue value={val} />
               </code>
             </td>
           </tr>

--- a/frontend/src/components/app-detail/handler-health-card.tsx
+++ b/frontend/src/components/app-detail/handler-health-card.tsx
@@ -4,6 +4,7 @@ import { useLocation } from "wouter";
 import { useRelativeTime } from "../../hooks/use-relative-time";
 import { STATUS_DOT_SIZE } from "../../utils/constants";
 import { formatDuration, formatRate, pluralize } from "../../utils/format";
+import { onActivateKeyDown } from "../../utils/keyboard";
 import { Chip } from "../shared/chip";
 import { StatusShape } from "../shared/status-shape";
 import { Tooltip } from "../shared/tooltip";
@@ -40,12 +41,7 @@ export function HandlerHealthCard({ item, appKey, instanceQs, tabIndex }: Handle
   const lastActiveDisplay = useRelativeTime(lastActiveAt);
   const failed = item.data.failed;
 
-  function handleKeyDown(e: KeyboardEvent) {
-    if (e.key === "Enter" || e.key === " ") {
-      e.preventDefault();
-      navigate(href);
-    }
-  }
+  const navigateToHandler = () => navigate(href);
 
   return (
     <div
@@ -55,8 +51,8 @@ export function HandlerHealthCard({ item, appKey, instanceQs, tabIndex }: Handle
       aria-label={`${item.name} handler details`}
       tabIndex={tabIndex}
       data-roving-item
-      onClick={() => navigate(href)}
-      onKeyDown={handleKeyDown}
+      onClick={navigateToHandler}
+      onKeyDown={onActivateKeyDown(navigateToHandler)}
     >
       <div class={styles.header}>
         <span aria-hidden="true">

--- a/frontend/src/components/shared/config-schema-view.module.css
+++ b/frontend/src/components/shared/config-schema-view.module.css
@@ -91,13 +91,7 @@
 }
 
 /* — Value registers (type implied by rendering) ——————————————————————— */
-.valString {
-  font-family: var(--font-mono);
-  font-size: var(--fs-mono-sm);
-  color: var(--ink-1);
-}
-
-.valNumber {
+.valScalar {
   font-family: var(--font-mono);
   font-size: var(--fs-mono-sm);
   color: var(--ink-1);

--- a/frontend/src/components/shared/config-schema-view.tsx
+++ b/frontend/src/components/shared/config-schema-view.tsx
@@ -30,6 +30,7 @@ import { Badge } from "./badge";
 import { Card } from "./card";
 import styles from "./config-schema-view.module.css";
 import { EmptyState } from "./empty-state";
+import { IconChevron } from "./icons";
 import { InfoPopover } from "./info-popover";
 
 interface ConfigSchemaViewProps {
@@ -214,14 +215,7 @@ export function ExpandableValue({ value }: { value: unknown }) {
   return (
     <span>
       <button type="button" class={styles.expandBtn} onClick={() => setExpanded(!expanded)} aria-expanded={expanded}>
-        <svg viewBox="0 0 12 12" width="10" height="10" aria-hidden="true">
-          <polyline
-            points={expanded ? "2,4 6,8 10,4" : "4,2 8,6 4,10"}
-            fill="none"
-            stroke="currentColor"
-            stroke-width="1.5"
-          />
-        </svg>
+        <IconChevron open={expanded} />
         {label}
       </button>
       {expanded && <pre class={styles.expandedPre}>{JSON.stringify(value, null, 2)}</pre>}
@@ -266,7 +260,7 @@ function FieldValue({ node, value, fieldKey }: { node: SchemaNode; value: unknow
   // Duration values are humanized ("30s", "1m 30s"); the raw value stays on hover.
   if (typeof value === "number" && isDurationField(node, fieldKey)) {
     return (
-      <span class={styles.valNumber} title={String(value)}>
+      <span class={styles.valScalar} title={String(value)}>
         {formatDurationField(value, fieldKey)}
       </span>
     );
@@ -277,7 +271,7 @@ function FieldValue({ node, value, fieldKey }: { node: SchemaNode; value: unknow
   }
 
   if (typeof value === "number") {
-    return <span class={styles.valNumber}>{value}</span>;
+    return <span class={styles.valScalar}>{value}</span>;
   }
 
   if (Array.isArray(value)) {
@@ -291,7 +285,7 @@ function FieldValue({ node, value, fieldKey }: { node: SchemaNode; value: unknow
     return <ExpandableValue value={value} />;
   }
 
-  return <span class={styles.valString}>{String(value)}</span>;
+  return <span class={styles.valScalar}>{String(value)}</span>;
 }
 
 /**
@@ -393,17 +387,11 @@ export function ConfigSchemaView({ schema, values, emptyMessage, frameworkFields
   const orderedFrameworkScalars = sortedByOrder(frameworkScalarKeys, properties);
   const orderedGroups = sortedByOrder(groupKeys, properties);
 
-  const userScalarFields = orderedUserScalars.map((key) => ({
-    key,
-    node: properties[key],
-    value: values[key] ?? null,
-  }));
+  const toFieldRows = (keys: string[]) =>
+    keys.map((key) => ({ key, node: properties[key], value: values[key] ?? null }));
 
-  const frameworkScalarFields = orderedFrameworkScalars.map((key) => ({
-    key,
-    node: properties[key],
-    value: values[key] ?? null,
-  }));
+  const userScalarFields = toFieldRows(orderedUserScalars);
+  const frameworkScalarFields = toFieldRows(orderedFrameworkScalars);
 
   // Build one section per group.
   const groupSections = orderedGroups.map((key) => {

--- a/frontend/src/components/shared/execution-table.tsx
+++ b/frontend/src/components/shared/execution-table.tsx
@@ -4,11 +4,13 @@ import { useRovingTabIndex } from "../../hooks/use-roving-tab-index";
 import { useSignal } from "../../hooks/use-signal";
 import { STATUS_DOT_SIZE } from "../../utils/constants";
 import { formatDuration, formatTimestamp, truncateId } from "../../utils/format";
+import { onActivateKeyDown } from "../../utils/keyboard";
 import { executionStatusKind } from "../../utils/status";
 import { Badge } from "./badge";
 import { DetailPanel } from "./detail-panel";
 import { EmptyState } from "./empty-state";
 import styles from "./execution-table.module.css";
+import { IconChevron } from "./icons";
 import { ShowMoreButton } from "./show-more-button";
 import { StatusShape } from "./status-shape";
 
@@ -28,13 +30,13 @@ export interface ExecutionRecord {
   thread_leaked: boolean;
 }
 
-interface Props {
+interface ExecutionTableProps {
   records: ExecutionRecord[];
   kind: "handler" | "job";
   tableId: string;
 }
 
-export function ExecutionTable({ records, kind, tableId }: Props) {
+export function ExecutionTable({ records, kind, tableId }: ExecutionTableProps) {
   const showAll = useSignal(false);
   const openRow = useSignal<number | null>(null);
   const visible = showAll.value ? records : records.slice(0, INITIAL_ROWS);
@@ -82,10 +84,11 @@ export function ExecutionTable({ records, kind, tableId }: Props) {
           {visible.map((record, i) => {
             const isOpen = openRow.value === i;
             const rowKey = record.execution_id ?? `${kind}-${i}`;
-            const isError = record.status === "error";
-            const isTimeout = record.status === "timed_out";
-            const isCancelled = record.status === "cancelled";
-            const threadLeaked = record.thread_leaked;
+            const statusKind = executionStatusKind(record.status);
+            const isThreadLeaked = record.thread_leaked;
+            const toggleRow = () => {
+              openRow.value = isOpen ? null : i;
+            };
 
             return [
               <tr
@@ -98,22 +101,19 @@ export function ExecutionTable({ records, kind, tableId }: Props) {
                 data-roving-item
                 onClick={() => {
                   setActiveIndex(i);
-                  openRow.value = isOpen ? null : i;
+                  toggleRow();
                 }}
-                onKeyDown={(e: KeyboardEvent) => {
-                  if (e.key === "Enter" || e.key === " ") {
-                    e.preventDefault();
-                    openRow.value = isOpen ? null : i;
-                  }
-                }}
+                onKeyDown={onActivateKeyDown(toggleRow)}
               >
                 <td class={styles.statusCell}>
                   <div class={styles.statusCellInner}>
-                    <StatusShape kind={executionStatusKind(record.status)} size={STATUS_DOT_SIZE} />
-                    {isError && record.error_type && <span class={styles.errorType}>{record.error_type}</span>}
-                    {isTimeout && <span class={styles.timeoutType}>timed out</span>}
-                    {isCancelled && <span class={styles.cancelledType}>cancelled</span>}
-                    {threadLeaked && (
+                    <StatusShape kind={statusKind} size={STATUS_DOT_SIZE} />
+                    {statusKind === "err" && record.error_type && (
+                      <span class={styles.errorType}>{record.error_type}</span>
+                    )}
+                    {statusKind === "warn" && <span class={styles.timeoutType}>timed out</span>}
+                    {statusKind === "cancel" && <span class={styles.cancelledType}>cancelled</span>}
+                    {isThreadLeaked && (
                       <Badge variant="warning" size="sm" aria-label="thread leaked past timeout">
                         thread leaked
                       </Badge>
@@ -124,14 +124,7 @@ export function ExecutionTable({ records, kind, tableId }: Props) {
                 <td>{formatDuration(record.duration_ms)}</td>
                 <td class="ht-col-trace ht-text-mono ht-text-xs">{truncateId(record.execution_id)}</td>
                 <td class="ht-text-muted">
-                  <svg viewBox="0 0 12 12" width="10" height="10" aria-hidden="true">
-                    <polyline
-                      points={isOpen ? "2,4 6,8 10,4" : "4,2 8,6 4,10"}
-                      fill="none"
-                      stroke="currentColor"
-                      stroke-width="1.5"
-                    />
-                  </svg>
+                  <IconChevron open={isOpen} />
                 </td>
               </tr>,
               isOpen && (

--- a/frontend/src/components/shared/icons.tsx
+++ b/frontend/src/components/shared/icons.tsx
@@ -214,6 +214,13 @@ export const IconHistory = () => (
   </svg>
 );
 
+/** Small inline chevron for expand/collapse toggles. */
+export const IconChevron = ({ open, size = 10 }: { open: boolean; size?: number }) => (
+  <svg viewBox="0 0 12 12" width={size} height={size} aria-hidden="true">
+    <polyline points={open ? "2,4 6,8 10,4" : "4,2 8,6 4,10"} fill="none" stroke="currentColor" stroke-width="1.5" />
+  </svg>
+);
+
 export const IconScrollText = () => (
   <svg class={styles.iconSvg} viewBox="0 0 24 24" aria-hidden="true">
     <path d="M15 12h-5" />

--- a/frontend/src/components/shared/log-table/log-table-row.tsx
+++ b/frontend/src/components/shared/log-table/log-table-row.tsx
@@ -5,6 +5,7 @@ import type { LogEntry } from "../../../api/endpoints";
 import { BREAKPOINT_MOBILE, useMediaQuery } from "../../../hooks/use-media-query";
 import { useRelativeTime } from "../../../hooks/use-relative-time";
 import { formatTimestamp } from "../../../utils/format";
+import { onActivateKeyDown } from "../../../utils/keyboard";
 import { AppLink } from "../app-link";
 import { LEVEL_ABBREV, levelClass } from "./constants";
 import styles from "./log-table-row.module.css";
@@ -32,12 +33,7 @@ export function LogTableRow({ entry, rowKey, visibleColumns, isSelected, onClick
       class={clsx(styles.row, isSelected && styles.selected)}
       data-level={entry.level}
       onClick={onClick}
-      onKeyDown={(e: KeyboardEvent) => {
-        if (e.key === "Enter" || e.key === " ") {
-          e.preventDefault();
-          onClick();
-        }
-      }}
+      onKeyDown={onActivateKeyDown(onClick)}
       tabIndex={tabIndex}
       role="button"
       data-roving-item

--- a/frontend/src/pages/apps-table-row.tsx
+++ b/frontend/src/pages/apps-table-row.tsx
@@ -5,11 +5,13 @@ import { ActionButtons } from "../components/shared/action-buttons";
 import { AppLink } from "../components/shared/app-link";
 import { Badge } from "../components/shared/badge";
 import { Chip } from "../components/shared/chip";
+import { IconChevron } from "../components/shared/icons";
 import { MiniSparkline } from "../components/shared/mini-sparkline";
 import { StatusShape } from "../components/shared/status-shape";
 import { useRelativeTime } from "../hooks/use-relative-time";
 import { type AppRow } from "../utils/app-data";
 import { formatTimestamp } from "../utils/format";
+import { onActivateKeyDown } from "../utils/keyboard";
 import { INACTIVE_STATUSES, statusToKind, statusToVariant } from "../utils/status";
 import styles from "./apps.module.css";
 
@@ -52,14 +54,7 @@ export function AppTableRow({
                   aria-label={`${isExpanded ? "Collapse" : "Expand"} ${app.app_key}`}
                   data-testid="app-row-expand"
                 >
-                  <svg viewBox="0 0 12 12" width="10" height="10" aria-hidden="true">
-                    <polyline
-                      points={isExpanded ? "2,4 6,8 10,4" : "4,2 8,6 4,10"}
-                      fill="none"
-                      stroke="currentColor"
-                      stroke-width="1.5"
-                    />
-                  </svg>
+                  <IconChevron open={isExpanded} />
                 </button>
               )}
             </span>
@@ -93,12 +88,7 @@ export function AppTableRow({
                   e.stopPropagation();
                   setErrorExpanded(!errorExpanded);
                 },
-                onKeyDown: (e: KeyboardEvent) => {
-                  if (e.key === "Enter" || e.key === " ") {
-                    e.preventDefault();
-                    setErrorExpanded(!errorExpanded);
-                  }
-                },
+                onKeyDown: onActivateKeyDown(() => setErrorExpanded(!errorExpanded)),
               }
             : {})}
         >

--- a/frontend/src/utils/keyboard.ts
+++ b/frontend/src/utils/keyboard.ts
@@ -1,0 +1,9 @@
+/** Call `callback` when Enter or Space is pressed, preventing default scroll/submit. */
+export function onActivateKeyDown(callback: () => void): (e: KeyboardEvent) => void {
+  return (e: KeyboardEvent) => {
+    if (e.key === "Enter" || e.key === " ") {
+      e.preventDefault();
+      callback();
+    }
+  };
+}

--- a/hassette.schema.json
+++ b/hassette.schema.json
@@ -1146,12 +1146,6 @@
             "label": "CORS Origins"
           }
         },
-        "event_buffer_size": {
-          "default": 500,
-          "description": "Maximum number of recent events to keep in the RuntimeQueryService ring buffer.",
-          "title": "Event Buffer Size",
-          "type": "integer"
-        },
         "log_buffer_size": {
           "default": 2000,
           "description": "Maximum number of log entries to keep in the LogCaptureHandler ring buffer.",

--- a/src/hassette/web/routes/apps.py
+++ b/src/hassette/web/routes/apps.py
@@ -7,6 +7,7 @@ from typing import Any
 from fastapi import APIRouter, HTTPException
 
 from hassette.app.app_config import AppConfig
+from hassette.config.classes import AppManifest
 from hassette.exceptions import TelemetryUnavailableError
 from hassette.web.config_view import deref_schema, mask_app_config, mask_values, resolve_app_config_cls
 from hassette.web.dependencies import HassetteDep, RuntimeDep, TelemetryDep
@@ -164,28 +165,28 @@ async def get_app_config(app_key: str, hassette: HassetteDep) -> AppConfigRespon
             if not isinstance(raw_schema, dict):
                 raise TypeError(f"model_json_schema() returned {type(raw_schema).__name__}, expected dict")
             config_schema, masked_config = _build_app_config_view(raw_schema, manifest.app_config)
-            return AppConfigResponse(
-                app_key=app_key,
-                filename=manifest.filename,
-                class_name=manifest.class_name,
-                enabled=manifest.enabled,
-                autostart=manifest.autostart,
-                app_config=masked_config,
-                config_schema=config_schema,
-                framework_fields=_FRAMEWORK_FIELDS,
-            )
+            return _build_config_response(app_key, manifest, masked_config, config_schema)
         except Exception:
             LOGGER.warning("Failed to generate config schema for %s", app_key, exc_info=True)
 
+    return _build_config_response(app_key, manifest, mask_app_config(None, manifest.app_config), None)
+
+
+def _build_config_response(
+    app_key: str,
+    manifest: AppManifest,
+    app_config: dict[str, Any] | list[dict[str, Any]],
+    config_schema: dict[str, Any] | None,
+) -> AppConfigResponse:
     return AppConfigResponse(
         app_key=app_key,
         filename=manifest.filename,
         class_name=manifest.class_name,
         enabled=manifest.enabled,
         autostart=manifest.autostart,
-        app_config=mask_app_config(None, manifest.app_config),
-        config_schema=None,
         framework_fields=_FRAMEWORK_FIELDS,
+        app_config=app_config,
+        config_schema=config_schema,
     )
 
 


### PR DESCRIPTION
### Style debt cleanup (table/grid & config components)

- Extracted a shared `onActivateKeyDown` keyboard util (`frontend/src/utils/keyboard.ts`) — the Enter/Space activation handler was duplicated three times across `handler-health-card.tsx`, `execution-table.tsx`, and `log-table-row.tsx`
- Extracted `IconChevron` from three copies of the same inline expand/collapse SVG (`config-schema-view.tsx`, `execution-table.tsx`, `apps-table-row.tsx`)
- Merged the byte-identical `.valString`/`.valNumber` CSS rule blocks into a single `.valScalar`
- Replaced hand-checked status strings (`"error"`, `"timed_out"`, `"cancelled"`) in `execution-table.tsx` with `executionStatusKind`, which already centralizes that taxonomy
- Extracted a `toFieldRows` helper in `ConfigSchemaView` to collapse duplicated `.map()` logic for user/framework scalar fields
- Renamed `val` → `value` in `ConfigValue`/`isConfigRecord` to match sibling naming, and `Props` → `ExecutionTableProps` / `threadLeaked` → `isThreadLeaked` for consistency with the rest of the codebase
- Hoisted the duplicated `AppConfigResponse` construction in `apps.py` into a module-level `_build_config_response` helper

These were pre-existing findings surfaced by nitpicker/clean-code reviews during earlier PRs (#750, #1154), tracked as #1155 and #1189. No behavior changes — pure structural cleanup.

Closes #1155
Closes #1189

### Clean-code filing conventions

Added `.claude/rules/clean-code-findings.md`, documenting how to file, label, and tag pre-existing code-quality findings surfaced during `/mine-clean-code` and `/mine-review` runs — issue shape, required labels (`type:enhancement`, `topic:code-quality`, milestone), grouping rules, and filing mechanics. This is the filing convention half of the tracking system described in #1112; the automated filing step (auto-filing findings during `/mine-ship`) is not part of this PR.

Partially addresses #1112

### Housekeeping

- Regenerated `hassette.schema.json` to drop the stale `event_buffer_size` field left over from a prior events-system removal
