### PR TITLE
feat: add time-since convenience properties to BaseState

### DIFF
--- a/docs/pages/core-concepts/states/index.md
+++ b/docs/pages/core-concepts/states/index.md
@@ -93,6 +93,8 @@ Every state object is a [`BaseState`][hassette.models.states.base.BaseState] sub
 
 **`last_changed`**, **`last_updated`**, **`last_reported`** are `ZonedDateTime | None` timestamps from HA. `ZonedDateTime` is from the [`whenever`](https://whenever.readthedocs.io/) library, which Hassette uses for all date/time operations — it behaves like a timezone-aware `datetime` and converts via `.to_stdlib()` when a library requires it. `last_changed` updates only when the state string changes. `last_updated` updates when state or attributes change. `last_reported` updates on every write.
 
+**`time_since_last_change`**, **`time_since_last_update`**, **`time_since_last_report`** return `TimeDelta | None` — the elapsed time since each corresponding timestamp, or `None` when the timestamp itself is absent. Useful for checks like "has this entity been in its current state for more than 10 minutes?" without manual arithmetic.
+
 **`entity_id`** and **`domain`** hold the full entity ID (`"light.kitchen"`) and its domain (`"light"`).
 
 **`context`** holds the HA event context that produced this state: `context.id`, `context.parent_id`, and `context.user_id`. It traces which automation or user triggered the change.

--- a/src/hassette/models/states/base.py
+++ b/src/hassette/models/states/base.py
@@ -5,8 +5,9 @@ from logging import getLogger
 from typing import Any, ClassVar, Generic, get_args
 
 from pydantic import AliasChoices, BaseModel, ConfigDict, Field, field_validator, model_validator
-from whenever import Date, PlainDateTime, Time, ZonedDateTime
+from whenever import Date, PlainDateTime, Time, TimeDelta, ZonedDateTime
 
+import hassette.utils.date_utils as date_utils
 from hassette.exceptions import NoDomainAnnotationError
 from hassette.models.states.catalog import register_state_converter
 from hassette.types import StateValueT
@@ -121,6 +122,27 @@ class BaseState(BaseModel, Generic[StateValueT]):
             return False
 
         return len(self.attributes.entity_id) > 1  # pyright: ignore[reportAttributeAccessIssue]
+
+    @property
+    def time_since_last_change(self) -> TimeDelta | None:
+        """Elapsed time since the state value last changed, or ``None`` if the timestamp is absent."""
+        if self.last_changed is None:
+            return None
+        return date_utils.now() - self.last_changed
+
+    @property
+    def time_since_last_update(self) -> TimeDelta | None:
+        """Elapsed time since the state or attributes last changed, or ``None`` if the timestamp is absent."""
+        if self.last_updated is None:
+            return None
+        return date_utils.now() - self.last_updated
+
+    @property
+    def time_since_last_report(self) -> TimeDelta | None:
+        """Elapsed time since the state was last reported, or ``None`` if the timestamp is absent."""
+        if self.last_reported is None:
+            return None
+        return date_utils.now() - self.last_reported
 
     @property
     def extras(self) -> dict[str, Any]:

--- a/src/hassette/models/states/base.py
+++ b/src/hassette/models/states/base.py
@@ -11,7 +11,6 @@ import hassette.utils.date_utils as date_utils
 from hassette.exceptions import NoDomainAnnotationError
 from hassette.models.states.catalog import register_state_converter
 from hassette.types import StateValueT
-from hassette.utils.date_utils import convert_datetime_str_to_system_tz, convert_utc_timestamp_to_system_tz
 
 LOGGER = getLogger(__name__)
 
@@ -164,10 +163,10 @@ class BaseState(BaseModel, Generic[StateValueT]):
         if value is None:
             return None
         if isinstance(value, int | float):
-            return convert_utc_timestamp_to_system_tz(value)
+            return date_utils.convert_utc_timestamp_to_system_tz(value)
         if isinstance(value, str):
             # need to use OffsetDateTime since the value is +00:00, not Z or a timezone
-            return convert_datetime_str_to_system_tz(value)
+            return date_utils.convert_datetime_str_to_system_tz(value)
 
         return value
 

--- a/src/hassette/test_utils/helpers.py
+++ b/src/hassette/test_utils/helpers.py
@@ -39,7 +39,7 @@ if TYPE_CHECKING:
     from hassette.resources.service import Service
     from hassette.types.types import BusErrorHandlerType, HandlerType, Predicate, SourceTier
 
-STATE_DICT_KEYS = frozenset({"last_changed", "last_updated", "context"})
+STATE_DICT_KEYS = frozenset({"last_changed", "last_updated", "last_reported", "context"})
 
 
 def noop() -> None:
@@ -148,6 +148,7 @@ def make_state_dict(
     attributes: dict[str, Any] | None = None,
     last_changed: str | None = None,
     last_updated: str | None = None,
+    last_reported: str | None = None,
     context: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     """Factory for creating state dictionary in Home Assistant format.
@@ -158,13 +159,14 @@ def make_state_dict(
         attributes: Entity attributes dict
         last_changed: ISO timestamp string
         last_updated: ISO timestamp string
+        last_reported: ISO timestamp string
         context: Event context dict
 
     Returns:
         Dictionary matching Home Assistant state format
     """
     now = _date_utils.now().format_iso()
-    return {
+    result = {
         "entity_id": entity_id,
         "state": state,
         "attributes": attributes or {},
@@ -172,6 +174,9 @@ def make_state_dict(
         "last_updated": last_updated or now,
         "context": context or {"id": str(uuid4()), "parent_id": None, "user_id": None},
     }
+    if last_reported is not None:
+        result["last_reported"] = last_reported
+    return result
 
 
 def split_state_kwargs(kwargs: dict[str, Any]) -> tuple[dict[str, Any], dict[str, Any]]:

--- a/tests/unit/models/test_state_time_since.py
+++ b/tests/unit/models/test_state_time_since.py
@@ -1,0 +1,56 @@
+"""Tests for BaseState.time_since_last_change/update/report properties."""
+
+from unittest.mock import patch
+
+import pytest
+from whenever import TimeDelta, ZonedDateTime
+
+from hassette.models.states.light import LightState
+from hassette.test_utils import make_light_state_dict
+
+FIXED_NOW = ZonedDateTime(2026, 7, 6, 12, 0, 0, tz="UTC")
+TEN_MINUTES_AGO = FIXED_NOW.subtract(minutes=10)
+
+
+@pytest.fixture(autouse=True)
+def _freeze_now():
+    with patch("hassette.utils.date_utils.now", return_value=FIXED_NOW):
+        yield
+
+
+class TestTimeSinceLastChange:
+    def test_returns_elapsed_time(self) -> None:
+        data = make_light_state_dict(last_changed=TEN_MINUTES_AGO.format_iso())
+        state = LightState(**data)
+        assert state.time_since_last_change == TimeDelta(minutes=10)
+
+    def test_returns_none_when_timestamp_is_none(self) -> None:
+        data = make_light_state_dict()
+        data["last_changed"] = None
+        state = LightState(**data)
+        assert state.time_since_last_change is None
+
+
+class TestTimeSinceLastUpdate:
+    def test_returns_elapsed_time(self) -> None:
+        data = make_light_state_dict(last_updated=TEN_MINUTES_AGO.format_iso())
+        state = LightState(**data)
+        assert state.time_since_last_update == TimeDelta(minutes=10)
+
+    def test_returns_none_when_timestamp_is_none(self) -> None:
+        data = make_light_state_dict()
+        data["last_updated"] = None
+        state = LightState(**data)
+        assert state.time_since_last_update is None
+
+
+class TestTimeSinceLastReport:
+    def test_returns_elapsed_time(self) -> None:
+        data = make_light_state_dict(last_reported=TEN_MINUTES_AGO.format_iso())
+        state = LightState(**data)
+        assert state.time_since_last_report == TimeDelta(minutes=10)
+
+    def test_returns_none_when_timestamp_is_none(self) -> None:
+        data = make_light_state_dict()
+        state = LightState(**data)
+        assert state.time_since_last_report is None


### PR DESCRIPTION
### State Models

- **Add `time_since_last_change`, `time_since_last_update`, and `time_since_last_report` properties to `BaseState`** — each returns the elapsed `TimeDelta` since the corresponding HA timestamp, or `None` when that timestamp is absent. Automations frequently need "how long has this entity been in its current state?"; this replaces manual `now() - state.last_changed` arithmetic with a direct property, mirroring the request in #964. All three HA timestamps are covered (not just `last_changed`) since they have distinct semantics and the cost of exposing all three is near zero.
- Consolidated the `date_utils` imports in `base.py` to a single module import (`import hassette.utils.date_utils as date_utils`) so the new properties and the existing conversion helpers share one reference instead of mixing named and qualified imports.
- Added `last_reported` to the `make_state_dict` test helper for parity with `last_changed`/`last_updated`, so tests can construct states with a controlled `last_reported` value.

Closes #964
