### PR TITLE
perf: collect coverage on Python 3.14 only in CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -123,19 +123,19 @@ jobs:
 
             - run: uv sync
 
-            # 3.12 skips coverage: sys.settrace overhead adds ~6min to the suite.
-            # sysmon (PEP 669) would fix this but can't measure branches until 3.14.
-            # Coverage from 3.11/3.13/3.14 is sufficient for the combined report.
+            # Coverage collected on 3.14 only — no version-gated code paths in
+            # the source, so one version gives the same coverage data as four.
+            # 3.14 also gets sysmon (PEP 669) automatically, the fastest backend.
             - name: Run tests with coverage
-              if: matrix.python-version != '3.12'
+              if: matrix.python-version == '3.14'
               run: uv run nox -t coverage -p ${{ matrix.python-version }}
 
-            - name: Run tests without coverage (3.12)
-              if: matrix.python-version == '3.12'
+            - name: Run tests without coverage
+              if: matrix.python-version != '3.14'
               run: uv run nox -s tests -p ${{ matrix.python-version }}
 
             - name: Upload coverage data
-              if: matrix.python-version != '3.12'
+              if: matrix.python-version == '3.14'
               uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
               with:
                   name: .coverage.${{ matrix.python-version }}
@@ -169,17 +169,17 @@ jobs:
 
             - run: uv sync
 
-            # Same 3.12 coverage skip as the test job — see comment there.
+            # Same coverage-on-3.14-only rationale as the test job.
             - name: Run system tests with coverage
-              if: matrix.python-version != '3.12'
+              if: matrix.python-version == '3.14'
               run: uv run nox -s system_with_coverage -p ${{ matrix.python-version }}
 
-            - name: Run system tests without coverage (3.12)
-              if: matrix.python-version == '3.12'
+            - name: Run system tests without coverage
+              if: matrix.python-version != '3.14'
               run: uv run nox -s system -p ${{ matrix.python-version }}
 
             - name: Upload coverage data
-              if: matrix.python-version != '3.12'
+              if: matrix.python-version == '3.14'
               uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
               with:
                   name: .coverage.system.${{ matrix.python-version }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -123,10 +123,19 @@ jobs:
 
             - run: uv sync
 
+            # 3.12 skips coverage: sys.settrace overhead adds ~6min to the suite.
+            # sysmon (PEP 669) would fix this but can't measure branches until 3.14.
+            # Coverage from 3.11/3.13/3.14 is sufficient for the combined report.
             - name: Run tests with coverage
+              if: matrix.python-version != '3.12'
               run: uv run nox -t coverage -p ${{ matrix.python-version }}
 
+            - name: Run tests without coverage (3.12)
+              if: matrix.python-version == '3.12'
+              run: uv run nox -s tests -p ${{ matrix.python-version }}
+
             - name: Upload coverage data
+              if: matrix.python-version != '3.12'
               uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
               with:
                   name: .coverage.${{ matrix.python-version }}
@@ -160,10 +169,17 @@ jobs:
 
             - run: uv sync
 
+            # Same 3.12 coverage skip as the test job — see comment there.
             - name: Run system tests with coverage
+              if: matrix.python-version != '3.12'
               run: uv run nox -s system_with_coverage -p ${{ matrix.python-version }}
 
+            - name: Run system tests without coverage (3.12)
+              if: matrix.python-version == '3.12'
+              run: uv run nox -s system -p ${{ matrix.python-version }}
+
             - name: Upload coverage data
+              if: matrix.python-version != '3.12'
               uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
               with:
                   name: .coverage.system.${{ matrix.python-version }}

--- a/noxfile.py
+++ b/noxfile.py
@@ -67,7 +67,6 @@ def tests(session: "Session"):
         "auto",
         "--dist",
         "loadscope",
-        "-v",
         "--tb=line",
         # Fail a hung test instead of letting CI hang until the job is cancelled.
         # thread method dumps every thread's stack then os._exit()s — it catches

--- a/src/hassette/config/helpers.py
+++ b/src/hassette/config/helpers.py
@@ -5,8 +5,7 @@ from collections.abc import Callable, Sequence
 from contextlib import suppress
 from importlib.metadata import version
 from pathlib import Path
-from typing import Any, cast, get_args
-from warnings import warn
+from typing import cast, get_args
 
 import platformdirs
 from packaging.version import Version
@@ -110,15 +109,11 @@ def filter_paths_to_unique_existing(value: Sequence[str | Path | None] | str | P
     return paths
 
 
+logger = logging.getLogger(__name__)
+
+
 def warn_log_level_not_valid(log_level: str, fallback_value: LOG_LEVEL_TYPE) -> None:
-    kwargs: dict[str, Any] = {}
-    if sys.version_info >= (3, 12):
-        kwargs["skip_file_prefixes"] = ("hassette.config.helpers", "pydantic")
-    warn(
-        f"Log level {log_level!r} is not valid, defaulting to {fallback_value!r}. ",
-        stacklevel=2,
-        **kwargs,
-    )
+    logger.warning("Log level %r is not valid, defaulting to %r", log_level, fallback_value)
 
 
 def get_log_level() -> LOG_LEVEL_TYPE:


### PR DESCRIPTION
## Summary

Reduces CI test time by collecting coverage on Python 3.14 only instead of all four matrix versions (3.11/3.12/3.13/3.14). There are no version-gated code paths in the source, so one version produces the same coverage data as four. 3.14 also gets the fastest backend (sysmon/PEP 669) automatically.

All versions still run the full test suite for correctness — just without coverage collection overhead.

## Changes

- **`.github/workflows/tests.yml`**: Coverage steps (`tests_with_coverage`, `system_with_coverage`) gated to `matrix.python-version == '3.14'`. Other versions run `tests`/`system` (no coverage).
- **`src/hassette/config/helpers.py`**: Replace `warnings.warn` with `logging.warning` for invalid log level config. This was the only `sys.version_info` gate in the source — removing it means all versions execute identical code paths, making multi-version coverage redundant.