### PR TITLE
chore: architecture designs for epic:hacs and epic:ha-addon

### DIFF
--- a/design/adrs/0004-companion-integration-transport.md
+++ b/design/adrs/0004-companion-integration-transport.md
@@ -1,0 +1,55 @@
+# ADR-0004: Companion integration transport — custom WS commands over hassette's existing HA connection
+
+**Status:** Accepted (2026-07-07)
+**Relates to:** #45, #46, #594 · `design/research/2026-07-07-companion-integration-architecture/research.md`
+
+## Context
+
+The `epic:hacs` companion integration must let hassette register real HA entities, services,
+devices, and webhooks — all of which require code inside HA's process. The two sides need a
+bidirectional channel: hassette pushes registrations and state; HA pushes entity commands,
+service invocations, and webhook payloads back. #45 sketched three transports (dedicated
+hassette-hosted API, MQTT Discovery, REST polling); prior art added two working models:
+hass-node-red (custom WS commands) and domovoy/ServEnts (plain HA services).
+
+## Decision
+
+The integration registers custom WebSocket commands (`hassette/*`) via
+`websocket_api.async_register_command`. Hassette calls them over the WebSocket connection it
+already maintains (`WebsocketService.send_and_wait` provides id-correlated request/response).
+For HA→hassette traffic, hassette opens a connection-scoped subscription
+(`hassette/subscribe`); the integration pushes `event_message` frames over it, and stores its
+cleanup callable in `connection.subscriptions`, which HA invokes automatically on disconnect.
+
+Consequently:
+
+- **Auth** rides the existing WS authentication. No new secrets, ports, or pairing flows.
+- **Availability is structural.** Disconnect fires the subscription cleanup; the integration
+  marks that instance's entities unavailable. Reconnect re-runs handshake + idempotent
+  re-registration.
+- **Version skew is handled at connect** via a `hassette/handshake` exchange that fails closed.
+- Payload shapes live in the shared `hassette-protocol` package (stdlib-only; voluptuous
+  validates on the HA side, hassette's own Pydantic models on its side).
+
+## Alternatives considered
+
+- **Plain HA services (ServEnts model):** simplest HA side, but no callback channel (command
+  entities, service triggering, and webhooks would need broadcast HA events), no disconnect
+  signal (stale entities stay available), no handshake. Rejected as a foundation; individual
+  convenience services may still be added later as an escape hatch.
+- **Hassette-hosted API the integration connects to** (#45 option 1): adds network
+  reachability config, a pairing secret, and a second reconnect state machine, with no
+  capability the chosen design lacks. Rejected.
+- **MQTT Discovery** (#45 option 2): ruled out by decision — no broker dependency, and no
+  callback path for services/webhooks.
+
+## Consequences
+
+- `WebsocketService.dispatch` gains subscription-id routing (today it assumes all
+  `type: "event"` frames are HA event envelopes).
+- Hassette's long-lived token must belong to an admin user (`@require_admin` on all
+  `hassette/*` commands).
+- Read-only entity support needs only hassette→HA commands; command entities, services, and
+  webhooks share one push envelope designed once.
+- The transport works unchanged for Docker, remote hosts, and the future HA add-on
+  (`epic:ha-addon`).

--- a/design/adrs/0005-ha-addon-packaging.md
+++ b/design/adrs/0005-ha-addon-packaging.md
@@ -1,0 +1,81 @@
+# ADR-0005: HA Add-on Packaging — Derived Image, Ingress-First Web UI
+
+**Date:** 2026-07-07
+**Status:** Accepted
+**Context:** `epic:ha-addon` (#71). Full analysis in
+`design/research/2026-07-07-ha-addon-architecture/research.md`.
+
+## Context
+
+Hassette needs a Home Assistant add-on distribution so HAOS/Supervised users can install it
+from the add-on store instead of composing Docker themselves. The two architectural choices
+that shape everything else: how the add-on image relates to the published hassette image, and
+how the web UI is exposed to the user.
+
+Constraints that drove the decision:
+
+- The hassette web API has **no authentication**. Any exposure model must not widen that gap.
+- Add-on users cannot substitute images — the supervisor owns the container, so runtime
+  dependency install (already implemented in `scripts/docker_start.sh` and chosen for exactly
+  this future in `design/specs/docker-dep-redesign/design.md`) is the only dep path.
+- Supervisor 2026.04 removed implicit `BUILD_FROM` injection and `build.yaml`; add-on
+  Dockerfiles use explicit `FROM`, and prebuilt images are referenced via the `image:` key.
+- The frontend is absolute-path throughout (Vite base `/`, hardcoded `/api` client base,
+  absolute `wouter` routes), which no ingress deployment can serve unmodified.
+
+## Decision
+
+**Derived image.** The add-on repo (`hassette-addon`, separate from the framework repo) builds
+a thin image `FROM ghcr.io/nodejsmith/hassette:<version>-py3.14`, adding only a `run.sh` that
+translates `/data/options.json` + `SUPERVISOR_TOKEN` into `HASSETTE__*` environment variables
+and execs the existing entrypoint chain. All supervisor-specific glue lives in the add-on repo;
+the main image carries zero add-on awareness.
+
+**Ingress-first exposure.** `ingress: true` proxying to hassette's existing port 8126. The
+supervisor authenticates the HA user before proxying, giving the unauthenticated web UI an auth
+layer for free; hassette additionally restricts clients to the ingress gateway when no host
+port is mapped. A host port mapping exists in `config.yaml` but ships disabled — opting in
+reproduces today's Docker trust model and is documented as unauthenticated.
+
+Supporting choices (detailed in the research brief): minimal options schema with real config in
+`hassette.toml` under the `addon_config` mount; new general-purpose `api_url`/`ws_url` config
+overrides so hassette can use the supervisor's proxy endpoints (`ws://supervisor/core/websocket`
+does not follow the `base_url + /api/websocket` pattern); watchdog pointed at the existing
+liveness endpoint `/api/health/live`, never at readiness, so supervisor restarts don't fight
+hassette's own HA-reconnect logic.
+
+## Alternatives considered
+
+**Add-on-aware main image** — `docker_start.sh` detects `SUPERVISOR_TOKEN`/`options.json`
+itself and the add-on references the stock image. One less image to publish, but supervisor
+logic would ship (dormant) to every Docker user, couple the framework release cycle to add-on
+manifest details, and put add-on debugging in the main repo. Rejected: the translation layer is
+~50 lines of shell; a derived image isolates it where it belongs.
+
+**Local Dockerfile build (no `image:` key)** — each user's machine builds on install. Rejected:
+multi-minute installs on Pi-class hardware, build failures surfacing on user machines, and we
+already publish multi-arch images.
+
+**Direct-port exposure only (AppDaemon model)** — skips the frontend base-path work entirely.
+Rejected: it exposes the auth-less UI on the LAN as the *only* access path, forfeits the
+sidebar embedding that #71 exists for, and the base-path work is a bounded, one-time frontend
+investment that also benefits reverse-proxy deployments.
+
+**MQTT/other transports for HA connection** — not applicable; the add-on changes nothing about
+how hassette talks to HA except the URLs and token source. ADR-0004's companion-integration
+transport rides the same connection unchanged.
+
+## Consequences
+
+- The frontend must become base-path-agnostic (prereq-01): `<base href>` injection from
+  `X-Ingress-Path`, with router/API/WS URLs derived from `document.baseURI`. This is the
+  epic's largest single work item and benefits non-add-on reverse-proxy users.
+- Hassette gains `api_url`/`ws_url` overrides (prereq-02) and `web_api.allowed_client_ips`
+  (prereq-03) — small, generally useful config additions; no add-on-specific code paths.
+- A second repo and image pipeline exist (`hassette-addon`), with version bumps automated off
+  hassette releases (prereq-05). The add-on version is pinned to an exact hassette release tag,
+  so add-on users update through the add-on store, never by image drift.
+- First start with user dependencies has a web-UI-unavailable install window; the uv cache
+  persists on `/data` so it is first-start-only. #615 (splash screen) remains the UX answer.
+- `hassette build` (#616) is decoupled from the epic: the supervisor owns the image, so the
+  add-on necessarily uses runtime install. #616 remains a standalone-Docker improvement.

--- a/design/research/2026-07-07-companion-integration-architecture/prereq-01-instance-identity.md
+++ b/design/research/2026-07-07-companion-integration-architecture/prereq-01-instance-identity.md
@@ -1,0 +1,27 @@
+# Prereq 01: Hassette instance identity
+
+**Repo:** hassette · **Blocks:** prereq-04
+
+Hassette has no stable cross-restart instance identity — only per-app `instance_name` and the
+per-run DB `session_id`. The integration namespaces devices, entities (`unique_id` prefix),
+and takeover semantics by `instance_id`, so it must exist before any registration protocol
+work.
+
+## Scope
+
+- Add `instance_id: str = "default"` to top-level hassette config (`hassette.toml`),
+  validated as a slug (lowercase, `[a-z0-9_]`, length-capped) since it embeds into HA
+  `unique_id`s.
+- Expose it on `Hassette` (alongside `ws_url` etc.) for the protocol client.
+- Surface in `hassette status` CLI output and the web UI config view (existing config
+  display machinery).
+- Docs: configuration reference entry; note that changing `instance_id` orphans previously
+  registered HA entities (the integration's sync sweep removes them under the old id only
+  when that id reconnects — document "pick once").
+
+## Files (change verb + path)
+
+- modify `src/hassette/config/` (top-level settings class + validation)
+- modify `src/hassette/core/core.py` (expose property)
+- modify CLI status output + web config endpoint where config fields are listed
+- add unit tests beside existing config validation tests

--- a/design/research/2026-07-07-companion-integration-architecture/prereq-02-ws-subscription-routing.md
+++ b/design/research/2026-07-07-companion-integration-architecture/prereq-02-ws-subscription-routing.md
@@ -1,0 +1,27 @@
+# Prereq 02: WebSocket subscription routing
+
+**Repo:** hassette · **Blocks:** prereq-04
+
+`WebsocketService.dispatch` assumes every `type: "event"` frame is an HA event envelope and
+funnels it to `create_event_from_hass`. Integration pushes arrive as `event_message` frames
+carrying the subscription's message id — they must be routed to a registered handler instead
+of being parsed as HA events.
+
+## Scope
+
+- Add a subscription routing table: `dict[int, handler]` mapping subscription message ids to
+  async handlers. `dispatch` checks the frame's `id` against the table before falling through
+  to the HA-event path (the existing all-events subscription id can itself live in the table,
+  making routing uniform).
+- Registration API on `WebsocketService`: subscribe-with-handler that sends the command via
+  `send_and_wait` and installs the route atomically; routes cleared in `partial_cleanup` /
+  `cleanup` alongside `_subscription_ids`.
+- Handler errors are isolated (log + continue), matching `dispatch`'s existing behavior.
+- Regression tests: routed frame reaches handler; unknown id falls through to HA-event path;
+  routes cleared on reconnect (follow the startup-race test pattern from CLAUDE.md — gate
+  with `asyncio.Event`, no sleeps).
+
+## Files
+
+- modify `src/hassette/core/websocket_service.py`
+- add/extend unit tests for dispatch routing

--- a/design/research/2026-07-07-companion-integration-architecture/prereq-03-protocol-package.md
+++ b/design/research/2026-07-07-companion-integration-architecture/prereq-03-protocol-package.md
@@ -1,0 +1,25 @@
+# Prereq 03: `hassette-protocol` package
+
+**Repo:** new (`hassette-protocol`) · **Blocks:** prereq-04, prereq-05, prereq-06
+
+Shared wire contract consumed by both hassette and `hass-hassette`.
+
+## Scope
+
+- New repo + PyPI package. Pure Python, **zero runtime dependencies**, Python ≥3.11,
+  setuptools or uv build backend (never hatchling).
+- Contents:
+  - Message-type string constants (`hassette/handshake`, `hassette/subscribe`,
+    `hassette/entity/register`, `hassette/entity/update`, `hassette/entity/remove`,
+    `hassette/sync`; reserved: `hassette/service/register`, `hassette/webhook/register`).
+  - `PROTOCOL_VERSION: int` (starts at 1; additive changes do not bump).
+  - `TypedDict` payload shapes for every command, response, and push envelope
+    (`entity_command` / `service_call` / `webhook` kinds).
+  - `StrEnum`s for platforms and entity commands.
+  - State coercion pure functions (bool→`on`/`off`, numeric→str, Enum→value, None→
+    unavailable; 255-char state limit enforced).
+  - Canonical JSON fixtures per message type, shipped as package data — both consumer repos
+    run contract tests against them.
+- No pydantic, no voluptuous: hassette layers Pydantic models over these shapes in its own
+  repo; the integration layers voluptuous schemas in its repo.
+- Release automation (release-please or equivalent) since both consumers pin versions.

--- a/design/research/2026-07-07-companion-integration-architecture/prereq-04-entity-registry-resource.md
+++ b/design/research/2026-07-07-companion-integration-architecture/prereq-04-entity-registry-resource.md
@@ -1,0 +1,44 @@
+# Prereq 04: `self.entities` per-app resource + protocol client
+
+**Repo:** hassette · **Blocked by:** prereq-01, prereq-02, prereq-03 · **Blocks:** prereq-06
+
+The hassette side of v0.1: an `EntityRegistry` core service (protocol client) plus a per-app
+`Entities` child resource.
+
+## Scope
+
+- **Core service** (sibling of `BusService` etc.): owns handshake on
+  `HASSETTE_EVENT_WEBSOCKET_CONNECTED`, re-registration after reconnect, the post-startup
+  `hassette/sync` sweep, a per-instance outbound queue with batched `entity/update` flushes
+  (last write per entity wins within a flush), and dispatch of `entity_command` pushes to the
+  owning entity's handler via the standard handler-invocation machinery (telemetry, error
+  isolation, and web-UI visibility like every other handler).
+- `before_shutdown` on the core service best-effort marks all registered entities unavailable
+  (same pattern as `WebsocketService.before_shutdown`); connection close guarantees the
+  outcome if the push doesn't get out.
+- **Per-app resource** `self.entities` (added in `App.__init__` via `add_child`, like
+  `self.bus`): `add_sensor`, `add_binary_sensor`, `add_switch`, `add_button`, `add_number`,
+  `add_select`. Returns typed handles with `set(value, attributes=..., available=...)`.
+  Declaration raises a specific exception when the integration is absent or the handshake
+  failed. App teardown marks its entities unavailable (not removed).
+- `unique_id` construction `hassette_{instance_id}_{app_key}_{instance_name}_{key}`;
+  duplicate `key` within an app instance raises at declaration.
+- Command entities: `on_command`/`off_command`/`press`/`set_value`/`select_option` handlers;
+  confirmed-by-default semantics, `assumed_state=True` opt-in.
+- Handshake failure / version mismatch: fail closed, log, surface status (web UI status
+  surface may be a follow-up issue; at minimum expose state on the service for the UI epic).
+- Tests: unit tests with faked WS responses/pushes; deterministic race tests per CLAUDE.md
+  patterns.
+- Docs: new docs-site page for entity registration (per `design-completeness.md`, ships with
+  the feature).
+
+## Files
+
+- add `src/hassette/core/entity_registry_service.py` (core service / protocol client)
+- add `src/hassette/entities/` (per-app `Entities` resource, typed entity handles,
+  declaration params)
+- modify `src/hassette/app/app.py` (add `self.entities` child in `App.__init__`)
+- modify `src/hassette/core/core.py` (register core service + `depends_on` wiring)
+- modify `src/hassette/exceptions.py` (integration-absent / handshake-failed exceptions)
+- add unit tests beside existing core-service tests; add docs page under
+  `docs/pages/core-concepts/`

--- a/design/research/2026-07-07-companion-integration-architecture/prereq-05-integration-skeleton.md
+++ b/design/research/2026-07-07-companion-integration-architecture/prereq-05-integration-skeleton.md
@@ -1,0 +1,28 @@
+# Prereq 05: `hass-hassette` integration skeleton
+
+**Repo:** new (`hass-hassette`) · **Blocked by:** prereq-03 · **Blocks:** prereq-06
+
+The HA-side scaffold, installable via HACS custom repository, before any entity platform
+exists.
+
+## Scope
+
+- Repo scaffold: `custom_components/hassette/` with `manifest.json` (domain `hassette`,
+  `iot_class: local_push`, `requirements: ["hassette-protocol==…"]`), `hacs.json` with
+  minimum-HA pin, README, license.
+- Single zero-config `config_flow` entry (one entry, no fields; abort on second).
+- WS command registration: `hassette/handshake` (protocol version exchange, hub device
+  creation per `instance_id`, takeover semantics for a reconnecting instance id) and
+  `hassette/subscribe` (store cleanup in `connection.subscriptions`; cleanup marks the
+  instance's entities unavailable). All commands `@require_admin`.
+- `Store`-backed instance/definition persistence keyed by `instance_id` (schema versioned).
+- CI: `hassfest` action, HACS validation action, `pytest-homeassistant-custom-component`
+  suite, contract tests against `hassette-protocol` fixtures.
+- Note: the first *tagged release* (required by HACS) is cut only after prereq-06 lands —
+  it is housekeeping that follows prereq-06, not part of this prereq's blocking scope.
+
+## Files
+
+- add `custom_components/hassette/` (`__init__.py`, `manifest.json`, `config_flow.py`,
+  `websocket.py`, `store.py`), `hacs.json`, `.github/workflows/` (hassfest, HACS, tests),
+  `tests/`, README, LICENSE — all in the new `hass-hassette` repo

--- a/design/research/2026-07-07-companion-integration-architecture/prereq-06-entity-platforms-e2e.md
+++ b/design/research/2026-07-07-companion-integration-architecture/prereq-06-entity-platforms-e2e.md
@@ -1,0 +1,32 @@
+# Prereq 06: Entity platforms end-to-end (v0.1 completion)
+
+**Repos:** hass-hassette + hassette · **Blocked by:** prereq-04, prereq-05
+
+Everything that makes v0.1 shippable: the six platforms working end-to-end with the full
+lifecycle matrix from `research.md`.
+
+## Scope
+
+- Platforms in `hass-hassette`: `sensor`, `binary_sensor`, `switch`, `button`, `number`,
+  `select`. Dynamic creation via dispatcher signals to pre-forwarded platforms;
+  `RestoreEntity`; device per app instance with `via_device` → instance hub.
+- `hassette/entity/register` (batch upsert), `hassette/entity/update` (batch state/
+  attributes/availability), `hassette/entity/remove`, `hassette/sync` orphan sweep.
+- Command platforms push `entity_command` envelopes over the subscription;
+  confirmed-by-default (no optimistic flip unless `assumed_state`).
+- Lifecycle verification against the research.md matrix: connection drop → unavailable;
+  HA restart → restored-but-unavailable until reconnect; app reload → unavailable then
+  re-registered; dropped entity → removed by sync.
+- **System test:** install `hass-hassette` into hassette's system-test HA container and the
+  demo stack; end-to-end test register → registry entry → command → handler → confirmed
+  state. This is the real safety net for the whole epic.
+- Docs both sides: HACS install guide (custom repo), entity API page, admin-token
+  requirement, recorder-exclusion note.
+
+## Files
+
+- add `custom_components/hassette/{sensor,binary_sensor,switch,button,number,select}.py` and
+  `entity.py` (base entity + dispatcher wiring) in `hass-hassette`
+- extend `custom_components/hassette/websocket.py` (register/update/remove/sync commands)
+- modify hassette system-test + demo-stack HA container setup to mount `hass-hassette`
+- add system test covering the register → command → confirmed-state loop

--- a/design/research/2026-07-07-companion-integration-architecture/research.md
+++ b/design/research/2026-07-07-companion-integration-architecture/research.md
@@ -1,0 +1,285 @@
+# Companion Integration Architecture (`epic:hacs`)
+
+**Date:** 2026-07-07
+**Status:** Decided — decisions recorded below were made with Jessica on 2026-07-07. Transport decision recorded in ADR-0004.
+**Anchor issues:** #45 (custom integration), #46 (`@template` decorator), #594 comment on #45 (webhook dependency)
+
+## Problem
+
+Hassette connects to Home Assistant as an external WebSocket/REST client. That surface is
+consumer-only. Four capabilities require code running inside HA's process:
+
+1. **Real registry entities** — `sensor`, `binary_sensor`, `switch`, etc. with `unique_id`,
+   device association, device class, and unit of measurement. `api.set_state()` entries are
+   ephemeral state-machine writes that vanish on HA restart.
+2. **Native services** — `hass.services.async_register()` has no WebSocket equivalent, so HA
+   automations cannot call `hassette.reload_app` today.
+3. **Device registry entries** — devices are created by integrations via `DeviceInfo`; no
+   external API exists.
+4. **Webhook registration** — `webhook.async_register()` is a Python API only (see the #594
+   research comment on #45).
+
+A companion HACS integration (domain `hassette`) closes all four gaps.
+
+## Decisions (2026-07-07)
+
+| # | Decision | Choice |
+|---|---|---|
+| D1 | Transport | Custom WS commands on hassette's existing HA connection; subscription push for HA→hassette callbacks (ADR-0004) |
+| D2 | MQTT Discovery | Ruled out — hassette must not require an MQTT broker |
+| D3 | Repo topology | Separate integration repo: **`hass-hassette`** |
+| D4 | Protocol source of truth | Shared PyPI package **`hassette-protocol`** (stdlib-only; no pydantic) |
+| D5 | Config flow | Single zero-config entry; instances self-identify at handshake |
+| D6 | MVP scope (v0.1) | Read-only entities **and** command entities — the callback envelope ships in v0.1 |
+| D7 | Framework services | v0.2 (`reload_app`, `start_app`, `stop_app`, trigger) |
+| D8 | App-declared services | Deferred — naming/collision design is an open question |
+| D9 | Webhook forwarding | Specced here, implemented v0.3+; #594 stays blocked until then |
+| D10 | #46 `@template` Stage 1 | Skipped — `@template` ships only integration-backed, never ephemeral |
+
+## Transport analysis
+
+Three candidate shapes (plus MQTT, ruled out by D2):
+
+**T1 — custom WS commands over hassette's existing connection** (the hass-node-red model).
+The integration registers `hassette/*` commands via `websocket_api.async_register_command`.
+Hassette calls them through `WebsocketService.send_and_wait`, which already provides message-id
+correlation and retry. For the reverse direction, hassette opens a connection-scoped
+subscription; the integration pushes `event_message` frames over it. Verified against
+hass-node-red's `websocket.py`: handlers store cleanup callables in
+`connection.subscriptions[msg_id]`, and HA invokes them automatically when the connection
+closes — a free liveness signal.
+
+- Auth rides the WS authentication hassette already performs. No new secrets, no pairing.
+- Availability is structural: connection drop → subscription cleanup → integration marks that
+  instance's entities unavailable. Reconnect → idempotent re-registration.
+- Topology-agnostic: identical behavior for Docker, remote host, or the future HA add-on
+  (`epic:ha-addon`). Nothing ever needs to reach hassette.
+- Cost: `WebsocketService.dispatch` currently assumes every `type: "event"` frame is an HA
+  event envelope; it needs a subscription-id routing table (prereq-02).
+
+**T2 — integration registers plain HA services** (the ServEnts/domovoy model). Simpler HA-side
+code, and service response values (HA 2023.7+) allow request/response. But there is no
+callback channel (HA→hassette falls back to broadcast HA events), no disconnect signal
+(stale entities remain "available" indefinitely), and no connect-time version handshake.
+Adequate for write-only sensors; wrong foundation for switches, services, and webhooks.
+
+**T3 — hassette hosts a server; the integration connects to it** (option 1 in #45). Strictly
+more moving parts than T1 — network reachability configuration, a pairing secret in
+`config_flow`, a second reconnect state machine — with no capability T1 lacks.
+
+**Verdict: T1** (D1). A structural consequence worth naming: read-only platforms need only the
+hassette→HA direction, while command entities, services, and webhooks all share one HA→hassette
+callback envelope. The envelope is designed once (v0.1, per D6) and reused for every later
+capability.
+
+## Architecture overview
+
+```mermaid
+flowchart TD
+    subgraph APP["App (user code)"]
+        E["self.entities<br/>per-app resource"]
+    end
+    subgraph HASSETTE["Hassette core"]
+        ER["EntityRegistry client<br/>(coalescing, ownership)"]
+        WS["WebsocketService<br/>send_and_wait + subscription routing"]
+    end
+    subgraph HA["Home Assistant"]
+        WSAPI["websocket_api<br/>hassette/* commands"]
+        INT["hass-hassette integration<br/>Store + dispatcher"]
+        PLAT["entity platforms<br/>sensor / binary_sensor / switch / …"]
+        REG["entity + device registry"]
+    end
+    E --> ER --> WS
+    WS -- "commands (handshake, subscribe,<br/>register, update, sync)" --> WSAPI --> INT
+    INT -- "subscription push (entity commands,<br/>service calls, webhooks)" --> WS
+    INT --> PLAT --> REG
+
+    style E fill:#e8f0ff,stroke:#6688cc
+    style ER fill:#fff0e8,stroke:#cc8844
+    style WS fill:#fff0e8,stroke:#cc8844
+    style WSAPI fill:#f0f0f0,stroke:#999
+    style INT fill:#f0f8e8,stroke:#88aa66
+    style PLAT fill:#f0f8e8,stroke:#88aa66
+    style REG fill:#f0f0f0,stroke:#999
+```
+
+### Identity model
+
+- **Instance identity (new):** hassette gains a config-level `instance_id` (default
+  `"default"`). Today only per-app `instance_name` and the per-run DB `session_id` exist;
+  neither is a stable cross-restart identity (prereq-01).
+- **unique_id scheme:** `hassette_{instance_id}_{app_key}_{instance_name}_{key}`. Collisions
+  are only possible within a single app instance and are raised locally at declaration time.
+- **Device grouping:** one hub device per hassette instance (created at handshake), one device
+  per app instance with `via_device` pointing at the hub. Entities attach to their app's
+  device. This delivers #45's "all hassette entities grouped under a Hassette device with
+  app-level sub-grouping" directly.
+- **Entity naming:** suggested object id defaults to `hassette_{app_key}_{key}`
+  (e.g. `sensor.hassette_climate_controller_comfort_index`); users rename freely in HA since
+  identity lives in `unique_id`.
+
+## Protocol design (v1)
+
+All payload shapes, message-type constants, and coercion rules live in `hassette-protocol`.
+Protocol version is a single integer; additive changes do not bump it.
+
+### Commands (hassette → HA)
+
+| Command | Payload (abridged) | Purpose |
+|---|---|---|
+| `hassette/handshake` | `protocol_version`, `hassette_version`, `instance_id`, `instance_name` | Version check; creates/claims the instance hub device. Response carries integration version + supported protocol range. |
+| `hassette/subscribe` | — | Opens the callback channel. Integration stores cleanup in `connection.subscriptions`; cleanup marks the instance's entities unavailable. |
+| `hassette/entity/register` | `device`, `entities: [...]` (batch) | Upsert entity definitions. Idempotent; definitions persisted in an HA `Store`. |
+| `hassette/entity/update` | `updates: [{unique_id, state?, attributes?, available?}]` (batch) | State/attribute/availability push. |
+| `hassette/entity/remove` | `unique_ids: [...]` | Explicit removal (app dropped an entity across reload). |
+| `hassette/sync` | `unique_ids: [...]` (full set for instance) | Orphan sweep: integration removes registry entries owned by this instance that are absent from the set. Sent after startup settles. |
+| `hassette/service/register` | *(v0.2)* service name, fields schema | Framework services first (D7). |
+| `hassette/webhook/register` | *(v0.3)* webhook_id, local_only | Per the #594 design constraints recorded on #45. |
+
+### Subscription pushes (HA → hassette)
+
+One envelope, `{kind, ...}`:
+
+- `{kind: "entity_command", unique_id, command, data}` — e.g. `turn_on`, `press`,
+  `set_value`, `select_option`.
+- `{kind: "service_call", service, data, context}` *(v0.2)*
+- `{kind: "webhook", webhook_id, payload}` *(v0.3)*
+
+### Command-entity semantics
+
+Confirmed-by-default: the integration does **not** optimistically flip state on a command; it
+forwards the command and waits for the resulting `entity/update`. `assumed_state=True` at
+declaration opts into optimistic behavior. Handler dispatch on the hassette side goes through
+the same invocation machinery as bus handlers, so command executions get telemetry, error
+isolation, and web-UI visibility like every other handler.
+
+### State coercion
+
+HA states are strings (≤255 chars); attributes are JSON. Coercion (`bool` → `on`/`off` for
+binary platforms, `float`/`int` → string, `Enum` → value, `None` → unavailable) is defined
+once as pure functions in `hassette-protocol` and used by both sides.
+
+## Lifecycle matrix
+
+| Event | Behavior |
+|---|---|
+| Connection drop | Subscription cleanup fires in HA → all entities of that instance become unavailable. Hassette's existing reconnect loop re-runs handshake + registration on `HASSETTE_EVENT_WEBSOCKET_CONNECTED`. |
+| HA restart | Integration loads definitions from `Store`, recreates entities as unavailable with `RestoreEntity` state. Hassette reconnects (existing retry loop) → handshake → re-register → available. |
+| Hassette restart (clean) | `before_shutdown` best-effort marks entities unavailable; connection close guarantees it regardless. |
+| App reload | App teardown sets its entities unavailable (not removed — reloads are routine; removal would churn HA's registry). Re-init re-registers. Entities dropped from code are removed by explicit `entity/remove` or the post-startup `sync` sweep. |
+| App removed from config | `sync` sweep removes its entities and device. |
+| Same `instance_id` reconnects while old connection lingers | Takeover: the newer handshake supersedes; the stale connection's cleanup is ignored for superseded instances. |
+| Protocol version mismatch | Handshake fails closed: hassette logs an error, disables integration-backed features, and surfaces the status in the web UI; everything else runs normally. |
+
+## `hassette-protocol` package
+
+- **Contents:** message-type constants, protocol version, `TypedDict` payload shapes,
+  `StrEnum`s, coercion functions, canonical JSON fixtures per message type.
+- **Constraints:** pure Python, zero runtime dependencies, Python ≥3.11. No pydantic — HA
+  pins its own pydantic and custom integrations must not import a conflicting one.
+- **Validation layering:** the integration validates inbound commands with voluptuous
+  (mandatory — `@websocket_command` takes voluptuous schemas); hassette validates inbound
+  pushes with its own Pydantic models that reference the shared shapes. Both repos run
+  contract tests against the package's fixtures, so drift fails CI on whichever side drifted.
+- **Home:** its own repo, so releases version independently and both consumers pin it. The
+  integration lists it in `manifest.json` `requirements`; hassette lists it in `pyproject.toml`.
+
+## Hassette-side app API (sketch)
+
+```python
+class ClimateApp(App[ClimateConfig]):
+    async def on_initialize(self):
+        self.comfort = await self.entities.add_sensor(
+            key="comfort_index",
+            name="Comfort Index",
+            unit_of_measurement="°F",
+            device_class="temperature",
+            state_class="measurement",
+        )
+        self.boost = await self.entities.add_switch(
+            key="boost_mode",
+            name="Boost Mode",
+            on_command=self.enable_boost,
+            off_command=self.disable_boost,
+        )
+        await self.comfort.set(72.4)
+```
+
+- `self.entities` is a per-app child resource (sibling of `self.bus` / `self.scheduler`),
+  torn down with the app like every other child.
+- Imperative API is the foundation. #46's `@template` decorator becomes sugar over it
+  (declaration + scheduled refresh), following the #530 scheduler-decorator pattern, and per
+  D10 ships only once this exists.
+- State pushes for one instance serialize through a single queue; bursts coalesce naturally
+  into batched `entity/update` frames (last write wins per entity within a flush).
+- When the integration is absent or the handshake failed, `add_*` raises a specific
+  exception at declaration time — no silent no-op entities.
+
+## HA-side integration design
+
+- **Repo `hass-hassette`**, domain `hassette`, single zero-config entry (D5). Instances appear
+  dynamically as hub devices under that entry.
+- Dynamic entity creation via dispatcher signals to pre-forwarded platforms (the pattern both
+  hass-node-red and ServEnts use); `RestoreEntity` for state across HA restarts; definitions
+  in an HA `Store` keyed by instance.
+- v0.1 platforms: `sensor`, `binary_sensor`, `switch`, `button`, `number`, `select` — the
+  four command platforms share the one callback envelope, so their marginal cost is small.
+- All `hassette/*` commands use `@require_admin` — entity/service registration is powerful.
+  Consequence: hassette's long-lived token must belong to an admin user. Document prominently.
+- CI: `hassfest` validation, HACS action, `pytest-homeassistant-custom-component` suite,
+  contract tests against `hassette-protocol` fixtures.
+
+## Risks
+
+- **Admin token requirement** — likely already true for most users, but it becomes a hard
+  requirement. Docs + a clear handshake error message.
+- **State-push storms** — a hot sensor loop could flood HA. Mitigated by per-instance
+  batching; if real-world use demands it, add per-entity min-interval throttling later
+  (observed-usage rule — don't build it speculatively).
+- **HA recorder growth** — every entity update is recorded by HA. Users control this with
+  HA's own `recorder` excludes; docs should mention it.
+- **Registry churn on reload** — mitigated by unavailable-not-removed semantics (lifecycle
+  matrix above).
+- **Three-repo coordination** — protocol changes touch up to three repos. Mitigated by the
+  additive-change rule (no version bump), contract tests, and the handshake failing closed.
+
+## Testing strategy
+
+- `hassette-protocol`: fixture round-trip tests.
+- `hass-hassette`: `pytest-homeassistant-custom-component` unit tests + hassfest + HACS action.
+- hassette: unit tests with faked command responses/pushes; **system tier** — install
+  `hass-hassette` into the system-test HA container (hassette already runs real HA in Docker),
+  giving true end-to-end coverage of register → entity in registry → command → handler →
+  state confirmed. Same lever for the demo stack, which doubles as the visual-QA surface for
+  any web-UI integration-status display.
+
+## Staging
+
+| Release | Scope |
+|---|---|
+| v0.1 | Handshake, subscribe, entity register/update/remove/sync; platforms sensor, binary_sensor, switch, button, number, select; availability + restore + orphan sweep; `self.entities` API; HACS-installable (custom repo). |
+| v0.2 | Framework services: `hassette.reload_app`, `start_app`, `stop_app`, handler trigger (D7). |
+| v0.3 | Webhook forwarding per the #594 constraints (D9); unblocks #594. |
+| v0.4+ | #46 `@template` decorator (D10); HACS default-store submission; app-declared custom services once naming is designed (D8). |
+
+## Open questions (deferred by decision)
+
+- **App-declared service naming (D8):** services are flat under domain `hassette`; per-app
+  namespacing (`hassette.{app_key}_{name}` vs. free naming + per-instance uniqueness
+  validation) needs its own small design before v0.4.
+- **Web UI surface:** an integration-status indicator (handshake state, protocol version,
+  entity count) and per-app entity lists belong in the monitoring UI eventually; scope when
+  v0.1 lands.
+
+## Verify at implementation time
+
+Facts below are stable HA patterns but must be checked against the current HA release when
+each prereq starts:
+
+- `websocket_api.async_register_command` / `@websocket_command` / `@require_admin` signatures
+  and the `connection.subscriptions` cleanup contract.
+- `RestoreEntity` and dynamic `async_add_entities` patterns; `Store` versioning/migration.
+- `homeassistant.components.webhook.async_register` import path (the pre-2024.9
+  `hass.components` path is deprecated — noted on #45).
+- HACS submission requirements and `hacs.json` minimum-HA pin.
+- HA service response values API (if used for anything beyond fire-and-forget in v0.2).

--- a/design/research/2026-07-07-companion-integration-architecture/research.md
+++ b/design/research/2026-07-07-companion-integration-architecture/research.md
@@ -271,6 +271,24 @@ class ClimateApp(App[ClimateConfig]):
   entity count) and per-app entity lists belong in the monitoring UI eventually; scope when
   v0.1 lands.
 
+## Future capability: retained availability (designed, not scheduled)
+
+Entities already persist outside hassette's lifecycle (`Store` definitions + `RestoreEntity`);
+only the `available` flag tracks the connection, and it is set by our own subscription
+cleanup. A per-entity `availability: "tracked" | "retained"` field on `entity/register`
+(default `tracked`) would let storage-like entities — counters, dates, rarely-changing
+computed values — stay available with their last state while hassette is down, matching HA
+helper semantics. Additive protocol change (no version bump); the cleanup callable skips
+retained entities.
+
+Constraints when this is picked up:
+
+- **Read-only platforms only** at first. A retained command entity is "available but
+  commands go nowhere"; reject-with-error is the only defensible semantic, and even that is
+  arguably worse UX than unavailable. Revisit only with a concrete use case.
+- Pair with a `last_updated_by_hassette`-style attribute convention so dashboards can show
+  staleness on retained live-derived values.
+
 ## Verify at implementation time
 
 Facts below are stable HA patterns but must be checked against the current HA release when

--- a/design/research/2026-07-07-ha-addon-architecture/prereq-01-ingress-ready-spa.md
+++ b/design/research/2026-07-07-ha-addon-architecture/prereq-01-ingress-ready-spa.md
@@ -1,0 +1,74 @@
+# Prereq 01 — Ingress-Ready SPA (Base-Path Support)
+
+**Repo:** hassette
+**Depends on:** nothing
+**Size:** large (the epic's biggest single work item)
+**Also benefits:** reverse-proxy deployments (`location /hassette/ { proxy_pass ... }`), which
+have the same served-under-a-prefix shape as ingress.
+
+## Problem
+
+Under ingress the browser loads the SPA at `/api/hassio_ingress/<token>/`, but every URL the
+frontend emits assumes it lives at `/`:
+
+| Absolute-path assumption | Location |
+|---|---|
+| Vite `base` defaults to `/` → `/assets/...`, `/fonts/...` refs in built HTML/JS | `frontend/vite.config.ts` (no `base` set) |
+| `BASE_URL = "/api"` | `frontend/src/api/client.ts:3` |
+| `WS_PATH = "/api/ws"` + `location.host` | `frontend/src/api/endpoints.ts:29`, `frontend/src/hooks/use-websocket.ts:42-43` |
+| `wouter` history routing, absolute routes (`/apps`, `/handlers`, ...) | `frontend/src/app.tsx:115-151` |
+| Absolute icon/script refs | `frontend/index.html:7,11` |
+
+Backend routes do **not** change: the supervisor strips the ingress prefix before forwarding,
+so hassette keeps serving `/api/...`, `/assets/...`, `/fonts/...` exactly as today. The
+external prefix arrives per-request in the `X-Ingress-Path` header and is only needed for URL
+*generation*.
+
+## Design (T3 in the research brief)
+
+1. **Backend — `<base href>` injection.** `src/hassette/web/app.py` currently returns
+   `index.html` as a static file from the catch-all route. Change: read `index.html` once at
+   startup, and on each SPA-serving response inject
+   `<base href="{x_ingress_path}/">` into `<head>` (empty header → `<base href="/">`).
+   This is string substitution against a placeholder comment in `index.html`, not a template
+   engine.
+2. **Vite — relative asset refs.** Set `base: "./"` in `frontend/vite.config.ts` so built
+   asset URLs are relative and resolve against the injected `<base>` (not against the current
+   SPA route — that is exactly what `<base>` exists for). Make `index.html` refs relative to
+   match.
+3. **Frontend — derive from `document.baseURI`.** One tiny module (e.g.
+   `frontend/src/api/base.ts`) exports the resolved base path. Consumers:
+   - `client.ts`: `BASE_URL = new URL("api", document.baseURI)`-style construction
+   - `use-websocket.ts`: build the WS URL from `document.baseURI` with the `http(s) → ws(s)`
+     protocol swap, replacing the `location.host + WS_PATH` construction
+   - `app.tsx`: `<Router base={basePath}>` (wouter supports a base prop; internal `<Link>`s
+     and routes stay as written)
+4. **Direct-port path unchanged.** No header → base `/` → behavior identical to today. The
+   Vite dev server (which serves its own `index.html` without the injection) needs the
+   placeholder handled — dev falls back to `/` naturally since Vite serves at root with the
+   existing `/api` proxy.
+
+## Files
+
+- Modify `frontend/vite.config.ts` — `base: "./"`
+- Modify `frontend/index.html` — relative refs + base-injection placeholder
+- Create `frontend/src/api/base.ts` — base-path resolution from `document.baseURI`
+- Modify `frontend/src/api/client.ts` — derive `BASE_URL`
+- Modify `frontend/src/api/endpoints.ts` — `WS_PATH` becomes relative or moves into `base.ts`
+- Modify `frontend/src/hooks/use-websocket.ts` — WS URL from base
+- Modify `frontend/src/app.tsx` — `<Router base=...>`
+- Modify `src/hassette/web/app.py` — index.html base injection in the SPA catch-all
+- Modify `tests/` — integration test: request `/` with and without `X-Ingress-Path`, assert
+  the injected `<base href>`; frontend unit tests for `base.ts` resolution
+- Modify `tests/e2e/` — one e2e that serves the app under a path prefix (reverse-proxy
+  fixture) and verifies navigation + API + WS connect (stretch; the integration test is the
+  floor)
+
+## Acceptance criteria
+
+- [ ] Built SPA works served at `/` (today's deployments — zero visual/behavioral change)
+- [ ] Built SPA works served under an arbitrary prefix when `X-Ingress-Path` is present:
+      assets load, client-side routes navigate and deep-link, REST calls and the WS connect
+      through the prefix
+- [ ] Vite dev server (`npm run dev`) still works with the `/api` proxy
+- [ ] No hardcoded `"/api"` or `"/assets"` URL construction remains in `frontend/src`

--- a/design/research/2026-07-07-ha-addon-architecture/prereq-02-supervisor-connection.md
+++ b/design/research/2026-07-07-ha-addon-architecture/prereq-02-supervisor-connection.md
@@ -1,0 +1,65 @@
+# Prereq 02 — Supervisor Connection Mode (`api_url` / `ws_url` Overrides)
+
+**Repo:** hassette
+**Depends on:** nothing
+**Size:** small
+**Also benefits:** reverse-proxy and split-endpoint HA setups where the REST and WS endpoints
+don't share `base_url`.
+
+## Problem
+
+Hassette derives both HA endpoints from one field: `base_url` (default
+`http://127.0.0.1:8123`) becomes REST `<base>/api/` and WS `<base>/api/websocket`
+(`src/hassette/utils/url_utils.py:51`, consumed via `hassette.ws_url` / `hassette.rest_url`,
+`src/hassette/core/core.py:264-270` — `ws_url` at 264-266, `rest_url` at 268-270).
+
+The supervisor's proxy endpoints don't follow that pattern:
+
+- REST: `http://supervisor/core/api`
+- WS: `ws://supervisor/core/websocket`  ← not `<base>/api/websocket`
+
+So no `base_url` value can express the pair. Auth is not a problem — the proxy accepts
+`SUPERVISOR_TOKEN` in the standard WS `auth` message and as a REST bearer token, both of which
+flow through the existing `token` field (`HASSETTE__TOKEN` env override,
+`src/hassette/config/config.py:131-140`).
+
+## Design (T4 in the research brief)
+
+Add two optional override fields to `HassetteConfig`:
+
+- `api_url: str | None = None` — full REST API base (e.g. `http://supervisor/core/api`)
+- `ws_url: str | None = None` — full WS endpoint (e.g. `ws://supervisor/core/websocket`)
+
+Resolution: when set, used verbatim; when unset, derived from `base_url` exactly as today.
+The derivation moves behind `hassette.rest_url` / `hassette.ws_url` so all consumers
+(`api_resource.py`, `websocket_service.py`) are untouched. Validation: reject setting
+`api_url`/`ws_url` to values that conflict in scheme (e.g. `ws_url` with `http://`) with the
+same friendly-error style as existing config validators.
+
+The add-on's `run.sh` sets `HASSETTE__API_URL` / `HASSETTE__WS_URL` / `HASSETTE__TOKEN`; env
+source precedence guarantees `hassette.toml` can't override them into a broken state.
+
+Non-goals: no `supervisor_mode` flag, no auto-detection of `SUPERVISOR_TOKEN` in hassette
+itself — all supervisor awareness stays in the add-on's run script (ADR-0005, derived-image
+decision).
+
+## Files
+
+- Modify `src/hassette/config/config.py` — add `api_url`, `ws_url` fields + validator
+- Modify `src/hassette/utils/url_utils.py` — override-aware URL construction
+- Modify `src/hassette/core/core.py` — `rest_url` / `ws_url` properties consume the overrides
+- Modify `tests/unit/` (config/url tests) — resolution matrix: neither set / both set / one
+  set / scheme-mismatch rejection
+- Modify `docs/pages/` (configuration reference page for connection settings) — document the
+  two fields and the reverse-proxy use case
+- Regenerate `hassette.schema.json` (config schema export) if the export script tracks
+  `HassetteConfig`
+
+## Acceptance criteria
+
+- [ ] `HASSETTE__API_URL=http://supervisor/core/api HASSETTE__WS_URL=ws://supervisor/core/websocket`
+      connects REST and WS through URLs that don't share a base
+- [ ] Unset overrides reproduce today's derivation byte-for-byte (pin with a test before
+      touching `url_utils.py`)
+- [ ] Scheme mismatch (`ws_url: "http://..."`) fails fast at config load with a clear message
+- [ ] Docs page covers the fields with the supervisor and reverse-proxy examples

--- a/design/research/2026-07-07-ha-addon-architecture/prereq-03-ingress-source-guard.md
+++ b/design/research/2026-07-07-ha-addon-architecture/prereq-03-ingress-source-guard.md
@@ -1,0 +1,55 @@
+# Prereq 03 — Ingress Source Guard (`web_api.allowed_client_ips`)
+
+**Repo:** hassette
+**Depends on:** nothing
+**Size:** small
+
+## Problem
+
+The add-on spec requires ingress add-ons to accept connections only from the ingress gateway
+(`172.30.32.2`) and deny all other clients. Hassette's web server binds `0.0.0.0:8126`
+(`WebApiConfig.host`, `src/hassette/config/models.py:319`) with no client filtering — the only
+middleware is CORS (`src/hassette/web/app.py:53-59`). Since the web API is unauthenticated,
+the guard is what makes "ingress-only" actually mean supervisor-authenticated-only inside the
+add-on's docker network.
+
+## Design (T5 in the research brief)
+
+New config field `web_api.allowed_client_ips: tuple[str, ...] | None = None`:
+
+- `None` (default) — allow all clients; today's behavior for every existing deployment.
+- Set — an ASGI middleware rejects (403) any connection whose peer address is not in the
+  list. Entries are IPs or CIDR networks (`ipaddress` stdlib parsing at config load). Applies
+  to HTTP and WebSocket alike (pure ASGI middleware, not FastAPI HTTP-only middleware, so the
+  `/api/ws` upgrade is covered).
+
+The add-on's `run.sh` sets `HASSETTE__WEB_API__ALLOWED_CLIENT_IPS='["172.30.32.2","127.0.0.1"]'`
+when the optional host port is unmapped (queried from `http://supervisor/addons/self/info`
+via `hassio_api: true`), and leaves the field unset when the user maps the port. Loopback stays
+allowed so in-container CLI use (`docker exec ... hassette status`) keeps working.
+
+Non-goals: this is not authentication and must not be described as such — it is a network
+allowlist that narrows the unauthenticated surface to the supervisor gateway. The real auth
+layer remains the audit gap's follow-up
+(`design/audits/2026-03-25-comprehensive-audit/web-frontend.md:178` — "without any rate
+limiting, authentication, or CSRF protection").
+
+## Files
+
+- Modify `src/hassette/config/models.py` — `allowed_client_ips` field on `WebApiConfig` +
+  parse/validate to `ipaddress` networks
+- Create `src/hassette/web/middleware.py` — ASGI client-IP allowlist middleware (first
+  middleware module; CORS stays where it is)
+- Modify `src/hassette/web/app.py` — install the middleware when the field is set
+- Modify `tests/integration/test_api.py` (or a sibling) — allowed IP passes, disallowed IP
+  gets 403 on HTTP and on WS upgrade, `None` allows all
+- Modify `docs/pages/` (web API configuration docs) — document the field and its add-on use
+- Regenerate `hassette.schema.json` if applicable
+
+## Acceptance criteria
+
+- [ ] Default config: behavior unchanged (no middleware installed, zero overhead)
+- [ ] With an allowlist: non-listed peers get 403 on REST and on the WS upgrade; listed peers
+      are unaffected
+- [ ] CIDR entries work (`172.30.32.0/23`)
+- [ ] Invalid entries fail at config load with a clear message, not at request time

--- a/design/research/2026-07-07-ha-addon-architecture/prereq-04-addon-repo-skeleton.md
+++ b/design/research/2026-07-07-ha-addon-architecture/prereq-04-addon-repo-skeleton.md
@@ -1,0 +1,66 @@
+# Prereq 04 — `hassette-addon` Repo Skeleton
+
+**Repo:** hassette-addon (new)
+**Depends on:** prereqs 01–03 shipped in a hassette release (the pinned base image must
+contain base-path support, URL overrides, and the source guard)
+**Size:** medium
+
+## Goal
+
+A working add-on installable from a custom repository URL: `repository.yaml` at the root, one
+`hassette/` add-on folder, a derived image, and the options→env run script. The full manifest
+sketch, run.sh responsibility list, and directory layout live in the research brief
+(`research.md`, "Add-on anatomy") — this prereq is the checklist for building it.
+
+## Key implementation notes
+
+- **Dockerfile** (Supervisor 2026.04 rules: explicit `FROM`, no `build.yaml`):
+  `FROM ghcr.io/nodejsmith/hassette:<version>-py3.14`, copy `run.sh`, set it as the
+  entrypoint's command (tini stays PID 1 via the base image's `ENTRYPOINT ["tini","--"]`;
+  `init: false` in the manifest so docker doesn't add a second init). Required labels
+  (`io.hass.version`, `io.hass.type`, `io.hass.arch`) via the publish workflow.
+- **run.sh** reads `/data/options.json` with the image's own Python (no bashio), exports the
+  `HASSETTE__*` set (research brief lists them: token, `api_url`/`ws_url`, app dir under
+  `/config/apps`, the web-port pin `HASSETTE__WEB_API__PORT=8126`, log level, install toggle,
+  `UV_CACHE_DIR=/data/uv_cache`, conditional
+  `allowed_client_ips`), seeds a commented starter `hassette.toml` + `apps/` on first run,
+  then `exec /app/scripts/docker_start.sh`.
+- **First-run seed** must be idempotent and never overwrite user files — presence check on
+  `hassette.toml` only.
+- **Port-mapping query** for the source guard: `GET http://supervisor/addons/self/info` with
+  `Authorization: Bearer $SUPERVISOR_TOKEN` (`hassio_api: true`); if `network["8126/tcp"]` is
+  null, export the allowlist restriction.
+- **DOCS.md** is the in-store documentation tab: installation, where config lives
+  (`/addon_configs/<repo>_hassette/`), how to add apps, the optional-port warning
+  (unauthenticated), and the first-start dep-install delay.
+- **Slug** is `hassette`; the host config dir is therefore `<repo-id>_hassette` where the repo
+  id derives from the repository URL hash — document it as "shown in the add-on's
+  Configuration tab" rather than hardcoding.
+
+## Files (all created, new repo)
+
+- `repository.yaml`
+- `hassette/config.yaml` — manifest per the research-brief sketch
+- `hassette/Dockerfile`
+- `hassette/run.sh`
+- `hassette/DOCS.md`
+- `hassette/CHANGELOG.md`
+- `hassette/icon.png`, `hassette/logo.png` — from the existing hassette logo asset
+- `hassette/translations/en.yaml` — labels/descriptions for the two options
+- `README.md` — repo-level: what this is, the add-store install link
+  (`my.home-assistant.io` deep link), pointer to hassette docs
+- `.github/workflows/` — see prereq-05 (can land as a stub building on push)
+
+## Acceptance criteria
+
+- [ ] Repo URL pastes into the add-on store and the add-on appears with icon and description
+- [ ] Fresh install on HAOS: starts, connects to HA via the supervisor proxy with zero
+      configuration, sidebar panel opens the dashboard through ingress (deep links included)
+- [ ] `hassette.toml` + `apps/` appear in `/addon_configs/...` on first start; an app added
+      there loads after restart
+- [ ] Watchdog: killing the process inside the container triggers a supervisor restart;
+      stopping HA core does **not** (liveness stays 200 while disconnected)
+- [ ] With the host port left unmapped, requests from another LAN host to `:8126` are refused;
+      after mapping the port they succeed (and DOCS.md states the trust implication)
+- [ ] Uninstall/reinstall preserves `addon_config` contents; `/data` (telemetry DB) is
+      recreated cleanly

--- a/design/research/2026-07-07-ha-addon-architecture/prereq-05-release-automation.md
+++ b/design/research/2026-07-07-ha-addon-architecture/prereq-05-release-automation.md
@@ -1,0 +1,58 @@
+# Prereq 05 — Release Automation (Image Build + Version Bump)
+
+**Repo:** hassette-addon (workflows), hassette (release trigger), homelab renovate config
+**Depends on:** prereq-04
+**Size:** small–medium
+
+## Goal
+
+A hassette release propagates to add-on users with no manual steps beyond merging one PR in
+`hassette-addon`. Two pipelines:
+
+1. **Add-on image build** (`hassette-addon` repo): on push/tag, build the derived image for
+   `amd64` + `aarch64` and push `ghcr.io/nodejsmith/hassette-addon-{arch}:<version>` (the
+   `{arch}` placeholder form the `image:` key expects), with the `io.hass.*` labels. Reuse the
+   buildx multi-arch pattern from hassette's `.github/workflows/build_and_publish_image.yml`
+   rather than the legacy `home-assistant/builder` action — we already know the buildx recipe
+   and it keeps both repos' CI idiomatic. Per-arch tags (not a single multi-arch manifest) are
+   the add-on convention the `{arch}` placeholder serves.
+2. **Version bump on hassette release**: when hassette publishes release `X.Y.Z`, open a PR in
+   `hassette-addon` updating `config.yaml` `version:` and the Dockerfile `FROM` pin, with the
+   hassette changelog excerpt in `hassette/CHANGELOG.md`. Mechanism options, in preference
+   order:
+   - `repository_dispatch` from hassette's release workflow (`workflow_call` step after image
+     publish) into `hassette-addon`, using a fine-grained PAT/GitHub App secret — immediate,
+     carries the changelog in the payload;
+   - the self-hosted Renovate on smithfamily (repo list in `~/homelab/renovate/config.json`)
+     tracking the ghcr base-image tag — near-zero code but no changelog propagation and up to
+     one schedule-interval of lag.
+
+   Start with Renovate (add `hassette-addon` to the repo list) to get coverage on day one;
+   graduate to `repository_dispatch` when the changelog-excerpt step is wanted.
+
+## Constraints
+
+- The add-on `version:` in `config.yaml` is what users see as "update available" — it must
+  equal the hassette version it ships (add-on-only fixes append a suffix, e.g. `0.35.0.1`,
+  which the add-on spec permits as a plain string).
+- Never auto-merge the bump PR: the add-on maintainer merge is the human gate that a release
+  is add-on-safe (e.g. a config-surface change needing run.sh updates).
+- The derived image build must fail if the pinned base tag doesn't exist yet (ordering guard:
+  hassette's image publish completes before the bump PR builds).
+
+## Files
+
+- Create `hassette-addon/.github/workflows/build.yml` — per-arch image build + publish + labels
+- Create `hassette-addon/.github/workflows/lint.yml` — add-on config lint
+  (`frenck/action-addon-linter` or the supervisor's schema check) on PRs
+- Modify `hassette/.github/workflows/build_and_publish_image.yml` (or the release-please
+  workflow) — dispatch hook (phase 2; skipped in the Renovate-first phase)
+- Modify `~/homelab/renovate/config.json` (smithfamily) — add `NodeJSmith/hassette-addon`
+
+## Acceptance criteria
+
+- [ ] Merging a version-bump PR in `hassette-addon` results in installable images for both
+      arches and the add-on store showing the update
+- [ ] A hassette release produces a bump PR in `hassette-addon` without manual action
+- [ ] A bump PR against a not-yet-published base tag fails CI rather than publishing a broken
+      add-on

--- a/design/research/2026-07-07-ha-addon-architecture/prereq-06-docs.md
+++ b/design/research/2026-07-07-ha-addon-architecture/prereq-06-docs.md
@@ -1,0 +1,51 @@
+# Prereq 06 — Documentation
+
+**Repo:** hassette (docs site), hassette-addon (DOCS.md written in prereq-04)
+**Depends on:** prereq-04 usable end-to-end (screenshots and verification steps need a real
+install)
+**Size:** small–medium
+
+## Goal
+
+The docs site treats the add-on as the primary installation path for HAOS/Supervised users,
+and stops saying hassette isn't available as an add-on.
+
+## Content
+
+1. **New getting-started page: "Install as a Home Assistant Add-on"** — sibling of the
+   existing Docker installation instructions and placed *first* for HAOS users. Covers: add the
+   repository URL (with a `my.home-assistant.io` deep-link button), install, start, open the
+   sidebar panel; where config lives (`/addon_configs/.../hassette.toml` + `apps/`, edited via
+   File Editor / Studio Code Server / Samba); adding the first app; the two options
+   (`log_level`, `install_requirements`); the optional direct port and its unauthenticated
+   trust model; the first-start dependency-install delay. Per `doc-rules.md`: getting-started
+   voice ("you"), numbered steps with visible progress, and a "Verify it's working" step
+   (sidebar panel shows the app running; `hassette log --app <key>` via the port or container
+   exec).
+2. **Update stale claims** — `docs/pages/getting-started/is-hassette-right-for-you.md:42`
+   says "It does not run as a Home Assistant add-on yet." (Line 36's "does not replace …
+   add-ons" statement is about HA's add-on ecosystem generally and stays true — leave it.)
+3. **Connection settings reference** — `api_url`/`ws_url` override fields land with prereq-02's
+   docs requirement; this prereq only cross-links them from the add-on page ("the add-on sets
+   these for you").
+4. **Comparison pages** — the AppDaemon comparison mentions deployment; add the add-on row
+   where installation methods are compared.
+
+## Files
+
+- Create `docs/pages/getting-started/ha-addon.md` (slug per existing getting-started naming)
+- Modify `docs/pages/getting-started/is-hassette-right-for-you.md` — remove/replace the
+  "not an add-on yet" statements
+- Modify `mkdocs.yml` — nav entry
+- Modify the getting-started index/installation page — route HAOS users to the add-on page
+- Add screenshots per `docs/screenshots.yml` conventions **only if** the page embeds UI images
+  — the add-on store/ingress views are HA UI, not hassette UI, so hand-captured images are
+  acceptable here (the capture tool's demo stack cannot render the HA add-on store)
+
+## Acceptance criteria
+
+- [ ] Docs build clean; nav places the add-on page before Docker for getting-started flow
+- [ ] No remaining "not available as an add-on" claims (`rg -i "add-on" docs/pages` audit)
+- [ ] `doc-persona-review` (followability) and `doc-accuracy-review` on the new/touched pages
+      pass per `.claude/rules/doc-rules.md` — persona verdict at least `followable-with-effort`,
+      no confirmed `WRONG`/`OUTDATED_API` on touched lines

--- a/design/research/2026-07-07-ha-addon-architecture/research.md
+++ b/design/research/2026-07-07-ha-addon-architecture/research.md
@@ -1,0 +1,298 @@
+# Home Assistant Add-on Architecture (`epic:ha-addon`)
+
+**Date:** 2026-07-07
+**Status:** Decided — decisions recorded below were made with Jessica on 2026-07-07. Packaging decision recorded in ADR-0005.
+**Anchor issues:** #71 (add-on umbrella), #616 (`hassette build` — decoupled by D6 below)
+
+## Problem
+
+Hassette ships as a Docker image users must compose themselves: pick a tag, mount `/config`,
+`/data`, and `/apps`, paste a long-lived HA access token, and manage restarts. For the large
+population running Home Assistant OS or Supervised, none of that is how software gets installed.
+They add a repository URL to the add-on store, click Install, and expect:
+
+1. **No token pasting** — the add-on system provides authenticated access to HA.
+2. **A sidebar UI** — the monitoring dashboard embedded in the HA frontend, behind HA's login.
+3. **Editable config in familiar places** — File Editor / Studio Code Server / Samba.
+4. **Supervision** — auto-restart on failure, logs in the Supervisor viewer, backups.
+
+Packaging hassette as an add-on closes all four. This brief records the architecture: what the
+add-on system gives us for free, the two real engineering seams (ingress base-path support and
+supervisor connection URLs), and the prereq breakdown.
+
+**Terminology note:** HA 2026.2 renamed "Add-ons" to "Apps" in the UI. The Supervisor APIs,
+schemas, and developer docs structure are unchanged; this brief uses "add-on" for the packaging
+concept to avoid collision with hassette's own "apps" (user automations).
+
+## Decisions (2026-07-07)
+
+| # | Decision | Choice |
+|---|---|---|
+| D1 | Web UI exposure | Ingress primary (sidebar panel, supervisor-authenticated); optional host port in `config.yaml`, disabled by default |
+| D2 | Repo topology | Separate repo **`hassette-addon`** (repository.yaml + one add-on folder) |
+| D3 | Image strategy | Derived add-on image `FROM ghcr.io/nodejsmith/hassette:<version>-py3.14`; options translation lives in the add-on's run script |
+| D4 | Options scope | Minimal, AppDaemon-style: `log_level` + dep-install toggle. Everything else stays in `hassette.toml` |
+| D5 | Config home | `addon_config:rw` map — host `/addon_configs/<repo-id>_hassette/` holds `hassette.toml` + `apps/`, mounted at `/config` in-container (`<repo-id>` is hash-derived from the repository URL, not the repo name; shown in the add-on UI) |
+| D6 | #616 `hassette build` | Decoupled from the epic — the supervisor owns the add-on image, so runtime dep install is the only path there; #616 remains a standalone-Docker improvement |
+| D7 | Release channels | Stable only in v0.1; an edge add-on (tracking the `main` image tag) is a cheap later addition as a second folder in the same repo |
+
+Technical decisions made in-session (recorded, not user-facing choices):
+
+| # | Decision | Choice |
+|---|---|---|
+| T1 | Watchdog target | Existing `/api/health/live` — pure liveness (200 while the event loop serves, independent of HA connection), so supervisor restarts never fight hassette's own WS reconnect logic. Readiness (`/api/health/ready`, 503-capable) is deliberately **not** the watchdog target |
+| T2 | Ingress port | `ingress_port: 8126` — hassette's existing web port; one server, one port, ingress proxies to it |
+| T3 | Base-path mechanism | Per-request `<base href>` injection into `index.html` from the `X-Ingress-Path` header; frontend derives router base, API base, and WS URL from `document.baseURI`; Vite emits relative asset refs. Backend routes stay at `/api/...` unchanged (the supervisor strips the ingress prefix before forwarding) |
+| T4 | Supervisor connection | New optional `api_url` / `ws_url` config overrides (general-purpose — also serves reverse-proxy users); the run script sets them to `http://supervisor/core/api` and `ws://supervisor/core/websocket` with `HASSETTE__TOKEN=$SUPERVISOR_TOKEN` |
+| T5 | Ingress source guard | New `web_api.allowed_client_ips` allowlist config (default: allow all, today's behavior). The run script restricts to the ingress gateway (`172.30.32.2`) plus loopback when the host port is not mapped, and leaves it open when the user opts into the port |
+| T6 | uv cache | `UV_CACHE_DIR=/data/uv_cache` in the add-on — `/data` persists across restarts, so runtime dep installs are warm after the first start |
+
+## What the add-on system gives us for free
+
+The container was shaped for this (the runtime dep-install design in
+`design/specs/docker-dep-redesign/design.md` explicitly rejected build-time-only installs
+"because the add-on system owns the image"). Grounded against the current image and code:
+
+- **Paths line up exactly.** The image expects `HASSETTE__CONFIG_DIR=/config`,
+  `HASSETTE__DATA_DIR=/data`, `HASSETTE__APP_DIR=/apps` (Dockerfile). The add-on `addon_config`
+  map mounts at `/config` in-container, and `/data` is the add-on system's private persistent
+  volume — included in HA backups, surviving restarts and updates. The telemetry DB already
+  defaults to `<data_dir>/hassette.db` → `/data/hassette.db` with zero changes. Apps move under
+  config (`HASSETTE__APP_DIR=/config/apps`) so users edit one directory.
+- **Logs are already Supervisor-shaped.** Hassette writes no log files — stdout/stderr
+  (`PYTHONUNBUFFERED=1`) plus SQLite persistence. The Supervisor log viewer criterion in #71
+  needs no work.
+- **Multi-arch matches.** CI publishes `linux/amd64,linux/arm64` to ghcr; the add-on spec
+  supports exactly `amd64` and `aarch64` (32-bit was dropped). The `image:` key with the
+  `{arch}` placeholder points at prebuilt images — no on-device builds.
+- **Auth to HA disappears as a user concern.** `homeassistant_api: true` in `config.yaml` gives
+  the container `http://supervisor/core/api` (REST) and `ws://supervisor/core/websocket` (WS)
+  with `SUPERVISOR_TOKEN` as the credential. Users never create or paste a token.
+- **Auth to the web UI disappears as a design gap** *(for the ingress path)*. Hassette's web
+  API has no authentication (known audit gap,
+  `design/audits/2026-03-25-comprehensive-audit/web-frontend.md`). Under ingress the supervisor
+  authenticates the HA user **before** proxying, and hassette only has to refuse non-gateway
+  clients (T5). The gap remains for the opt-in direct port (D1) — same trust model as today's
+  Docker deployment, documented as such.
+- **Supervision.** `boot: auto` restarts on host reboot; the watchdog URL (T1) restarts on
+  hang; `startup: application` orders hassette after HA core is up.
+
+## The two engineering seams
+
+### Seam 1 — ingress base-path (the frontend is absolute-path throughout)
+
+Under ingress the browser loads the SPA at `/api/hassio_ingress/<token>/`. Everything the
+frontend emits today assumes it lives at `/`:
+
+- Vite `base` defaults to `/` → built asset refs are `/assets/...`, `/fonts/...`
+- `frontend/src/api/client.ts`: `BASE_URL = "/api"` (hardcoded)
+- `frontend/src/api/endpoints.ts`: `WS_PATH = "/api/ws"`, connected via
+  `location.host + WS_PATH`
+- `wouter` history routing with absolute routes (`/apps`, `/handlers`, ...)
+- `index.html`: absolute icon href
+
+The fix does **not** touch backend route paths. The supervisor strips the ingress prefix before
+forwarding, so the backend keeps serving `/api/...`, `/assets/...` as-is; it forwards the
+external prefix in the `X-Ingress-Path` request header. The recipe (T3):
+
+1. Backend serves `index.html` through a tiny per-request template step: inject
+   `<base href="{X-Ingress-Path or ''}/">`.
+2. Vite builds with relative asset refs so they resolve against the injected base on every
+   route (not against the current SPA route).
+3. Frontend derives everything from `document.baseURI`: `wouter`'s `<Router base=...>`, the
+   REST base (`new URL("api/", document.baseURI)`), and the WS URL (same, with the ws/wss
+   protocol swap).
+4. Direct-port access injects an empty base and behaves exactly as today.
+
+Ingress supports WebSockets and streaming natively, so `/api/ws` works through the proxy
+unchanged. Full details and file list in prereq-01.
+
+### Seam 2 — supervisor connection URLs don't follow hassette's URL pattern
+
+Hassette builds its WS URL as `base_url + /api/websocket` (`src/hassette/utils/url_utils.py`).
+The supervisor proxy endpoints are `http://supervisor/core/api` and
+`ws://supervisor/core/websocket` — the WS path is **not** `<base>/api/websocket`, so
+`base_url` alone can't express the pair. T4 adds optional `api_url` / `ws_url` overrides
+(useful independently for reverse-proxy setups); when unset, both derive from `base_url` as
+today. The run script sets both plus `HASSETTE__TOKEN=$SUPERVISOR_TOKEN`. The WS auth flow is
+unchanged — the proxy accepts `SUPERVISOR_TOKEN` in the standard `auth` message. Details in
+prereq-02.
+
+## Add-on anatomy (the `hassette-addon` repo)
+
+```
+hassette-addon/
+├── repository.yaml          # name, url, maintainer
+└── hassette/
+    ├── config.yaml          # manifest (below)
+    ├── Dockerfile           # FROM ghcr.io/nodejsmith/hassette:<version>-py3.14 + run.sh
+    ├── run.sh               # options.json + SUPERVISOR_TOKEN → HASSETTE__* env, exec entrypoint
+    ├── DOCS.md              # in-store documentation tab
+    ├── CHANGELOG.md
+    ├── icon.png / logo.png
+    └── translations/en.yaml # options UI labels
+```
+
+`config.yaml` sketch (spec-current as of Supervisor 2026.04 — no `build.yaml`, explicit `FROM`):
+
+```yaml
+name: Hassette
+slug: hassette
+version: "0.35.0"            # tracks hassette releases (prereq-05 automation)
+url: https://github.com/NodeJSmith/hassette
+arch: [aarch64, amd64]
+image: ghcr.io/nodejsmith/hassette-addon-{arch}
+init: false                  # image ships tini as PID 1
+startup: application
+boot: auto
+homeassistant_api: true      # supervisor core proxy + SUPERVISOR_TOKEN
+hassio_api: true             # run.sh queries addons/self/info for port-mapping state (T5)
+ingress: true
+ingress_port: 8126
+panel_icon: mdi:robot
+panel_title: Hassette
+watchdog: http://[HOST]:[PORT:8126]/api/health/live
+ports:
+  8126/tcp: null             # optional direct access, disabled by default (D1)
+ports_description:
+  8126/tcp: Web UI/API without ingress (unauthenticated — leave disabled unless you need CLI access)
+# no webui: key — with ingress enabled, the info page's "Open Web UI" button routes through
+# ingress; a webui: URL would point at the default-unmapped host port and dangle
+map:
+  - type: addon_config
+    read_only: false
+options:
+  log_level: INFO
+  install_requirements: false
+schema:
+  log_level: list(DEBUG|INFO|WARNING|ERROR)?
+  install_requirements: bool?
+```
+
+`run.sh` responsibilities (all glue lives here, main image untouched — D3):
+
+1. Read `/data/options.json` (python is in the image; no bashio dependency).
+2. Export: `HASSETTE__TOKEN=$SUPERVISOR_TOKEN`, `HASSETTE__API_URL=http://supervisor/core/api`,
+   `HASSETTE__WS_URL=ws://supervisor/core/websocket`, `HASSETTE__APP_DIR=/config/apps`,
+   `HASSETTE__WEB_API__PORT=8126` (pins the port the ingress proxy targets — env precedence
+   forecloses a `hassette.toml` port change silently breaking ingress),
+   `HASSETTE__LOGGING__LOG_LEVEL`, `HASSETTE__INSTALL_DEPS`, `UV_CACHE_DIR=/data/uv_cache`.
+3. Seed `/config/hassette.toml` and `/config/apps/` with a commented starter on first run.
+4. Query `http://supervisor/addons/self/info` — if the 8126 host port is unmapped, export the
+   `web_api.allowed_client_ips` restriction (ingress gateway + loopback) (T5).
+5. `exec /app/scripts/docker_start.sh` — the existing entrypoint chain (dep install →
+   `hassette run`) runs unmodified.
+
+### Architecture overview
+
+```mermaid
+flowchart TD
+    subgraph BROWSER["Browser"]
+        UI["HA frontend<br/>sidebar panel"]
+    end
+    subgraph HAHOST["Home Assistant host"]
+        SUP["Supervisor<br/>ingress gateway + watchdog"]
+        CORE["HA core<br/>websocket_api"]
+        subgraph ADDON["hassette add-on container"]
+            RUN["run.sh<br/>options → env"]
+            START["docker_start.sh<br/>runtime dep install"]
+            H["hassette run<br/>web :8126"]
+        end
+        CFG[("/addon_configs/…_hassette<br/>hassette.toml + apps/")]
+        DATA[("/data<br/>hassette.db + uv cache")]
+    end
+    UI -- "authenticated ingress<br/>X-Ingress-Path" --> SUP -- "proxy :8126" --> H
+    SUP -- "watchdog GET /api/health/live" --> H
+    H -- "ws://supervisor/core/websocket<br/>SUPERVISOR_TOKEN" --> SUP -- proxy --> CORE
+    RUN --> START --> H
+    CFG --> H
+    DATA --> H
+
+    style UI fill:#e8f0ff,stroke:#6688cc
+    style SUP fill:#f0f0f0,stroke:#999
+    style CORE fill:#f0f0f0,stroke:#999
+    style RUN fill:#fff0e8,stroke:#cc8844
+    style START fill:#fff0e8,stroke:#cc8844
+    style H fill:#fff0e8,stroke:#cc8844
+    style CFG fill:#f0f8e8,stroke:#88aa66
+    style DATA fill:#f0f8e8,stroke:#88aa66
+```
+
+## Startup, failure, and the watchdog
+
+The container start sequence is `run.sh → docker_start.sh (dep install) → hassette run`. Two
+interactions matter:
+
+- **The install window.** With user deps, the web server is not listening for the 10–30+ s of
+  runtime install; ingress shows a gateway error and the watchdog URL fails during that window.
+  Mitigations: the warm uv cache on `/data` (T6) makes this a first-start-only cost, and the
+  supervisor's watchdog tolerates startup (it acts on an add-on that *was* up). #615 (splash
+  screen) remains the UX answer for the first-start gap and stays on this epic.
+- **Crash loops.** `design/research/2026-06-16-telemetry-db-rollback-safety/research.md`
+  flagged that an external restart policy converts a single fatal exit into a crash loop. The
+  supervisor's watchdog is rate-limited — hardcoded to at most 10 restart attempts per
+  30-minute window, after which it gives up and leaves the add-on stopped (no exponential
+  backoff; see home-assistant discussion #743 and the supervisor's hardcoded throttle). That
+  is the desired failure shape: bounded thrash, then visible failure. Liveness-only watchdog
+  (T1) keeps "HA connection down" from ever counting as "hassette dead."
+
+## Configuration mapping (D4, D5)
+
+One config language: `hassette.toml` in `/addon_configs/<repo-id>_hassette/`, exactly the file
+Docker users write. The options schema stays minimal because every removed option is a support
+question avoided — and connection settings, the usual bulk of add-on options, are fully
+automatic here (T4).
+
+| Concern | Where it lives | Mechanism |
+|---|---|---|
+| HA URL + token | nowhere (automatic) | `SUPERVISOR_TOKEN` + proxy URLs via run.sh |
+| Log level | options schema | `HASSETTE__LOGGING__LOG_LEVEL` |
+| requirements.txt install | options schema | `HASSETTE__INSTALL_DEPS` |
+| Apps, per-app config | `hassette.toml` `[hassette.apps]` | unchanged |
+| App code + deps (`uv.lock`) | `/config/apps` (host: `addon_configs/.../apps`) | `HASSETTE__APP_DIR` |
+| Web port | pinned (not user-settable) | `HASSETTE__WEB_API__PORT=8126` from run.sh — `ingress_port` is baked into the manifest, so the toml must not be able to move the server off it |
+| Retention, everything else | `hassette.toml` | unchanged |
+
+Note the precedence guarantee: pydantic-settings source order is init > env > dotenv > secrets
+> TOML, so the supervisor-critical values run.sh sets via env (`api_url`, `ws_url`, `token`,
+app dir, web port) cannot be overridden into a broken state from `hassette.toml`. DOCS.md
+states plainly that the web port is fixed at 8126 inside the add-on.
+
+## What this epic does NOT include
+
+- **#616 `hassette build`** (D6) — supervisor-owned image means runtime install is the add-on
+  path, which already exists and was designed for this. #616 stays open for standalone Docker
+  users, off this epic.
+- **Web UI authentication** — the direct-port path remains unauthenticated by design in v0.1
+  (opt-in, documented). A real auth layer is the audit gap's follow-up, not add-on scope.
+- **Edge channel** (D7) — deferred; a second folder in `hassette-addon` when wanted.
+- **The companion integration** — independent. ADR-0004's transport carries over unchanged:
+  hassette still connects *out* to HA's websocket API (now via the supervisor proxy), and the
+  `hassette/*` custom commands ride that connection identically. Nothing ever connects to
+  hassette, so the add-on's network posture doesn't affect `epic:hacs`.
+
+## Prerequisites
+
+| # | Prereq | Repo | Depends on |
+|---|---|---|---|
+| 01 | Ingress-ready SPA (base-path support) | hassette | — |
+| 02 | Supervisor connection mode (`api_url`/`ws_url` overrides) | hassette | — |
+| 03 | Ingress source guard (`web_api.allowed_client_ips`) | hassette | — |
+| 04 | Add-on repo skeleton (manifest, Dockerfile, run.sh, docs) | hassette-addon | 01–03 shipped in a hassette release |
+| 05 | Release automation (image build, version bump on hassette release) | both | 04 |
+| 06 | Docs (installation page, add-on setup, update "not an add-on yet" claims) | hassette | 04 usable end-to-end |
+
+01–03 are independent of each other and can land in any order; they are ordinary hassette PRs
+with no add-on dependency. 04 is the first artifact in the new repo and consumes a released
+image containing 01–03.
+
+## Open questions (deferred, not blocking)
+
+- **`system_packages`-style options** (apt packages at start, AppDaemon-style): deferred until
+  someone needs a compiled dependency that has no wheel. Cheap to add to run.sh later.
+- **Ingress + `hassette` CLI**: the CLI targets the web API over HTTP; through ingress it would
+  need an HA token and the ingress URL. v0.1 answer: CLI users enable the optional port (D1) or
+  exec into the container. A supervisor-aware CLI transport is a possible later nicety.
+- **Backup hooks**: `/data` (DB) and `addon_config` are both included in HA backups by default;
+  whether the DB should be excluded (`backup_exclude`) to shrink backups is a post-v0.1 tuning
+  question.


### PR DESCRIPTION
## Summary

Design artifacts for the two packaging/integration epics, produced before any implementation code exists. Both sets follow the same shape: research brief with decisions recorded inline, an ADR for the load-bearing choice, and implementation-ordered prereq breakdowns with per-task file lists. Both reviewed via fine-toothed-comb with all findings applied.

### Companion integration (`epic:hacs`)

- **`design/research/2026-07-07-companion-integration-architecture/research.md`** — full brief: capability gap analysis, transport comparison, protocol design (v1 message set), lifecycle matrix, `hassette-protocol` package design, risks, testing strategy, and v0.1–v0.4 staging. Decisions D1–D10 recorded inline.
- **`design/adrs/0004-companion-integration-transport.md`** — the transport decision: custom `hassette/*` WS commands over hassette's existing HA connection, with a connection-scoped subscription for HA→hassette pushes (hass-node-red model).
- **prereq-01…06** — implementation-ordered breakdowns with dependency graph and per-task file lists.

Key decisions: repo `hass-hassette` + shared stdlib-only `hassette-protocol` package; single zero-config entry; sensors **and** command entities in v0.1; framework services v0.2; webhooks v0.3 (unblocks #594); #46's ephemeral Stage 1 dropped.

### HA add-on (`epic:ha-addon`)

- **`design/research/2026-07-07-ha-addon-architecture/research.md`** — full brief: what the add-on system gives for free (paths, logs, multi-arch, supervisor auth), the two engineering seams (ingress base-path support; supervisor proxy URLs), add-on anatomy with `config.yaml` sketch and run.sh responsibilities, startup/watchdog/crash-loop analysis, and config mapping. Decisions D1–D7 + technical decisions T1–T6 recorded inline.
- **`design/adrs/0005-ha-addon-packaging.md`** — the packaging decision: derived add-on image `FROM` the published hassette image (supervisor glue isolated in a new `hassette-addon` repo), ingress-first web UI exposure with an optional disabled-by-default host port.
- **prereq-01…06** — ingress-ready SPA (base-path), `api_url`/`ws_url` overrides, `web_api.allowed_client_ips` source guard, add-on repo skeleton, release automation, docs.

Key decisions: ingress primary (supervisor-authenticated sidebar panel — resolves the web-UI auth question structurally); minimal AppDaemon-style options with real config in `hassette.toml` under `addon_config`; `SUPERVISOR_TOKEN` + proxy URLs eliminate token pasting; #616 decoupled from the epic (the supervisor owns the image, so runtime dep install is the add-on path). ADR-0004's transport carries over unchanged.

Docs-only (`design/`), no runtime changes.

Refs #45, #46, #594, #71, #616