### PR TITLE
fix: harden bus predicate handling and async callable detection

### DIFF
--- a/src/hassette/bus/listeners.py
+++ b/src/hassette/bus/listeners.py
@@ -558,7 +558,11 @@ class Listener:
         """Check if the event matches the listener's predicate."""
         if self.predicate is None:
             return True
-        matched = self.predicate(ev)
+        try:
+            matched = self.predicate(ev)
+        except Exception:
+            self.logger.exception("Predicate raised for %s; skipping this listener", self)
+            return False
 
         verdict = "matched" if matched else "did not match"
         self.logger.debug("Listener %s %s predicate for event: %s", self, verdict, ev)

--- a/src/hassette/event_handling/predicates.py
+++ b/src/hassette/event_handling/predicates.py
@@ -45,7 +45,7 @@ import inspect
 import typing
 from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass, field
-from inspect import isawaitable, iscoroutinefunction
+from inspect import isawaitable
 from logging import getLogger
 from typing import Any, Generic, TypeGuard, TypeVar
 
@@ -54,6 +54,7 @@ from boltons.iterutils import is_collection
 from hassette.const import ANY_VALUE, MISSING_VALUE, NOT_PROVIDED
 from hassette.types import ChangeType, ComparisonCondition, EventT
 from hassette.utils.func_utils import callable_stable_name as callable_name
+from hassette.utils.func_utils import is_async_callable
 from hassette.utils.glob_utils import is_glob
 
 from .accessors import (
@@ -562,8 +563,7 @@ def compare_value(actual: Any, condition: "ChangeType") -> bool:
     if not callable(condition):
         return actual == condition
 
-    # Disallow async predicates to keep filters pure/fast.
-    if iscoroutinefunction(condition):
+    if is_async_callable(condition):
         raise TypeError("Async predicates are not supported; make the condition synchronous.")
 
     if typing.TYPE_CHECKING:
@@ -625,9 +625,15 @@ def normalize_where(where: "Predicate | Sequence[Predicate] | None") -> "Predica
     if where is None:
         return None
 
-    # prevent circular import only when needed
+    if is_async_callable(where):
+        raise TypeError(f"Bus predicates must be synchronous; got async callable {where!r}")
+
     if is_predicate_collection(where):
-        return AllOf.ensure_iterable(where)
+        flat = ensure_tuple(where)
+        for pred in flat:
+            if is_async_callable(pred):
+                raise TypeError(f"Bus predicates must be synchronous; got async callable {pred!r}")
+        return AllOf(flat)
 
     # help the type checker know that `where` is not an Sequence here
     if typing.TYPE_CHECKING:

--- a/src/hassette/event_handling/predicates.py
+++ b/src/hassette/event_handling/predicates.py
@@ -615,24 +615,29 @@ def is_predicate_collection(obj: Any) -> TypeGuard[Sequence["Predicate"]]:
     return is_collection(obj)
 
 
+def _reject_async_predicate(pred: Any) -> None:
+    if is_async_callable(pred):
+        raise TypeError(f"Bus predicates must be synchronous; got async callable {pred!r}")
+
+
 def normalize_where(where: "Predicate | Sequence[Predicate] | None") -> "Predicate | None":
-    """Normalize a 'where' clause into a single Predicate (usually AllOf.ensure_iterable), or None.
+    """Normalize a 'where' clause into a single Predicate, or None.
+
+    Rejects async callables (including inside collections) at registration time.
 
     - If where is None → None
-    - If where is a predicate collection (list/tuple/set/...) → AllOf.ensure_iterable(where)
+    - If where is a predicate collection (list/tuple/set/...) → AllOf wrapping flattened members
     - Otherwise (single predicate or mapping handled elsewhere) → where
     """
     if where is None:
         return None
 
-    if is_async_callable(where):
-        raise TypeError(f"Bus predicates must be synchronous; got async callable {where!r}")
+    _reject_async_predicate(where)
 
     if is_predicate_collection(where):
         flat = ensure_tuple(where)
         for pred in flat:
-            if is_async_callable(pred):
-                raise TypeError(f"Bus predicates must be synchronous; got async callable {pred!r}")
+            _reject_async_predicate(pred)
         return AllOf(flat)
 
     # help the type checker know that `where` is not an Sequence here

--- a/src/hassette/test_utils/harness.py
+++ b/src/hassette/test_utils/harness.py
@@ -80,7 +80,7 @@ async def wait_for(
     loop = asyncio.get_running_loop()
     deadline = loop.time() + timeout
     while True:
-        result = (await predicate()) if is_async else predicate()  # pyright: ignore[reportGeneralIssues]
+        result = (await predicate()) if is_async else predicate()  # pyright: ignore[reportGeneralTypeIssues]
         if result:
             return
         if loop.time() >= deadline:

--- a/src/hassette/test_utils/harness.py
+++ b/src/hassette/test_utils/harness.py
@@ -40,6 +40,7 @@ from hassette.test_utils.config import TEST_TOKEN
 from hassette.test_utils.reset import reset_app_handler, reset_bus, reset_mock_api, reset_scheduler, reset_state_proxy
 from hassette.test_utils.test_server import SimpleTestServer
 from hassette.types.enums import ResourceStatus
+from hassette.utils.func_utils import is_async_callable
 
 if typing.TYPE_CHECKING:
     from hassette.config.classes import AppManifest
@@ -75,7 +76,7 @@ async def wait_for(
     interval: float = 0.02,
     desc: str = "condition",
 ) -> None:
-    is_async = inspect.iscoroutinefunction(predicate)
+    is_async = is_async_callable(predicate)
     loop = asyncio.get_running_loop()
     deadline = loop.time() + timeout
     while True:

--- a/tests/unit/bus/test_bus_where.py
+++ b/tests/unit/bus/test_bus_where.py
@@ -1,0 +1,142 @@
+"""Tests for bus where= predicate hardening: async rejection and raising-predicate isolation.
+
+Covers:
+- normalize_where() rejects async callables at registration time (#1243 part B, #1244)
+- compare_value() rejects async callable instances (#1244)
+- Listener.matches() catches raising predicates and returns False (#1243 part A)
+- wait_for() detects async callable instances (#1244)
+"""
+
+from types import SimpleNamespace
+
+import pytest
+
+from hassette.event_handling.predicates import compare_value, normalize_where
+from hassette.test_utils.harness import wait_for
+from hassette.test_utils.helpers import create_listener
+
+
+class TestNormalizeWhereAsyncRejection:
+    """normalize_where() rejects async callable predicates at registration time."""
+
+    def test_async_function_raises_type_error(self) -> None:
+        async def pred(_ev: object) -> bool:
+            return True
+
+        with pytest.raises(TypeError, match="synchronous"):
+            normalize_where(pred)
+
+    def test_async_callable_instance_raises_type_error(self) -> None:
+        class AsyncPred:
+            async def __call__(self, _ev: object) -> bool:
+                return True
+
+        with pytest.raises(TypeError, match="synchronous"):
+            normalize_where(AsyncPred())
+
+    def test_sequence_with_async_member_raises_type_error(self) -> None:
+        def sync_pred(_ev: object) -> bool:
+            return True
+
+        async def async_pred(_ev: object) -> bool:
+            return True
+
+        with pytest.raises(TypeError, match="synchronous"):
+            normalize_where([sync_pred, async_pred])
+
+    def test_sequence_with_async_callable_instance_raises_type_error(self) -> None:
+        def sync_pred(_ev: object) -> bool:
+            return True
+
+        class AsyncPred:
+            async def __call__(self, _ev: object) -> bool:
+                return True
+
+        with pytest.raises(TypeError, match="synchronous"):
+            normalize_where([sync_pred, AsyncPred()])
+
+    def test_sync_callable_passes(self) -> None:
+        def pred(_ev: object) -> bool:
+            return True
+
+        result = normalize_where(pred)
+        assert result is pred
+
+    def test_none_passes(self) -> None:
+        assert normalize_where(None) is None
+
+
+class TestCompareValueAsyncCallableInstance:
+    """compare_value() rejects async callable instances, not just async def functions."""
+
+    def test_async_callable_instance_raises_type_error(self) -> None:
+        class AsyncCondition:
+            async def __call__(self, _value: object) -> bool:
+                return True
+
+        with pytest.raises(TypeError, match="Async predicates are not supported"):
+            compare_value("x", AsyncCondition())
+
+
+class TestListenerMatchesRaisingPredicate:
+    """Listener.matches() catches raising predicates and returns False."""
+
+    def test_raising_predicate_returns_false(self) -> None:
+        def bad_pred(_ev: object) -> bool:
+            raise ValueError("boom")
+
+        listener = create_listener(where=bad_pred)
+        ev = SimpleNamespace(payload=SimpleNamespace())
+
+        assert listener.matches(ev) is False
+
+    def test_raising_predicate_does_not_propagate(self) -> None:
+        def bad_pred(_ev: object) -> bool:
+            raise RuntimeError("unexpected")
+
+        listener = create_listener(where=bad_pred)
+        ev = SimpleNamespace(payload=SimpleNamespace())
+
+        # Should not raise — exception is caught and logged
+        listener.matches(ev)
+
+    def test_normal_predicate_still_works(self) -> None:
+        def good_pred(_ev: object) -> bool:
+            return True
+
+        listener = create_listener(where=good_pred)
+        ev = SimpleNamespace(payload=SimpleNamespace())
+
+        assert listener.matches(ev) is True
+
+    def test_false_predicate_still_works(self) -> None:
+        def reject_pred(_ev: object) -> bool:
+            return False
+
+        listener = create_listener(where=reject_pred)
+        ev = SimpleNamespace(payload=SimpleNamespace())
+
+        assert listener.matches(ev) is False
+
+
+class TestWaitForAsyncCallableInstance:
+    """wait_for() correctly detects async callable instances."""
+
+    async def test_async_callable_instance_detected(self) -> None:
+        call_count = 0
+
+        class AsyncPred:
+            async def __call__(self) -> bool:
+                nonlocal call_count
+                call_count += 1
+                return True
+
+        await wait_for(AsyncPred(), timeout=1.0, desc="async callable instance")
+        assert call_count >= 1
+
+    async def test_sync_callable_instance_works(self) -> None:
+        class SyncPred:
+            def __call__(self) -> bool:
+                return True
+
+        await wait_for(SyncPred(), timeout=1.0, desc="sync callable instance")


### PR DESCRIPTION
### Bus predicate isolation (#1243 part A)

- Wrapped predicate invocation in `Listener.matches()` in a `try`/`except`. Previously a single raising predicate propagated out of `BusService.dispatch()` before any listener was dispatched, silently killing the fanout for every other listener subscribed to that event — no execution record for any of them. Now the raising listener is skipped and logged (with listener identity); sibling listeners still receive the event.

### Async predicate rejection at registration time (#1243 part B)

- `normalize_where()` now rejects async predicates at registration time with `TypeError`, mirroring the scheduler's existing `_build_predicate_invoker` behavior. Previously an async predicate passed to bus `where=` was silently accepted; at match time `self.predicate(ev)` returned a coroutine object (always truthy), so `matches()` returned `True` regardless of the predicate's actual logic, plus a "coroutine was never awaited" warning at runtime.
- Validation extends into predicate collections — each member of a sequence passed to `where=` is checked, not just a single top-level predicate.
- Extracted a shared `_reject_async_predicate()` helper so the single-predicate and collection-member validation paths can't drift.

### Async callable-instance detection (#1244)

- `compare_value()` (`predicates.py`) and `wait_for()` (`test_utils/harness.py`) used `inspect.iscoroutinefunction()`, which misses callable instances with `async def __call__` — such an object would slip past detection and return a coroutine (always truthy) instead of a bool. Both now use `is_async_callable()` from `hassette.utils.func_utils`, matching the fix already applied to the scheduler in #1242.

### Tests

- 13 new tests in `tests/unit/bus/test_bus_where.py` covering async rejection (including collection members), predicate-raising isolation without cross-listener impact, and async callable-instance detection for both `compare_value` and `wait_for`.

### Housekeeping

- Fixed a stale Pyright ignore rule code in `harness.py` (`reportGeneralIssues` → `reportGeneralTypeIssues`).

Closes #1243
Closes #1244
