### PR TITLE
feat: route raising bus predicates to on_error handlers and telemetry

### DIFF
--- a/docs/pages/core-concepts/bus/methods.md
+++ b/docs/pages/core-concepts/bus/methods.md
@@ -239,7 +239,7 @@ All four accept `handler`, `where`, `kwargs`, `name`, and `**opts`. [Service sup
 
 ### App-level handler
 
-`bus.on_error(handler)` registers a fallback called when any listener on the bus raises. This call is synchronous — no `await` needed. The handler receives a [`BusErrorContext`][hassette.bus.error_context.BusErrorContext].
+`bus.on_error(handler)` registers a fallback called when any listener on the bus raises — either in the handler itself or in a `where=` predicate. This call is synchronous — no `await` needed. The handler receives a [`BusErrorContext`][hassette.bus.error_context.BusErrorContext].
 
 ```python
 --8<-- "pages/core-concepts/bus/snippets/handlers/bus_error_handler_app.py"

--- a/docs/pages/core-concepts/internals/service-details.md
+++ b/docs/pages/core-concepts/internals/service-details.md
@@ -52,7 +52,7 @@ Events with other `event_type` values expand to only the base topic.
 
 `BusService` iterates the three topics in order and collects matching listeners from the `Router`. The router stores two separate indexes: one for exact topics, one for glob topics. A listener is collected at most once, deduplicated by `listener_id`.
 
-Each collected listener runs `Listener.matches(event)`. Predicates registered via `P.*` and conditions registered via `C.*` are evaluated here. Listeners that fail the predicate are silently skipped.
+Each collected listener runs `Listener.matches(event)`. Predicates registered via `P.*` and conditions registered via `C.*` are evaluated here. Listeners whose predicate returns `False` are silently skipped. A predicate that *raises* an exception is logged, recorded as an `ExecutionRecord` with `status="error"`, and routed to the listener's `on_error` handler (or the app-level fallback). The raising listener is skipped, but sibling listeners in the same fanout are unaffected.
 
 Each passing listener spawns a [`TaskBucket`][hassette.task_bucket.task_bucket.TaskBucket] task that calls `CommandExecutor.execute()`. All matching listeners for a given event run in parallel.
 

--- a/src/hassette/bus/duration_hold.py
+++ b/src/hassette/bus/duration_hold.py
@@ -82,11 +82,18 @@ class DurationHoldManager:
         """Check hold predicates (state-value only) against an event.
 
         Falls back to ``listener.matches()`` when no hold predicate is set.
+        Catches predicate exceptions here because the duration-hold path has no
+        executor access for telemetry recording — a raising predicate logs and
+        returns False so the spawned timer task doesn't crash.
         """
         hold_pred = listener.duration_config.hold_predicate if listener.duration_config else None
-        if hold_pred is None:
-            return listener.matches(event)
-        return hold_pred(event)
+        try:
+            if hold_pred is None:
+                return listener.matches(event)
+            return hold_pred(event)
+        except Exception:
+            self.logger.exception("Predicate raised in hold_matches for %s; treating as non-match", listener)
+            return False
 
     async def immediate_fire_task(self, listener: Listener) -> None:
         """Fire a handler immediately with the current entity state.

--- a/src/hassette/bus/listeners.py
+++ b/src/hassette/bus/listeners.py
@@ -555,15 +555,14 @@ class Listener:
         return changed
 
     def matches(self, ev: "Event[Any]") -> bool:
-        """Check if the event matches the listener's predicate."""
+        """Check if the event matches the listener's predicate.
+
+        Raises if the predicate raises — the caller (BusService.dispatch) handles
+        isolation, telemetry recording, and error-handler routing.
+        """
         if self.predicate is None:
             return True
-        try:
-            matched = self.predicate(ev)
-        except Exception:
-            self.logger.exception("Predicate raised for %s; skipping this listener", self)
-            return False
-
+        matched = self.predicate(ev)
         verdict = "matched" if matched else "did not match"
         self.logger.debug("Listener %s %s predicate for event: %s", self, verdict, ev)
         return matched

--- a/src/hassette/core/bus_service.py
+++ b/src/hassette/core/bus_service.py
@@ -1,17 +1,22 @@
 import asyncio
 import time
+import traceback
 import typing
 from collections import defaultdict
 from typing import Any, ClassVar
 from uuid import uuid4
 
+import uuid_utils
+
 import hassette.utils.date_utils as _date_utils
 from hassette.bus.duration_hold import DurationHoldManager
+from hassette.bus.error_context import BusErrorContext
 from hassette.bus.invocation import build_tracked_invoke_fn
 from hassette.bus.listeners import DurationConfig, Listener, Subscription
 from hassette.bus.router import Router
 from hassette.core.database_service import DatabaseService
 from hassette.core.event_filter import EventFilter
+from hassette.core.execution_record import ExecutionRecord
 from hassette.core.registration import ListenerRegistration
 from hassette.core.sync_executor_service import SyncExecutorService
 from hassette.event_handling.predicates import summarize_top_level
@@ -376,14 +381,23 @@ class BusService(Service):
 
         routes = self.expand_topics(base_topic, event)  # ordered: most specific -> least
         chosen: dict[int, tuple[str, Listener]] = {}  # listener_id -> (matched_route, listener)
+        failed: set[int] = set()  # listener_ids whose predicates raised (dedup across routes)
 
         # Route first, then dedupe by "first match wins" because routes are ordered by specificity
         for route in routes:
             listeners = self.router.get_topic_listeners(route)
             for listener in listeners:
-                if listener.listener_id in chosen:
+                if listener.listener_id in chosen or listener.listener_id in failed:
                     continue
-                if listener.matches(event):
+                predicate_start = time.time()
+                try:
+                    matched = listener.matches(event)
+                except Exception as exc:
+                    failed.add(listener.listener_id)
+                    self.logger.exception("Predicate raised for %s; skipping this listener", listener)
+                    self._record_predicate_failure(listener, route, event, exc, predicate_start)
+                    continue
+                if matched:
                     chosen[listener.listener_id] = (route, listener)
 
         if not chosen:
@@ -494,6 +508,64 @@ class BusService(Service):
     def duration_timers_active(self) -> int:
         """Number of currently active duration timers."""
         return self._duration_hold.duration_timers_active
+
+    def _record_predicate_failure(
+        self, listener: "Listener", topic: str, event: "Event[Any]", exc: Exception, start_ts: float
+    ) -> None:
+        """Record a raising predicate as a failed execution and route to error handlers.
+
+        Mirrors SchedulerService._record_predicate_failure: the handler never ran, so this
+        bypasses CommandExecutor._execute() — but the outcome is an 'error' record so a broken
+        predicate is visible in telemetry. The per-listener on_error handler (or the app-level
+        fallback) is invoked with a BusErrorContext.
+
+        Args:
+            listener: The listener whose predicate raised.
+            topic: The topic (route) the listener matched on.
+            event: The event being dispatched when the predicate raised.
+            exc: The exception the predicate raised.
+            start_ts: Unix timestamp when predicate evaluation began.
+        """
+        try:
+            session_id: int | None = self.hassette.session_id
+        except RuntimeError:
+            session_id = None
+
+        traceback_str = "".join(traceback.format_exception(exc))
+        execution_id = str(uuid_utils.uuid7())
+        record = ExecutionRecord(
+            kind="handler",
+            listener_id=listener.db_id,
+            session_id=session_id,
+            execution_start_ts=start_ts,
+            duration_ms=(time.time() - start_ts) * 1000,
+            status="error",
+            error_type=type(exc).__name__,
+            error_message=str(exc),
+            error_traceback=traceback_str,
+            app_key=listener.identity.app_key,
+            instance_index=listener.identity.instance_index,
+            source_tier=listener.identity.source_tier,
+            execution_id=execution_id,
+        )
+        self._executor.enqueue_record(record)
+
+        resolver = listener.invoker.app_error_handler_resolver
+        app_level_error_handler = resolver() if resolver is not None else None
+        error_handler = listener.invoker.error_handler or app_level_error_handler
+        if error_handler is not None:
+            ctx = BusErrorContext(
+                exception=exc,
+                traceback=traceback_str,
+                execution_id=execution_id,
+                topic=topic,
+                listener_name=repr(listener),
+                event=event,
+            )
+            self.task_bucket.spawn(
+                self._executor.invoke_error_handler(error_handler, ctx),
+                name="bus:predicate_error_handler",
+            )
 
     async def _dispatch(self, topic: str, event: "Event[Any]", listener: "Listener") -> None:
         """Dispatch an event to a specific listener.

--- a/src/hassette/core/bus_service.py
+++ b/src/hassette/core/bus_service.py
@@ -395,7 +395,10 @@ class BusService(Service):
                 except Exception as exc:
                     failed.add(listener.listener_id)
                     self.logger.exception("Predicate raised for %s; skipping this listener", listener)
-                    self._record_predicate_failure(listener, route, event, exc, predicate_start)
+                    try:
+                        self._record_predicate_failure(listener, route, event, exc, predicate_start)
+                    except Exception:
+                        self.logger.exception("Failed to record predicate failure for %s", listener)
                     continue
                 if matched:
                     chosen[listener.listener_id] = (route, listener)

--- a/tests/integration/bus/test_bus_predicate_failure.py
+++ b/tests/integration/bus/test_bus_predicate_failure.py
@@ -1,0 +1,221 @@
+"""Integration tests for bus predicate failure → ExecutionRecord + error handler routing (#1255).
+
+Verifies that a raising where= predicate on a bus listener:
+- Creates an ExecutionRecord with status='error' and correct error details
+- Invokes the per-listener or app-level error handler with a BusErrorContext
+- Does not crash sibling listeners in the same fanout (isolation from #1243)
+- Records exactly once for glob-registered listeners (dedup across expanded routes)
+"""
+
+import asyncio
+from types import SimpleNamespace
+from typing import TYPE_CHECKING
+
+from hassette.bus.error_context import BusErrorContext
+from hassette.events.base import Event
+from hassette.test_utils import create_state_change_event, wait_for
+
+if TYPE_CHECKING:
+    from hassette.test_utils.harness import HassetteHarness
+
+
+async def test_predicate_failure_enqueues_error_record(hassette_with_bus: "HassetteHarness") -> None:
+    """A raising predicate produces an ExecutionRecord with status='error'."""
+    hassette = hassette_with_bus
+    bus = hassette.bus
+    executor = hassette.bus_service._executor
+
+    executor.enqueue_record.reset_mock()
+
+    def bad_predicate(_ev: object) -> bool:
+        raise ZeroDivisionError("boom")
+
+    async def handler(_event: Event) -> None:
+        pass
+
+    await bus.on(topic="test.pred_record", handler=handler, where=bad_predicate, name="pred_record")
+
+    event = Event(topic="test.pred_record", payload=SimpleNamespace())
+    await hassette.send_event(event)
+    await wait_for(lambda: executor.enqueue_record.call_count > 0, desc="record enqueued")
+
+    record = executor.enqueue_record.call_args[0][0]
+    assert record.kind == "handler"
+    assert record.status == "error"
+    assert record.error_type == "ZeroDivisionError"
+    assert record.error_message == "boom"
+    assert record.error_traceback is not None
+    assert "ZeroDivisionError" in record.error_traceback
+    assert record.execution_id is not None
+
+
+async def test_predicate_failure_invokes_per_listener_error_handler(hassette_with_bus: "HassetteHarness") -> None:
+    """A raising predicate routes to the per-listener on_error handler."""
+    hassette = hassette_with_bus
+    bus = hassette.bus
+    executor = hassette.bus_service._executor
+
+    executor.invoke_error_handler.reset_mock()
+    executor.enqueue_record.reset_mock()
+
+    def bad_predicate(_ev: object) -> bool:
+        raise ValueError("pred failed")
+
+    async def handler(_event: Event) -> None:
+        pass
+
+    async def on_error(ctx: BusErrorContext) -> None:
+        pass
+
+    await bus.on(
+        topic="test.pred_per_listener",
+        handler=handler,
+        where=bad_predicate,
+        on_error=on_error,
+        name="pred_per_listener",
+    )
+
+    event = Event(topic="test.pred_per_listener", payload=SimpleNamespace())
+    await hassette.send_event(event)
+    await wait_for(lambda: executor.invoke_error_handler.call_count > 0, desc="error handler invoked")
+
+    handler_arg, ctx = executor.invoke_error_handler.call_args[0]
+    assert handler_arg is on_error
+    assert isinstance(ctx, BusErrorContext)
+    assert isinstance(ctx.exception, ValueError)
+    assert str(ctx.exception) == "pred failed"
+    assert ctx.topic == "test.pred_per_listener"
+    assert ctx.execution_id is not None
+
+    record = executor.enqueue_record.call_args[0][0]
+    assert ctx.execution_id == record.execution_id
+
+
+async def test_predicate_failure_invokes_app_level_error_handler(hassette_with_bus: "HassetteHarness") -> None:
+    """When no per-listener handler exists, predicate failure routes to the app-level handler."""
+    hassette = hassette_with_bus
+    bus = hassette.bus
+    executor = hassette.bus_service._executor
+
+    executor.invoke_error_handler.reset_mock()
+
+    def bad_predicate(_ev: object) -> bool:
+        raise RuntimeError("app level test")
+
+    async def handler(_event: Event) -> None:
+        pass
+
+    async def app_on_error(ctx: BusErrorContext) -> None:
+        pass
+
+    bus.on_error(app_on_error)
+    await bus.on(
+        topic="test.pred_app_level",
+        handler=handler,
+        where=bad_predicate,
+        name="pred_app_level",
+    )
+
+    event = Event(topic="test.pred_app_level", payload=SimpleNamespace())
+    await hassette.send_event(event)
+    await wait_for(lambda: executor.invoke_error_handler.call_count > 0, desc="app-level error handler invoked")
+
+    handler_arg, ctx = executor.invoke_error_handler.call_args[0]
+    assert handler_arg is app_on_error
+    assert isinstance(ctx.exception, RuntimeError)
+
+
+async def test_predicate_failure_does_not_crash_sibling_listeners(hassette_with_bus: "HassetteHarness") -> None:
+    """A raising predicate on one listener does not prevent sibling listeners from firing."""
+    hassette = hassette_with_bus
+    bus = hassette.bus
+
+    sibling_ran = asyncio.Event()
+
+    def bad_predicate(_ev: object) -> bool:
+        raise TypeError("broken predicate")
+
+    async def bad_handler(_event: Event) -> None:
+        pass
+
+    async def good_handler(_event: Event) -> None:
+        hassette.task_bucket.post_to_loop(sibling_ran.set)
+
+    await bus.on(topic="test.pred_isolation", handler=bad_handler, where=bad_predicate, name="pred_isolation_bad")
+    await bus.on(topic="test.pred_isolation", handler=good_handler, name="pred_isolation_good")
+
+    event = Event(topic="test.pred_isolation", payload=SimpleNamespace())
+    await hassette.send_event(event)
+
+    await asyncio.wait_for(sibling_ran.wait(), timeout=2.0)
+
+
+async def test_predicate_failure_no_error_handler_still_records(hassette_with_bus: "HassetteHarness") -> None:
+    """When no error handler is registered, predicate failure still records but doesn't crash."""
+    hassette = hassette_with_bus
+    bus = hassette.bus
+    executor = hassette.bus_service._executor
+
+    bus._error_handler = None
+    executor.enqueue_record.reset_mock()
+    executor.invoke_error_handler.reset_mock()
+
+    def bad_predicate(_ev: object) -> bool:
+        raise KeyError("no handler")
+
+    async def handler(_event: Event) -> None:
+        pass
+
+    await bus.on(topic="test.pred_no_handler", handler=handler, where=bad_predicate, name="pred_no_handler")
+
+    event = Event(topic="test.pred_no_handler", payload=SimpleNamespace())
+    await hassette.send_event(event)
+    await wait_for(lambda: executor.enqueue_record.call_count > 0, desc="record enqueued without error handler")
+
+    record = executor.enqueue_record.call_args[0][0]
+    assert record.status == "error"
+    assert record.error_type == "KeyError"
+
+    executor.invoke_error_handler.assert_not_called()
+
+
+async def test_glob_listener_predicate_failure_recorded_once(hassette_with_bus: "HassetteHarness") -> None:
+    """A glob-registered listener's predicate failure is recorded exactly once across expanded routes.
+
+    State-changed events expand to three routes (entity, domain-glob, base). A glob listener
+    matches on multiple routes — without dedup, the predicate would raise and record once per
+    matching route.
+    """
+    hassette = hassette_with_bus
+    bus = hassette.bus
+    executor = hassette.bus_service._executor
+
+    bus._error_handler = None
+    executor.enqueue_record.reset_mock()
+    executor.invoke_error_handler.reset_mock()
+
+    call_count = 0
+
+    def counting_bad_predicate(_ev: object) -> bool:
+        nonlocal call_count
+        call_count += 1
+        raise ValueError("glob boom")
+
+    async def handler(_event: Event) -> None:
+        pass
+
+    await bus.on_state_change(
+        "light.*",
+        handler=handler,
+        where=counting_bad_predicate,
+        name="glob_pred_failure",
+    )
+
+    event = create_state_change_event(entity_id="light.office", old_value="off", new_value="on")
+    await hassette.send_event(event)
+    await wait_for(lambda: executor.enqueue_record.call_count > 0, desc="record enqueued for glob listener")
+
+    assert call_count == 1, f"Predicate evaluated {call_count} times, expected exactly 1"
+    assert executor.enqueue_record.call_count == 1, (
+        f"ExecutionRecord enqueued {executor.enqueue_record.call_count} times, expected exactly 1"
+    )

--- a/tests/unit/bus/test_bus_where.py
+++ b/tests/unit/bus/test_bus_where.py
@@ -79,26 +79,31 @@ class TestCompareValueAsyncCallableInstance:
 
 
 class TestListenerMatchesRaisingPredicate:
-    """Listener.matches() catches raising predicates and returns False."""
+    """Listener.matches() propagates raising predicates to the caller.
 
-    def test_raising_predicate_returns_false(self) -> None:
+    BusService.dispatch() is responsible for isolation, telemetry recording,
+    and error-handler routing (#1255).
+    """
+
+    def test_raising_predicate_propagates(self) -> None:
         def bad_pred(_ev: object) -> bool:
             raise ValueError("boom")
 
         listener = create_listener(where=bad_pred)
         ev = SimpleNamespace(payload=SimpleNamespace())
 
-        assert listener.matches(ev) is False
+        with pytest.raises(ValueError, match="boom"):
+            listener.matches(ev)
 
-    def test_raising_predicate_does_not_propagate(self) -> None:
+    def test_raising_predicate_preserves_exception_type(self) -> None:
         def bad_pred(_ev: object) -> bool:
             raise RuntimeError("unexpected")
 
         listener = create_listener(where=bad_pred)
         ev = SimpleNamespace(payload=SimpleNamespace())
 
-        # Should not raise — exception is caught and logged
-        listener.matches(ev)
+        with pytest.raises(RuntimeError, match="unexpected"):
+            listener.matches(ev)
 
     def test_normal_predicate_still_works(self) -> None:
         def good_pred(_ev: object) -> bool:

--- a/tests/unit/bus/test_duration_hold.py
+++ b/tests/unit/bus/test_duration_hold.py
@@ -381,6 +381,44 @@ class TestHoldMatches:
 
         assert result is True
 
+    def test_raising_hold_predicate_returns_false(self) -> None:
+        """hold_matches catches a raising hold_predicate and returns False."""
+        manager = make_manager()
+
+        def bad_pred(_ev: object) -> bool:
+            raise ValueError("hold boom")
+
+        listener = create_listener(
+            topic="hass.event.state_changed.light.kitchen",
+            entity_id="light.kitchen",
+            duration=5.0,
+            hold_predicate=bad_pred,
+        )
+        event = MagicMock()
+
+        result = manager.hold_matches(listener, event)
+        assert result is False
+
+    def test_raising_listener_predicate_in_hold_matches_returns_false(self) -> None:
+        """hold_matches catches a raising listener.matches() fallback and returns False."""
+        manager = make_manager()
+
+        def bad_pred(_ev: object) -> bool:
+            raise RuntimeError("matches boom")
+
+        listener = create_listener(
+            topic="hass.event.state_changed.light.kitchen",
+            entity_id="light.kitchen",
+            duration=5.0,
+            where=bad_pred,
+        )
+        assert listener.duration_config is not None
+        assert listener.duration_config.hold_predicate is None
+
+        event = MagicMock()
+        result = manager.hold_matches(listener, event)
+        assert result is False
+
     def test_falls_back_when_no_duration_config(self) -> None:
         """hold_matches falls back to listener.matches when duration_config is None.
 

--- a/tests/unit/core/test_bus_service_predicate_failure.py
+++ b/tests/unit/core/test_bus_service_predicate_failure.py
@@ -1,0 +1,145 @@
+"""Unit tests for BusService._record_predicate_failure and dispatch predicate-error isolation."""
+
+import time
+from types import SimpleNamespace
+from typing import TYPE_CHECKING
+from unittest.mock import AsyncMock, MagicMock, PropertyMock, patch
+
+from hassette.bus.error_context import BusErrorContext
+from hassette.core.bus_service import BusService
+from hassette.events.base import Event
+from hassette.test_utils.helpers import create_listener
+
+if TYPE_CHECKING:
+    from hassette.bus.listeners import Listener
+
+
+def make_bus_service() -> tuple[BusService, MagicMock]:
+    """Build a BusService with mocked dependencies for unit testing."""
+    hassette = MagicMock()
+    hassette.session_id = 42
+    hassette.config.lifecycle.max_concurrent_dispatches = 10
+    hassette.config.lifecycle.event_handler_timeout_seconds = 30.0
+    hassette.config.logging.bus_service = "INFO"
+    hassette.config.logging.all_events = False
+    hassette.config.logging.all_hass_events = False
+    hassette.config.logging.all_hassette_events = False
+    hassette.config.bus_excluded_domains = []
+    hassette.config.bus_excluded_entities = []
+
+    executor = MagicMock()
+    executor.enqueue_record = MagicMock()
+    executor.invoke_error_handler = AsyncMock()
+
+    bs = object.__new__(BusService)
+    bs.hassette = hassette
+    bs._executor = executor
+    bs.logger = MagicMock()
+    bs.task_bucket = MagicMock()
+
+    return bs, executor
+
+
+def make_listener_with_error_handler(error_handler=None, app_resolver=None) -> "Listener":
+    listener = create_listener(topic="test.pred", error_handler=error_handler)
+    if app_resolver is not None:
+        listener.invoker.set_app_error_handler_resolver(app_resolver)
+    listener.mark_registered(99)
+    return listener
+
+
+class TestRecordPredicateFailure:
+    def test_enqueues_error_record_with_correct_fields(self) -> None:
+        bs, executor = make_bus_service()
+        listener = make_listener_with_error_handler()
+        event = Event(topic="test.pred", payload=SimpleNamespace())
+        exc = ValueError("boom")
+
+        start_ts = time.time()
+        bs._record_predicate_failure(listener, "test.pred", event, exc, start_ts)
+
+        executor.enqueue_record.assert_called_once()
+        record = executor.enqueue_record.call_args[0][0]
+        assert record.kind == "handler"
+        assert record.status == "error"
+        assert record.error_type == "ValueError"
+        assert record.error_message == "boom"
+        assert record.listener_id == 99
+        assert record.session_id == 42
+        assert record.execution_id is not None
+
+    def test_session_id_fallback_on_runtime_error(self) -> None:
+        bs, executor = make_bus_service()
+        type(bs.hassette).session_id = PropertyMock(side_effect=RuntimeError("no session"))
+
+        listener = make_listener_with_error_handler()
+        event = Event(topic="test.pred", payload=SimpleNamespace())
+
+        bs._record_predicate_failure(listener, "test.pred", event, ValueError("x"), time.time())
+
+        record = executor.enqueue_record.call_args[0][0]
+        assert record.session_id is None
+
+    def test_invokes_per_listener_error_handler(self) -> None:
+        bs, _executor = make_bus_service()
+
+        async def on_error(ctx: BusErrorContext) -> None:
+            pass
+
+        listener = make_listener_with_error_handler(error_handler=on_error)
+        event = Event(topic="test.pred", payload=SimpleNamespace())
+
+        bs._record_predicate_failure(listener, "test.pred", event, ValueError("x"), time.time())
+
+        bs.task_bucket.spawn.assert_called_once()
+
+    def test_invokes_app_level_error_handler_as_fallback(self) -> None:
+        bs, _executor = make_bus_service()
+
+        async def app_handler(ctx: BusErrorContext) -> None:
+            pass
+
+        listener = make_listener_with_error_handler(app_resolver=lambda: app_handler)
+        event = Event(topic="test.pred", payload=SimpleNamespace())
+
+        bs._record_predicate_failure(listener, "test.pred", event, ValueError("x"), time.time())
+
+        bs.task_bucket.spawn.assert_called_once()
+
+    def test_no_error_handler_skips_spawn(self) -> None:
+        bs, _executor = make_bus_service()
+        listener = make_listener_with_error_handler()
+        event = Event(topic="test.pred", payload=SimpleNamespace())
+
+        bs._record_predicate_failure(listener, "test.pred", event, ValueError("x"), time.time())
+
+        bs.task_bucket.spawn.assert_not_called()
+
+
+class TestDispatchPredicateRecordingIsolation:
+    async def test_record_failure_caught_by_inner_try_except(self) -> None:
+        """The inner try/except around _record_predicate_failure swallows its exceptions."""
+        bs, _executor = make_bus_service()
+        bs.router = MagicMock()
+        bs._event_filter = MagicMock()
+        bs._event_filter.should_skip.return_value = False
+        bs._dispatch_semaphore = MagicMock()
+        bs._dispatch_semaphore.locked.return_value = False
+        bs._dispatch_semaphore.acquire = AsyncMock()
+        bs._dispatch_pending = 0
+        bs._dispatch_idle_event = MagicMock()
+
+        def raising_pred(_ev: object) -> bool:
+            raise ValueError("pred boom")
+
+        listener = create_listener(where=raising_pred)
+        bs.router.get_topic_listeners.return_value = [listener]
+        event = Event(topic="test.pred", payload=SimpleNamespace())
+
+        with (
+            patch.object(bs, "_record_predicate_failure", side_effect=RuntimeError("record crash")),
+            patch.object(bs, "expand_topics", return_value=["test.pred"]),
+        ):
+            await bs.dispatch("test.pred", event)
+
+        bs.logger.exception.assert_any_call("Failed to record predicate failure for %s", listener)


### PR DESCRIPTION
### Bus predicate failure isolation and observability

- Previously, a raising `where=` predicate on a bus listener was caught inside `Listener.matches()`, logged, and silently treated as a non-match — the rest of the fanout continued but the failure was invisible in telemetry and no `on_error` handler was ever consulted (unlike the equivalent scheduler path, `SchedulerService._record_predicate_failure()`).
- `Listener.matches()` now lets predicate exceptions propagate; `BusService.dispatch()` catches them per-listener, so a broken predicate on one listener no longer silently swallows the failure while still not blocking evaluation of sibling listeners on the same event.
- Each predicate failure is now written as an `ExecutionRecord` with `status="error"`, populated `error_type`/`error_message`/`error_traceback`, and dispatched to the listener's `error_handler` (or the app-level fallback) via a `BusErrorContext` — mirroring how handler-raise failures are already recorded and routed in `CommandExecutor.execute_handler()`.
- `DurationHoldManager.hold_matches()` gets its own local try/except, since the duration-hold path has no executor access to record telemetry — a raising hold predicate logs and returns `False` without crashing the spawned timer task.
- Docs (`bus/methods.md`, `internals/service-details.md`) updated to describe the new raise-vs-return-`False` split.

### Tests

- New integration suite (`tests/integration/bus/test_bus_predicate_failure.py`) covers: `ExecutionRecord` creation on predicate raise, error-handler invocation with the right context, sibling-listener isolation, and glob-route dedup so a single raising listener records only once.
- `tests/unit/bus/test_bus_where.py` updated: `Listener.matches()` unit tests now assert propagation instead of swallowing, since isolation moved to the dispatch layer.

Closes #1255
