### PR TITLE
fix: harden SyncExecutorService restart and concurrency edge cases

### DIFF
--- a/src/hassette/core/service_watcher.py
+++ b/src/hassette/core/service_watcher.py
@@ -390,6 +390,23 @@ class ServiceWatcher(Resource):
         self._restarting.add(key)
         budget.record_restart()
 
+        # Spawn the backoff + restart as a detached task so this handler returns
+        # immediately and releases its dispatch semaphore slot.
+        self.task_bucket.spawn(
+            self.execute_restart(name, role, key, spec, services, budget),
+            name=f"service_watcher:restart:{key}",
+        )
+
+    async def execute_restart(
+        self,
+        name: str,
+        role: object,
+        key: str,
+        spec: RestartSpec,
+        services: list[Service],
+        budget: RestartBudget,
+    ) -> None:
+        """Execute backoff sleep and service restart (runs as a detached task)."""
         attempts = budget.current_attempts()
 
         # Step 6: Apply exponential backoff with shutdown-safe sleep
@@ -398,29 +415,28 @@ class ServiceWatcher(Resource):
             spec.backoff_max_seconds,
         )
 
-        if backoff > 0:
-            self.logger.info(
-                "%s '%s' restarting (attempt %d, waiting %.1fs)",
-                role,
-                name,
-                attempts,
-                backoff,
-            )
-            completed = await self.shutdown_safe_sleep(backoff)
-            if not completed or self.hassette.shutdown_event.is_set():
-                self.logger.debug("%s '%s' backoff sleep aborted (shutdown requested)", role, name)
-                self._restarting.discard(key)
-                return
-
-        self.logger.debug("%s '%s' is being restarted after '%s'", role, name, event.payload.data.status)
-
-        if len(services) > 1:
-            self.logger.warning("Multiple %s found for '%s', restarting all", role, name)
-
-        # Step 7: Restart the service — catch and log exceptions, do NOT double-count budget.
-        # Clear in-restart guard AFTER the entire loop so concurrent FAILED events cannot
-        # enter restart_service() while restarts are still in progress.
         try:
+            if backoff > 0:
+                self.logger.info(
+                    "%s '%s' restarting (attempt %d, waiting %.1fs)",
+                    role,
+                    name,
+                    attempts,
+                    backoff,
+                )
+                completed = await self.shutdown_safe_sleep(backoff)
+                if not completed or self.hassette.shutdown_event.is_set():
+                    self.logger.debug("%s '%s' backoff sleep aborted (shutdown requested)", role, name)
+                    return
+
+            self.logger.debug("%s '%s' is being restarted", role, name)
+
+            if len(services) > 1:
+                self.logger.warning("Multiple %s found for '%s', restarting all", role, name)
+
+            # Step 7: Restart the service — catch and log exceptions, do NOT double-count budget.
+            # Clear in-restart guard in the finally AFTER the entire loop so concurrent FAILED
+            # events cannot enter restart_service() while restarts are still in progress.
             for svc in services:
                 try:
                     await svc.restart()
@@ -505,6 +521,22 @@ class ServiceWatcher(Resource):
         spec = service.restart_spec if isinstance(service, Service) else None
         readiness_timeout = spec.startup_timeout_seconds if spec is not None else 30.0
 
+        # Spawn readiness check as a detached task so this handler returns
+        # immediately and releases its dispatch semaphore slot.
+        self.task_bucket.spawn(
+            self.await_service_readiness(service, name, role, key, readiness_timeout),
+            name=f"service_watcher:readiness:{key}",
+        )
+
+    async def await_service_readiness(
+        self,
+        service: Resource,
+        name: str,
+        role: object,
+        key: str,
+        readiness_timeout: float,
+    ) -> None:
+        """Wait for a restarted service to become ready and reset its budget (runs as a detached task)."""
         try:
             await service.wait_ready(timeout=readiness_timeout)
         except TimeoutError:
@@ -514,17 +546,14 @@ class ServiceWatcher(Resource):
                 name,
                 readiness_timeout,
             )
-            # Readiness timeout does NOT affect the restart budget
             return
 
         self.logger.debug("%s '%s' is running and ready, resetting restart budget", role, name)
 
-        # Reset budget on confirmed recovery
         budget = self._budgets.get(key)
         if budget:
             budget.reset()
 
-        # Clear in-restart flag — restart succeeded
         self._restarting.discard(key)
 
     async def reconcile_after_bus_recovery(self) -> None:

--- a/src/hassette/core/sync_executor_service.py
+++ b/src/hassette/core/sync_executor_service.py
@@ -54,15 +54,14 @@ SYNC_EXECUTOR_THREAD_NAME_PREFIX = "hassette-sync"
 class SyncExecutorService(Service):
     """Service that owns the dedicated thread-pool executor for sync user code.
 
-    The executor is constructed in __init__ (not a startup hook). Once wire_services()
-    has registered this service, hassette.sync_executor returns a live executor; before
-    that the property raises RuntimeError. Constructing in __init__ avoids a None window
-    on the service instance itself once it exists.
+    The executor is constructed in ``on_initialize()`` so that restart-in-place
+    (``shutdown`` → ``initialize`` on the same instance, driven by ServiceWatcher)
+    rebuilds the thread pool.  Consumers (BusService, SchedulerService, AppHandler)
+    declare ``depends_on=[SyncExecutorService]`` and wait for readiness, so no
+    consumer can submit work before the pool exists.
 
     SyncExecutorService declares depends_on=[] (it needs no DB or other service).
-    Its consumers (BusService, SchedulerService, AppHandler) declare
-    depends_on=[SyncExecutorService], which causes wave-based shutdown to tear
-    them down before the executor.
+    Wave-based shutdown tears consumers down before this service.
     """
 
     depends_on: ClassVar[list[type[Resource]]] = []
@@ -83,9 +82,12 @@ class SyncExecutorService(Service):
 
     def __init__(self, hassette: "Hassette", *, parent: Resource | None = None) -> None:
         super().__init__(hassette, parent=parent)
-        # Construct immediately — no None window before serve() runs.
+        self._active_workers = 0
+        self._last_saturation_warn_ts = 0.0
+
+    async def on_initialize(self) -> None:
         self.executor = InterruptibleThreadPoolExecutor(
-            max_workers=hassette.config.lifecycle.sync_executor_max_workers,
+            max_workers=self.hassette.config.lifecycle.sync_executor_max_workers,
             thread_name_prefix=SYNC_EXECUTOR_THREAD_NAME_PREFIX,
         )
         self._active_workers = 0
@@ -196,6 +198,8 @@ class SyncExecutorService(Service):
         ``sync_executor_shutdown_timeout_seconds`` below ``resource_shutdown_timeout_seconds``
         to give the wave explicit headroom.
         """
+        if not hasattr(self, "executor"):
+            return
         lifecycle = self.hassette.config.lifecycle
         budget = min(
             lifecycle.sync_executor_shutdown_timeout_seconds,

--- a/src/hassette/task_bucket/task_bucket.py
+++ b/src/hassette/task_bucket/task_bucket.py
@@ -15,6 +15,8 @@ from hassette.resources.base import Resource
 from hassette.types.types import LOG_LEVEL_TYPE, CoroLikeT
 from hassette.utils.func_utils import is_async_callable
 
+_CROSS_THREAD_SPAWN_TIMEOUT_SECS = 10.0
+
 
 @dataclass
 class SyncWorkerHandle:
@@ -175,7 +177,18 @@ class TaskBucket(Resource):
                     result.set_exception(e)
 
             self.hassette.loop.call_soon_threadsafe(_create)
-            return result.result()  # block this worker thread briefly to hand back the Task
+            try:
+                return result.result(timeout=_CROSS_THREAD_SPAWN_TIMEOUT_SECS)
+            except CfTimeoutError:
+                self.logger.error(
+                    "Cross-thread spawn of '%s' timed out after %.0fs waiting for the event loop",
+                    name,
+                    _CROSS_THREAD_SPAWN_TIMEOUT_SECS,
+                )
+                raise RuntimeError(
+                    f"Cross-thread spawn of '{name}' timed out waiting for the event loop "
+                    "— the loop may have stopped or is severely congested"
+                ) from None
 
     def run_in_thread(self, fn: Callable[P, R], *args: P.args, **kwargs: P.kwargs) -> "asyncio.Future[R]":
         """Run a synchronous function on the dedicated sync-handler executor.

--- a/tests/integration/test_service_watcher.py
+++ b/tests/integration/test_service_watcher.py
@@ -77,10 +77,7 @@ def get_dummy_service(
         restart_spec: ClassVar[RestartSpec] = spec
 
         async def serve(self):
-            try:
-                await asyncio.Event().wait()
-            except asyncio.CancelledError:
-                raise
+            await asyncio.Event().wait()
 
         async def on_shutdown(self):
             called["cancel"] += 1

--- a/tests/integration/test_service_watcher.py
+++ b/tests/integration/test_service_watcher.py
@@ -35,6 +35,33 @@ async def get_service_watcher_mock(hassette_with_bus):
         await reset_hassette_lifecycle(hassette, original_children=original_children)
 
 
+async def restart_and_await(watcher: ServiceWatcher, event: HassetteServiceEvent) -> None:
+    """Call restart_service and wait for the spawned execute_restart task to complete.
+
+    restart_service now spawns the backoff+restart as a detached task and returns
+    immediately. Tests that call restart_service sequentially need to wait for the
+    in-restart flag to clear before the next call.
+    """
+    key = watcher.service_key(event.payload.data.resource_name, event.payload.data.role)
+    was_restarting = key in watcher._restarting
+    await watcher.restart_service(event)
+    if not was_restarting and key in watcher._restarting:
+        await wait_for(
+            lambda: key not in watcher._restarting,
+            desc=f"execute_restart for {key} completed",
+            timeout=5.0,
+        )
+
+
+async def on_running_and_await(watcher: ServiceWatcher, event: HassetteServiceEvent) -> None:
+    """Call on_service_running and wait for the spawned readiness task to complete."""
+    pending_before = set(watcher.task_bucket.pending_tasks())
+    await watcher.on_service_running(event)
+    new_tasks = set(watcher.task_bucket.pending_tasks()) - pending_before
+    for task in new_tasks:
+        await asyncio.wait_for(asyncio.shield(task), timeout=5.0)
+
+
 def get_dummy_service(
     called: dict[str, int],
     hassette,
@@ -50,7 +77,10 @@ def get_dummy_service(
         restart_spec: ClassVar[RestartSpec] = spec
 
         async def serve(self):
-            pass
+            try:
+                await asyncio.Event().wait()
+            except asyncio.CancelledError:
+                raise
 
         async def on_shutdown(self):
             called["cancel"] += 1
@@ -112,10 +142,10 @@ async def test_always_failing_service_stops_after_max_attempts(get_service_watch
     event = make_service_failed_event(dummy_service)
     key = watcher.service_key(dummy_service.class_name, dummy_service.role)
 
-    # Each call to restart_service increments budget and attempts restart.
+    # Each call to restart_service increments budget and spawns a restart task.
     # The service fails on restart but exceptions are caught.
     for _ in range(3):
-        await watcher.restart_service(event)
+        await restart_and_await(watcher, event)
 
     budget = watcher._budgets.get(key)
     assert budget is not None
@@ -147,7 +177,7 @@ async def test_crashed_event_emitted_before_shutdown(get_service_watcher_mock: S
     event = make_service_failed_event(dummy_service)
 
     # First call uses the one budget slot
-    await watcher.restart_service(event)
+    await restart_and_await(watcher, event)
 
     # Second call exceeds budget — should emit CRASHED then shutdown
     mock_send = AsyncMock()
@@ -194,7 +224,7 @@ async def test_exponential_backoff(get_service_watcher_mock: ServiceWatcher):
 
     with patch.object(watcher, "shutdown_safe_sleep", side_effect=mock_shutdown_safe_sleep):
         for _ in range(3):
-            await watcher.restart_service(event)
+            await restart_and_await(watcher, event)
 
     # attempt 1: backoff = 1.0 * 2^0 = 1.0
     # attempt 2: backoff = 1.0 * 2^1 = 2.0
@@ -222,7 +252,7 @@ async def test_budget_reset_on_recovery(get_service_watcher_mock: ServiceWatcher
 
     # Accumulate 2 restart attempts
     for _ in range(2):
-        await watcher.restart_service(event)
+        await restart_and_await(watcher, event)
 
     budget = watcher._budgets[key]
     budget.evict_expired()
@@ -230,7 +260,7 @@ async def test_budget_reset_on_recovery(get_service_watcher_mock: ServiceWatcher
 
     # Mark the service ready, then fire RUNNING event — budget should reset
     dummy_service.mark_ready(reason="test")
-    await watcher.on_service_running(make_service_running_event(dummy_service))
+    await on_running_and_await(watcher, make_service_running_event(dummy_service))
 
     budget.evict_expired()
     assert len(budget._timestamps) == 0  # budget reset
@@ -254,12 +284,12 @@ async def test_permanent_exhaustion_triggers_shutdown(get_service_watcher_mock: 
     event = make_service_failed_event(dummy_service)
 
     # Use up budget
-    await watcher.restart_service(event)
-    await watcher.restart_service(event)
+    await restart_and_await(watcher, event)
+    await restart_and_await(watcher, event)
 
     assert not hassette.shutdown_event.is_set(), "Should not shutdown until budget exhausted"
 
-    # Exhaust budget
+    # Exhaust budget (budget check is synchronous — no spawn needed)
     await watcher.restart_service(event)
     assert hassette.shutdown_event.is_set()
 
@@ -285,9 +315,9 @@ async def test_permanent_exhaustion_records_fatal_reason(get_service_watcher_moc
     hassette.children.append(dummy_service)
 
     event = make_service_failed_event(dummy_service)
-    await watcher.restart_service(event)
-    await watcher.restart_service(event)
-    await watcher.restart_service(event)  # exhausts → handle_exhaustion (PERMANENT)
+    await restart_and_await(watcher, event)
+    await restart_and_await(watcher, event)
+    await watcher.restart_service(event)  # exhausts → handle_exhaustion (PERMANENT, no spawn)
 
     assert hassette._fatal_shutdown_reason is not None
     assert dummy_service.class_name in hassette._fatal_shutdown_reason
@@ -336,8 +366,8 @@ async def test_transient_exhaustion_enters_cooldown(get_service_watcher_mock: Se
     key = watcher.service_key(dummy_service.class_name, dummy_service.role)
 
     # Use up budget
-    await watcher.restart_service(event)
-    await watcher.restart_service(event)
+    await restart_and_await(watcher, event)
+    await restart_and_await(watcher, event)
 
     # Capture events emitted on exhaustion
     emitted_events: list = []
@@ -347,7 +377,7 @@ async def test_transient_exhaustion_enters_cooldown(get_service_watcher_mock: Se
 
     hassette.send_event = capture_event  # pyright: ignore[reportAttributeAccessIssue]
 
-    # Exhaust budget
+    # Exhaust budget (budget check is synchronous — no spawn needed)
     await watcher.restart_service(event)
 
     hassette.send_event = hassette._event_stream_service.send_event  # pyright: ignore[reportAttributeAccessIssue]
@@ -385,8 +415,8 @@ async def test_temporary_exhaustion_stays_dead(get_service_watcher_mock: Service
     event = make_service_failed_event(dummy_service)
 
     # Use up budget
-    await watcher.restart_service(event)
-    await watcher.restart_service(event)
+    await restart_and_await(watcher, event)
+    await restart_and_await(watcher, event)
 
     emitted_events: list = []
 
@@ -395,7 +425,7 @@ async def test_temporary_exhaustion_stays_dead(get_service_watcher_mock: Service
 
     hassette.send_event = capture_event  # pyright: ignore[reportAttributeAccessIssue]
 
-    # Exhaust budget
+    # Exhaust budget (budget check is synchronous — no spawn needed)
     await watcher.restart_service(event)
 
     hassette.send_event = hassette._event_stream_service.send_event  # pyright: ignore[reportAttributeAccessIssue]
@@ -570,7 +600,7 @@ async def test_shutdown_safe_sleep_aborts_on_shutdown(get_service_watcher_mock: 
     # Set shutdown event to trigger early abort during backoff
     hassette.shutdown_event.set()
 
-    await watcher.restart_service(event)
+    await restart_and_await(watcher, event)
 
     # Service should NOT have been restarted
     assert call_counts["start"] == 0, "Service should not restart when shutdown is requested during backoff"
@@ -597,8 +627,8 @@ async def test_budget_reset_on_recovery_confirmed(get_service_watcher_mock: Serv
     key = watcher.service_key(dummy_service.class_name, dummy_service.role)
 
     # Accumulate 2 restart attempts
-    await watcher.restart_service(event)
-    await watcher.restart_service(event)
+    await restart_and_await(watcher, event)
+    await restart_and_await(watcher, event)
 
     budget = watcher._budgets[key]
     budget.evict_expired()
@@ -606,7 +636,7 @@ async def test_budget_reset_on_recovery_confirmed(get_service_watcher_mock: Serv
 
     # Mark the service ready, then fire RUNNING event — budget should reset
     dummy_service.mark_ready(reason="test")
-    await watcher.on_service_running(make_service_running_event(dummy_service))
+    await on_running_and_await(watcher, make_service_running_event(dummy_service))
 
     budget.evict_expired()
     assert len(budget._timestamps) == 0  # budget.reset() was called
@@ -632,14 +662,20 @@ async def test_readiness_timeout_no_budget_impact(get_service_watcher_mock: Serv
     key = watcher.service_key(dummy_service.class_name, dummy_service.role)
 
     # Accumulate 1 restart attempt
-    await watcher.restart_service(event)
+    await restart_and_await(watcher, event)
 
     budget = watcher._budgets[key]
     budget.evict_expired()
     count_before = len(budget._timestamps)
 
     # Fire RUNNING event WITHOUT marking ready — timeout will occur, no budget impact
+    # on_service_running spawns a readiness task; wait for it to time out
     await watcher.on_service_running(make_service_running_event(dummy_service))
+    await wait_for(
+        lambda: watcher.task_bucket.pending_tasks() == [],
+        desc="readiness timeout task completed",
+        timeout=5.0,
+    )
 
     budget.evict_expired()
     assert len(budget._timestamps) == count_before, "Readiness timeout should not impact restart budget"
@@ -665,9 +701,9 @@ async def test_cooldown_then_recovery(get_service_watcher_mock: ServiceWatcher):
     key = watcher.service_key(dummy_service.class_name, dummy_service.role)
 
     # Use up the budget (1 restart)
-    await watcher.restart_service(event)
+    await restart_and_await(watcher, event)
 
-    # Exhaust budget — should schedule cooldown task
+    # Exhaust budget — should schedule cooldown task (budget check is synchronous)
     await watcher.restart_service(event)
 
     assert key in watcher._cooldown_tasks
@@ -817,7 +853,7 @@ async def test_restart_exception_caught_no_double_count(get_service_watcher_mock
     dummy_service.restart = raise_on_restart  # pyright: ignore[reportAttributeAccessIssue]
 
     # Should not propagate the exception from restart
-    await watcher.restart_service(event)
+    await restart_and_await(watcher, event)
 
     budget = watcher._budgets.get(key)
     assert budget is not None

--- a/tests/unit/core/test_service_watcher_coverage.py
+++ b/tests/unit/core/test_service_watcher_coverage.py
@@ -16,7 +16,7 @@ from hassette.events import HassetteServiceEvent
 from hassette.events.base import HassettePayload
 from hassette.events.hassette import ServiceStatusPayload
 from hassette.resources.restart import RestartSpec
-from hassette.test_utils import make_mock_hassette, make_service_failed_event, make_service_running_event
+from hassette.test_utils import make_mock_hassette, make_service_failed_event, make_service_running_event, wait_for
 from hassette.types import ResourceStatus, Topic
 from hassette.types.enums import RestartType
 
@@ -272,6 +272,8 @@ class TestRestartServiceMultipleMatches:
         event = make_service_failed_event(svc_a)
 
         await watcher.restart_service(event)
+        key = watcher.service_key(svc_a.class_name, svc_a.role)
+        await wait_for(lambda: key not in watcher._restarting, desc="execute_restart completed")
 
         svc_a.restart.assert_awaited_once()
         svc_b.restart.assert_awaited_once()
@@ -363,6 +365,7 @@ class TestOnServiceRunningBudgetNoneBranch:
 
         event = make_service_running_event(dummy)
         await watcher.on_service_running(event)
+        await wait_for(lambda: key not in watcher._restarting, desc="await_service_readiness completed")
 
         assert key not in watcher._restarting
         assert key not in watcher._budgets

--- a/tests/unit/test_sync_executor_service.py
+++ b/tests/unit/test_sync_executor_service.py
@@ -1,11 +1,12 @@
 """Unit tests for SyncExecutorService.
 
 Executor construction and wiring covers:
-- Executor is constructed in __init__ (no None window)
+- Executor is constructed in on_initialize (survives restart-in-place)
 - Service is registered in wire_services() and reachable via hassette.sync_executor
 - depends_on=[] (leaf dependency — no DB or other service required)
 - BusService, SchedulerService, AppHandler declare depends_on=[SyncExecutorService]
 - Dependency graph validation still passes after registration
+- Regression: restart-in-place (shutdown → initialize) rebuilds the thread pool
 - Regression: AppSync shutdown hook submitting sync work during shutdown completes
   without RuntimeError: cannot schedule new futures after shutdown
 
@@ -49,6 +50,7 @@ from hassette.core.sync_executor_service import (
     _SATURATION_PROBE_INTERVAL_SECS,
     _SATURATION_WARN_RATE_LIMIT_SECS,
     _SATURATION_WARN_THRESHOLD,
+    SYNC_EXECUTOR_THREAD_NAME_PREFIX,
     SyncExecutorService,
 )
 from hassette.resources.base import Resource
@@ -81,8 +83,8 @@ def make_test_config(max_workers: int = 4, shutdown_timeout: float = 5.0) -> Has
     )
 
 
-def make_service(max_workers: int = 4, shutdown_timeout: float = 5.0) -> SyncExecutorService:
-    """Build a SyncExecutorService with a mock Hassette."""
+def make_mock_hassette(max_workers: int = 4, shutdown_timeout: float = 5.0) -> MagicMock:
+    """Build a mock Hassette configured for SyncExecutorService tests."""
     config = make_test_config(max_workers=max_workers, shutdown_timeout=shutdown_timeout)
     mock_hassette = MagicMock()
     mock_hassette.config = config
@@ -90,7 +92,22 @@ def make_service(max_workers: int = 4, shutdown_timeout: float = 5.0) -> SyncExe
     mock_hassette.shutdown_event = asyncio.Event()
     mock_hassette.children = []
     mock_hassette._should_skip_dependency_check = MagicMock(return_value=True)
-    return SyncExecutorService(mock_hassette)
+    return mock_hassette
+
+
+def make_service(max_workers: int = 4, shutdown_timeout: float = 5.0) -> SyncExecutorService:
+    """Build a SyncExecutorService with executor ready for use.
+
+    Constructs the executor inline (simulating on_initialize) so sync tests
+    can use the service without entering an async context.
+    """
+    mock_hassette = make_mock_hassette(max_workers=max_workers, shutdown_timeout=shutdown_timeout)
+    svc = SyncExecutorService(mock_hassette)
+    svc.executor = InterruptibleThreadPoolExecutor(
+        max_workers=mock_hassette.config.lifecycle.sync_executor_max_workers,
+        thread_name_prefix=SYNC_EXECUTOR_THREAD_NAME_PREFIX,
+    )
+    return svc
 
 
 # Class-level structure tests (no event loop needed)
@@ -127,57 +144,71 @@ class TestSyncExecutorServiceClassAttrs:
 
 
 class TestExecutorConstruction:
-    def test_executor_constructed_in_init(self) -> None:
-        """Executor is built in __init__, not lazily — no None window."""
-        config = make_test_config(max_workers=3)
-        mock_hassette = MagicMock()
-        mock_hassette.config = config
-        mock_hassette.task_bucket = MagicMock()
-        mock_hassette.shutdown_event = asyncio.Event()
-        mock_hassette.children = []
-        mock_hassette._should_skip_dependency_check = MagicMock(return_value=True)
-
+    def test_executor_not_available_before_initialize(self) -> None:
+        """Executor does not exist after __init__ — only after on_initialize."""
+        mock_hassette = make_mock_hassette(max_workers=3)
         svc = SyncExecutorService(mock_hassette)
+        assert not hasattr(svc, "executor")
+
+    @pytest.mark.anyio
+    async def test_executor_constructed_in_on_initialize(self) -> None:
+        """Executor is built in on_initialize, not __init__, so restart rebuilds it."""
+        mock_hassette = make_mock_hassette(max_workers=3)
+        svc = SyncExecutorService(mock_hassette)
+
+        await svc.on_initialize()
 
         assert svc.executor is not None
         assert isinstance(svc.executor, InterruptibleThreadPoolExecutor)
-        # Clean up immediately
         svc.executor.shutdown(join_threads_or_timeout=False)
 
-    def test_executor_uses_config_max_workers(self) -> None:
+    @pytest.mark.anyio
+    async def test_executor_uses_config_max_workers(self) -> None:
         """Executor is constructed with max_workers from lifecycle config."""
-        config = make_test_config(max_workers=7)
-        mock_hassette = MagicMock()
-        mock_hassette.config = config
-        mock_hassette.task_bucket = MagicMock()
-        mock_hassette.shutdown_event = asyncio.Event()
-        mock_hassette.children = []
-        mock_hassette._should_skip_dependency_check = MagicMock(return_value=True)
-
+        mock_hassette = make_mock_hassette(max_workers=7)
         svc = SyncExecutorService(mock_hassette)
+
+        await svc.on_initialize()
 
         assert svc.executor._max_workers == 7  # pyright: ignore[reportAttributeAccessIssue]
         svc.executor.shutdown(join_threads_or_timeout=False)
 
     def test_executor_thread_name_prefix(self) -> None:
         """Worker threads get the 'hassette-sync' prefix for identifiability in logs."""
-        config = make_test_config()
-        mock_hassette = MagicMock()
-        mock_hassette.config = config
-        mock_hassette.task_bucket = MagicMock()
-        mock_hassette.shutdown_event = asyncio.Event()
-        mock_hassette.children = []
-        mock_hassette._should_skip_dependency_check = MagicMock(return_value=True)
+        svc = make_service()
 
-        svc = SyncExecutorService(mock_hassette)
-
-        # Spawn a thread to verify prefix
         future = svc.executor.submit(lambda: None)
         future.result(timeout=2.0)
-        # GIL protects this read from corruption; count may be stale by one due
-        # to concurrent _adjust_thread_count, but thread names are stable once set.
         thread_names = {t.name for t in svc.executor._threads}  # pyright: ignore[reportAttributeAccessIssue]
         assert all("hassette-sync" in name for name in thread_names)
+        svc.executor.shutdown(join_threads_or_timeout=False)
+
+    @pytest.mark.anyio
+    async def test_restart_rebuilds_executor(self) -> None:
+        """Shutdown then on_initialize on the same instance rebuilds a usable pool."""
+        mock_hassette = make_mock_hassette(max_workers=2)
+        svc = SyncExecutorService(mock_hassette)
+        await svc.on_initialize()
+
+        first_executor = svc.executor
+        result: list[str] = []
+        future = first_executor.submit(lambda: result.append("before"))
+        future.result(timeout=2.0)
+        assert result == ["before"]
+
+        await svc.on_shutdown()
+
+        with pytest.raises(RuntimeError, match="cannot schedule new futures after shutdown"):
+            first_executor.submit(lambda: None)
+
+        await svc.on_initialize()
+        assert svc.executor is not first_executor
+
+        result.clear()
+        future = svc.executor.submit(lambda: result.append("after"))
+        future.result(timeout=2.0)
+        assert result == ["after"]
+
         svc.executor.shutdown(join_threads_or_timeout=False)
 
 
@@ -249,19 +280,21 @@ class TestWireServicesRegistration:
             assert h._sync_executor_service is not None
             assert isinstance(h._sync_executor_service, SyncExecutorService)
         finally:
-            if h._sync_executor_service is not None:
+            if h._sync_executor_service is not None and hasattr(h._sync_executor_service, "executor"):
                 h._sync_executor_service.executor.shutdown(join_threads_or_timeout=False)
 
-    def test_sync_executor_property_returns_executor(self, isolated_hassette_context: object) -> None:
-        """hassette.sync_executor returns the InterruptibleThreadPoolExecutor."""
+    @pytest.mark.anyio
+    async def test_sync_executor_property_returns_executor(self, isolated_hassette_context: object) -> None:
+        """hassette.sync_executor returns the InterruptibleThreadPoolExecutor after initialization."""
         config = make_test_config()
         h = Hassette(config)
         try:
             h.wire_services()
+            await h._sync_executor_service.on_initialize()
             executor = h.sync_executor
             assert isinstance(executor, InterruptibleThreadPoolExecutor)
         finally:
-            if h._sync_executor_service is not None:
+            if h._sync_executor_service is not None and hasattr(h._sync_executor_service, "executor"):
                 h._sync_executor_service.executor.shutdown(join_threads_or_timeout=False)
 
     def test_sync_executor_property_raises_before_wire_services(self) -> None:
@@ -280,7 +313,7 @@ class TestWireServicesRegistration:
             svc = h.sync_executor_service
             assert isinstance(svc, SyncExecutorService)
         finally:
-            if h._sync_executor_service is not None:
+            if h._sync_executor_service is not None and hasattr(h._sync_executor_service, "executor"):
                 h._sync_executor_service.executor.shutdown(join_threads_or_timeout=False)
 
     def test_sync_executor_service_property_raises_before_wire_services(self) -> None:
@@ -298,7 +331,7 @@ class TestWireServicesRegistration:
             # Should not raise — SyncExecutorService is a leaf, graph stays acyclic.
             h.wire_services()
         finally:
-            if h._sync_executor_service is not None:
+            if h._sync_executor_service is not None and hasattr(h._sync_executor_service, "executor"):
                 h._sync_executor_service.executor.shutdown(join_threads_or_timeout=False)
 
 
@@ -327,18 +360,10 @@ class TestShutdownOrderingRegression:
         is set.  Because the executor shuts down *after* its consumers, the submit
         must succeed — not raise RuntimeError: cannot schedule new futures after shutdown.
         """
-        config = make_test_config(max_workers=2, shutdown_timeout=2.0)
-        mock_hassette = MagicMock()
-        mock_hassette.config = config
-        mock_hassette.task_bucket = MagicMock()
-        mock_hassette.shutdown_event = asyncio.Event()
-        mock_hassette.children = []
-        mock_hassette._should_skip_dependency_check = MagicMock(return_value=True)
-
-        svc = SyncExecutorService(mock_hassette)
+        svc = make_service(max_workers=2, shutdown_timeout=2.0)
 
         # Simulate: shutdown_event fires (consumers are being torn down)
-        mock_hassette.shutdown_event.set()
+        svc.hassette.shutdown_event.set()
 
         # The executor itself has NOT been shut down yet — it outlives consumers.
         # An AppSync on_shutdown hook submits sync work at this point.
@@ -356,15 +381,7 @@ class TestShutdownOrderingRegression:
 
         This is the failure mode the depends_on ordering prevents.
         """
-        config = make_test_config()
-        mock_hassette = MagicMock()
-        mock_hassette.config = config
-        mock_hassette.task_bucket = MagicMock()
-        mock_hassette.shutdown_event = asyncio.Event()
-        mock_hassette.children = []
-        mock_hassette._should_skip_dependency_check = MagicMock(return_value=True)
-
-        svc = SyncExecutorService(mock_hassette)
+        svc = make_service()
         svc.executor.shutdown(timeout=1.0)
 
         with pytest.raises(RuntimeError, match="cannot schedule new futures after shutdown"):
@@ -378,15 +395,7 @@ class TestOnShutdown:
     @pytest.mark.anyio
     async def test_on_shutdown_calls_executor_shutdown_with_budget(self) -> None:
         """on_shutdown passes sync_executor_shutdown_timeout_seconds as the budget."""
-        config = make_test_config(shutdown_timeout=7.5)
-        mock_hassette = MagicMock()
-        mock_hassette.config = config
-        mock_hassette.task_bucket = MagicMock()
-        mock_hassette.shutdown_event = asyncio.Event()
-        mock_hassette.children = []
-        mock_hassette._should_skip_dependency_check = MagicMock(return_value=True)
-
-        svc = SyncExecutorService(mock_hassette)
+        svc = make_service(shutdown_timeout=7.5)
 
         shutdown_calls: list[dict] = []
         original_shutdown = svc.executor.shutdown
@@ -401,6 +410,13 @@ class TestOnShutdown:
 
         assert len(shutdown_calls) == 1
         assert shutdown_calls[0]["kwargs"].get("timeout") == 7.5
+
+    @pytest.mark.anyio
+    async def test_on_shutdown_skips_when_executor_not_initialized(self) -> None:
+        """on_shutdown is a no-op if on_initialize was never called."""
+        mock_hassette = make_mock_hassette()
+        svc = SyncExecutorService(mock_hassette)
+        await svc.on_shutdown()
 
 
 # SyncExecutorService's restart_spec is covered by the parametrized tests in
@@ -1009,15 +1025,8 @@ class TestTrackSubmission:
     @pytest.mark.anyio
     async def test_run_in_thread_calls_saturation_check(self) -> None:
         """After run_in_thread submits work, track_submission is called (which calls log check)."""
-        config = make_test_config(max_workers=1, shutdown_timeout=5.0)
-        mock_hassette = MagicMock()
-        mock_hassette.config = config
-        mock_hassette.task_bucket = MagicMock()
-        mock_hassette.shutdown_event = asyncio.Event()
-        mock_hassette.children = []
-        mock_hassette._should_skip_dependency_check = MagicMock(return_value=True)
-
-        svc = SyncExecutorService(mock_hassette)
+        svc = make_service(max_workers=1, shutdown_timeout=5.0)
+        mock_hassette = svc.hassette
         mock_hassette.sync_executor_service = svc
         mock_hassette.sync_executor = svc.executor
 

--- a/tests/unit/test_sync_executor_service.py
+++ b/tests/unit/test_sync_executor_service.py
@@ -83,7 +83,7 @@ def make_test_config(max_workers: int = 4, shutdown_timeout: float = 5.0) -> Has
     )
 
 
-def make_mock_hassette(max_workers: int = 4, shutdown_timeout: float = 5.0) -> MagicMock:
+def make_sync_executor_hassette(max_workers: int = 4, shutdown_timeout: float = 5.0) -> MagicMock:
     """Build a mock Hassette configured for SyncExecutorService tests."""
     config = make_test_config(max_workers=max_workers, shutdown_timeout=shutdown_timeout)
     mock_hassette = MagicMock()
@@ -101,7 +101,7 @@ def make_service(max_workers: int = 4, shutdown_timeout: float = 5.0) -> SyncExe
     Constructs the executor inline (simulating on_initialize) so sync tests
     can use the service without entering an async context.
     """
-    mock_hassette = make_mock_hassette(max_workers=max_workers, shutdown_timeout=shutdown_timeout)
+    mock_hassette = make_sync_executor_hassette(max_workers=max_workers, shutdown_timeout=shutdown_timeout)
     svc = SyncExecutorService(mock_hassette)
     svc.executor = InterruptibleThreadPoolExecutor(
         max_workers=mock_hassette.config.lifecycle.sync_executor_max_workers,
@@ -146,14 +146,14 @@ class TestSyncExecutorServiceClassAttrs:
 class TestExecutorConstruction:
     def test_executor_not_available_before_initialize(self) -> None:
         """Executor does not exist after __init__ — only after on_initialize."""
-        mock_hassette = make_mock_hassette(max_workers=3)
+        mock_hassette = make_sync_executor_hassette(max_workers=3)
         svc = SyncExecutorService(mock_hassette)
         assert not hasattr(svc, "executor")
 
     @pytest.mark.anyio
     async def test_executor_constructed_in_on_initialize(self) -> None:
         """Executor is built in on_initialize, not __init__, so restart rebuilds it."""
-        mock_hassette = make_mock_hassette(max_workers=3)
+        mock_hassette = make_sync_executor_hassette(max_workers=3)
         svc = SyncExecutorService(mock_hassette)
 
         await svc.on_initialize()
@@ -165,7 +165,7 @@ class TestExecutorConstruction:
     @pytest.mark.anyio
     async def test_executor_uses_config_max_workers(self) -> None:
         """Executor is constructed with max_workers from lifecycle config."""
-        mock_hassette = make_mock_hassette(max_workers=7)
+        mock_hassette = make_sync_executor_hassette(max_workers=7)
         svc = SyncExecutorService(mock_hassette)
 
         await svc.on_initialize()
@@ -186,7 +186,7 @@ class TestExecutorConstruction:
     @pytest.mark.anyio
     async def test_restart_rebuilds_executor(self) -> None:
         """Shutdown then on_initialize on the same instance rebuilds a usable pool."""
-        mock_hassette = make_mock_hassette(max_workers=2)
+        mock_hassette = make_sync_executor_hassette(max_workers=2)
         svc = SyncExecutorService(mock_hassette)
         await svc.on_initialize()
 
@@ -414,7 +414,7 @@ class TestOnShutdown:
     @pytest.mark.anyio
     async def test_on_shutdown_skips_when_executor_not_initialized(self) -> None:
         """on_shutdown is a no-op if on_initialize was never called."""
-        mock_hassette = make_mock_hassette()
+        mock_hassette = make_sync_executor_hassette()
         svc = SyncExecutorService(mock_hassette)
         await svc.on_shutdown()
 

--- a/tests/unit/test_task_bucket.py
+++ b/tests/unit/test_task_bucket.py
@@ -1,4 +1,4 @@
-"""Unit tests for TaskBucket.pending_tasks() public accessor.
+"""Unit tests for TaskBucket.
 
 Tests cover the snapshot-semantics and filtering guarantees of
 ``TaskBucket.pending_tasks()``:
@@ -8,9 +8,16 @@ Tests cover the snapshot-semantics and filtering guarantees of
 - Excludes tasks that have already completed
 - Excludes tasks that have been cancelled
 - Returns a new list (snapshot) each call — not a reference to the internal set
+
+Cross-thread spawn:
+- Raises RuntimeError (not hangs) when the event loop is stopped
 """
 
 import asyncio
+import threading
+from concurrent.futures import Future as CfFuture
+from concurrent.futures import TimeoutError as CfTimeout
+from unittest.mock import patch
 
 import pytest
 
@@ -156,3 +163,35 @@ class TestSpawnTaskNaming:
 
         gate.set()
         await task
+
+
+class TestCrossThreadSpawnTimeout:
+    """Cross-thread spawn raises RuntimeError instead of hanging when the loop is unresponsive."""
+
+    async def test_cross_thread_spawn_timeout_raises_runtime_error(self) -> None:
+        """spawn() wraps CfTimeoutError into a descriptive RuntimeError."""
+        mock_h = make_mock_hassette()
+        mock_h.loop_thread_id = -1  # force cross-thread path
+        bucket = TaskBucket(mock_h)
+
+        error: Exception | None = None
+
+        async def noop() -> None:
+            pass
+
+        def try_spawn() -> None:
+            nonlocal error
+            try:
+                bucket.spawn(noop(), name="doomed-task")
+            except RuntimeError as e:
+                error = e
+
+        with patch.object(CfFuture, "result", side_effect=CfTimeout("timed out")):
+            t = threading.Thread(target=try_spawn)
+            t.start()
+            t.join(timeout=5.0)
+
+        assert not t.is_alive(), "Spawn thread should not hang"
+        assert error is not None, "Expected RuntimeError from timed-out cross-thread spawn"
+        assert "doomed-task" in str(error)
+        assert "timed out" in str(error).lower()


### PR DESCRIPTION
### SyncExecutorService restart-in-place

- Move executor construction from `__init__` to `on_initialize()`. Previously the thread pool was built once at construction time, so `ServiceWatcher`-driven restart-in-place (`on_shutdown()` → `on_initialize()` on the same instance) shut the pool down permanently — every subsequent sync submission raised `RuntimeError: cannot schedule new futures after shutdown` with no way to recover.
- Guard `on_shutdown()` against a missing `executor` attribute, since a restart cycle can now reach shutdown before `on_initialize()` has run.

### TaskBucket cross-thread spawn timeout

- `spawn()`'s cross-thread path blocked on `result.result()` with no timeout to hand a `Task` back to the calling thread. If the event loop stopped or was severely congested, the calling thread hung forever. Add a 10s timeout that raises a descriptive `RuntimeError` instead.

### ServiceWatcher dispatch semaphore starvation

- `restart_service` and `on_service_running` used to run backoff, restart, and readiness-wait inline inside the event handler, holding the dispatch semaphore slot for the full duration. Both now spawn that work as a detached task via `TaskBucket` so the handler returns — and releases its slot — immediately, preventing a slow restart/readiness cycle from starving other dispatches.
- Test helpers (`restart_and_await`, `on_running_and_await`) wait for the spawned task to settle so existing assertions on budget state and restart flags still hold.

Closes #1225
Closes #1226
