### PR TITLE
fix: leaked app listeners/jobs and websocket subscribe double-fire on retry

### DIFF
--- a/src/hassette/core/app_lifecycle_service.py
+++ b/src/hassette/core/app_lifecycle_service.py
@@ -138,6 +138,7 @@ class AppLifecycleService(Resource):
                     get_short_traceback(5),
                 )
                 inst.status = STOPPED
+                await self.cleanup_failed_instance(inst)
                 self.registry.record_failure(app_key, idx, e)
                 await self.emit_app_state_change(inst, status=FAILED, prev_status=STARTING, exception=e)
             except Exception as e:
@@ -148,6 +149,7 @@ class AppLifecycleService(Resource):
                     get_short_traceback(5),
                 )
                 inst.status = STOPPED
+                await self.cleanup_failed_instance(inst)
                 self.registry.record_failure(app_key, idx, e)
                 await self.emit_app_state_change(inst, status=FAILED, prev_status=STARTING, exception=e)
             finally:
@@ -156,6 +158,38 @@ class AppLifecycleService(Resource):
         # Post-ready reconciliation: retire stale rows from previous sessions.
         # Runs after the instance loop to ensure all registrations are complete.
         await self.reconcile_app_registrations(app_key, instances)
+
+    async def cleanup_failed_instance(self, inst: "App[AppConfig]") -> None:
+        """Remove bus listeners and scheduler jobs registered by an instance that failed to initialize.
+
+        Bounded by a short timeout so a broken cleanup path cannot turn an init failure into a hang.
+        Must run before record_failure, which pops the instance from the registry — after that point,
+        the normal shutdown path can never reach these registrations.
+        """
+        cleanup_timeout = 5
+        try:
+            with anyio.fail_after(cleanup_timeout):
+                try:
+                    inst.bus.remove_all_listeners()
+                except Exception:
+                    self.logger.warning(
+                        "Listener cleanup failed for instance '%s'",
+                        inst.app_config.instance_name,
+                        exc_info=True,
+                    )
+                try:
+                    await self.hassette.scheduler_service.remove_jobs_by_owner(inst.scheduler.owner_id)
+                except Exception:
+                    self.logger.warning(
+                        "Job cleanup failed for instance '%s'",
+                        inst.app_config.instance_name,
+                        exc_info=True,
+                    )
+        except TimeoutError:
+            self.logger.warning(
+                "Cleanup timed out for failed instance '%s' — some listeners or jobs may leak until restart",
+                inst.app_config.instance_name,
+            )
 
     async def shutdown_instance(self, inst: "App[AppConfig]", instance_index: int | None = None) -> None:
         """Shutdown a single app instance.

--- a/src/hassette/core/websocket_service.py
+++ b/src/hassette/core/websocket_service.py
@@ -399,17 +399,53 @@ class WebsocketService(Service):
             await self.raw_recv()
 
     async def subscribe_events(self, event_type: str | None = None) -> int:
-        """Subscribe to HA events; returns the subscription ID (the message id you sent)."""
+        """Subscribe to HA events; returns the subscription ID HA confirmed.
+
+        Handles its own retry loop (rather than delegating to send_and_wait) because
+        subscribe_events has side effects: each send creates a real subscription on HA.
+        Before each retry, the previous attempt's subscription is proactively unsubscribed
+        in case HA processed it despite the timeout. If all retries exhaust, the final
+        attempt's subscription is not cleaned up here — reconnect handles that case.
+        """
         payload: dict[str, Any] = {"type": "subscribe_events"}
         if event_type is not None:
-            payload["event_type"] = event_type  # omit to get all events
+            payload["event_type"] = event_type
 
-        payload["id"] = sub_id = self.get_next_message_id()
-        # Use send_and_wait so we see success/error deterministically
-        await self.send_and_wait(**payload)
-        # HA replies with {'id': <same>, 'type': 'result', 'success': True}
-        # We return our own id as the subscription handle for unsubscribe
-        return sub_id
+        last_abandoned_id: int | None = None
+
+        @retry(
+            retry=retry_if_exception(lambda e: isinstance(e, FailedMessageError) and e.code is None),
+            stop=stop_after_attempt(MAX_RETRY_ATTEMPTS),
+            wait=wait_exponential_jitter(),
+            before_sleep=before_sleep_log(self.logger, logging.WARNING),
+            reraise=True,
+        )
+        async def subscribe_with_retry() -> int:
+            nonlocal last_abandoned_id
+            if last_abandoned_id is not None:
+                with suppress(Exception):
+                    await self.send_json(
+                        type="unsubscribe_events",
+                        subscription=last_abandoned_id,
+                        id=self.get_next_message_id(),
+                    )
+
+            msg_id = self.get_next_message_id()
+            fut = self.hassette.loop.create_future()
+            self._response_futures[msg_id] = fut
+            try:
+                await self.send_json(**{**payload, "id": msg_id})
+                await asyncio.wait_for(fut, timeout=self.resp_timeout_seconds)
+                return msg_id
+            except TimeoutError:
+                last_abandoned_id = msg_id
+                raise FailedMessageError(
+                    f"subscribe_events response timed out after {self.resp_timeout_seconds}s"
+                ) from None
+            finally:
+                self._response_futures.pop(msg_id, None)
+
+        return await subscribe_with_retry()
 
     async def cleanup(self) -> None:
         """Cleanup resources after the WebSocket connection is closed."""

--- a/tests/integration/test_websocket_service.py
+++ b/tests/integration/test_websocket_service.py
@@ -878,3 +878,108 @@ async def test_service_status_stays_running_during_early_drop(
     status, ready = statuses_during_retry[0]
     assert status == ResourceStatus.RUNNING, f"Expected RUNNING status, got {status}"
     assert not ready, "Expected is_ready()=False during early-drop retry"
+
+
+class TestSubscribeEventsRetry:
+    """Regression tests for #1221: subscribe_events double-subscribe on retry."""
+
+    async def test_returns_confirmed_id_after_retry(self, websocket_service: WebsocketService) -> None:
+        """After a timeout+retry, subscribe_events returns the ID from the successful attempt."""
+        websocket_service.hassette.config.websocket.response_timeout_seconds = 0
+        call_count = 0
+
+        async def send_side_effect(**data: object) -> None:
+            nonlocal call_count
+            call_count += 1
+            if data.get("type") == "subscribe_events" and call_count >= 2:
+                websocket_service.hassette.config.websocket.response_timeout_seconds = 5
+                msg_id = data["id"]
+                fut = websocket_service._response_futures[msg_id]
+                fut.set_result(None)
+
+        websocket_service.send_json = AsyncMock(side_effect=send_side_effect)
+
+        sub_id = await websocket_service.subscribe_events()
+
+        subscribe_calls = [
+            c for c in websocket_service.send_json.call_args_list if c.kwargs.get("type") == "subscribe_events"
+        ]
+        first_attempt_id = subscribe_calls[0].kwargs["id"]
+        second_attempt_id = subscribe_calls[1].kwargs["id"]
+
+        assert first_attempt_id != second_attempt_id, "Retry should use a different msg_id"
+        assert sub_id == second_attempt_id, "Returned ID must match the attempt HA confirmed"
+        assert sub_id != first_attempt_id, "Returned ID must not be the abandoned first attempt"
+
+    async def test_proactively_unsubscribes_abandoned_attempt(self, websocket_service: WebsocketService) -> None:
+        """On retry, the abandoned subscription is proactively unsubscribed."""
+        websocket_service.hassette.config.websocket.response_timeout_seconds = 0
+        call_count = 0
+
+        async def send_side_effect(**data: object) -> None:
+            nonlocal call_count
+            call_count += 1
+            if data.get("type") == "subscribe_events" and call_count >= 3:
+                websocket_service.hassette.config.websocket.response_timeout_seconds = 5
+                msg_id = data["id"]
+                fut = websocket_service._response_futures[msg_id]
+                fut.set_result(None)
+
+        websocket_service.send_json = AsyncMock(side_effect=send_side_effect)
+
+        await websocket_service.subscribe_events()
+
+        all_calls = websocket_service.send_json.call_args_list
+        unsubscribe_calls = [c for c in all_calls if c.kwargs.get("type") == "unsubscribe_events"]
+        subscribe_calls = [c for c in all_calls if c.kwargs.get("type") == "subscribe_events"]
+        first_attempt_id = subscribe_calls[0].kwargs["id"]
+
+        assert len(unsubscribe_calls) >= 1, "Should proactively unsubscribe the abandoned attempt"
+        assert unsubscribe_calls[0].kwargs["subscription"] == first_attempt_id
+
+    async def test_cleanup_targets_confirmed_id_only(self, websocket_service: WebsocketService) -> None:
+        """_subscription_ids contains only the confirmed ID, not abandoned ones."""
+        websocket_service.hassette.config.websocket.response_timeout_seconds = 0
+        call_count = 0
+
+        async def send_side_effect(**data: object) -> None:
+            nonlocal call_count
+            call_count += 1
+            if data.get("type") == "subscribe_events" and call_count >= 2:
+                websocket_service.hassette.config.websocket.response_timeout_seconds = 5
+                msg_id = data["id"]
+                fut = websocket_service._response_futures[msg_id]
+                fut.set_result(None)
+
+        websocket_service.send_json = AsyncMock(side_effect=send_side_effect)
+
+        sub_id = await websocket_service.subscribe_events()
+        websocket_service._subscription_ids.add(sub_id)
+
+        subscribe_calls = [
+            c for c in websocket_service.send_json.call_args_list if c.kwargs.get("type") == "subscribe_events"
+        ]
+        first_attempt_id = subscribe_calls[0].kwargs["id"]
+
+        assert sub_id in websocket_service._subscription_ids
+        assert first_attempt_id not in websocket_service._subscription_ids
+
+    async def test_no_response_futures_leak_after_retry(self, websocket_service: WebsocketService) -> None:
+        """All response futures are cleaned up after retry, even for abandoned attempts."""
+        websocket_service.hassette.config.websocket.response_timeout_seconds = 0
+        call_count = 0
+
+        async def send_side_effect(**data: object) -> None:
+            nonlocal call_count
+            call_count += 1
+            if data.get("type") == "subscribe_events" and call_count >= 2:
+                websocket_service.hassette.config.websocket.response_timeout_seconds = 5
+                msg_id = data["id"]
+                fut = websocket_service._response_futures[msg_id]
+                fut.set_result(None)
+
+        websocket_service.send_json = AsyncMock(side_effect=send_side_effect)
+
+        await websocket_service.subscribe_events()
+
+        assert websocket_service._response_futures == {}, "All futures should be cleaned up"

--- a/tests/integration/test_websocket_service.py
+++ b/tests/integration/test_websocket_service.py
@@ -880,24 +880,31 @@ async def test_service_status_stays_running_during_early_drop(
     assert not ready, "Expected is_ready()=False during early-drop retry"
 
 
+def _make_subscribe_side_effect(ws: WebsocketService, *, succeed_on_call: int = 2):
+    """Build a send_json side effect that times out subscribe_events until the Nth call."""
+    call_count = 0
+
+    async def side_effect(**data: object) -> None:
+        nonlocal call_count
+        call_count += 1
+        if data.get("type") == "subscribe_events" and call_count >= succeed_on_call:
+            ws.hassette.config.websocket.response_timeout_seconds = 5
+            msg_id = data["id"]
+            fut = ws._response_futures[msg_id]
+            fut.set_result(None)
+
+    return side_effect
+
+
 class TestSubscribeEventsRetry:
     """Regression tests for #1221: subscribe_events double-subscribe on retry."""
 
     async def test_returns_confirmed_id_after_retry(self, websocket_service: WebsocketService) -> None:
         """After a timeout+retry, subscribe_events returns the ID from the successful attempt."""
         websocket_service.hassette.config.websocket.response_timeout_seconds = 0
-        call_count = 0
-
-        async def send_side_effect(**data: object) -> None:
-            nonlocal call_count
-            call_count += 1
-            if data.get("type") == "subscribe_events" and call_count >= 2:
-                websocket_service.hassette.config.websocket.response_timeout_seconds = 5
-                msg_id = data["id"]
-                fut = websocket_service._response_futures[msg_id]
-                fut.set_result(None)
-
-        websocket_service.send_json = AsyncMock(side_effect=send_side_effect)
+        websocket_service.send_json = AsyncMock(
+            side_effect=_make_subscribe_side_effect(websocket_service, succeed_on_call=2)
+        )
 
         sub_id = await websocket_service.subscribe_events()
 
@@ -914,18 +921,9 @@ class TestSubscribeEventsRetry:
     async def test_proactively_unsubscribes_abandoned_attempt(self, websocket_service: WebsocketService) -> None:
         """On retry, the abandoned subscription is proactively unsubscribed."""
         websocket_service.hassette.config.websocket.response_timeout_seconds = 0
-        call_count = 0
-
-        async def send_side_effect(**data: object) -> None:
-            nonlocal call_count
-            call_count += 1
-            if data.get("type") == "subscribe_events" and call_count >= 3:
-                websocket_service.hassette.config.websocket.response_timeout_seconds = 5
-                msg_id = data["id"]
-                fut = websocket_service._response_futures[msg_id]
-                fut.set_result(None)
-
-        websocket_service.send_json = AsyncMock(side_effect=send_side_effect)
+        websocket_service.send_json = AsyncMock(
+            side_effect=_make_subscribe_side_effect(websocket_service, succeed_on_call=3)
+        )
 
         await websocket_service.subscribe_events()
 
@@ -940,18 +938,9 @@ class TestSubscribeEventsRetry:
     async def test_cleanup_targets_confirmed_id_only(self, websocket_service: WebsocketService) -> None:
         """_subscription_ids contains only the confirmed ID, not abandoned ones."""
         websocket_service.hassette.config.websocket.response_timeout_seconds = 0
-        call_count = 0
-
-        async def send_side_effect(**data: object) -> None:
-            nonlocal call_count
-            call_count += 1
-            if data.get("type") == "subscribe_events" and call_count >= 2:
-                websocket_service.hassette.config.websocket.response_timeout_seconds = 5
-                msg_id = data["id"]
-                fut = websocket_service._response_futures[msg_id]
-                fut.set_result(None)
-
-        websocket_service.send_json = AsyncMock(side_effect=send_side_effect)
+        websocket_service.send_json = AsyncMock(
+            side_effect=_make_subscribe_side_effect(websocket_service, succeed_on_call=2)
+        )
 
         sub_id = await websocket_service.subscribe_events()
         websocket_service._subscription_ids.add(sub_id)
@@ -967,18 +956,9 @@ class TestSubscribeEventsRetry:
     async def test_no_response_futures_leak_after_retry(self, websocket_service: WebsocketService) -> None:
         """All response futures are cleaned up after retry, even for abandoned attempts."""
         websocket_service.hassette.config.websocket.response_timeout_seconds = 0
-        call_count = 0
-
-        async def send_side_effect(**data: object) -> None:
-            nonlocal call_count
-            call_count += 1
-            if data.get("type") == "subscribe_events" and call_count >= 2:
-                websocket_service.hassette.config.websocket.response_timeout_seconds = 5
-                msg_id = data["id"]
-                fut = websocket_service._response_futures[msg_id]
-                fut.set_result(None)
-
-        websocket_service.send_json = AsyncMock(side_effect=send_side_effect)
+        websocket_service.send_json = AsyncMock(
+            side_effect=_make_subscribe_side_effect(websocket_service, succeed_on_call=2)
+        )
 
         await websocket_service.subscribe_events()
 

--- a/tests/unit/core/conftest.py
+++ b/tests/unit/core/conftest.py
@@ -130,6 +130,7 @@ def mock_hassette() -> AsyncMock:
     hassette.bus_service.router = MagicMock()
     hassette.bus_service.router.get_listeners_by_owner = Mock(return_value=[])
     hassette.scheduler_service = MagicMock()
+    hassette.scheduler_service.remove_jobs_by_owner = MagicMock(side_effect=lambda _owner: asyncio.sleep(0))
     hassette.session_id = 1
     return hassette
 

--- a/tests/unit/core/test_app_lifecycle_service.py
+++ b/tests/unit/core/test_app_lifecycle_service.py
@@ -256,6 +256,124 @@ class TestInitializeInstances:
         assert len(failed_calls) == 1
 
 
+class TestCleanupFailedInstance:
+    async def test_exception_cleans_up_listeners_before_record_failure(
+        self,
+        lifecycle_service: AppLifecycleService,
+        mock_app_instance: AsyncMock,
+        mock_manifest: MagicMock,
+        mock_hassette: MagicMock,
+        mock_registry: MagicMock,
+    ) -> None:
+        """Bus listeners registered before the failure are removed via Bus.remove_all_listeners."""
+        mock_app_instance.initialize.side_effect = ValueError("boom")
+        instances = {0: mock_app_instance}
+
+        await lifecycle_service.initialize_instances("test_app", instances, mock_manifest)
+
+        mock_app_instance.bus.remove_all_listeners.assert_called_once()
+
+    async def test_exception_cleans_up_jobs_before_record_failure(
+        self,
+        lifecycle_service: AppLifecycleService,
+        mock_app_instance: AsyncMock,
+        mock_manifest: MagicMock,
+        mock_hassette: MagicMock,
+        mock_registry: MagicMock,
+    ) -> None:
+        """Scheduler jobs registered before the failure are removed."""
+        mock_app_instance.initialize.side_effect = ValueError("boom")
+        instances = {0: mock_app_instance}
+
+        await lifecycle_service.initialize_instances("test_app", instances, mock_manifest)
+
+        mock_hassette.scheduler_service.remove_jobs_by_owner.assert_called_once_with(
+            mock_app_instance.scheduler.owner_id,
+        )
+
+    async def test_timeout_cleans_up_listeners_and_jobs(
+        self,
+        lifecycle_service: AppLifecycleService,
+        mock_app_instance: AsyncMock,
+        mock_manifest: MagicMock,
+        mock_hassette: MagicMock,
+        mock_registry: MagicMock,
+    ) -> None:
+        """TimeoutError path also cleans up listeners and jobs."""
+        mock_app_instance.initialize.side_effect = TimeoutError("Timed out")
+        instances = {0: mock_app_instance}
+
+        await lifecycle_service.initialize_instances("test_app", instances, mock_manifest)
+
+        mock_app_instance.bus.remove_all_listeners.assert_called_once()
+        mock_hassette.scheduler_service.remove_jobs_by_owner.assert_called_once_with(
+            mock_app_instance.scheduler.owner_id,
+        )
+
+    async def test_cleanup_runs_before_record_failure(
+        self,
+        lifecycle_service: AppLifecycleService,
+        mock_app_instance: AsyncMock,
+        mock_manifest: MagicMock,
+        mock_hassette: MagicMock,
+        mock_registry: MagicMock,
+    ) -> None:
+        """Cleanup runs before record_failure pops the instance from the registry."""
+        call_order: list[str] = []
+
+        mock_app_instance.bus.remove_all_listeners = Mock(side_effect=lambda: call_order.append("cleanup_listeners"))
+        original_side_effect = mock_hassette.scheduler_service.remove_jobs_by_owner.side_effect
+
+        async def track_jobs(owner):
+            call_order.append("cleanup_jobs")
+            return await original_side_effect(owner)
+
+        mock_hassette.scheduler_service.remove_jobs_by_owner = MagicMock(side_effect=track_jobs)
+        mock_registry.record_failure.side_effect = lambda *_args: call_order.append("record_failure")
+        mock_app_instance.initialize.side_effect = ValueError("boom")
+        instances = {0: mock_app_instance}
+
+        await lifecycle_service.initialize_instances("test_app", instances, mock_manifest)
+
+        assert call_order == ["cleanup_listeners", "cleanup_jobs", "record_failure"]
+
+    async def test_cleanup_failure_does_not_prevent_record_failure(
+        self,
+        lifecycle_service: AppLifecycleService,
+        mock_app_instance: AsyncMock,
+        mock_manifest: MagicMock,
+        mock_hassette: MagicMock,
+        mock_registry: MagicMock,
+    ) -> None:
+        """If cleanup raises, init failure is still recorded."""
+        mock_app_instance.bus.remove_all_listeners.side_effect = RuntimeError("cleanup exploded")
+        mock_app_instance.initialize.side_effect = ValueError("boom")
+        instances = {0: mock_app_instance}
+
+        await lifecycle_service.initialize_instances("test_app", instances, mock_manifest)
+
+        mock_registry.record_failure.assert_called_once()
+
+    async def test_bus_cleanup_failure_does_not_skip_scheduler_cleanup(
+        self,
+        lifecycle_service: AppLifecycleService,
+        mock_app_instance: AsyncMock,
+        mock_manifest: MagicMock,
+        mock_hassette: MagicMock,
+        mock_registry: MagicMock,
+    ) -> None:
+        """Bus listener cleanup failure does not prevent scheduler job cleanup."""
+        mock_app_instance.bus.remove_all_listeners.side_effect = RuntimeError("bus exploded")
+        mock_app_instance.initialize.side_effect = ValueError("boom")
+        instances = {0: mock_app_instance}
+
+        await lifecycle_service.initialize_instances("test_app", instances, mock_manifest)
+
+        mock_hassette.scheduler_service.remove_jobs_by_owner.assert_called_once_with(
+            mock_app_instance.scheduler.owner_id,
+        )
+
+
 class TestShutdownInstance:
     async def test_calls_shutdown(self, lifecycle_service: AppLifecycleService, mock_app_instance: AsyncMock) -> None:
         """Calls inst.shutdown()."""

--- a/tests/unit/core/test_app_lifecycle_service.py
+++ b/tests/unit/core/test_app_lifecycle_service.py
@@ -262,8 +262,6 @@ class TestCleanupFailedInstance:
         lifecycle_service: AppLifecycleService,
         mock_app_instance: AsyncMock,
         mock_manifest: MagicMock,
-        mock_hassette: MagicMock,
-        mock_registry: MagicMock,
     ) -> None:
         """Bus listeners registered before the failure are removed via Bus.remove_all_listeners."""
         mock_app_instance.initialize.side_effect = ValueError("boom")
@@ -279,7 +277,6 @@ class TestCleanupFailedInstance:
         mock_app_instance: AsyncMock,
         mock_manifest: MagicMock,
         mock_hassette: MagicMock,
-        mock_registry: MagicMock,
     ) -> None:
         """Scheduler jobs registered before the failure are removed."""
         mock_app_instance.initialize.side_effect = ValueError("boom")
@@ -297,7 +294,6 @@ class TestCleanupFailedInstance:
         mock_app_instance: AsyncMock,
         mock_manifest: MagicMock,
         mock_hassette: MagicMock,
-        mock_registry: MagicMock,
     ) -> None:
         """TimeoutError path also cleans up listeners and jobs."""
         mock_app_instance.initialize.side_effect = TimeoutError("Timed out")
@@ -342,7 +338,6 @@ class TestCleanupFailedInstance:
         lifecycle_service: AppLifecycleService,
         mock_app_instance: AsyncMock,
         mock_manifest: MagicMock,
-        mock_hassette: MagicMock,
         mock_registry: MagicMock,
     ) -> None:
         """If cleanup raises, init failure is still recorded."""
@@ -360,7 +355,6 @@ class TestCleanupFailedInstance:
         mock_app_instance: AsyncMock,
         mock_manifest: MagicMock,
         mock_hassette: MagicMock,
-        mock_registry: MagicMock,
     ) -> None:
         """Bus listener cleanup failure does not prevent scheduler job cleanup."""
         mock_app_instance.bus.remove_all_listeners.side_effect = RuntimeError("bus exploded")

--- a/tests/unit/core/test_websocket_service_coverage.py
+++ b/tests/unit/core/test_websocket_service_coverage.py
@@ -64,11 +64,14 @@ class TestSubscribeEvents:
         """subscribe_events sends a bare subscribe_events payload when no event_type is given."""
         captured: dict = {}
 
-        async def fake_send_and_wait(**data):
+        async def fake_send_json(**data):
             captured.update(data)
-            return {"success": True}
+            msg_id = data["id"]
+            fut = websocket_service._response_futures.get(msg_id)
+            if fut and not fut.done():
+                fut.set_result(None)
 
-        websocket_service.send_and_wait = fake_send_and_wait  # boundary-exempt: collaborator of subscribe_events
+        websocket_service.send_json = AsyncMock(side_effect=fake_send_json)
 
         sub_id = await websocket_service.subscribe_events()
 
@@ -80,11 +83,14 @@ class TestSubscribeEvents:
         """subscribe_events includes the event_type filter in the payload when given."""
         captured: dict = {}
 
-        async def fake_send_and_wait(**data):
+        async def fake_send_json(**data):
             captured.update(data)
-            return {"success": True}
+            msg_id = data["id"]
+            fut = websocket_service._response_futures.get(msg_id)
+            if fut and not fut.done():
+                fut.set_result(None)
 
-        websocket_service.send_and_wait = fake_send_and_wait  # boundary-exempt: collaborator of subscribe_events
+        websocket_service.send_json = AsyncMock(side_effect=fake_send_json)
 
         sub_id = await websocket_service.subscribe_events(event_type="state_changed")
 


### PR DESCRIPTION
### App init failure cleanup

- When an app's `on_initialize` fails (exception or timeout), bus listeners and scheduler jobs it already registered are now removed before the instance is dropped from the registry. Previously these registrations kept firing indefinitely as ghost listeners/jobs with no owning instance. `cleanup_failed_instance()` calls `Bus.remove_all_listeners()` and `remove_jobs_by_owner()` independently — one failing doesn't block the other — and the whole cleanup is bounded by a 5-second timeout so a broken cleanup path can't turn an init failure into a hang.
- Cleanup runs before `registry.record_failure()`, which pops the instance from the registry. After that point the normal shutdown path can no longer reach these registrations, so the ordering matters.

### WebSocket subscribe retry fix

- `subscribe_events` now runs its own retry loop instead of delegating to `send_and_wait`. The previous approach could double-subscribe on retry: if HA processed the first attempt despite the client timing out, a second `subscribe_events` call created a second live subscription, and only the abandoned first `msg_id` was ever tracked for cleanup — leading to duplicate event delivery and an unsubscribe that targeted the wrong ID.
- Before each retry, the previous attempt's subscription is proactively unsubscribed in case HA processed it despite the timeout. The method returns the `msg_id` HA actually confirmed, not the first attempt's ID, so `cleanup()` targets real subscription IDs.

Closes #1220
Closes #1221
