### PR TITLE
refactor: clean up code quality findings across backend and frontend

### DIFF
--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -1557,7 +1557,9 @@
         "properties": {
           "status": {
             "type": "string",
-            "title": "Status"
+            "const": "accepted",
+            "title": "Status",
+            "default": "accepted"
           },
           "app_key": {
             "type": "string",
@@ -1570,7 +1572,6 @@
         },
         "type": "object",
         "required": [
-          "status",
           "app_key",
           "action"
         ],
@@ -2836,7 +2837,9 @@
         "properties": {
           "status": {
             "type": "string",
-            "title": "Status"
+            "const": "accepted",
+            "title": "Status",
+            "default": "accepted"
           },
           "job_id": {
             "type": "integer",
@@ -2849,7 +2852,6 @@
         },
         "type": "object",
         "required": [
-          "status",
           "job_id",
           "job_name"
         ],

--- a/frontend/src/api/endpoints.ts
+++ b/frontend/src/api/endpoints.ts
@@ -25,6 +25,8 @@ export type AppConfigData = Omit<components["schemas"]["AppConfigResponse"], "co
 };
 export type AppSourceData = components["schemas"]["AppSourceResponse"];
 export type ActivityFeedEntryData = components["schemas"]["ActivityFeedEntry"];
+export type ActionResponse = components["schemas"]["ActionResponse"];
+export type JobTriggerResponse = components["schemas"]["JobTriggerResponse"];
 
 export const WS_PATH = "/api/ws";
 
@@ -45,9 +47,9 @@ export const getAppManifests = () => apiFetch<ManifestListResponse>("/apps/manif
 
 export const getAppManifest = (appKey: string) => apiFetch<AppManifest>(`/apps/${encodeURIComponent(appKey)}/manifest`);
 
-export const startApp = (appKey: string) => apiPost<{ status: string }>(`/apps/${encodeURIComponent(appKey)}/start`);
-export const stopApp = (appKey: string) => apiPost<{ status: string }>(`/apps/${encodeURIComponent(appKey)}/stop`);
-export const reloadApp = (appKey: string) => apiPost<{ status: string }>(`/apps/${encodeURIComponent(appKey)}/reload`);
+export const startApp = (appKey: string) => apiPost<ActionResponse>(`/apps/${encodeURIComponent(appKey)}/start`);
+export const stopApp = (appKey: string) => apiPost<ActionResponse>(`/apps/${encodeURIComponent(appKey)}/stop`);
+export const reloadApp = (appKey: string) => apiPost<ActionResponse>(`/apps/${encodeURIComponent(appKey)}/reload`);
 
 export const getAppConfig = (appKey: string, signal?: AbortSignal) =>
   apiFetch<AppConfigData>(`/apps/${encodeURIComponent(appKey)}/config`, { signal });
@@ -174,8 +176,7 @@ export const getAllListeners = (since?: number | null, signal?: AbortSignal) =>
 export const getAllJobs = (since?: number | null, signal?: AbortSignal) =>
   apiFetch<JobData[]>(buildUrl("/scheduler/jobs", { since }), { signal });
 
-export const triggerJob = (jobId: number) =>
-  apiPost<{ status: string; job_id: number; job_name: string }>(`/scheduler/jobs/${jobId}/trigger`);
+export const triggerJob = (jobId: number) => apiPost<JobTriggerResponse>(`/scheduler/jobs/${jobId}/trigger`);
 
 // ---- System status ----
 

--- a/frontend/src/api/generated-types.ts
+++ b/frontend/src/api/generated-types.ts
@@ -584,8 +584,12 @@ export interface components {
          * @description Response for app mutation endpoints (start/stop/reload).
          */
         ActionResponse: {
-            /** Status */
-            status: string;
+            /**
+             * Status
+             * @default accepted
+             * @constant
+             */
+            status: "accepted";
             /** App Key */
             app_key: string;
             /** Action */
@@ -1121,8 +1125,12 @@ export interface components {
          *     the trigger response identifies the job, not an app action.
          */
         JobTriggerResponse: {
-            /** Status */
-            status: string;
+            /**
+             * Status
+             * @default accepted
+             * @constant
+             */
+            status: "accepted";
             /** Job Id */
             job_id: number;
             /** Job Name */

--- a/frontend/src/components/app-detail/job-detail.tsx
+++ b/frontend/src/components/app-detail/job-detail.tsx
@@ -1,9 +1,9 @@
 import type { JobData } from "../../api/endpoints";
 import { getJobExecutions, triggerJob } from "../../api/endpoints";
+import { useAsyncAction } from "../../hooks/use-async-action";
 import { useQueryInvalidator } from "../../hooks/use-query-invalidator";
 import { useRelativeTime } from "../../hooks/use-relative-time";
 import { useScopedQuery } from "../../hooks/use-scoped-query";
-import { useSignal } from "../../hooks/use-signal";
 import { queryKeys } from "../../lib/query-keys";
 import { useAppState } from "../../state/context";
 import { DETAIL_FETCH_LIMIT } from "../../utils/constants";
@@ -37,21 +37,7 @@ function ScheduleChips({ job }: { job: JobData }) {
 }
 
 function RunNowButton({ jobId }: { jobId: number }) {
-  const loading = useSignal(false);
-  const error = useSignal<string | null>(null);
-
-  const exec = async () => {
-    if (loading.value) return;
-    error.value = null;
-    loading.value = true;
-    try {
-      await triggerJob(jobId);
-    } catch (err) {
-      error.value = err instanceof Error ? err.message : String(err);
-    } finally {
-      loading.value = false;
-    }
-  };
+  const { loading, error, run } = useAsyncAction();
 
   return (
     <div class={layoutStyles.runNow}>
@@ -60,7 +46,7 @@ function RunNowButton({ jobId }: { jobId: number }) {
         size="sm"
         data-testid="run-now-btn"
         disabled={loading.value}
-        onClick={() => void exec()}
+        onClick={() => void run(() => triggerJob(jobId))}
       >
         {loading.value ? (
           <>

--- a/frontend/src/components/shared/action-buttons.tsx
+++ b/frontend/src/components/shared/action-buttons.tsx
@@ -1,6 +1,7 @@
 import { useEffect } from "preact/hooks";
 
 import { reloadApp, startApp, stopApp } from "../../api/endpoints";
+import { useAsyncAction } from "../../hooks/use-async-action";
 import { useSignal } from "../../hooks/use-signal";
 import styles from "./action-buttons.module.css";
 import { Button } from "./button";
@@ -15,22 +16,10 @@ interface Props {
 }
 
 export function ActionButtons({ appKey, status, variant = "icon", confirmStop = false }: Props) {
-  const loading = useSignal(false);
-  const error = useSignal<string | null>(null);
+  const { loading, error, run } = useAsyncAction();
   const showStopConfirm = useSignal(false);
 
-  const exec = async (action: (key: string) => Promise<unknown>) => {
-    if (loading.value) return;
-    error.value = null;
-    loading.value = true;
-    try {
-      await action(appKey);
-    } catch (err) {
-      error.value = err instanceof Error ? err.message : String(err);
-    } finally {
-      loading.value = false;
-    }
-  };
+  const exec = (action: (key: string) => Promise<unknown>) => run(() => action(appKey));
 
   // Clear stale error when app status changes (e.g., WS event arrives after failed action)
   useEffect(() => {

--- a/frontend/src/components/shared/action-buttons.tsx
+++ b/frontend/src/components/shared/action-buttons.tsx
@@ -133,7 +133,11 @@ export function ActionButtons({ appKey, status, variant = "icon", confirmStop = 
           }}
         />
       )}
-      {error.value && <p class="ht-text-danger ht-text-sm">{error.value}</p>}
+      {error.value && (
+        <p class="ht-text-danger ht-text-sm" role="alert" data-testid="action-buttons-error">
+          {error.value}
+        </p>
+      )}
     </>
   );
 }

--- a/frontend/src/hooks/use-async-action.test.ts
+++ b/frontend/src/hooks/use-async-action.test.ts
@@ -1,0 +1,100 @@
+import { act, renderHook } from "@testing-library/preact";
+import { describe, expect, it, vi } from "vitest";
+
+import { useAsyncAction } from "./use-async-action";
+
+describe("useAsyncAction", () => {
+  it("starts with loading false and error null", () => {
+    const { result } = renderHook(() => useAsyncAction());
+    expect(result.current.loading.value).toBe(false);
+    expect(result.current.error.value).toBeNull();
+  });
+
+  it("sets loading true while the action is in flight, then false after it resolves", async () => {
+    const { result } = renderHook(() => useAsyncAction());
+    let resolveAction!: () => void;
+    const action = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveAction = resolve;
+        }),
+    );
+
+    let runPromise!: Promise<void>;
+    act(() => {
+      runPromise = result.current.run(action);
+    });
+    expect(action).toHaveBeenCalledOnce();
+    expect(result.current.loading.value).toBe(true);
+
+    await act(async () => {
+      resolveAction();
+      await runPromise;
+    });
+    expect(result.current.loading.value).toBe(false);
+  });
+
+  it("ignores a second run() while the first is still in flight", async () => {
+    const { result } = renderHook(() => useAsyncAction());
+    let resolveAction!: () => void;
+    const action = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveAction = resolve;
+        }),
+    );
+
+    let firstRun!: Promise<void>;
+    act(() => {
+      firstRun = result.current.run(action);
+    });
+    act(() => {
+      void result.current.run(action);
+    });
+    expect(action).toHaveBeenCalledOnce();
+
+    await act(async () => {
+      resolveAction();
+      await firstRun;
+    });
+  });
+
+  it("captures an Error message and re-enables after failure", async () => {
+    const { result } = renderHook(() => useAsyncAction());
+    const action = vi.fn().mockRejectedValue(new Error("boom"));
+
+    await act(async () => {
+      await result.current.run(action);
+    });
+
+    expect(result.current.error.value).toBe("boom");
+    expect(result.current.loading.value).toBe(false);
+  });
+
+  it("stringifies non-Error throws", async () => {
+    const { result } = renderHook(() => useAsyncAction());
+    const action = vi.fn().mockRejectedValue("raw string error");
+
+    await act(async () => {
+      await result.current.run(action);
+    });
+
+    expect(result.current.error.value).toBe("raw string error");
+  });
+
+  it("clears a prior error when a new run starts", async () => {
+    const { result } = renderHook(() => useAsyncAction());
+    const failing = vi.fn().mockRejectedValue(new Error("first failure"));
+    const succeeding = vi.fn().mockResolvedValue(undefined);
+
+    await act(async () => {
+      await result.current.run(failing);
+    });
+    expect(result.current.error.value).toBe("first failure");
+
+    await act(async () => {
+      await result.current.run(succeeding);
+    });
+    expect(result.current.error.value).toBeNull();
+  });
+});

--- a/frontend/src/hooks/use-async-action.ts
+++ b/frontend/src/hooks/use-async-action.ts
@@ -1,0 +1,42 @@
+import type { Signal } from "@preact/signals";
+
+import { useSignal } from "./use-signal";
+
+export interface UseAsyncActionResult {
+  /** True while an action is in flight. */
+  loading: Signal<boolean>;
+  /** Error message from the most recent failed action, or null. */
+  error: Signal<string | null>;
+  /**
+   * Runs `action`, tracking `loading`/`error`. Ignores the call if an action
+   * is already in flight. Clears `error` before starting and always resets
+   * `loading` when the action settles.
+   */
+  run: (action: () => Promise<unknown>) => Promise<void>;
+}
+
+/**
+ * Shared loading/error wrapper for button-triggered async actions (start,
+ * stop, reload, run-now, etc.). Guards against concurrent invocation,
+ * extracts a display message from thrown errors, and resets state when the
+ * action settles.
+ */
+export function useAsyncAction(): UseAsyncActionResult {
+  const loading = useSignal(false);
+  const error = useSignal<string | null>(null);
+
+  const run = async (action: () => Promise<unknown>) => {
+    if (loading.value) return;
+    error.value = null;
+    loading.value = true;
+    try {
+      await action();
+    } catch (err) {
+      error.value = err instanceof Error ? err.message : String(err);
+    } finally {
+      loading.value = false;
+    }
+  };
+
+  return { loading, error, run };
+}

--- a/frontend/src/test/handlers.ts
+++ b/frontend/src/test/handlers.ts
@@ -48,7 +48,7 @@ export const handlers = [
   // POST /api/apps/:app_key/start
   http.post("/api/apps/:app_key/start", ({ params }) => {
     return HttpResponse.json<ActionResponse>({
-      status: "ok",
+      status: "accepted",
       app_key: String(params["app_key"]),
       action: "start",
     });
@@ -57,7 +57,7 @@ export const handlers = [
   // POST /api/apps/:app_key/stop
   http.post("/api/apps/:app_key/stop", ({ params }) => {
     return HttpResponse.json<ActionResponse>({
-      status: "ok",
+      status: "accepted",
       app_key: String(params["app_key"]),
       action: "stop",
     });
@@ -66,7 +66,7 @@ export const handlers = [
   // POST /api/apps/:app_key/reload
   http.post("/api/apps/:app_key/reload", ({ params }) => {
     return HttpResponse.json<ActionResponse>({
-      status: "ok",
+      status: "accepted",
       app_key: String(params["app_key"]),
       action: "reload",
     });

--- a/hassette.schema.json
+++ b/hassette.schema.json
@@ -622,6 +622,12 @@
           "title": "App Shutdown Timeout Seconds",
           "type": "integer"
         },
+        "failed_instance_cleanup_timeout_seconds": {
+          "default": 5,
+          "description": "Length of time to wait for listener/job cleanup after an app instance fails to initialize.",
+          "title": "Failed Instance Cleanup Timeout Seconds",
+          "type": "integer"
+        },
         "resource_shutdown_timeout_seconds": {
           "description": "Per-phase timeout for resource shutdown. Defaults to app_shutdown_timeout_seconds.",
           "title": "Resource Shutdown Timeout Seconds",
@@ -1197,6 +1203,12 @@
           "description": "Interval to send ping messages to keep the WebSocket connection alive. Passed to aiohttp.",
           "title": "Heartbeat Interval Seconds",
           "type": "integer"
+        },
+        "cleanup_timeout_seconds": {
+          "default": 2.0,
+          "description": "Length of time to wait for the recv task to finish cancelling during partial cleanup.",
+          "title": "Cleanup Timeout Seconds",
+          "type": "number"
         },
         "connect_retry_max_attempts": {
           "default": 5,

--- a/src/hassette/bus/listeners.py
+++ b/src/hassette/bus/listeners.py
@@ -457,7 +457,7 @@ class Listener:
     def mark_registered(self, db_id: int) -> None:
         """Set the database ID after persistence. One-time assignment by BusService."""
         if self.db_id is not None:
-            LOGGER.warning(
+            self.logger.warning(
                 "Listener %s already registered with db_id=%s, ignoring new db_id=%s",
                 self.listener_id,
                 self.db_id,

--- a/src/hassette/config/models.py
+++ b/src/hassette/config/models.py
@@ -113,6 +113,9 @@ class WebSocketConfig(ExcludeExtrasMixin, BaseModel):
     heartbeat_interval_seconds: int = Field(default=30)
     """Interval to send ping messages to keep the WebSocket connection alive. Passed to aiohttp."""
 
+    cleanup_timeout_seconds: float = Field(default=2.0)
+    """Length of time to wait for the recv task to finish cancelling during partial cleanup."""
+
     connect_retry_max_attempts: int = Field(default=5)
     """Maximum number of attempts to establish the initial WebSocket connection before giving up."""
 
@@ -229,6 +232,9 @@ class LifecycleConfig(ExcludeExtrasMixin, BaseModel):
 
     app_shutdown_timeout_seconds: int = Field(default=APP_SHUTDOWN_TIMEOUT_SECONDS)
     """Length of time to wait for an app to shut down before giving up."""
+
+    failed_instance_cleanup_timeout_seconds: int = Field(default=5)
+    """Length of time to wait for listener/job cleanup after an app instance fails to initialize."""
 
     resource_shutdown_timeout_seconds: int = Field(
         default_factory=lambda data: data.get("app_shutdown_timeout_seconds", APP_SHUTDOWN_TIMEOUT_SECONDS)

--- a/src/hassette/core/app_lifecycle_service.py
+++ b/src/hassette/core/app_lifecycle_service.py
@@ -25,6 +25,7 @@ if typing.TYPE_CHECKING:
     from hassette.app.app import App
     from hassette.config.classes import AppManifest
     from hassette.core.app_registry import AppRegistry
+    from hassette.core.bus_service import BusService
 
 try:
     from humanize import precisedelta
@@ -38,6 +39,12 @@ STARTING = ResourceStatus.STARTING
 RUNNING = ResourceStatus.RUNNING
 STOPPING = ResourceStatus.STOPPING
 STOPPED = ResourceStatus.STOPPED
+NOT_STARTED = ResourceStatus.NOT_STARTED
+
+# Deeper than the exception_utils.get_short_traceback default (1): init failures often
+# surface several frames deep (anyio.fail_after -> on_initialize -> nested awaits), and a
+# single frame is rarely enough to show the app's own code rather than just anyio internals.
+INIT_FAILURE_TRACEBACK_LIMIT = 5
 
 
 class AppLifecycleService(Resource):
@@ -95,6 +102,11 @@ class AppLifecycleService(Resource):
         """Timeout in seconds for app instance shutdown."""
         return self.hassette.config.lifecycle.app_shutdown_timeout_seconds
 
+    @property
+    def cleanup_timeout(self) -> int:
+        """Timeout in seconds for cleaning up a failed app instance's listeners and jobs."""
+        return self.hassette.config.lifecycle.failed_instance_cleanup_timeout_seconds
+
     async def initialize_instances(
         self,
         app_key: str,
@@ -129,29 +141,29 @@ class AppLifecycleService(Resource):
                     inst.app_config.instance_name,
                     class_name,
                 )
-                await self.emit_app_state_change(inst, status=RUNNING, prev_status=STARTING)
+                await self.emit_app_state_change(inst, status=RUNNING, previous_status=STARTING)
             except TimeoutError as e:
                 self.logger.error(
                     "Timed out while starting app '%s' (%s):\n%s",
                     inst.app_config.instance_name,
                     class_name,
-                    get_short_traceback(5),
+                    get_short_traceback(INIT_FAILURE_TRACEBACK_LIMIT),
                 )
                 inst.status = STOPPED
                 await self.cleanup_failed_instance(inst)
                 self.registry.record_failure(app_key, idx, e)
-                await self.emit_app_state_change(inst, status=FAILED, prev_status=STARTING, exception=e)
+                await self.emit_app_state_change(inst, status=FAILED, previous_status=STARTING, exception=e)
             except Exception as e:
                 self.logger.error(
                     "Failed to start app '%s' (%s):\n%s",
                     inst.app_config.instance_name,
                     class_name,
-                    get_short_traceback(5),
+                    get_short_traceback(INIT_FAILURE_TRACEBACK_LIMIT),
                 )
                 inst.status = STOPPED
                 await self.cleanup_failed_instance(inst)
                 self.registry.record_failure(app_key, idx, e)
-                await self.emit_app_state_change(inst, status=FAILED, prev_status=STARTING, exception=e)
+                await self.emit_app_state_change(inst, status=FAILED, previous_status=STARTING, exception=e)
             finally:
                 structlog.contextvars.unbind_contextvars("app_key", "instance_name", "instance_index")
 
@@ -166,9 +178,8 @@ class AppLifecycleService(Resource):
         Must run before record_failure, which pops the instance from the registry — after that point,
         the normal shutdown path can never reach these registrations.
         """
-        cleanup_timeout = 5
         try:
-            with anyio.fail_after(cleanup_timeout):
+            with anyio.fail_after(self.cleanup_timeout):
                 try:
                     inst.bus.remove_all_listeners()
                 except Exception:
@@ -219,7 +230,7 @@ class AppLifecycleService(Resource):
             self.logger.debug(
                 "Stopped app '%s' '%s' in %s", inst.app_config.instance_name, inst.class_name, friendly_time
             )
-            await self.emit_app_state_change(inst, status=STOPPED, prev_status=STOPPING)
+            await self.emit_app_state_change(inst, status=STOPPED, previous_status=STOPPING)
         except Exception as e:
             self.logger.error(
                 "Failed to stop app '%s' after %s seconds:\n%s",
@@ -227,7 +238,7 @@ class AppLifecycleService(Resource):
                 self.shutdown_timeout,
                 get_short_traceback(),
             )
-            await self.emit_app_state_change(inst, status=FAILED, prev_status=STOPPING, exception=e)
+            await self.emit_app_state_change(inst, status=FAILED, previous_status=STOPPING, exception=e)
         finally:
             if instance_index is not None:
                 structlog.contextvars.unbind_contextvars("app_key", "instance_name", "instance_index")
@@ -264,12 +275,12 @@ class AppLifecycleService(Resource):
         self,
         app: "App[AppConfig]",
         status: ResourceStatus,
-        prev_status: ResourceStatus | None = None,
+        previous_status: ResourceStatus | None = None,
         exception: Exception | BaseException | None = None,
     ) -> None:
         """Emit an app state change event via Hassette's event system."""
         event = HassetteAppStateEvent.from_data(
-            app=app, status=status, previous_status=prev_status, exception=exception
+            app=app, status=status, previous_status=previous_status, exception=exception
         )
         await self.hassette.send_event(event)
 
@@ -332,7 +343,7 @@ class AppLifecycleService(Resource):
         instances = self.registry.get_apps_by_key(app_key)
         if instances:
             for inst in instances.values():
-                event = HassetteAppStateEvent.from_data(app=inst, status=ResourceStatus.NOT_STARTED)
+                event = HassetteAppStateEvent.from_data(app=inst, status=NOT_STARTED)
                 await self.hassette.send_event(event)
             await self.initialize_instances(app_key, instances, app_manifest)
 
@@ -553,6 +564,80 @@ class AppLifecycleService(Resource):
 
         return previously_blocked - currently_blocked
 
+    def collect_live_listener_ids(self, app_key: str, instances: "dict[int, App[AppConfig]]") -> set[int]:
+        """Collect listener db_ids registered by all instances.
+
+        Registration is synchronous with the DB — db_ids are set before on_initialize() returns.
+        """
+        live_listener_ids: set[int] = set()
+        for inst in instances.values():
+            try:
+                for listener in inst.bus.get_listeners():
+                    if listener.db_id is not None:
+                        live_listener_ids.add(listener.db_id)
+            except Exception:
+                self.logger.warning(
+                    "Failed to collect listener IDs from app '%s' instance — proceeding with partial set",
+                    app_key,
+                )
+        return live_listener_ids
+
+    def merge_router_listener_ids(
+        self,
+        app_key: str,
+        instances: "dict[int, App[AppConfig]]",
+        bus_service: "BusService",
+        live_listener_ids: set[int],
+    ) -> set[int]:
+        """Union in listener db_ids the Router knows are active.
+
+        Avoids retiring rows for mid-session active handlers that ``collect_live_listener_ids``
+        may have missed. Returns a new set rather than mutating ``live_listener_ids``.
+        """
+        try:
+            router = bus_service.router
+            router_ids: set[int] = set()
+            for inst in instances.values():
+                for listener in router.get_listeners_by_owner(inst.bus.owner_id):
+                    if listener.db_id is not None:
+                        router_ids.add(listener.db_id)
+            return live_listener_ids | router_ids
+        except Exception:
+            self.logger.warning(
+                "Router safety guard failed for app '%s' — proceeding with collected live IDs only",
+                app_key,
+            )
+            return live_listener_ids
+
+    def collect_live_job_ids(self, app_key: str, instances: "dict[int, App[AppConfig]]") -> list[int]:
+        """Collect scheduled-job db_ids registered by all instances."""
+        live_job_ids: list[int] = []
+        for inst in instances.values():
+            try:
+                live_job_ids.extend(inst.scheduler.get_job_db_ids())
+            except Exception:
+                self.logger.warning(
+                    "Failed to collect job IDs from app '%s' instance — proceeding with partial set",
+                    app_key,
+                )
+        return live_job_ids
+
+    def resolve_session_id(self, app_key: str) -> int | None:
+        """Resolve the current session ID for the once=True cleanup guard.
+
+        Returns None (degraded mode) if the session ID is unavailable — once=True
+        cleanup is skipped and deferred to the next restart.
+        """
+        try:
+            return self.hassette.session_id
+        except Exception:
+            self.logger.warning(
+                "session_id unavailable for app '%s' — reconciliation running in degraded mode; "
+                "once=True cleanup skipped (deferred to next restart)",
+                app_key,
+            )
+            return None
+
     async def reconcile_app_registrations(
         self,
         app_key: str,
@@ -571,57 +656,10 @@ class AppLifecycleService(Resource):
         try:
             bus_service = self.hassette.bus_service
 
-            # Collect live listener IDs from all instances.
-            # Registration is synchronous — db_ids are set before on_initialize() returns.
-            live_listener_ids: set[int] = set()
-            for inst in instances.values():
-                try:
-                    listeners = inst.bus.get_listeners()
-                    for listener in listeners:
-                        if listener.db_id is not None:
-                            live_listener_ids.add(listener.db_id)
-                except Exception:
-                    self.logger.warning(
-                        "Failed to collect listener IDs from app '%s' instance — proceeding with partial set",
-                        app_key,
-                    )
-
-            # Router safety guard: union with IDs of listeners the Router knows
-            # are active, to avoid retiring rows for mid-session active handlers.
-            try:
-                router = bus_service.router
-                for inst in instances.values():
-                    router_listeners = router.get_listeners_by_owner(inst.bus.owner_id)
-                    for listener in router_listeners:
-                        if listener.db_id is not None:
-                            live_listener_ids.add(listener.db_id)
-            except Exception:
-                self.logger.warning(
-                    "Router safety guard failed for app '%s' — proceeding with collected live IDs only",
-                    app_key,
-                )
-
-            # Collect live job IDs from all instances.
-            live_job_ids: list[int] = []
-            for inst in instances.values():
-                try:
-                    live_job_ids.extend(inst.scheduler.get_job_db_ids())
-                except Exception:
-                    self.logger.warning(
-                        "Failed to collect job IDs from app '%s' instance — proceeding with partial set",
-                        app_key,
-                    )
-
-            # Get current session ID for once=True guard.
-            try:
-                session_id: int | None = self.hassette.session_id
-            except Exception:
-                session_id = None
-                self.logger.warning(
-                    "session_id unavailable for app '%s' — reconciliation running in degraded mode; "
-                    "once=True cleanup skipped (deferred to next restart)",
-                    app_key,
-                )
+            live_listener_ids = self.collect_live_listener_ids(app_key, instances)
+            live_listener_ids = self.merge_router_listener_ids(app_key, instances, bus_service, live_listener_ids)
+            live_job_ids = self.collect_live_job_ids(app_key, instances)
+            session_id = self.resolve_session_id(app_key)
 
             await self.hassette.command_executor.reconcile_registrations(
                 app_key,

--- a/src/hassette/core/bus_service.py
+++ b/src/hassette/core/bus_service.py
@@ -380,10 +380,36 @@ class BusService(Service):
             self.logger.debug("Event: %r", event)
 
         routes = self.expand_topics(base_topic, event)  # ordered: most specific -> least
+        chosen = self._match_listeners(routes, event)
+        if not chosen:
+            return
+
+        listeners_by_route = self._group_by_route(chosen)
+
+        # loop over routes so we always log in order of specificity
+        for route in routes:
+            listeners = listeners_by_route.get(route)
+            if not listeners:
+                continue
+
+            self.logger.debug("Dispatch fanout %s -> %s (%d listener(s))", base_topic, route, len(listeners))
+            for listener in listeners:
+                await self._spawn_dispatch_task(route, event, listener)
+
+    def _match_listeners(self, routes: list[str], event: "Event[Any]") -> dict[int, tuple[str, Listener]]:
+        """Resolve the listeners that match ``event`` across ``routes``.
+
+        Routes first, then dedupes by "first match wins" because routes are ordered by
+        specificity (most specific -> least). A predicate that raises is recorded as a
+        failed execution via ``_record_predicate_failure`` and excluded from further routes
+        for this dispatch, but the listener itself is not removed from the router.
+
+        Returns:
+            A dict mapping ``listener_id`` to the ``(matched_route, listener)`` it matched on.
+        """
         chosen: dict[int, tuple[str, Listener]] = {}  # listener_id -> (matched_route, listener)
         failed: set[int] = set()  # listener_ids whose predicates raised (dedup across routes)
 
-        # Route first, then dedupe by "first match wins" because routes are ordered by specificity
         for route in routes:
             listeners = self.router.get_topic_listeners(route)
             for listener in listeners:
@@ -403,58 +429,57 @@ class BusService(Service):
                 if matched:
                     chosen[listener.listener_id] = (route, listener)
 
-        if not chosen:
-            return
+        return chosen
 
-        # group by route for logging
-        listeners_by_route = defaultdict(list)
+    def _group_by_route(self, chosen: dict[int, tuple[str, Listener]]) -> dict[str, list[Listener]]:
+        """Group matched listeners by the route they matched on, for ordered per-route logging."""
+        listeners_by_route: dict[str, list[Listener]] = defaultdict(list)
         for route, listener in chosen.values():
             listeners_by_route[route].append(listener)
+        return listeners_by_route
 
-        # loop over routes so we always log in order of specificity
-        for route in routes:
-            listeners = listeners_by_route.get(route)
-            if not listeners:
-                continue
+    async def _spawn_dispatch_task(self, route: str, event: "Event[Any]", listener: "Listener") -> None:
+        """Acquire a dispatch slot for ``listener`` and spawn its handler task.
 
-            self.logger.debug("Dispatch fanout %s -> %s (%d listener(s))", base_topic, route, len(listeners))
-            for listener in listeners:
-                # Acquire a slot before spawning so the fan-out can't outrun handler capacity.
-                # A blocked acquire stalls the dispatch loop -> serve loop -> inbound channel,
-                # propagating backpressure to the WS reader. locked() exactly predicts a blocking
-                # acquire here: no await separates the two, so no other task changes the count between.
-                if self._dispatch_semaphore.locked():
-                    # Keep this call before the `await acquire()` below: the BLOCK-path test
-                    # `test_block_listener_blocks_then_runs_under_saturation` hooks
-                    # `warn_dispatch_saturated` as a deterministic signal that dispatch has reached
-                    # the block. Moving it after the acquire would make that test pass vacuously.
-                    self.warn_dispatch_saturated()
-                    if listener.options.backpressure is BackpressurePolicy.DROP_NEWEST:
-                        # Single writer: this loop, on the event loop, NO await between locked() and
-                        # the increment — the same no-await window that makes the saturation check
-                        # race-free. Do not insert an await (e.g. metrics emit) between them.
-                        listener.invoker.backpressure_dropped += 1
-                        self.logger.debug(
-                            "backpressure drop_newest: skipping event for %s",
-                            listener.identity.name or listener.identity.handler_short_name,
-                        )
-                        continue  # no acquire, no spawn, no pending/idle bookkeeping
-                await self._dispatch_semaphore.acquire()
+        Honors the listener's backpressure policy when the dispatch semaphore is saturated,
+        and unwinds slot/pending bookkeeping by hand if the spawn itself fails.
+        """
+        # Acquire a slot before spawning so the fan-out can't outrun handler capacity.
+        # A blocked acquire stalls the dispatch loop -> serve loop -> inbound channel,
+        # propagating backpressure to the WS reader. locked() exactly predicts a blocking
+        # acquire here: no await separates the two, so no other task changes the count between.
+        if self._dispatch_semaphore.locked():
+            # Keep this call before the `await acquire()` below: the BLOCK-path test
+            # `test_block_listener_blocks_then_runs_under_saturation` hooks
+            # `warn_dispatch_saturated` as a deterministic signal that dispatch has reached
+            # the block. Moving it after the acquire would make that test pass vacuously.
+            self.warn_dispatch_saturated()
+            if listener.options.backpressure is BackpressurePolicy.DROP_NEWEST:
+                # Single writer: this loop, on the event loop, NO await between locked() and
+                # the increment — the same no-await window that makes the saturation check
+                # race-free. Do not insert an await (e.g. metrics emit) between them.
+                listener.invoker.backpressure_dropped += 1
+                self.logger.debug(
+                    "backpressure drop_newest: skipping event for %s",
+                    listener.identity.name or listener.identity.handler_short_name,
+                )
+                return  # no acquire, no spawn, no pending/idle bookkeeping
+        await self._dispatch_semaphore.acquire()
 
-                self._dispatch_pending += 1
-                self._dispatch_idle_event.clear()
-                try:
-                    task = self.task_bucket.spawn(self._dispatch(route, event, listener), name="bus:dispatch_listener")
-                except BaseException:
-                    # Spawn failed: no task runs, so no done-callback fires. Release the slot and
-                    # unwind the pending bookkeeping by hand.
-                    self._dispatch_semaphore.release()
-                    self.decrement_dispatch_pending()
-                    raise
-                # Release the slot before decrementing pending so a newly-unblocked waiter sees
-                # a consistent state (slot free, pending still counts the completing task).
-                task.add_done_callback(self.release_dispatch_slot)
-                task.add_done_callback(self.on_dispatch_done)
+        self._dispatch_pending += 1
+        self._dispatch_idle_event.clear()
+        try:
+            task = self.task_bucket.spawn(self._dispatch(route, event, listener), name="bus:dispatch_listener")
+        except BaseException:
+            # Spawn failed: no task runs, so no done-callback fires. Release the slot and
+            # unwind the pending bookkeeping by hand.
+            self._dispatch_semaphore.release()
+            self.decrement_dispatch_pending()
+            raise
+        # Release the slot before decrementing pending so a newly-unblocked waiter sees
+        # a consistent state (slot free, pending still counts the completing task).
+        task.add_done_callback(self.release_dispatch_slot)
+        task.add_done_callback(self.on_dispatch_done)
 
     def expand_topics(self, topic: str, event: Event[Any]) -> list[str]:
         payload = event.payload

--- a/src/hassette/core/scheduler_service.py
+++ b/src/hassette/core/scheduler_service.py
@@ -643,7 +643,7 @@ class SchedulerService(Service):
         """Return all currently scheduled jobs across all apps."""
         return await self._job_queue.get_all()
 
-    async def trigger_job(self, db_id: int) -> "ScheduledJob":
+    async def trigger_job(self, job_id: int) -> "ScheduledJob":
         """Look up a job on the live scheduler heap by its database id.
 
         Used by the manual-trigger route handler (``POST /api/scheduler/jobs/{job_id}/trigger``)
@@ -651,22 +651,22 @@ class SchedulerService(Service):
         responsible for any guard pre-check and for dispatching the job.
 
         Args:
-            db_id: The job's ``scheduled_jobs.id`` database row id.
+            job_id: The job's ``scheduled_jobs.id`` database row id (``ScheduledJob.db_id``).
 
         Returns:
             The matching ScheduledJob from the live heap.
 
         Raises:
-            ValueError: If no job with the given db_id is found on the live heap. This covers
+            ValueError: If no job with the given job_id is found on the live heap. This covers
                 a one-shot job that already fired, a job mid-execution from its scheduled fire
                 (popped from the heap by ``dispatch_and_log`` and not yet re-enqueued), and a
                 job whose owning app is not running.
         """
         live_jobs = await self.get_all_jobs()
-        live_by_db_id = {job.db_id: job for job in live_jobs if job.db_id is not None}
-        job = live_by_db_id.get(db_id)
+        live_by_job_id = {job.db_id: job for job in live_jobs if job.db_id is not None}
+        job = live_by_job_id.get(job_id)
         if job is None:
-            raise ValueError(f"Job {db_id} is not currently triggerable")
+            raise ValueError(f"Job {job_id} is not currently triggerable")
         return job
 
     def remove_jobs_by_owner(self, owner: str) -> asyncio.Task[None]:

--- a/src/hassette/core/websocket_service.py
+++ b/src/hassette/core/websocket_service.py
@@ -70,7 +70,11 @@ RETRYABLE = (
 # the server is unreachable, not that it dropped a post-auth connection.
 EARLY_DROP_RETRYABLE = (RetryableConnectionClosedError, ServerDisconnectedError)
 MAX_RETRY_ATTEMPTS = 5
-_CLEANUP_TIMEOUT = 2.0
+
+# Number of stack frames to keep when logging an invalid connection-state transition.
+# 3 is enough to show the caller that triggered the transition without dumping the
+# full call stack down into asyncio internals.
+INVALID_TRANSITION_TRACE_LIMIT = 3
 
 
 class WebsocketService(Service):
@@ -166,7 +170,7 @@ class WebsocketService(Service):
                         to_status=new,
                         resource_name=self.unique_name,
                     )
-                frame_summary = "".join(traceback.format_stack(limit=3)[:-1]).strip()
+                frame_summary = "".join(traceback.format_stack(limit=INVALID_TRANSITION_TRACE_LIMIT)[:-1]).strip()
                 self.logger.warning(
                     "Invalid WebSocket connection state transition for '%s': %r → %r\n%s",
                     self.unique_name,
@@ -201,6 +205,10 @@ class WebsocketService(Service):
         return self.hassette.config.websocket.authentication_timeout_seconds
 
     @property
+    def cleanup_timeout_seconds(self) -> float:
+        return self.hassette.config.websocket.cleanup_timeout_seconds
+
+    @property
     def connected(self) -> bool:
         return self._connection_state == ConnectionState.CONNECTED
 
@@ -211,8 +219,8 @@ class WebsocketService(Service):
     async def before_shutdown(self) -> None:
         await self.send_connection_lost_event()
 
-    async def serve(self) -> None:
-        """Connect to the WebSocket and run the receive loop."""
+    def log_resilience_budget(self) -> None:
+        """Log the early-drop and connection retry budget that bounds recovery time."""
         config = self.hassette.config
         max_early_drops = config.websocket.early_drop_max_retries
         max_recovery = config.websocket.max_recovery_seconds
@@ -226,12 +234,62 @@ class WebsocketService(Service):
             self.restart_spec.budget_intensity,
         )
 
+    def compute_recovery_windows(self, recovery_started_at: float | None) -> tuple[float, float]:
+        """Compute (seconds since last connect, seconds since recovery began) for drop classification."""
+        elapsed = (time.monotonic() - self._connected_at) if self._connected_at is not None else float("inf")
+        recovery_elapsed = (time.monotonic() - recovery_started_at) if recovery_started_at is not None else 0.0
+        return elapsed, recovery_elapsed
+
+    def is_early_drop(self, exc: Exception, early_drop_attempts: int, elapsed: float, recovery_elapsed: float) -> bool:
+        """Classify exc as an early drop (retry in place) versus a genuine failure (propagate)."""
+        config = self.hassette.config.websocket
+        return (
+            elapsed < config.early_drop_stable_window_seconds
+            and isinstance(exc, EARLY_DROP_RETRYABLE)
+            and early_drop_attempts < config.early_drop_max_retries
+            and recovery_elapsed < config.max_recovery_seconds
+        )
+
+    async def handle_early_drop(
+        self, exc: Exception, elapsed: float, early_drop_attempts: int, max_early_drops: int
+    ) -> None:
+        """Log, notify, clean up, and back off after an early connection drop, then set CONNECTING.
+
+        Sends the connection-lost event before marking not-ready so the idempotency guard passes.
+        """
+        close_code = getattr(exc, "close_code", None)
+        self.logger.warning(
+            "WebSocket early drop detected (elapsed=%.1fs, attempt=%d/%d%s) — retrying",
+            elapsed,
+            early_drop_attempts,
+            max_early_drops,
+            f", close_code={close_code}" if close_code is not None else "",
+        )
+        await self.send_connection_lost_event()
+        self.mark_not_ready(reason="Early drop detected")
+        await self._emit_readiness_event()
+        await self.partial_cleanup()
+        await self.early_drop_backoff(early_drop_attempts)
+        # Set CONNECTING before the next retry
+        self.set_connection_state(ConnectionState.CONNECTING)
+
+    async def handle_genuine_failure(self) -> None:
+        """Transition to DISCONNECTED and notify listeners of a non-recoverable serve() failure."""
+        self.set_connection_state(ConnectionState.DISCONNECTED)
+        await self.send_connection_lost_event()
+        self.mark_not_ready(reason="WebSocket recv loop failed")
+        await self._emit_readiness_event()
+
+    async def serve(self) -> None:
+        """Connect to the WebSocket and run the receive loop."""
+        self.log_resilience_budget()
+        max_early_drops = self.hassette.config.websocket.early_drop_max_retries
+
         async with self._connect_lock:
             timeout = ClientTimeout(connect=self.connection_timeout_seconds, total=self.total_timeout_seconds)
 
             async with aiohttp.ClientSession(timeout=timeout) as session:
                 early_drop_attempts = 0
-                stable_window = config.websocket.early_drop_stable_window_seconds
                 recovery_started_at: float | None = None
 
                 # Set CONNECTING before the first connection attempt
@@ -248,44 +306,15 @@ class WebsocketService(Service):
                         self.set_connection_state(ConnectionState.DISCONNECTED)
                         raise
                     except Exception as exc:
-                        elapsed = (
-                            (time.monotonic() - self._connected_at) if self._connected_at is not None else float("inf")
-                        )
-                        recovery_elapsed = (
-                            (time.monotonic() - recovery_started_at) if recovery_started_at is not None else 0.0
-                        )
-                        is_early = (
-                            elapsed < stable_window
-                            and isinstance(exc, EARLY_DROP_RETRYABLE)
-                            and early_drop_attempts < max_early_drops
-                            and recovery_elapsed < max_recovery
-                        )
-                        if is_early:
+                        elapsed, recovery_elapsed = self.compute_recovery_windows(recovery_started_at)
+                        if self.is_early_drop(exc, early_drop_attempts, elapsed, recovery_elapsed):
                             if recovery_started_at is None:
                                 recovery_started_at = time.monotonic()
                             early_drop_attempts += 1
-                            close_code = getattr(exc, "close_code", None)
-                            self.logger.warning(
-                                "WebSocket early drop detected (elapsed=%.1fs, attempt=%d/%d%s) — retrying",
-                                elapsed,
-                                early_drop_attempts,
-                                max_early_drops,
-                                f", close_code={close_code}" if close_code is not None else "",
-                            )
-                            # Send event before marking not-ready so the idempotency guard passes
-                            await self.send_connection_lost_event()
-                            self.mark_not_ready(reason="Early drop detected")
-                            await self._emit_readiness_event()
-                            await self.partial_cleanup()
-                            await self.early_drop_backoff(early_drop_attempts)
-                            # Set CONNECTING before the next retry
-                            self.set_connection_state(ConnectionState.CONNECTING)
+                            await self.handle_early_drop(exc, elapsed, early_drop_attempts, max_early_drops)
                             continue
                         # Genuine failure — propagate to _serve_wrapper
-                        self.set_connection_state(ConnectionState.DISCONNECTED)
-                        await self.send_connection_lost_event()
-                        self.mark_not_ready(reason="WebSocket recv loop failed")
-                        await self._emit_readiness_event()
+                        await self.handle_genuine_failure()
                         raise
 
     async def connect_ws(self, session: aiohttp.ClientSession) -> None:
@@ -344,7 +373,7 @@ class WebsocketService(Service):
             with suppress(Exception):
                 await asyncio.wait_for(
                     asyncio.gather(self._recv_task, return_exceptions=True),
-                    timeout=_CLEANUP_TIMEOUT,
+                    timeout=self.cleanup_timeout_seconds,
                 )
 
         if self._ws is not None and not self._ws.closed:
@@ -398,6 +427,31 @@ class WebsocketService(Service):
         while True:
             await self.raw_recv()
 
+    async def send_and_await_response(self, payload: dict[str, Any], msg_id: int) -> Any:
+        """Register a response future for msg_id, send payload, and await the reply.
+
+        Registers the future before sending so a fast reply arriving before ``send_json``
+        returns is never dropped. Always pops the future from ``_response_futures`` on
+        exit — success, timeout, or any other exception.
+
+        Args:
+            payload: The JSON payload to send. Must already include ``"id": msg_id``.
+            msg_id: The message id used to correlate the response future.
+
+        Returns:
+            The response payload once ``respond_if_necessary`` resolves the future.
+
+        Raises:
+            TimeoutError: If no response arrives within ``resp_timeout_seconds``.
+        """
+        fut = self.hassette.loop.create_future()
+        self._response_futures[msg_id] = fut
+        try:
+            await self.send_json(**payload)
+            return await asyncio.wait_for(fut, timeout=self.resp_timeout_seconds)
+        finally:
+            self._response_futures.pop(msg_id, None)
+
     async def subscribe_events(self, event_type: str | None = None) -> int:
         """Subscribe to HA events; returns the subscription ID HA confirmed.
 
@@ -431,19 +485,14 @@ class WebsocketService(Service):
                     )
 
             msg_id = self.get_next_message_id()
-            fut = self.hassette.loop.create_future()
-            self._response_futures[msg_id] = fut
             try:
-                await self.send_json(**{**payload, "id": msg_id})
-                await asyncio.wait_for(fut, timeout=self.resp_timeout_seconds)
+                await self.send_and_await_response({**payload, "id": msg_id}, msg_id)
                 return msg_id
             except TimeoutError:
                 last_abandoned_id = msg_id
                 raise FailedMessageError(
                     f"subscribe_events response timed out after {self.resp_timeout_seconds}s"
                 ) from None
-            finally:
-                self._response_futures.pop(msg_id, None)
 
         return await subscribe_with_retry()
 
@@ -521,17 +570,12 @@ class WebsocketService(Service):
             else:
                 data["id"] = msg_id = self.get_next_message_id()
 
-            fut = self.hassette.loop.create_future()
-            self._response_futures[msg_id] = fut
             try:
-                await self.send_json(**data)
-                return await asyncio.wait_for(fut, timeout=self.resp_timeout_seconds)
+                return await self.send_and_await_response(data, msg_id)
             except TimeoutError:
                 raise FailedMessageError(
                     f"Response timed out after {self.resp_timeout_seconds}s (data: {data})"
                 ) from None
-            finally:
-                self._response_futures.pop(msg_id, None)
 
         return await send_with_retry()
 

--- a/src/hassette/event_handling/predicates.py
+++ b/src/hassette/event_handling/predicates.py
@@ -47,7 +47,7 @@ from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass, field
 from inspect import isawaitable
 from logging import getLogger
-from typing import Any, Generic, TypeGuard, TypeVar
+from typing import Any, Generic, Self, TypeGuard, TypeVar
 
 from boltons.iterutils import is_collection
 
@@ -98,31 +98,37 @@ class Guard(typing.Generic[EventT]):
         return "custom condition"
 
 
+def _summarize(obj: Any, non_callable_fallback: Callable[[Any], str]) -> str:
+    """Return a human-readable summary of a predicate or condition.
+
+    Delegates to the object's ``summarize()`` method when available, falls back to a
+    stable callable name for callables, or to ``non_callable_fallback`` otherwise.
+    """
+    if hasattr(obj, "summarize"):
+        return obj.summarize()  # pyright: ignore[reportAttributeAccessIssue]
+    if callable(obj):
+        return callable_name(obj)
+    return non_callable_fallback(obj)
+
+
 def _summarize_predicate(predicate: "Predicate") -> str:
     """Return a human-readable summary of a predicate.
 
     Delegates to the predicate's ``summarize()`` method when available,
-    otherwise falls back to a stable callable name.
+    otherwise falls back to a stable callable name, or ``repr()`` for
+    non-callable values.
     """
-    if hasattr(predicate, "summarize"):
-        return predicate.summarize()  # pyright: ignore[reportAttributeAccessIssue]
-    if callable(predicate):
-        return callable_name(predicate)
-    return repr(predicate)
+    return _summarize(predicate, repr)
 
 
 def _summarize_condition(condition: Any) -> str:
     """Return a human-readable summary of a condition.
 
     Delegates to the condition's ``summarize()`` method when available,
-    falls back to a stable callable name for callables, or ``repr()``
+    falls back to a stable callable name for callables, or ``str()``
     for non-callable literals.
     """
-    if hasattr(condition, "summarize"):
-        return condition.summarize()
-    if callable(condition):
-        return callable_name(condition)
-    return str(condition)
+    return _summarize(condition, str)
 
 
 def _strip_outer_parens(s: str) -> str:
@@ -155,11 +161,24 @@ def summarize_top_level(predicate: "Predicate") -> str:
 
 
 @dataclass(frozen=True)
-class AllOf:
-    """Predicate that evaluates to True if all of the contained predicates evaluate to True."""
+class _PredicateCombinator:
+    """Base for combinators that wrap a tuple of predicates.
+
+    Provides the shared ``ensure_iterable`` constructor that flattens a single predicate
+    or a (possibly nested) collection of predicates into the combinator's tuple form.
+    """
 
     predicates: tuple["Predicate", ...]
     """The predicates to evaluate."""
+
+    @classmethod
+    def ensure_iterable(cls, where: "Predicate | Sequence[Predicate]") -> Self:
+        return cls(ensure_tuple(where))
+
+
+@dataclass(frozen=True)
+class AllOf(_PredicateCombinator):
+    """Predicate that evaluates to True if all of the contained predicates evaluate to True."""
 
     def __call__(self, value: "Event") -> bool:
         return all(p(value) for p in self.predicates)
@@ -170,17 +189,10 @@ class AllOf:
             return f"({joined})"
         return joined
 
-    @classmethod
-    def ensure_iterable(cls, where: "Predicate | Sequence[Predicate] | list[Predicate]") -> "AllOf":
-        return cls(ensure_tuple(where))
-
 
 @dataclass(frozen=True)
-class AnyOf:
+class AnyOf(_PredicateCombinator):
     """Predicate that evaluates to True if any of the contained predicates evaluate to True."""
-
-    predicates: tuple["Predicate", ...]
-    """The predicates to evaluate."""
 
     def __call__(self, event: "Event") -> bool:
         return any(p(event) for p in self.predicates)
@@ -190,10 +202,6 @@ class AnyOf:
         if len(self.predicates) >= 2:
             return f"({joined})"
         return joined
-
-    @classmethod
-    def ensure_iterable(cls, where: "Predicate | Sequence[Predicate]") -> "AnyOf":
-        return cls(ensure_tuple(where))
 
 
 @dataclass(frozen=True)
@@ -415,6 +423,11 @@ class AttrDidChange:
         return f"attr {self.attr_name} changed"
 
 
+def _glob_or_literal(value: str) -> "str | Glob":
+    """Wrap ``value`` in a Glob condition if it contains glob syntax, else return it as-is."""
+    return Glob(value) if is_glob(value) else value
+
+
 @dataclass(frozen=True)
 class DomainMatches:
     """Checks if the event domain matches a specific value."""
@@ -422,8 +435,7 @@ class DomainMatches:
     domain: str
 
     def __call__(self, value: "HassEvent", /) -> bool:
-        cond = Glob(self.domain) if is_glob(self.domain) else self.domain
-        return ValueIs(source=get_domain, condition=cond)(value)
+        return ValueIs(source=get_domain, condition=_glob_or_literal(self.domain))(value)
 
     def summarize(self) -> str:
         return f"domain {self.domain}"
@@ -439,8 +451,7 @@ class EntityMatches:
     entity_id: str
 
     def __call__(self, value: "HassEvent", /) -> bool:
-        cond = Glob(self.entity_id) if is_glob(self.entity_id) else self.entity_id
-        return ValueIs(source=get_entity_id, condition=cond)(value)
+        return ValueIs(source=get_entity_id, condition=_glob_or_literal(self.entity_id))(value)
 
     def summarize(self) -> str:
         return f"entity {self.entity_id}"
@@ -456,8 +467,7 @@ class ServiceMatches:
     service: str
 
     def __call__(self, value: "HassEvent", /) -> bool:
-        cond = Glob(self.service) if is_glob(self.service) else self.service
-        return ValueIs(source=get_path("payload.data.service"), condition=cond)(value)
+        return ValueIs(source=get_path("payload.data.service"), condition=_glob_or_literal(self.service))(value)
 
     def summarize(self) -> str:
         return f"service {self.service}"

--- a/src/hassette/event_handling/predicates.py
+++ b/src/hassette/event_handling/predicates.py
@@ -160,6 +160,11 @@ def summarize_top_level(predicate: "Predicate") -> str:
     return _strip_outer_parens(_summarize_predicate(predicate))
 
 
+def _glob_or_literal(value: str) -> "str | Glob":
+    """Wrap ``value`` in a Glob condition if it contains glob syntax, else return it as-is."""
+    return Glob(value) if is_glob(value) else value
+
+
 @dataclass(frozen=True)
 class _PredicateCombinator:
     """Base for combinators that wrap a tuple of predicates.
@@ -421,11 +426,6 @@ class AttrDidChange:
 
     def summarize(self) -> str:
         return f"attr {self.attr_name} changed"
-
-
-def _glob_or_literal(value: str) -> "str | Glob":
-    """Wrap ``value`` in a Glob condition if it contains glob syntax, else return it as-is."""
-    return Glob(value) if is_glob(value) else value
 
 
 @dataclass(frozen=True)

--- a/src/hassette/test_utils/harness.py
+++ b/src/hassette/test_utils/harness.py
@@ -92,6 +92,22 @@ async def shutdown_resource(res: Resource) -> None:
     await res.shutdown()
 
 
+@contextlib.contextmanager
+def _collect_shutdown_errors(
+    errors: list[Exception],
+    exc_types: type[Exception] | tuple[type[Exception], ...] = Exception,
+) -> Generator[None, None, None]:
+    """Run the wrapped block, appending any matching exception to ``errors`` instead of raising.
+
+    Used by ``HassetteHarness.stop()`` so a failure in one teardown step doesn't skip the rest —
+    all collected errors are raised together as an ExceptionGroup once teardown finishes.
+    """
+    try:
+        yield
+    except exc_types as exc:
+        errors.append(exc)
+
+
 async def _harness_dispatch(
     invoke_fn: Callable[[], Awaitable[None]],
     error_handler: Callable[..., Any] | None,
@@ -533,42 +549,63 @@ class HassetteHarness:
 
     async def start(self) -> "HassetteHarness":
         self._resolve_dependencies()
+        loop, loop_thread_id = self._setup_loop_emulation()
+        self._maybe_install_loop_watchdog(loop, loop_thread_id)
+        await self._start_components()
+        self._install_default_mocks()
 
-        # Emulate run_forever() on the real Hassette: populate the backing slots that the
-        # public loop / loop_thread_id accessors read. These are read-only properties with no
-        # setter, so the harness writes the private slots directly — the same way run_forever
-        # does — rather than reaching through a public accessor.
-        self.hassette._loop = asyncio.get_running_loop()
-        self._previous_task_factory = self.hassette._loop.get_task_factory()
-        self.hassette._loop_thread_id = threading.get_ident()
+        self.hassette.ready_event.set()
+        await self.hassette.start_children_and_wait(timeout=Timeouts.WAIT_FOR_READY)
+
+        self._capture_original_app_manifests()
+
+        return self
+
+    def _setup_loop_emulation(self) -> tuple[asyncio.AbstractEventLoop, int]:
+        """Emulate run_forever() on the real Hassette: populate the backing slots that the
+        public loop / loop_thread_id accessors read. These are read-only properties with no
+        setter, so the harness writes the private slots directly — the same way run_forever
+        does — rather than reaching through a public accessor.
+        """
+        loop = asyncio.get_running_loop()
+        loop_thread_id = threading.get_ident()
+        self.hassette._loop = loop
+        self._previous_task_factory = loop.get_task_factory()
+        self.hassette._loop_thread_id = loop_thread_id
         self.hassette.task_bucket = TaskBucket(cast("Hassette", self.hassette), parent=self.hassette)  # pyright: ignore[reportArgumentType]
-        self.hassette._loop.set_task_factory(make_task_factory(self.hassette.task_bucket))  # pyright: ignore[reportArgumentType]
+        loop.set_task_factory(make_task_factory(self.hassette.task_bucket))  # pyright: ignore[reportArgumentType]
+        return loop, loop_thread_id
 
-        # Install Tier 1 loop-responsiveness watchdog when a real CommandExecutor is present.
-        # The harness uses mock executors by default; the watchdog only activates when the
-        # executor has a live current_execution attribute (i.e., it is a real CommandExecutor).
+    def _maybe_install_loop_watchdog(self, loop: asyncio.AbstractEventLoop, loop_thread_id: int) -> None:
+        """Install Tier 1 loop-responsiveness watchdog when a real CommandExecutor is present.
+
+        The harness uses mock executors by default; the watchdog only activates when the
+        executor has a live current_execution attribute (i.e., it is a real CommandExecutor).
+        """
         executor = getattr(self.hassette, "_command_executor", None)
-        if (
+        if not (
             executor is not None
             and isinstance(executor, CommandExecutor)
             and self.hassette.config.blocking_io.watchdog_enabled
         ):
-            _loop = self.hassette._loop
-            self.hassette._loop_watchdog = LoopWatchdog(
-                self.hassette,
-                loop=_loop,
-                loop_thread_id=self.hassette._loop_thread_id,
-                executor=executor,
-                # Mirror core.py: marshal record_blocking_event onto the loop thread so integration
-                # tests exercise the same Tier 1 persistence path as production. Without on_stall the
-                # watchdog warns but drops telemetry. Gate on is_running() like core does.
-                on_stall=lambda ev: (
-                    _loop.call_soon_threadsafe(executor.record_blocking_event, ev) if _loop.is_running() else None
-                ),
-            )
-            self.hassette._loop_watchdog.start()
+            return
 
-        # Start components in dependency order
+        self.hassette._loop_watchdog = LoopWatchdog(
+            self.hassette,
+            loop=loop,
+            loop_thread_id=loop_thread_id,
+            executor=executor,
+            # Mirror core.py: marshal record_blocking_event onto the loop thread so integration
+            # tests exercise the same Tier 1 persistence path as production. Without on_stall the
+            # watchdog warns but drops telemetry. Gate on is_running() like core does.
+            on_stall=lambda ev: (
+                loop.call_soon_threadsafe(executor.record_blocking_event, ev) if loop.is_running() else None
+            ),
+        )
+        self.hassette._loop_watchdog.start()
+
+    async def _start_components(self) -> None:
+        """Start components in dependency order via their registered starter coroutines."""
         for component in STARTUP_ORDER:
             if not self.has_component(component):
                 continue
@@ -576,7 +613,8 @@ class HassetteHarness:
             if starter:
                 await starter(self)
 
-        # Set up API and websocket mocks if not provided by a real component
+    def _install_default_mocks(self) -> None:
+        """Set up API, websocket, and state mocks not already provided by a real component."""
         if not self.hassette._api_service:
             self.hassette._api_service = AsyncMock()
             self.hassette._api_service.ready_event = asyncio.Event()
@@ -597,15 +635,12 @@ class HassetteHarness:
         if not self.has_component("bus"):
             self.hassette.send_event = AsyncMock()
 
-        self.hassette.ready_event.set()
-        await self.hassette.start_children_and_wait(timeout=Timeouts.WAIT_FOR_READY)
-
+    def _capture_original_app_manifests(self) -> None:
+        """Snapshot app manifests after startup so reset() can restore them between tests."""
         if self.has_component("app_handler"):
             self._original_app_manifests = {
                 k: v.model_copy(deep=True) for k, v in self.app_handler.registry.manifests.items()
             }
-
-        return self
 
     async def stop(self) -> None:
         self.hassette.shutdown_event.set()
@@ -616,41 +651,31 @@ class HassetteHarness:
             # warnings during teardown and ensures no daemon thread outlives the test. A failed
             # stop() can leave a daemon thread alive across tests, so surface it like the rest.
             if self.hassette._loop_watchdog is not None:
-                try:
+                with _collect_shutdown_errors(shutdown_errors):
                     self.hassette._loop_watchdog.stop()
-                except Exception as exc:
-                    shutdown_errors.append(exc)
                 self.hassette._loop_watchdog = None
 
             # Shut down in reverse order so dependents stop before their dependencies.
             for resource in reversed(self.hassette.children):
-                try:
+                with _collect_shutdown_errors(shutdown_errors):
                     await shutdown_resource(resource)
-                except Exception as exc:
-                    shutdown_errors.append(exc)
 
             # Close event streams after all children have stopped — children send
             # STOPPED status events during shutdown, so streams must stay open until then.
             # Use _close_streams_now() to bypass the no-op override on _HarnessEventStreamService,
             # which prevents test-initiated hassette.shutdown() calls from closing streams prematurely.
-            try:
+            with _collect_shutdown_errors(shutdown_errors):
                 ess = self.hassette._event_stream_service
                 if isinstance(ess, _HarnessEventStreamService) and not ess.event_streams_closed:
                     await ess._close_streams_now()
-            except Exception as exc:
-                shutdown_errors.append(exc)
 
-            try:
+            with _collect_shutdown_errors(shutdown_errors):
                 await self._exit_stack.aclose()
-            except Exception as exc:
-                shutdown_errors.append(exc)
 
             # Assert clean AFTER all other cleanup so assertion errors are not masked.
-            try:
+            with _collect_shutdown_errors(shutdown_errors, exc_types=AssertionError):
                 if self.api_mock is not None:
                     self.api_mock.assert_clean()
-            except AssertionError as exc:
-                shutdown_errors.append(exc)
         finally:
             # Reset the global singleton unconditionally, ahead of the loop teardown below so a
             # failure restoring the loop can't skip it. If any statement above escapes the

--- a/src/hassette/test_utils/web_helpers.py
+++ b/src/hassette/test_utils/web_helpers.py
@@ -26,6 +26,7 @@ from hassette.scheduler.triggers import After, Cron, Every, Once
 from hassette.schemas.app_snapshots import AppFullSnapshot, AppInstanceInfo, AppManifestInfo
 from hassette.schemas.telemetry_models import ActivityFeedEntry, Execution, JobSummary
 from hassette.test_utils.config import DEFAULT_TEST_APP_KEY
+from hassette.types.enums import ExecutionMode
 from hassette.types.types import ExecutionStatus, SchedulerPredicate
 from hassette.web.models import (
     AppConfigResponse,
@@ -252,6 +253,8 @@ def make_real_job(
     app_key: str = "",
     instance_index: int = 0,
     predicate: SchedulerPredicate | None = None,
+    mode: ExecutionMode = ExecutionMode.SINGLE,
+    db_id: int | None = None,
 ) -> ScheduledJob:
     """Build a real ``ScheduledJob`` instance for tests that need full object behavior.
 
@@ -269,6 +272,9 @@ def make_real_job(
         instance_index: Optional app instance index.
         predicate: Optional ``where=`` predicate. Does not set ``predicate_invoker`` —
             callers that need DI resolution should pass one when constructing their own job.
+        mode: Execution-mode guard for the job. Defaults to ``ExecutionMode.SINGLE``.
+        db_id: Database row id to stamp onto the job, as if already registered. Defaults to
+            ``None`` (unregistered).
     """
     return ScheduledJob(
         owner_id=owner_id,
@@ -281,6 +287,8 @@ def make_real_job(
         app_key=app_key,
         instance_index=instance_index,
         predicate=predicate,
+        mode=mode,
+        db_id=db_id,
     )
 
 

--- a/src/hassette/web/models.py
+++ b/src/hassette/web/models.py
@@ -396,7 +396,7 @@ class TelemetryStatusResponse(BaseModel):
 class ActionResponse(BaseModel):
     """Response for app mutation endpoints (start/stop/reload)."""
 
-    status: str
+    status: Literal["accepted"] = "accepted"
     app_key: str
     action: str
 
@@ -408,7 +408,7 @@ class JobTriggerResponse(BaseModel):
     the trigger response identifies the job, not an app action.
     """
 
-    status: str
+    status: Literal["accepted"] = "accepted"
     job_id: int
     job_name: str
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -19,6 +19,7 @@ from hassette.config.models import (
     WebApiConfig,
     WebSocketConfig,
 )
+from hassette.core.migration_runner import run_migrations
 from hassette.models.states.catalog import restore_catalog, snapshot_catalog
 from hassette.task_bucket import TaskBucket
 
@@ -179,6 +180,21 @@ def test_config_with_temp_path(tmp_path_factory: pytest.TempPathFactory) -> Hass
 def test_events_path() -> Path:
     """Provide the path to the test events directory."""
     return TEST_EVENTS_PATH
+
+
+@pytest.fixture(scope="session")
+def _migrated_db_template(tmp_path_factory: pytest.TempPathFactory) -> Path:
+    """Run migrations once per pytest worker and return the migrated DB file path.
+
+    Under xdist, each worker runs this independently — still a large win since each worker has
+    many DB-heavy tests. Copying this file takes <1ms vs ~700ms for running migrations from
+    scratch. Shared by both unit and integration suites: `run_migrations()` produces the same
+    on-disk schema as booting a real `DatabaseService`, without the service lifecycle overhead.
+    """
+    tmpl_dir = tmp_path_factory.mktemp("db_template")
+    db_path = tmpl_dir / "hassette.db"
+    run_migrations(db_path)
+    return db_path
 
 
 @pytest.fixture

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,6 +1,5 @@
 """Shared fixtures for integration tests."""
 
-import asyncio
 import shutil
 import time
 from collections.abc import AsyncIterator
@@ -88,36 +87,6 @@ async def client(app):
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test") as ac:
         yield ac
-
-
-@pytest.fixture(scope="session")
-def _migrated_db_template(tmp_path_factory: pytest.TempPathFactory) -> Path:
-    """Run Alembic migrations once per pytest worker and return the migrated DB file path.
-
-    Under xdist (-n 2), each worker runs this independently — still a large win since each
-    worker has ~75+ DB-heavy tests. Copying this file (~135KB) takes <1ms vs ~700ms for
-    running migrations from scratch.
-    """
-    tmpl_dir = tmp_path_factory.mktemp("db_template")
-    mock = make_mock_hassette(
-        data_dir=tmpl_dir,
-        set_loop=False,
-        sealed=False,
-        database={"max_size_mb": 0, "telemetry_write_queue_max": 500},
-        lifecycle={"resource_shutdown_timeout_seconds": 5},
-        web_api={"run": True},
-    )
-
-    db_service = DatabaseService(mock, parent=mock)
-
-    loop = asyncio.new_event_loop()
-    try:
-        loop.run_until_complete(db_service.on_initialize())
-        loop.run_until_complete(db_service.on_shutdown())
-    finally:
-        loop.close()
-
-    return tmpl_dir / "hassette.db"
 
 
 @pytest.fixture

--- a/tests/integration/web_api/test_trigger_job.py
+++ b/tests/integration/web_api/test_trigger_job.py
@@ -5,9 +5,9 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-import hassette.utils.date_utils as date_utils
 from hassette.scheduler.classes import ScheduledJob
 from hassette.scheduler.triggers import After, Every
+from hassette.test_utils.web_helpers import make_real_job
 from hassette.types.enums import ExecutionMode
 
 if TYPE_CHECKING:
@@ -31,15 +31,7 @@ def make_scheduled_job(
     returns True — used to test the SINGLE-mode pre-check and the RESTART/QUEUED/PARALLEL
     bypass of that pre-check.
     """
-    job = ScheduledJob(
-        owner_id="test_owner",
-        next_run=date_utils.now(),
-        job=lambda: None,
-        mode=mode,
-        trigger=trigger,
-        name=name,
-    )
-    job.db_id = db_id
+    job = make_real_job(name=name, trigger=trigger, mode=mode, db_id=db_id)
     if guard_running:
         job.guard = MagicMock()  # pyright: ignore[reportAttributeAccessIssue]
         job.guard.is_running.return_value = True

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1,5 +1,6 @@
 """Shared fixtures for tests/unit/."""
 
+import asyncio
 import collections.abc
 import gc
 import inspect
@@ -20,6 +21,8 @@ import structlog.stdlib
 
 from hassette import context
 from hassette.api.api import Api
+from hassette.config import HassetteConfig
+from hassette.core.sync_executor_service import SYNC_EXECUTOR_THREAD_NAME_PREFIX, SyncExecutorService
 from hassette.exceptions import HassetteForgottenAwaitWarning
 from hassette.logging_ import (
     CorrelationFilter,
@@ -31,11 +34,45 @@ from hassette.logging_ import (
 )
 from hassette.models.entities.light import LightEntity
 from hassette.models.states import LightState
+from hassette.task_bucket.interruptible_executor import InterruptibleThreadPoolExecutor
 
 if TYPE_CHECKING:
     from contextvars import Token
 
     from hassette import Hassette
+
+TEST_TOKEN = "test-token"
+
+
+def make_test_config(max_workers: int = 4, shutdown_timeout: float = 5.0) -> HassetteConfig:
+    return HassetteConfig(
+        token=TEST_TOKEN,
+        lifecycle={
+            "sync_executor_max_workers": max_workers,
+            "sync_executor_shutdown_timeout_seconds": shutdown_timeout,
+        },
+    )
+
+
+def make_sync_executor_hassette(max_workers: int = 4, shutdown_timeout: float = 5.0) -> MagicMock:
+    config = make_test_config(max_workers=max_workers, shutdown_timeout=shutdown_timeout)
+    mock_hassette = MagicMock()
+    mock_hassette.config = config
+    mock_hassette.task_bucket = MagicMock()
+    mock_hassette.shutdown_event = asyncio.Event()
+    mock_hassette.children = []
+    mock_hassette._should_skip_dependency_check = MagicMock(return_value=True)
+    return mock_hassette
+
+
+def make_service(max_workers: int = 4, shutdown_timeout: float = 5.0) -> SyncExecutorService:
+    mock_hassette = make_sync_executor_hassette(max_workers=max_workers, shutdown_timeout=shutdown_timeout)
+    svc = SyncExecutorService(mock_hassette)
+    svc.executor = InterruptibleThreadPoolExecutor(
+        max_workers=mock_hassette.config.lifecycle.sync_executor_max_workers,
+        thread_name_prefix=SYNC_EXECUTOR_THREAD_NAME_PREFIX,
+    )
+    return svc
 
 
 def make_mock_parent() -> MagicMock:

--- a/tests/unit/core/conftest.py
+++ b/tests/unit/core/conftest.py
@@ -17,7 +17,6 @@ from hassette.core.app_lifecycle_service import AppLifecycleService
 from hassette.core.bus_service import BusService, compute_elapsed, make_synthetic_state_event
 from hassette.core.command_executor import CommandExecutor
 from hassette.core.event_filter import EventFilter
-from hassette.core.migration_runner import run_migrations
 from hassette.core.service_watcher import ServiceWatcher
 from hassette.core.telemetry.repository import TelemetryRepository
 from hassette.resources.restart import RestartSpec
@@ -358,15 +357,6 @@ def make_bus_service(*, config_timeout: float | None = 600.0, max_concurrent_dis
     svc._dispatch_semaphore = asyncio.Semaphore(max_concurrent_dispatches)
     svc._last_saturation_warn_ts = 0.0
     return svc
-
-
-@pytest.fixture(scope="session")
-def _migrated_db_template(tmp_path_factory: pytest.TempPathFactory) -> Path:
-    """Run the real migration runner once per session and return the template DB path."""
-    tmpl_dir = tmp_path_factory.mktemp("telemetry_repo_db")
-    db_path = tmpl_dir / "hassette.db"
-    run_migrations(db_path)
-    return db_path
 
 
 @pytest.fixture

--- a/tests/unit/core/test_scheduler_service_trigger.py
+++ b/tests/unit/core/test_scheduler_service_trigger.py
@@ -14,10 +14,9 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-import hassette.utils.date_utils as date_utils
 from hassette.commands import ExecuteJob
 from hassette.core.scheduler_service import SchedulerService
-from hassette.scheduler.classes import ScheduledJob
+from hassette.test_utils.web_helpers import make_real_job
 from hassette.types.enums import ExecutionMode
 
 
@@ -45,22 +44,11 @@ def make_scheduler_service() -> SchedulerService:
     return svc
 
 
-def make_job(mode: ExecutionMode = ExecutionMode.SINGLE) -> ScheduledJob:
-    """Create a minimal ScheduledJob for testing."""
-    now = date_utils.now()
-    return ScheduledJob(
-        owner_id="test_owner",
-        next_run=now,
-        job=lambda: None,
-        mode=mode,
-    )
-
-
 class TestRunJobTriggerMode:
     async def test_run_job_passes_trigger_mode_to_execute_job(self) -> None:
         """run_job(trigger_mode='manual') threads through to ExecuteJob.trigger_mode."""
         svc = make_scheduler_service()
-        job = make_job()
+        job = make_real_job()
 
         await svc.run_job(job, trigger_mode="manual")
 
@@ -72,7 +60,7 @@ class TestRunJobTriggerMode:
     async def test_run_job_defaults_trigger_mode_to_none(self) -> None:
         """run_job() called without trigger_mode produces ExecuteJob.trigger_mode=None."""
         svc = make_scheduler_service()
-        job = make_job()
+        job = make_real_job()
 
         await svc.run_job(job)
 
@@ -88,7 +76,7 @@ class TestRunJobWithGuardTriggerMode:
     async def test_threads_trigger_mode(self, mode: ExecutionMode) -> None:
         """run_job_with_guard(trigger_mode='manual') threads through to run_job for both modes."""
         svc = make_scheduler_service()
-        job = make_job(mode=mode)
+        job = make_real_job(mode=mode)
         svc.run_job = (
             AsyncMock()
         )  # boundary-exempt: collaborator of run_job_with_guard  # pyright: ignore[reportAttributeAccessIssue]
@@ -101,7 +89,7 @@ class TestRunJobWithGuardTriggerMode:
     async def test_defaults_trigger_mode_to_none(self, mode: ExecutionMode) -> None:
         """run_job_with_guard() without trigger_mode passes None through for both modes."""
         svc = make_scheduler_service()
-        job = make_job(mode=mode)
+        job = make_real_job(mode=mode)
         svc.run_job = (
             AsyncMock()
         )  # boundary-exempt: collaborator of run_job_with_guard  # pyright: ignore[reportAttributeAccessIssue]
@@ -115,8 +103,7 @@ class TestTriggerJob:
     async def test_returns_job_found_on_heap(self) -> None:
         """trigger_job() returns the ScheduledJob whose db_id matches on the live heap."""
         svc = make_scheduler_service()
-        job = make_job()
-        job.db_id = 42
+        job = make_real_job(db_id=42)
         svc.get_all_jobs = AsyncMock(
             return_value=[job]
         )  # boundary-exempt: collaborator of trigger_job  # pyright: ignore[reportAttributeAccessIssue]
@@ -128,8 +115,7 @@ class TestTriggerJob:
     async def test_raises_value_error_for_missing_db_id(self) -> None:
         """trigger_job() raises ValueError when no job on the heap matches db_id."""
         svc = make_scheduler_service()
-        other_job = make_job()
-        other_job.db_id = 1
+        other_job = make_real_job(db_id=1)
         svc.get_all_jobs = AsyncMock(
             return_value=[other_job]
         )  # boundary-exempt: collaborator of trigger_job  # pyright: ignore[reportAttributeAccessIssue]

--- a/tests/unit/core/test_telemetry_repository.py
+++ b/tests/unit/core/test_telemetry_repository.py
@@ -10,6 +10,8 @@ from hassette.core.telemetry.repository import TelemetryRepository
 from hassette.test_utils.config import DEFAULT_TEST_APP_KEY
 from hassette.test_utils.factories import make_job_registration, make_listener_registration
 
+ONCE_LISTENER_NAME = "test_app.on_event.once"
+
 
 async def test_register_listener_inserts_and_returns_id(
     telemetry_repo: TelemetryRepository,
@@ -58,7 +60,7 @@ async def test_register_job_persists_group(
     cursor = await telemetry_db.execute('SELECT "group" FROM scheduled_jobs WHERE id = ?', (job_id,))
     row = await cursor.fetchone()
     assert row is not None
-    assert row[0] == "morning", f"Expected group='morning', got {row[0]!r}"
+    assert row["group"] == "morning", f"Expected group='morning', got {row['group']!r}"
 
 
 async def test_register_job_persists_null_group(
@@ -72,7 +74,7 @@ async def test_register_job_persists_null_group(
     cursor = await telemetry_db.execute('SELECT "group" FROM scheduled_jobs WHERE id = ?', (job_id,))
     row = await cursor.fetchone()
     assert row is not None
-    assert row[0] is None, f"Expected group=None, got {row[0]!r}"
+    assert row["group"] is None, f"Expected group=None, got {row['group']!r}"
 
 
 async def test_register_job_persists_name_auto_true(
@@ -86,7 +88,7 @@ async def test_register_job_persists_name_auto_true(
     cursor = await telemetry_db.execute("SELECT name_auto FROM scheduled_jobs WHERE id = ?", (job_id,))
     row = await cursor.fetchone()
     assert row is not None
-    assert row[0] == 1
+    assert row["name_auto"] == 1
 
 
 async def test_register_job_persists_name_auto_false(
@@ -100,7 +102,7 @@ async def test_register_job_persists_name_auto_false(
     cursor = await telemetry_db.execute("SELECT name_auto FROM scheduled_jobs WHERE id = ?", (job_id,))
     row = await cursor.fetchone()
     assert row is not None
-    assert row[0] == 0
+    assert row["name_auto"] == 0
 
 
 async def test_mark_job_cancelled_sets_cancelled_at(
@@ -114,7 +116,7 @@ async def test_mark_job_cancelled_sets_cancelled_at(
     cursor = await telemetry_db.execute("SELECT cancelled_at FROM scheduled_jobs WHERE id = ?", (job_id,))
     row = await cursor.fetchone()
     assert row is not None
-    assert row[0] is None, "cancelled_at should be NULL before cancellation"
+    assert row["cancelled_at"] is None, "cancelled_at should be NULL before cancellation"
 
     before_ts = time.time()
     await telemetry_repo.mark_job_cancelled(job_id)
@@ -123,8 +125,10 @@ async def test_mark_job_cancelled_sets_cancelled_at(
     cursor = await telemetry_db.execute("SELECT cancelled_at FROM scheduled_jobs WHERE id = ?", (job_id,))
     row = await cursor.fetchone()
     assert row is not None
-    assert row[0] is not None, "cancelled_at should be set after mark_job_cancelled()"
-    assert before_ts <= row[0] <= after_ts, f"cancelled_at={row[0]} should be between {before_ts} and {after_ts}"
+    assert row["cancelled_at"] is not None, "cancelled_at should be set after mark_job_cancelled()"
+    assert before_ts <= row["cancelled_at"] <= after_ts, (
+        f"cancelled_at={row['cancelled_at']} should be between {before_ts} and {after_ts}"
+    )
 
 
 async def test_reconcile_deletes_stale_without_history(
@@ -137,13 +141,13 @@ async def test_reconcile_deletes_stale_without_history(
 
     await telemetry_repo.reconcile_registrations(DEFAULT_TEST_APP_KEY, [], [])
 
-    cursor = await telemetry_db.execute("SELECT COUNT(*) FROM listeners WHERE id = ?", (listener_id,))
+    cursor = await telemetry_db.execute("SELECT COUNT(*) AS count FROM listeners WHERE id = ?", (listener_id,))
     row = await cursor.fetchone()
-    assert row[0] == 0, "Stale listener without history should be deleted"
+    assert row["count"] == 0, "Stale listener without history should be deleted"
 
-    cursor = await telemetry_db.execute("SELECT COUNT(*) FROM scheduled_jobs WHERE id = ?", (job_id,))
+    cursor = await telemetry_db.execute("SELECT COUNT(*) AS count FROM scheduled_jobs WHERE id = ?", (job_id,))
     row = await cursor.fetchone()
-    assert row[0] == 0, "Stale job without history should be deleted"
+    assert row["count"] == 0, "Stale job without history should be deleted"
 
 
 async def test_reconcile_retires_stale_with_history(
@@ -173,12 +177,12 @@ async def test_reconcile_retires_stale_with_history(
     cursor = await telemetry_db.execute("SELECT retired_at FROM listeners WHERE id = ?", (listener_id,))
     row = await cursor.fetchone()
     assert row is not None
-    assert row[0] is not None, "Stale listener with history should have retired_at set"
+    assert row["retired_at"] is not None, "Stale listener with history should have retired_at set"
 
     cursor = await telemetry_db.execute("SELECT retired_at FROM scheduled_jobs WHERE id = ?", (job_id,))
     row = await cursor.fetchone()
     assert row is not None
-    assert row[0] is not None, "Stale job with history should have retired_at set"
+    assert row["retired_at"] is not None, "Stale job with history should have retired_at set"
 
 
 async def test_reconcile_preserves_live_listeners(
@@ -193,13 +197,13 @@ async def test_reconcile_preserves_live_listeners(
 
     await telemetry_repo.reconcile_registrations(DEFAULT_TEST_APP_KEY, [id_a], [])
 
-    cursor = await telemetry_db.execute("SELECT COUNT(*) FROM listeners WHERE id = ?", (id_a,))
+    cursor = await telemetry_db.execute("SELECT COUNT(*) AS count FROM listeners WHERE id = ?", (id_a,))
     row = await cursor.fetchone()
-    assert row[0] == 1, "Live listener should be preserved"
+    assert row["count"] == 1, "Live listener should be preserved"
 
-    cursor = await telemetry_db.execute("SELECT COUNT(*) FROM listeners WHERE id = ?", (id_b,))
+    cursor = await telemetry_db.execute("SELECT COUNT(*) AS count FROM listeners WHERE id = ?", (id_b,))
     row = await cursor.fetchone()
-    assert row[0] == 0, "Stale listener without history should be deleted"
+    assert row["count"] == 0, "Stale listener without history should be deleted"
 
 
 @pytest.mark.usefixtures("telemetry_session_id")
@@ -208,7 +212,7 @@ async def test_reconcile_deletes_once_true_previous_session(
     telemetry_db: aiosqlite.Connection,
 ) -> None:
     """reconcile_registrations() deletes once=True rows from previous sessions (no current executions)."""
-    once_reg = make_listener_registration(once=True, name="test_app.on_event.once")
+    once_reg = make_listener_registration(once=True, name=ONCE_LISTENER_NAME)
     once_id = await telemetry_repo.register_listener(once_reg)
 
     now = time.time()
@@ -222,9 +226,9 @@ async def test_reconcile_deletes_once_true_previous_session(
 
     await telemetry_repo.reconcile_registrations(DEFAULT_TEST_APP_KEY, [], [], session_id=new_session_id)
 
-    cursor = await telemetry_db.execute("SELECT COUNT(*) FROM listeners WHERE id = ?", (once_id,))
+    cursor = await telemetry_db.execute("SELECT COUNT(*) AS count FROM listeners WHERE id = ?", (once_id,))
     row = await cursor.fetchone()
-    assert row[0] == 0, "once=True listener from previous session should be deleted"
+    assert row["count"] == 0, "once=True listener from previous session should be deleted"
 
 
 async def test_reconcile_preserves_once_true_with_current_executions(
@@ -233,7 +237,7 @@ async def test_reconcile_preserves_once_true_with_current_executions(
     telemetry_session_id: int,
 ) -> None:
     """reconcile_registrations() preserves once=True rows that have current-session executions."""
-    once_reg = make_listener_registration(once=True, name="test_app.on_event.once")
+    once_reg = make_listener_registration(once=True, name=ONCE_LISTENER_NAME)
     once_id = await telemetry_repo.register_listener(once_reg)
 
     # Create an execution in the CURRENT session
@@ -246,9 +250,9 @@ async def test_reconcile_preserves_once_true_with_current_executions(
 
     await telemetry_repo.reconcile_registrations(DEFAULT_TEST_APP_KEY, [], [], session_id=telemetry_session_id)
 
-    cursor = await telemetry_db.execute("SELECT COUNT(*) FROM listeners WHERE id = ?", (once_id,))
+    cursor = await telemetry_db.execute("SELECT COUNT(*) AS count FROM listeners WHERE id = ?", (once_id,))
     row = await cursor.fetchone()
-    assert row[0] == 1, "once=True listener with current-session executions should be preserved"
+    assert row["count"] == 1, "once=True listener with current-session executions should be preserved"
 
 
 async def test_reconcile_empty_ids_no_crash(
@@ -280,7 +284,7 @@ async def test_reconcile_resets_retired_at_on_reupsert(
     cursor = await telemetry_db.execute("SELECT retired_at FROM listeners WHERE id = ?", (listener_id,))
     row = await cursor.fetchone()
     assert row is not None
-    assert row[0] is not None, "Row should be retired after reconciliation"
+    assert row["retired_at"] is not None, "Row should be retired after reconciliation"
 
     new_id = await telemetry_repo.register_listener(reg)
     assert new_id == listener_id, "Re-upsert should return the same ID"
@@ -288,7 +292,7 @@ async def test_reconcile_resets_retired_at_on_reupsert(
     cursor = await telemetry_db.execute("SELECT retired_at FROM listeners WHERE id = ?", (listener_id,))
     row = await cursor.fetchone()
     assert row is not None
-    assert row[0] is None, "retired_at should be reset to NULL after re-upsert"
+    assert row["retired_at"] is None, "retired_at should be reset to NULL after re-upsert"
 
 
 async def test_upsert_same_natural_key_returns_same_id(
@@ -296,18 +300,18 @@ async def test_upsert_same_natural_key_returns_same_id(
 ) -> None:
     """register_listener() with same natural key returns the same ID (upsert)."""
     reg = make_listener_registration()
-    id1 = await telemetry_repo.register_listener(reg)
-    id2 = await telemetry_repo.register_listener(reg)
-    assert id1 == id2
+    id_a = await telemetry_repo.register_listener(reg)
+    id_b = await telemetry_repo.register_listener(reg)
+    assert id_a == id_b
 
 
 async def test_upsert_different_natural_key_returns_new_id(
     telemetry_repo: TelemetryRepository,
 ) -> None:
     """register_listener() with different topic returns a new ID."""
-    id1 = await telemetry_repo.register_listener(make_listener_registration(topic="topic.a", name="test_app.on_a"))
-    id2 = await telemetry_repo.register_listener(make_listener_registration(topic="topic.b", name="test_app.on_b"))
-    assert id1 != id2
+    id_a = await telemetry_repo.register_listener(make_listener_registration(topic="topic.a", name="test_app.on_a"))
+    id_b = await telemetry_repo.register_listener(make_listener_registration(topic="topic.b", name="test_app.on_b"))
+    assert id_a != id_b
 
 
 async def test_upsert_updates_mutable_fields(
@@ -319,13 +323,13 @@ async def test_upsert_updates_mutable_fields(
     listener_id = await telemetry_repo.register_listener(reg)
 
     updated_reg = make_listener_registration(debounce=5.0)
-    id2 = await telemetry_repo.register_listener(updated_reg)
-    assert id2 == listener_id
+    new_id = await telemetry_repo.register_listener(updated_reg)
+    assert new_id == listener_id
 
     cursor = await telemetry_db.execute("SELECT debounce FROM listeners WHERE id = ?", (listener_id,))
     row = await cursor.fetchone()
     assert row is not None
-    assert row[0] == 5.0
+    assert row["debounce"] == 5.0
 
 
 async def test_once_true_upserts_by_name_topic(
@@ -334,14 +338,14 @@ async def test_once_true_upserts_by_name_topic(
 ) -> None:
     """once=True listeners with a name upsert on (name, topic) like once=False listeners."""
     # Two registrations with same name+topic — should upsert to same row
-    once_reg = make_listener_registration(once=True, name="test_app.on_event.once")
-    id1 = await telemetry_repo.register_listener(once_reg)
-    id2 = await telemetry_repo.register_listener(once_reg)
-    assert id1 == id2
+    once_reg = make_listener_registration(once=True, name=ONCE_LISTENER_NAME)
+    id_a = await telemetry_repo.register_listener(once_reg)
+    id_b = await telemetry_repo.register_listener(once_reg)
+    assert id_a == id_b
 
-    cursor = await telemetry_db.execute("SELECT COUNT(*) FROM listeners WHERE name = 'test_app.on_event.once'")
+    cursor = await telemetry_db.execute("SELECT COUNT(*) AS count FROM listeners WHERE name = ?", (ONCE_LISTENER_NAME,))
     row = await cursor.fetchone()
-    assert row[0] == 1, "Upsert should produce a single row, not two inserts"
+    assert row["count"] == 1, "Upsert should produce a single row, not two inserts"
 
 
 async def test_upsert_does_not_update_human_description(
@@ -353,13 +357,13 @@ async def test_upsert_does_not_update_human_description(
     listener_id = await telemetry_repo.register_listener(reg)
 
     reg2 = make_listener_registration(human_description="entity light.kitchen")
-    id2 = await telemetry_repo.register_listener(reg2)
-    assert id2 == listener_id
+    new_id = await telemetry_repo.register_listener(reg2)
+    assert new_id == listener_id
 
     cursor = await telemetry_db.execute("SELECT human_description FROM listeners WHERE id = ?", (listener_id,))
     row = await cursor.fetchone()
     assert row is not None
-    assert row[0] == "entity light.kitchen"
+    assert row["human_description"] == "entity light.kitchen"
 
 
 async def test_upsert_with_name_overrides_key(
@@ -458,9 +462,9 @@ async def test_persist_execution_batch_handles_empty_list(
     """persist_execution_batch() with empty list completes without error and inserts nothing."""
     await telemetry_repo.persist_execution_batch([])
 
-    cursor = await telemetry_db.execute("SELECT COUNT(*) FROM executions")
+    cursor = await telemetry_db.execute("SELECT COUNT(*) AS count FROM executions")
     row = await cursor.fetchone()
-    assert row[0] == 0
+    assert row["count"] == 0
 
 
 async def test_persist_execution_batch_unified(
@@ -561,13 +565,13 @@ async def test_reconcile_deletes_stale_job_not_in_live_set(
 
     await telemetry_repo.reconcile_registrations(DEFAULT_TEST_APP_KEY, [], [job_id_a])
 
-    cursor = await telemetry_db.execute("SELECT COUNT(*) FROM scheduled_jobs WHERE id = ?", (job_id_a,))
+    cursor = await telemetry_db.execute("SELECT COUNT(*) AS count FROM scheduled_jobs WHERE id = ?", (job_id_a,))
     row = await cursor.fetchone()
-    assert row[0] == 1, "Live job should be preserved"
+    assert row["count"] == 1, "Live job should be preserved"
 
-    cursor = await telemetry_db.execute("SELECT COUNT(*) FROM scheduled_jobs WHERE id = ?", (job_id_b,))
+    cursor = await telemetry_db.execute("SELECT COUNT(*) AS count FROM scheduled_jobs WHERE id = ?", (job_id_b,))
     row = await cursor.fetchone()
-    assert row[0] == 0, "Stale job without history should be deleted (non-empty live_job_ids branch)"
+    assert row["count"] == 0, "Stale job without history should be deleted (non-empty live_job_ids branch)"
 
 
 async def test_reconcile_retires_stale_job_with_history_non_empty_live_set(
@@ -591,12 +595,14 @@ async def test_reconcile_retires_stale_job_with_history_non_empty_live_set(
     cursor = await telemetry_db.execute("SELECT retired_at FROM scheduled_jobs WHERE id = ?", (job_id_b,))
     row = await cursor.fetchone()
     assert row is not None
-    assert row[0] is not None, "Stale job with history should have retired_at set (non-empty live_job_ids branch)"
+    assert row["retired_at"] is not None, (
+        "Stale job with history should have retired_at set (non-empty live_job_ids branch)"
+    )
 
     cursor = await telemetry_db.execute("SELECT retired_at FROM scheduled_jobs WHERE id = ?", (job_id_a,))
     row = await cursor.fetchone()
     assert row is not None
-    assert row[0] is None, "Live job should not be retired"
+    assert row["retired_at"] is None, "Live job should not be retired"
 
 
 async def test_reconcile_once_true_delete_non_empty_live_listener_ids(
@@ -607,7 +613,7 @@ async def test_reconcile_once_true_delete_non_empty_live_listener_ids(
     live_reg = make_listener_registration(topic="topic.live", name="test_app.live")
     live_id = await telemetry_repo.register_listener(live_reg)
 
-    once_reg = make_listener_registration(once=True, name="test_app.on_event.once")
+    once_reg = make_listener_registration(once=True, name=ONCE_LISTENER_NAME)
     once_id = await telemetry_repo.register_listener(once_reg)
 
     now = time.time()
@@ -621,15 +627,15 @@ async def test_reconcile_once_true_delete_non_empty_live_listener_ids(
 
     await telemetry_repo.reconcile_registrations(DEFAULT_TEST_APP_KEY, [live_id], [], session_id=new_session_id)
 
-    cursor = await telemetry_db.execute("SELECT COUNT(*) FROM listeners WHERE id = ?", (once_id,))
+    cursor = await telemetry_db.execute("SELECT COUNT(*) AS count FROM listeners WHERE id = ?", (once_id,))
     row = await cursor.fetchone()
-    assert row[0] == 0, (
+    assert row["count"] == 0, (
         "once=True listener from previous session should be deleted (non-empty live_listener_ids branch)"
     )
 
-    cursor = await telemetry_db.execute("SELECT COUNT(*) FROM listeners WHERE id = ?", (live_id,))
+    cursor = await telemetry_db.execute("SELECT COUNT(*) AS count FROM listeners WHERE id = ?", (live_id,))
     row = await cursor.fetchone()
-    assert row[0] == 1, "Live listener should be preserved"
+    assert row["count"] == 1, "Live listener should be preserved"
 
 
 async def test_mark_listener_cancelled_sets_cancelled_at(
@@ -643,7 +649,7 @@ async def test_mark_listener_cancelled_sets_cancelled_at(
     cursor = await telemetry_db.execute("SELECT cancelled_at FROM listeners WHERE id = ?", (listener_id,))
     row = await cursor.fetchone()
     assert row is not None
-    assert row[0] is None, "cancelled_at should be NULL before cancellation"
+    assert row["cancelled_at"] is None, "cancelled_at should be NULL before cancellation"
 
     before_ts = time.time()
     await telemetry_repo.mark_listener_cancelled(listener_id)
@@ -652,8 +658,8 @@ async def test_mark_listener_cancelled_sets_cancelled_at(
     cursor = await telemetry_db.execute("SELECT cancelled_at FROM listeners WHERE id = ?", (listener_id,))
     row = await cursor.fetchone()
     assert row is not None
-    assert row[0] is not None, "cancelled_at should be set after mark_listener_cancelled()"
-    assert before_ts <= row[0] <= after_ts
+    assert row["cancelled_at"] is not None, "cancelled_at should be set after mark_listener_cancelled()"
+    assert before_ts <= row["cancelled_at"] <= after_ts
 
 
 async def test_register_listener_clears_cancelled_at_on_reregistration(
@@ -669,7 +675,7 @@ async def test_register_listener_clears_cancelled_at_on_reregistration(
     cursor = await telemetry_db.execute("SELECT cancelled_at FROM listeners WHERE id = ?", (listener_id,))
     row = await cursor.fetchone()
     assert row is not None
-    assert row[0] is not None, "cancelled_at should be set after mark_listener_cancelled()"
+    assert row["cancelled_at"] is not None, "cancelled_at should be set after mark_listener_cancelled()"
 
     new_id = await telemetry_repo.register_listener(reg)
     assert new_id == listener_id, "Re-registration must preserve the row id"
@@ -677,4 +683,4 @@ async def test_register_listener_clears_cancelled_at_on_reregistration(
     cursor = await telemetry_db.execute("SELECT cancelled_at FROM listeners WHERE id = ?", (listener_id,))
     row = await cursor.fetchone()
     assert row is not None
-    assert row[0] is None, "cancelled_at should be cleared to NULL after re-registration"
+    assert row["cancelled_at"] is None, "cancelled_at should be cleared to NULL after re-registration"

--- a/tests/unit/task_bucket/test_interruptible_executor.py
+++ b/tests/unit/task_bucket/test_interruptible_executor.py
@@ -51,8 +51,8 @@ def capture_warnings(logger_name: str = _EXECUTOR_LOGGER) -> Iterator[list[loggi
     logger itself, and the logger's level is pinned to WARNING for the duration so the
     record is not filtered by an ancestor's level.
 
-    test_sync_executor_service.py works around the same ``propagate=False`` problem by
-    mock-patching the service logger's ``.warning`` method instead.
+    test_sync_executor_service_saturation.py works around the same ``propagate=False``
+    problem by mock-patching the service logger's ``.warning`` method instead.
     """
     records: list[logging.LogRecord] = []
 

--- a/tests/unit/test_sync_executor_service_saturation.py
+++ b/tests/unit/test_sync_executor_service_saturation.py
@@ -1,16 +1,6 @@
-"""Unit tests for SyncExecutorService.
+"""Unit tests for SyncExecutorService saturation warnings and shutdown behavior.
 
-Executor construction and wiring covers:
-- Executor is constructed in on_initialize (survives restart-in-place)
-- Service is registered in wire_services() and reachable via hassette.sync_executor
-- depends_on=[] (leaf dependency — no DB or other service required)
-- BusService, SchedulerService, AppHandler declare depends_on=[SyncExecutorService]
-- Dependency graph validation still passes after registration
-- Regression: restart-in-place (shutdown → initialize) rebuilds the thread pool
-- Regression: AppSync shutdown hook submitting sync work during shutdown completes
-  without RuntimeError: cannot schedule new futures after shutdown
-
-Saturation and shutdown covers:
+Covers:
 - Submission-time saturation WARNING fires near pool ceiling, rate-limited.
 - Periodic probe emits saturation WARNING even when submissions have stopped.
 - Python busy-loop worker interrupted within shutdown budget; name+stack logged.
@@ -18,7 +8,11 @@ Saturation and shutdown covers:
 - C-blocked worker (time.sleep) logged and abandoned; shutdown completes.
 - Custom max_workers and shutdown_timeout change behavior; defaults apply when unset.
 
-Uses the asyncio.Event gate pattern from CLAUDE.md to hold workers across boundaries.
+Uses the asyncio.Event/threading.Event gate pattern from CLAUDE.md to hold workers
+across boundaries.
+
+Construction, wiring, and dependency-graph tests live in
+test_sync_executor_service_wiring.py.
 """
 
 import asyncio
@@ -27,25 +21,19 @@ import os
 import sys
 import threading
 import time
-from contextvars import ContextVar
-from typing import Any, ClassVar
+from typing import Any
 from unittest.mock import MagicMock, patch
 
 import coverage
 import pytest
 from pydantic import ValidationError
 
-import hassette.context as ctx_module
 import hassette.task_bucket.interruptible_executor as ie_module
 from hassette.config import HassetteConfig
-from hassette.core.app_handler import AppHandler
-from hassette.core.bus_service import BusService
 from hassette.core.command_executor import (  # pyright: ignore[reportPrivateUsage]
     _CAPACITY_WARN_RATE_LIMIT_SECS,
     _CAPACITY_WARN_THRESHOLD,
 )
-from hassette.core.core import Hassette
-from hassette.core.scheduler_service import SchedulerService
 from hassette.core.sync_executor_service import (
     _SATURATION_PROBE_INTERVAL_SECS,
     _SATURATION_WARN_RATE_LIMIT_SECS,
@@ -53,12 +41,8 @@ from hassette.core.sync_executor_service import (
     SYNC_EXECUTOR_THREAD_NAME_PREFIX,
     SyncExecutorService,
 )
-from hassette.resources.base import Resource
-from hassette.resources.restart import RestartSpec
 from hassette.task_bucket.interruptible_executor import InterruptibleThreadPoolExecutor
 from hassette.task_bucket.task_bucket import TaskBucket
-from hassette.types.enums import RestartType
-from hassette.utils.service_utils import validate_dependency_graph
 
 # async_raise(SystemExit) into a worker stuck in a C-level call (time.sleep) deadlocks under
 # coverage's settrace tracer on Python 3.11. Python 3.12+ trace via sys.monitoring (PEP 669)
@@ -110,284 +94,6 @@ def make_service(max_workers: int = 4, shutdown_timeout: float = 5.0) -> SyncExe
     return svc
 
 
-# Class-level structure tests (no event loop needed)
-
-
-class TestSyncExecutorServiceClassAttrs:
-    def test_depends_on_is_empty(self) -> None:
-        """SyncExecutorService is a leaf dependency — no DB or other service required."""
-        assert SyncExecutorService.depends_on == []
-
-    def test_restart_spec_declared(self) -> None:
-        """restart_spec is declared directly on SyncExecutorService, not inherited."""
-        assert "restart_spec" in SyncExecutorService.__dict__
-        assert isinstance(SyncExecutorService.restart_spec, RestartSpec)
-
-    def test_restart_type_permanent(self) -> None:
-        """A long-lived executor matches the PERMANENT strategy of BusService/SchedulerService."""
-        assert SyncExecutorService.restart_spec.restart_type is RestartType.PERMANENT
-
-    def test_bus_service_depends_on_sync_executor(self) -> None:
-        """BusService declares SyncExecutorService in depends_on."""
-        assert SyncExecutorService in BusService.depends_on
-
-    def test_scheduler_service_depends_on_sync_executor(self) -> None:
-        """SchedulerService declares SyncExecutorService in depends_on."""
-        assert SyncExecutorService in SchedulerService.depends_on
-
-    def test_app_handler_depends_on_sync_executor(self) -> None:
-        """AppHandler declares SyncExecutorService in depends_on."""
-        assert SyncExecutorService in AppHandler.depends_on
-
-
-# Executor construction (no event loop needed)
-
-
-class TestExecutorConstruction:
-    def test_executor_not_available_before_initialize(self) -> None:
-        """Executor does not exist after __init__ — only after on_initialize."""
-        mock_hassette = make_sync_executor_hassette(max_workers=3)
-        svc = SyncExecutorService(mock_hassette)
-        assert not hasattr(svc, "executor")
-
-    @pytest.mark.anyio
-    async def test_executor_constructed_in_on_initialize(self) -> None:
-        """Executor is built in on_initialize, not __init__, so restart rebuilds it."""
-        mock_hassette = make_sync_executor_hassette(max_workers=3)
-        svc = SyncExecutorService(mock_hassette)
-
-        await svc.on_initialize()
-
-        assert svc.executor is not None
-        assert isinstance(svc.executor, InterruptibleThreadPoolExecutor)
-        svc.executor.shutdown(join_threads_or_timeout=False)
-
-    @pytest.mark.anyio
-    async def test_executor_uses_config_max_workers(self) -> None:
-        """Executor is constructed with max_workers from lifecycle config."""
-        mock_hassette = make_sync_executor_hassette(max_workers=7)
-        svc = SyncExecutorService(mock_hassette)
-
-        await svc.on_initialize()
-
-        assert svc.executor._max_workers == 7  # pyright: ignore[reportAttributeAccessIssue]
-        svc.executor.shutdown(join_threads_or_timeout=False)
-
-    def test_executor_thread_name_prefix(self) -> None:
-        """Worker threads get the 'hassette-sync' prefix for identifiability in logs."""
-        svc = make_service()
-
-        future = svc.executor.submit(lambda: None)
-        future.result(timeout=2.0)
-        thread_names = {t.name for t in svc.executor._threads}  # pyright: ignore[reportAttributeAccessIssue]
-        assert all("hassette-sync" in name for name in thread_names)
-        svc.executor.shutdown(join_threads_or_timeout=False)
-
-    @pytest.mark.anyio
-    async def test_restart_rebuilds_executor(self) -> None:
-        """Shutdown then on_initialize on the same instance rebuilds a usable pool."""
-        mock_hassette = make_sync_executor_hassette(max_workers=2)
-        svc = SyncExecutorService(mock_hassette)
-        await svc.on_initialize()
-
-        first_executor = svc.executor
-        result: list[str] = []
-        future = first_executor.submit(lambda: result.append("before"))
-        future.result(timeout=2.0)
-        assert result == ["before"]
-
-        await svc.on_shutdown()
-
-        with pytest.raises(RuntimeError, match="cannot schedule new futures after shutdown"):
-            first_executor.submit(lambda: None)
-
-        await svc.on_initialize()
-        assert svc.executor is not first_executor
-
-        result.clear()
-        future = svc.executor.submit(lambda: result.append("after"))
-        future.result(timeout=2.0)
-        assert result == ["after"]
-
-        svc.executor.shutdown(join_threads_or_timeout=False)
-
-
-# Dependency graph validation
-
-
-class TestDependencyGraph:
-    def test_graph_is_acyclic_with_sync_executor(self) -> None:
-        """Adding SyncExecutorService keeps the dependency graph acyclic."""
-        # Build a minimal type list matching the real registration order:
-        # SyncExecutorService (leaf) → BusService, SchedulerService, AppHandler depend on it.
-
-        class _Leaf(Resource):
-            depends_on: ClassVar[list[type[Resource]]] = []
-
-            async def on_initialize(self) -> None:
-                pass
-
-        class _Consumer(Resource):
-            depends_on: ClassVar[list[type[Resource]]] = [_Leaf]
-
-            async def on_initialize(self) -> None:
-                pass
-
-        # validate_dependency_graph raises ValueError on cycles; should not raise here.
-        validate_dependency_graph([_Leaf, _Consumer])
-
-    def test_sync_executor_is_leaf_node(self) -> None:
-        """SyncExecutorService depends on nothing — it is always a leaf in the graph."""
-        # Reachable deps of SyncExecutorService are empty.
-        all_deps: set[type[Resource]] = set()
-        for dep in SyncExecutorService.depends_on:
-            all_deps.add(dep)
-        assert SyncExecutorService not in all_deps  # no self-reference
-        assert len(SyncExecutorService.depends_on) == 0
-
-
-# wire_services() registration and hassette.sync_executor property
-
-
-@pytest.fixture(autouse=False)
-def isolated_hassette_context(monkeypatch: pytest.MonkeyPatch):
-    """Swap HASSETTE_INSTANCE and HASSETTE_CONFIG for fresh ContextVars.
-
-    wire_services() sets both globals; using fresh ContextVars per test prevents
-    bleed between tests running in the same process.  monkeypatch restores them
-    automatically after the test.
-    """
-    fresh_instance: ContextVar = ContextVar("HASSETTE_INSTANCE")
-    fresh_config: ContextVar = ContextVar("HASSETTE_CONFIG")
-    monkeypatch.setattr(ctx_module, "HASSETTE_INSTANCE", fresh_instance)
-    monkeypatch.setattr(ctx_module, "HASSETTE_CONFIG", fresh_config)
-    return fresh_instance
-    # monkeypatch auto-restores both ContextVars after the test.
-
-
-class TestWireServicesRegistration:
-    """Tests that call wire_services().
-
-    Each test uses the isolated_hassette_context fixture to avoid ContextVar bleed.
-    """
-
-    def test_sync_executor_service_registered_after_wire_services(self, isolated_hassette_context: object) -> None:
-        """After wire_services(), _sync_executor_service is populated."""
-        config = make_test_config()
-        h = Hassette(config)
-        try:
-            h.wire_services()
-            assert h._sync_executor_service is not None
-            assert isinstance(h._sync_executor_service, SyncExecutorService)
-        finally:
-            if h._sync_executor_service is not None and hasattr(h._sync_executor_service, "executor"):
-                h._sync_executor_service.executor.shutdown(join_threads_or_timeout=False)
-
-    @pytest.mark.anyio
-    async def test_sync_executor_property_returns_executor(self, isolated_hassette_context: object) -> None:
-        """hassette.sync_executor returns the InterruptibleThreadPoolExecutor after initialization."""
-        config = make_test_config()
-        h = Hassette(config)
-        try:
-            h.wire_services()
-            await h._sync_executor_service.on_initialize()
-            executor = h.sync_executor
-            assert isinstance(executor, InterruptibleThreadPoolExecutor)
-        finally:
-            if h._sync_executor_service is not None and hasattr(h._sync_executor_service, "executor"):
-                h._sync_executor_service.executor.shutdown(join_threads_or_timeout=False)
-
-    def test_sync_executor_property_raises_before_wire_services(self) -> None:
-        """hassette.sync_executor raises RuntimeError when wire_services() hasn't been called."""
-        config = make_test_config()
-        h = Hassette(config)
-        with pytest.raises(RuntimeError, match="wire_services"):
-            _ = h.sync_executor
-
-    def test_sync_executor_service_property_returns_service(self, isolated_hassette_context: object) -> None:
-        """hassette.sync_executor_service returns the SyncExecutorService instance."""
-        config = make_test_config()
-        h = Hassette(config)
-        try:
-            h.wire_services()
-            svc = h.sync_executor_service
-            assert isinstance(svc, SyncExecutorService)
-        finally:
-            if h._sync_executor_service is not None and hasattr(h._sync_executor_service, "executor"):
-                h._sync_executor_service.executor.shutdown(join_threads_or_timeout=False)
-
-    def test_sync_executor_service_property_raises_before_wire_services(self) -> None:
-        """hassette.sync_executor_service raises RuntimeError before wire_services()."""
-        config = make_test_config()
-        h = Hassette(config)
-        with pytest.raises(RuntimeError, match="wire_services"):
-            _ = h.sync_executor_service
-
-    def test_wire_services_graph_validates_without_error(self, isolated_hassette_context: object) -> None:
-        """wire_services() completes without ValueError from the dependency graph validator."""
-        config = make_test_config()
-        h = Hassette(config)
-        try:
-            # Should not raise — SyncExecutorService is a leaf, graph stays acyclic.
-            h.wire_services()
-        finally:
-            if h._sync_executor_service is not None and hasattr(h._sync_executor_service, "executor"):
-                h._sync_executor_service.executor.shutdown(join_threads_or_timeout=False)
-
-
-# Shutdown regression: AppSync hook submits work during shutdown
-
-
-class TestShutdownOrderingRegression:
-    """Regression test for Finding 1: AppSync shutdown hook submits to an already-closed pool.
-
-    With Bus/Scheduler/AppHandler depending on SyncExecutorService, wave-based shutdown
-    tears them down *before* the executor — so sync submissions during their shutdown
-    hooks run against a live pool, not a closed one.
-
-    This test simulates the race by submitting work to the executor *after* the
-    shutdown_event fires (mimicking an AppSync on_shutdown hook) and confirms no
-    RuntimeError is raised. The *structural* ordering guarantee (executor in an
-    earlier shutdown wave) is enforced by the `depends_on` class-attribute tests in
-    TestSyncExecutorServiceClassAttrs; this test verifies the runtime consequence —
-    a live pool accepts work during consumer shutdown.
-    """
-
-    def test_executor_accepts_work_during_consumers_shutdown(self) -> None:
-        """Executor stays alive while its consumers (Bus/Scheduler/AppHandler) shut down.
-
-        Simulates an AppSync shutdown hook calling run_in_thread after shutdown_event
-        is set.  Because the executor shuts down *after* its consumers, the submit
-        must succeed — not raise RuntimeError: cannot schedule new futures after shutdown.
-        """
-        svc = make_service(max_workers=2, shutdown_timeout=2.0)
-
-        # Simulate: shutdown_event fires (consumers are being torn down)
-        svc.hassette.shutdown_event.set()
-
-        # The executor itself has NOT been shut down yet — it outlives consumers.
-        # An AppSync on_shutdown hook submits sync work at this point.
-        result: list[str] = []
-        future = svc.executor.submit(lambda: result.append("ran"))
-        future.result(timeout=2.0)
-
-        assert result == ["ran"], "Sync work submitted during consumer shutdown must complete"
-
-        # Now shut down the executor (what SyncExecutorService.on_shutdown does).
-        svc.executor.shutdown(timeout=2.0)
-
-    def test_submit_after_executor_shutdown_raises(self) -> None:
-        """Confirms baseline: submitting to a *closed* executor raises RuntimeError.
-
-        This is the failure mode the depends_on ordering prevents.
-        """
-        svc = make_service()
-        svc.executor.shutdown(timeout=1.0)
-
-        with pytest.raises(RuntimeError, match="cannot schedule new futures after shutdown"):
-            svc.executor.submit(lambda: None)
-
-
 # on_shutdown uses configured budget
 
 
@@ -417,10 +123,6 @@ class TestOnShutdown:
         mock_hassette = make_sync_executor_hassette()
         svc = SyncExecutorService(mock_hassette)
         await svc.on_shutdown()
-
-
-# SyncExecutorService's restart_spec is covered by the parametrized tests in
-# test_service_restart_specs.py (ALL_SERVICES now includes it) — no duplicate here.
 
 
 # Saturation warnings and shutdown interruption

--- a/tests/unit/test_sync_executor_service_saturation.py
+++ b/tests/unit/test_sync_executor_service_saturation.py
@@ -22,7 +22,7 @@ import sys
 import threading
 import time
 from typing import Any
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 import coverage
 import pytest
@@ -38,11 +38,11 @@ from hassette.core.sync_executor_service import (
     _SATURATION_PROBE_INTERVAL_SECS,
     _SATURATION_WARN_RATE_LIMIT_SECS,
     _SATURATION_WARN_THRESHOLD,
-    SYNC_EXECUTOR_THREAD_NAME_PREFIX,
     SyncExecutorService,
 )
 from hassette.task_bucket.interruptible_executor import InterruptibleThreadPoolExecutor
 from hassette.task_bucket.task_bucket import TaskBucket
+from tests.unit.conftest import TEST_TOKEN, make_service, make_sync_executor_hassette
 
 # async_raise(SystemExit) into a worker stuck in a C-level call (time.sleep) deadlocks under
 # coverage's settrace tracer on Python 3.11. Python 3.12+ trace via sys.monitoring (PEP 669)
@@ -52,47 +52,6 @@ skip_c_blocked_under_coverage_py311 = pytest.mark.skipif(
     sys.version_info < (3, 12) and coverage.Coverage.current() is not None,
     reason="async_raise into a C-blocked worker deadlocks under coverage's settrace tracer on Python 3.11",
 )
-
-# Helpers
-
-
-def make_test_config(max_workers: int = 4, shutdown_timeout: float = 5.0) -> HassetteConfig:
-    """Build a minimal HassetteConfig for unit tests."""
-    return HassetteConfig(
-        token="test-token",
-        lifecycle={
-            "sync_executor_max_workers": max_workers,
-            "sync_executor_shutdown_timeout_seconds": shutdown_timeout,
-        },
-    )
-
-
-def make_sync_executor_hassette(max_workers: int = 4, shutdown_timeout: float = 5.0) -> MagicMock:
-    """Build a mock Hassette configured for SyncExecutorService tests."""
-    config = make_test_config(max_workers=max_workers, shutdown_timeout=shutdown_timeout)
-    mock_hassette = MagicMock()
-    mock_hassette.config = config
-    mock_hassette.task_bucket = MagicMock()
-    mock_hassette.shutdown_event = asyncio.Event()
-    mock_hassette.children = []
-    mock_hassette._should_skip_dependency_check = MagicMock(return_value=True)
-    return mock_hassette
-
-
-def make_service(max_workers: int = 4, shutdown_timeout: float = 5.0) -> SyncExecutorService:
-    """Build a SyncExecutorService with executor ready for use.
-
-    Constructs the executor inline (simulating on_initialize) so sync tests
-    can use the service without entering an async context.
-    """
-    mock_hassette = make_sync_executor_hassette(max_workers=max_workers, shutdown_timeout=shutdown_timeout)
-    svc = SyncExecutorService(mock_hassette)
-    svc.executor = InterruptibleThreadPoolExecutor(
-        max_workers=mock_hassette.config.lifecycle.sync_executor_max_workers,
-        thread_name_prefix=SYNC_EXECUTOR_THREAD_NAME_PREFIX,
-    )
-    return svc
-
 
 # on_shutdown uses configured budget
 
@@ -646,7 +605,7 @@ class TestConfigBehavior:
 
     def test_default_max_workers_is_reasonable(self) -> None:
         """Default max_workers is min(32, cpu_count + 4) — a reasonable pool ceiling."""
-        config = HassetteConfig(token="test-token")
+        config = HassetteConfig(token=TEST_TOKEN)
         expected = min(32, (os.cpu_count() or 1) + 4)
         assert config.lifecycle.sync_executor_max_workers == expected
 
@@ -672,14 +631,14 @@ class TestConfigBehavior:
 
     def test_default_shutdown_timeout_is_10s(self) -> None:
         """Default sync_executor_shutdown_timeout_seconds is 10.0 (HA's value)."""
-        config = HassetteConfig(token="test-token")
+        config = HassetteConfig(token=TEST_TOKEN)
         assert config.lifecycle.sync_executor_shutdown_timeout_seconds == 10.0
 
     def test_validator_rejects_shutdown_timeout_gte_total(self) -> None:
         """sync_executor_shutdown_timeout_seconds >= total_shutdown_timeout_seconds is rejected."""
         with pytest.raises(ValidationError, match="sync_executor_shutdown_timeout_seconds"):
             HassetteConfig(
-                token="test-token",
+                token=TEST_TOKEN,
                 lifecycle={
                     "sync_executor_shutdown_timeout_seconds": 30.0,
                     "total_shutdown_timeout_seconds": 30,  # equal — must be rejected

--- a/tests/unit/test_sync_executor_service_wiring.py
+++ b/tests/unit/test_sync_executor_service_wiring.py
@@ -14,66 +14,23 @@ Saturation warnings, shutdown-interruption, and config-driven behavior tests liv
 test_sync_executor_service_saturation.py.
 """
 
-import asyncio
 from contextvars import ContextVar
 from typing import ClassVar
-from unittest.mock import MagicMock
 
 import pytest
 
 import hassette.context as ctx_module
-from hassette.config import HassetteConfig
 from hassette.core.app_handler import AppHandler
 from hassette.core.bus_service import BusService
 from hassette.core.core import Hassette
 from hassette.core.scheduler_service import SchedulerService
-from hassette.core.sync_executor_service import SYNC_EXECUTOR_THREAD_NAME_PREFIX, SyncExecutorService
+from hassette.core.sync_executor_service import SyncExecutorService
 from hassette.resources.base import Resource
 from hassette.resources.restart import RestartSpec
 from hassette.task_bucket.interruptible_executor import InterruptibleThreadPoolExecutor
 from hassette.types.enums import RestartType
 from hassette.utils.service_utils import validate_dependency_graph
-
-# Helpers
-
-
-def make_test_config(max_workers: int = 4, shutdown_timeout: float = 5.0) -> HassetteConfig:
-    """Build a minimal HassetteConfig for unit tests."""
-    return HassetteConfig(
-        token="test-token",
-        lifecycle={
-            "sync_executor_max_workers": max_workers,
-            "sync_executor_shutdown_timeout_seconds": shutdown_timeout,
-        },
-    )
-
-
-def make_sync_executor_hassette(max_workers: int = 4, shutdown_timeout: float = 5.0) -> MagicMock:
-    """Build a mock Hassette configured for SyncExecutorService tests."""
-    config = make_test_config(max_workers=max_workers, shutdown_timeout=shutdown_timeout)
-    mock_hassette = MagicMock()
-    mock_hassette.config = config
-    mock_hassette.task_bucket = MagicMock()
-    mock_hassette.shutdown_event = asyncio.Event()
-    mock_hassette.children = []
-    mock_hassette._should_skip_dependency_check = MagicMock(return_value=True)
-    return mock_hassette
-
-
-def make_service(max_workers: int = 4, shutdown_timeout: float = 5.0) -> SyncExecutorService:
-    """Build a SyncExecutorService with executor ready for use.
-
-    Constructs the executor inline (simulating on_initialize) so sync tests
-    can use the service without entering an async context.
-    """
-    mock_hassette = make_sync_executor_hassette(max_workers=max_workers, shutdown_timeout=shutdown_timeout)
-    svc = SyncExecutorService(mock_hassette)
-    svc.executor = InterruptibleThreadPoolExecutor(
-        max_workers=mock_hassette.config.lifecycle.sync_executor_max_workers,
-        thread_name_prefix=SYNC_EXECUTOR_THREAD_NAME_PREFIX,
-    )
-    return svc
-
+from tests.unit.conftest import make_service, make_sync_executor_hassette, make_test_config
 
 # Class-level structure tests (no event loop needed)
 

--- a/tests/unit/test_sync_executor_service_wiring.py
+++ b/tests/unit/test_sync_executor_service_wiring.py
@@ -1,0 +1,357 @@
+"""Unit tests for SyncExecutorService construction, wiring, and dependency graph.
+
+Covers:
+- Executor is constructed in on_initialize (survives restart-in-place)
+- Service is registered in wire_services() and reachable via hassette.sync_executor
+- depends_on=[] (leaf dependency — no DB or other service required)
+- BusService, SchedulerService, AppHandler declare depends_on=[SyncExecutorService]
+- Dependency graph validation still passes after registration
+- Regression: restart-in-place (shutdown → initialize) rebuilds the thread pool
+- Regression: AppSync shutdown hook submitting sync work during shutdown completes
+  without RuntimeError: cannot schedule new futures after shutdown
+
+Saturation warnings, shutdown-interruption, and config-driven behavior tests live in
+test_sync_executor_service_saturation.py.
+"""
+
+import asyncio
+from contextvars import ContextVar
+from typing import ClassVar
+from unittest.mock import MagicMock
+
+import pytest
+
+import hassette.context as ctx_module
+from hassette.config import HassetteConfig
+from hassette.core.app_handler import AppHandler
+from hassette.core.bus_service import BusService
+from hassette.core.core import Hassette
+from hassette.core.scheduler_service import SchedulerService
+from hassette.core.sync_executor_service import SYNC_EXECUTOR_THREAD_NAME_PREFIX, SyncExecutorService
+from hassette.resources.base import Resource
+from hassette.resources.restart import RestartSpec
+from hassette.task_bucket.interruptible_executor import InterruptibleThreadPoolExecutor
+from hassette.types.enums import RestartType
+from hassette.utils.service_utils import validate_dependency_graph
+
+# Helpers
+
+
+def make_test_config(max_workers: int = 4, shutdown_timeout: float = 5.0) -> HassetteConfig:
+    """Build a minimal HassetteConfig for unit tests."""
+    return HassetteConfig(
+        token="test-token",
+        lifecycle={
+            "sync_executor_max_workers": max_workers,
+            "sync_executor_shutdown_timeout_seconds": shutdown_timeout,
+        },
+    )
+
+
+def make_sync_executor_hassette(max_workers: int = 4, shutdown_timeout: float = 5.0) -> MagicMock:
+    """Build a mock Hassette configured for SyncExecutorService tests."""
+    config = make_test_config(max_workers=max_workers, shutdown_timeout=shutdown_timeout)
+    mock_hassette = MagicMock()
+    mock_hassette.config = config
+    mock_hassette.task_bucket = MagicMock()
+    mock_hassette.shutdown_event = asyncio.Event()
+    mock_hassette.children = []
+    mock_hassette._should_skip_dependency_check = MagicMock(return_value=True)
+    return mock_hassette
+
+
+def make_service(max_workers: int = 4, shutdown_timeout: float = 5.0) -> SyncExecutorService:
+    """Build a SyncExecutorService with executor ready for use.
+
+    Constructs the executor inline (simulating on_initialize) so sync tests
+    can use the service without entering an async context.
+    """
+    mock_hassette = make_sync_executor_hassette(max_workers=max_workers, shutdown_timeout=shutdown_timeout)
+    svc = SyncExecutorService(mock_hassette)
+    svc.executor = InterruptibleThreadPoolExecutor(
+        max_workers=mock_hassette.config.lifecycle.sync_executor_max_workers,
+        thread_name_prefix=SYNC_EXECUTOR_THREAD_NAME_PREFIX,
+    )
+    return svc
+
+
+# Class-level structure tests (no event loop needed)
+
+
+class TestSyncExecutorServiceClassAttrs:
+    def test_depends_on_is_empty(self) -> None:
+        """SyncExecutorService is a leaf dependency — no DB or other service required."""
+        assert SyncExecutorService.depends_on == []
+
+    def test_restart_spec_declared(self) -> None:
+        """restart_spec is declared directly on SyncExecutorService, not inherited."""
+        assert "restart_spec" in SyncExecutorService.__dict__
+        assert isinstance(SyncExecutorService.restart_spec, RestartSpec)
+
+    def test_restart_type_permanent(self) -> None:
+        """A long-lived executor matches the PERMANENT strategy of BusService/SchedulerService."""
+        assert SyncExecutorService.restart_spec.restart_type is RestartType.PERMANENT
+
+    def test_bus_service_depends_on_sync_executor(self) -> None:
+        """BusService declares SyncExecutorService in depends_on."""
+        assert SyncExecutorService in BusService.depends_on
+
+    def test_scheduler_service_depends_on_sync_executor(self) -> None:
+        """SchedulerService declares SyncExecutorService in depends_on."""
+        assert SyncExecutorService in SchedulerService.depends_on
+
+    def test_app_handler_depends_on_sync_executor(self) -> None:
+        """AppHandler declares SyncExecutorService in depends_on."""
+        assert SyncExecutorService in AppHandler.depends_on
+
+
+# SyncExecutorService's restart_spec is covered by the parametrized tests in
+# test_service_restart_specs.py (ALL_SERVICES now includes it) — no duplicate here.
+
+
+# Executor construction (no event loop needed)
+
+
+class TestExecutorConstruction:
+    def test_executor_not_available_before_initialize(self) -> None:
+        """Executor does not exist after __init__ — only after on_initialize."""
+        mock_hassette = make_sync_executor_hassette(max_workers=3)
+        svc = SyncExecutorService(mock_hassette)
+        assert not hasattr(svc, "executor")
+
+    @pytest.mark.anyio
+    async def test_executor_constructed_in_on_initialize(self) -> None:
+        """Executor is built in on_initialize, not __init__, so restart rebuilds it."""
+        mock_hassette = make_sync_executor_hassette(max_workers=3)
+        svc = SyncExecutorService(mock_hassette)
+
+        await svc.on_initialize()
+
+        assert svc.executor is not None
+        assert isinstance(svc.executor, InterruptibleThreadPoolExecutor)
+        svc.executor.shutdown(join_threads_or_timeout=False)
+
+    @pytest.mark.anyio
+    async def test_executor_uses_config_max_workers(self) -> None:
+        """Executor is constructed with max_workers from lifecycle config."""
+        mock_hassette = make_sync_executor_hassette(max_workers=7)
+        svc = SyncExecutorService(mock_hassette)
+
+        await svc.on_initialize()
+
+        assert svc.executor._max_workers == 7  # pyright: ignore[reportAttributeAccessIssue]
+        svc.executor.shutdown(join_threads_or_timeout=False)
+
+    def test_executor_thread_name_prefix(self) -> None:
+        """Worker threads get the 'hassette-sync' prefix for identifiability in logs."""
+        svc = make_service()
+
+        future = svc.executor.submit(lambda: None)
+        future.result(timeout=2.0)
+        thread_names = {t.name for t in svc.executor._threads}  # pyright: ignore[reportAttributeAccessIssue]
+        assert all("hassette-sync" in name for name in thread_names)
+        svc.executor.shutdown(join_threads_or_timeout=False)
+
+    @pytest.mark.anyio
+    async def test_restart_rebuilds_executor(self) -> None:
+        """Shutdown then on_initialize on the same instance rebuilds a usable pool."""
+        mock_hassette = make_sync_executor_hassette(max_workers=2)
+        svc = SyncExecutorService(mock_hassette)
+        await svc.on_initialize()
+
+        first_executor = svc.executor
+        result: list[str] = []
+        future = first_executor.submit(lambda: result.append("before"))
+        future.result(timeout=2.0)
+        assert result == ["before"]
+
+        await svc.on_shutdown()
+
+        with pytest.raises(RuntimeError, match="cannot schedule new futures after shutdown"):
+            first_executor.submit(lambda: None)
+
+        await svc.on_initialize()
+        assert svc.executor is not first_executor
+
+        result.clear()
+        future = svc.executor.submit(lambda: result.append("after"))
+        future.result(timeout=2.0)
+        assert result == ["after"]
+
+        svc.executor.shutdown(join_threads_or_timeout=False)
+
+
+# Dependency graph validation
+
+
+class TestDependencyGraph:
+    def test_graph_is_acyclic_with_sync_executor(self) -> None:
+        """Adding SyncExecutorService keeps the dependency graph acyclic."""
+        # Build a minimal type list matching the real registration order:
+        # SyncExecutorService (leaf) → BusService, SchedulerService, AppHandler depend on it.
+
+        class _Leaf(Resource):
+            depends_on: ClassVar[list[type[Resource]]] = []
+
+            async def on_initialize(self) -> None:
+                pass
+
+        class _Consumer(Resource):
+            depends_on: ClassVar[list[type[Resource]]] = [_Leaf]
+
+            async def on_initialize(self) -> None:
+                pass
+
+        # validate_dependency_graph raises ValueError on cycles; should not raise here.
+        validate_dependency_graph([_Leaf, _Consumer])
+
+    def test_sync_executor_is_leaf_node(self) -> None:
+        """SyncExecutorService depends on nothing — it is always a leaf in the graph."""
+        # Reachable deps of SyncExecutorService are empty.
+        all_deps: set[type[Resource]] = set()
+        for dep in SyncExecutorService.depends_on:
+            all_deps.add(dep)
+        assert SyncExecutorService not in all_deps  # no self-reference
+        assert len(SyncExecutorService.depends_on) == 0
+
+
+# wire_services() registration and hassette.sync_executor property
+
+
+@pytest.fixture(autouse=False)
+def isolated_hassette_context(monkeypatch: pytest.MonkeyPatch):
+    """Swap HASSETTE_INSTANCE and HASSETTE_CONFIG for fresh ContextVars.
+
+    wire_services() sets both globals; using fresh ContextVars per test prevents
+    bleed between tests running in the same process.  monkeypatch restores them
+    automatically after the test.
+    """
+    fresh_instance: ContextVar = ContextVar("HASSETTE_INSTANCE")
+    fresh_config: ContextVar = ContextVar("HASSETTE_CONFIG")
+    monkeypatch.setattr(ctx_module, "HASSETTE_INSTANCE", fresh_instance)
+    monkeypatch.setattr(ctx_module, "HASSETTE_CONFIG", fresh_config)
+    return fresh_instance
+    # monkeypatch auto-restores both ContextVars after the test.
+
+
+class TestWireServicesRegistration:
+    """Tests that call wire_services().
+
+    Each test uses the isolated_hassette_context fixture to avoid ContextVar bleed.
+    """
+
+    def test_sync_executor_service_registered_after_wire_services(self, isolated_hassette_context: object) -> None:
+        """After wire_services(), _sync_executor_service is populated."""
+        config = make_test_config()
+        h = Hassette(config)
+        try:
+            h.wire_services()
+            assert h._sync_executor_service is not None
+            assert isinstance(h._sync_executor_service, SyncExecutorService)
+        finally:
+            if h._sync_executor_service is not None and hasattr(h._sync_executor_service, "executor"):
+                h._sync_executor_service.executor.shutdown(join_threads_or_timeout=False)
+
+    @pytest.mark.anyio
+    async def test_sync_executor_property_returns_executor(self, isolated_hassette_context: object) -> None:
+        """hassette.sync_executor returns the InterruptibleThreadPoolExecutor after initialization."""
+        config = make_test_config()
+        h = Hassette(config)
+        try:
+            h.wire_services()
+            await h._sync_executor_service.on_initialize()
+            executor = h.sync_executor
+            assert isinstance(executor, InterruptibleThreadPoolExecutor)
+        finally:
+            if h._sync_executor_service is not None and hasattr(h._sync_executor_service, "executor"):
+                h._sync_executor_service.executor.shutdown(join_threads_or_timeout=False)
+
+    def test_sync_executor_property_raises_before_wire_services(self) -> None:
+        """hassette.sync_executor raises RuntimeError when wire_services() hasn't been called."""
+        config = make_test_config()
+        h = Hassette(config)
+        with pytest.raises(RuntimeError, match="wire_services"):
+            _ = h.sync_executor
+
+    def test_sync_executor_service_property_returns_service(self, isolated_hassette_context: object) -> None:
+        """hassette.sync_executor_service returns the SyncExecutorService instance."""
+        config = make_test_config()
+        h = Hassette(config)
+        try:
+            h.wire_services()
+            svc = h.sync_executor_service
+            assert isinstance(svc, SyncExecutorService)
+        finally:
+            if h._sync_executor_service is not None and hasattr(h._sync_executor_service, "executor"):
+                h._sync_executor_service.executor.shutdown(join_threads_or_timeout=False)
+
+    def test_sync_executor_service_property_raises_before_wire_services(self) -> None:
+        """hassette.sync_executor_service raises RuntimeError before wire_services()."""
+        config = make_test_config()
+        h = Hassette(config)
+        with pytest.raises(RuntimeError, match="wire_services"):
+            _ = h.sync_executor_service
+
+    def test_wire_services_graph_validates_without_error(self, isolated_hassette_context: object) -> None:
+        """wire_services() completes without ValueError from the dependency graph validator."""
+        config = make_test_config()
+        h = Hassette(config)
+        try:
+            # Should not raise — SyncExecutorService is a leaf, graph stays acyclic.
+            h.wire_services()
+        finally:
+            if h._sync_executor_service is not None and hasattr(h._sync_executor_service, "executor"):
+                h._sync_executor_service.executor.shutdown(join_threads_or_timeout=False)
+
+
+# Shutdown regression: AppSync hook submits work during shutdown
+
+
+class TestShutdownOrderingRegression:
+    """Regression test for Finding 1: AppSync shutdown hook submits to an already-closed pool.
+
+    With Bus/Scheduler/AppHandler depending on SyncExecutorService, wave-based shutdown
+    tears them down *before* the executor — so sync submissions during their shutdown
+    hooks run against a live pool, not a closed one.
+
+    This test simulates the race by submitting work to the executor *after* the
+    shutdown_event fires (mimicking an AppSync on_shutdown hook) and confirms no
+    RuntimeError is raised. The *structural* ordering guarantee (executor in an
+    earlier shutdown wave) is enforced by the `depends_on` class-attribute tests in
+    TestSyncExecutorServiceClassAttrs; this test verifies the runtime consequence —
+    a live pool accepts work during consumer shutdown.
+    """
+
+    def test_executor_accepts_work_during_consumers_shutdown(self) -> None:
+        """Executor stays alive while its consumers (Bus/Scheduler/AppHandler) shut down.
+
+        Simulates an AppSync shutdown hook calling run_in_thread after shutdown_event
+        is set.  Because the executor shuts down *after* its consumers, the submit
+        must succeed — not raise RuntimeError: cannot schedule new futures after shutdown.
+        """
+        svc = make_service(max_workers=2, shutdown_timeout=2.0)
+
+        # Simulate: shutdown_event fires (consumers are being torn down)
+        svc.hassette.shutdown_event.set()
+
+        # The executor itself has NOT been shut down yet — it outlives consumers.
+        # An AppSync on_shutdown hook submits sync work at this point.
+        result: list[str] = []
+        future = svc.executor.submit(lambda: result.append("ran"))
+        future.result(timeout=2.0)
+
+        assert result == ["ran"], "Sync work submitted during consumer shutdown must complete"
+
+        # Now shut down the executor (what SyncExecutorService.on_shutdown does).
+        svc.executor.shutdown(timeout=2.0)
+
+    def test_submit_after_executor_shutdown_raises(self) -> None:
+        """Confirms baseline: submitting to a *closed* executor raises RuntimeError.
+
+        This is the failure mode the depends_on ordering prevents.
+        """
+        svc = make_service()
+        svc.executor.shutdown(timeout=1.0)
+
+        with pytest.raises(RuntimeError, match="cannot schedule new futures after shutdown"):
+            svc.executor.submit(lambda: None)


### PR DESCRIPTION
Clean-code cleanup pass across 11 issues filed by recent `/mine-clean-code` and nitpicker reviews. All changes are internal — no behavior change, no public API change. Backend (8700+), frontend (1350) test suites, pyright, and ruff all pass.

### Backend service refactors

- `bus_service.py`: extract `_match_listeners`, `_group_by_route`, and `_spawn_dispatch_task` out of the 82-line `dispatch()`, bringing it down to 25 lines while preserving every inline comment documenting concurrency invariants (semaphore race-freedom, `DROP_NEWEST` no-await window, spawn-failure unwind) verbatim in their new locations
- `app_lifecycle_service.py` / `websocket_service.py`: replace hardcoded cleanup timeouts with config-backed properties, extract a shared `send_and_await_response` helper to remove duplicated retry bodies, replace magic numbers with named constants, and split `serve()` and `reconcile_app_registrations()` into smaller focused methods
- `predicates.py` / `harness.py`: consolidate `_summarize_predicate`/`_summarize_condition` onto a shared `_summarize()` helper, extract a `_PredicateCombinator` base class for `AllOf`/`AnyOf`, and split `HassetteHarness.start()`/`stop()` into focused private methods; also fixes `Listener.mark_registered()` to use `self.logger` instead of the module-level logger
- Scheduler/command-executor: rename `SchedulerService.trigger_job()`'s `db_id` parameter to `job_id` to match the route layer's path parameter and REST response field naming, and consolidate duplicated `ScheduledJob` test factories behind an extended `make_real_job()`

### Frontend

- Extract a reusable `useAsyncAction` hook from `RunNowButton` and `ActionButtons`, which had near-identical inline exec wrappers managing loading state, error extraction, and double-click prevention; also adds `role="alert"` and `data-testid="action-buttons-error"` to `ActionButtons`' error display, matching the pattern already used by `RunNowButton`
- Replace inline type literals in `endpoints.ts` with the generated `ActionResponse`/`JobTriggerResponse` types, aligning endpoint wrappers with every other type alias in the file
- Tighten `ActionResponse.status`/`JobTriggerResponse.status` from bare `str` to `Literal["accepted"]`, matching the existing `LivenessResponse` pattern, and regenerate the OpenAPI spec and frontend types so the schema emits an enum instead of a plain string — this also caught three MSW mock handlers returning a `status` value ("ok") the real endpoints never send

### Test infrastructure

- `test_telemetry_repository.py`: convert positional row access (`row[0]`) to dict-style (`row["col"]`) to match the `aiosqlite.Row` row factory, extract a repeated string literal into `ONCE_LISTENER_NAME`, and standardize ID variable naming across paired-registration and re-registration scenarios
- Split the 1057-line `test_sync_executor_service.py` into `test_sync_executor_service_wiring.py` (construction, `wire_services()`, dependency-graph validation) and `test_sync_executor_service_saturation.py` (saturation warnings, periodic probe, shutdown interruption) along the boundary already named in the file's own module docstring — same 51 test functions, verified by diffing the sorted test-name sets
- Consolidate the duplicated shared test helpers (`make_test_config`, `make_sync_executor_hassette`, `make_service`, `TEST_TOKEN`) introduced by that split into `conftest.py`
- Move the shared `_migrated_db_template` fixture into `tests/conftest.py`, calling `run_migrations()` directly instead of booting a full `DatabaseService` (with a throwaway event loop) just to produce a migrated schema file

Closes #1209
Closes #1210
Closes #1214
Closes #1215
Closes #1217
Closes #1218
Closes #1219
Closes #1256
Closes #1260
Closes #1262
Closes #1265
