### PR TITLE
refactor: clean up ServiceWatcher long methods, duplication, and test boilerplate

### DIFF
--- a/src/hassette/core/service_watcher.py
+++ b/src/hassette/core/service_watcher.py
@@ -21,6 +21,7 @@ if typing.TYPE_CHECKING:
     from hassette import Hassette
 
 DEFAULT_READINESS_TIMEOUT = 30.0
+SERVICE_STATUS_PATH = "payload.data.status"
 
 
 class RestartBudget:
@@ -123,13 +124,12 @@ class ServiceWatcher(Resource):
             self._budgets[key] = RestartBudget(spec.budget_intensity, spec.budget_period_seconds)
         return self._budgets[key]
 
-    def set_service_status(self, name: str, role: object, status: ResourceStatus, context: str) -> None:
+    def set_service_status(self, name: str, role: object, status: ResourceStatus, context: str | None = None) -> None:
         """Find the service by name/role and set its status, warning if not found."""
         services = self.get_service(name, role)
         if not services:
-            self.logger.warning(
-                "No %s found for '%s' after %s, skipping %s status set", role, name, context, status.value
-            )
+            label = context if context is not None else status.name
+            self.logger.warning("No %s found for '%s' after %s, skipping status set", role, name, label)
             return
         services[0].status = status
 
@@ -154,9 +154,7 @@ class ServiceWatcher(Resource):
         role: object,
         status: ResourceStatus,
         previous_status: ResourceStatus,
-        exception: str | None = None,
-        exception_type: str | None = None,
-        exception_traceback: str | None = None,
+        source_payload: ServiceStatusPayload | None = None,
         retry_at: float | None = None,
     ) -> HassetteServiceEvent:
         """Build a HassetteServiceEvent for a service status transition."""
@@ -170,9 +168,9 @@ class ServiceWatcher(Resource):
                     role=role,  # pyright: ignore[reportArgumentType]
                     status=status,
                     previous_status=previous_status,
-                    exception=exception,
-                    exception_type=exception_type,
-                    exception_traceback=exception_traceback,
+                    exception=source_payload.exception if source_payload else None,
+                    exception_type=source_payload.exception_type if source_payload else None,
+                    exception_traceback=source_payload.exception_traceback if source_payload else None,
                     retry_at=retry_at,
                     ready=False,
                     ready_phase=None,
@@ -204,9 +202,7 @@ class ServiceWatcher(Resource):
                 role=role,
                 status=ResourceStatus.CRASHED,
                 previous_status=ResourceStatus.FAILED,
-                exception=status_payload.exception,
-                exception_type=status_payload.exception_type,
-                exception_traceback=status_payload.exception_traceback,
+                source_payload=status_payload,
             )
             await self.hassette.send_event(crashed_event)
             await self.hassette.shutdown()
@@ -225,13 +221,11 @@ class ServiceWatcher(Resource):
                 role=role,
                 status=ResourceStatus.EXHAUSTED_COOLING,
                 previous_status=ResourceStatus.FAILED,
-                exception=status_payload.exception,
-                exception_type=status_payload.exception_type,
-                exception_traceback=status_payload.exception_traceback,
+                source_payload=status_payload,
                 retry_at=retry_at,
             )
             await self.hassette.send_event(cooling_event)
-            self.set_service_status(name, role, ResourceStatus.EXHAUSTED_COOLING, "EXHAUSTED_COOLING")
+            self.set_service_status(name, role, ResourceStatus.EXHAUSTED_COOLING)
             # Cancel existing cooldown for this service if any
             existing = self._cooldown_tasks.get(key)
             if existing and not existing.done():
@@ -253,12 +247,10 @@ class ServiceWatcher(Resource):
                 role=role,
                 status=ResourceStatus.EXHAUSTED_DEAD,
                 previous_status=ResourceStatus.FAILED,
-                exception=status_payload.exception,
-                exception_type=status_payload.exception_type,
-                exception_traceback=status_payload.exception_traceback,
+                source_payload=status_payload,
             )
             await self.hassette.send_event(dead_event)
-            self.set_service_status(name, role, ResourceStatus.EXHAUSTED_DEAD, "EXHAUSTED_DEAD")
+            self.set_service_status(name, role, ResourceStatus.EXHAUSTED_DEAD)
 
     async def cooldown_and_retry(self, name: str, role: object, key: str, spec: RestartSpec) -> None:
         """Long-cooldown sleep followed by budget reset and restart attempt.
@@ -348,9 +340,7 @@ class ServiceWatcher(Resource):
                 role=role,
                 status=ResourceStatus.CRASHED,
                 previous_status=ResourceStatus.FAILED,
-                exception=status_payload.exception,
-                exception_type=status_payload.exception_type,
-                exception_traceback=status_payload.exception_traceback,
+                source_payload=status_payload,
             )
             await self.hassette.send_event(crashed_event)
             await self.hassette.shutdown()
@@ -435,9 +425,9 @@ class ServiceWatcher(Resource):
             # Step 7: Restart the service — catch and log exceptions, do NOT double-count budget.
             # Clear in-restart guard in the finally AFTER the entire loop so concurrent FAILED
             # events cannot enter restart_service() while restarts are still in progress.
-            for svc in services:
+            for service in services:
                 try:
-                    await svc.restart()
+                    await service.restart()
                 except Exception as e:
                     self.logger.error(
                         "%s '%s' restart raised an exception (service left in FAILED state): %s",
@@ -449,10 +439,11 @@ class ServiceWatcher(Resource):
             self._restarting.discard(key)
 
     async def log_service_event(self, event: HassetteServiceEvent) -> None:
-        name = event.payload.data.resource_name
-        role = event.payload.data.role
-
-        status, previous_status = event.payload.data.status, event.payload.data.previous_status
+        status_payload = event.payload.data
+        name = status_payload.resource_name
+        role = status_payload.role
+        status = status_payload.status
+        previous_status = status_payload.previous_status
 
         if status == previous_status:
             self.logger.debug("%s '%s' status unchanged at '%s', not logging", role, name, status)
@@ -462,8 +453,8 @@ class ServiceWatcher(Resource):
             "%s '%s' transitioned to status '%s' from '%s'",
             role,
             name,
-            event.payload.data.status,
-            event.payload.data.previous_status,
+            status,
+            previous_status,
         )
 
     async def shutdown_if_crashed(self, event: HassetteServiceEvent) -> None:
@@ -605,13 +596,13 @@ class ServiceWatcher(Resource):
             topic=topic,
             handler=self.restart_service,
             name="hassette.service_watcher.restart_service",
-            where=P.ValueIs(source=get_path("payload.data.status"), condition=ResourceStatus.FAILED),
+            where=P.ValueIs(source=get_path(SERVICE_STATUS_PATH), condition=ResourceStatus.FAILED),
         )
         await self.bus.on(
             topic=topic,
             handler=self.shutdown_if_crashed,
             name="hassette.service_watcher.shutdown_if_crashed",
-            where=P.ValueIs(source=get_path("payload.data.status"), condition=ResourceStatus.CRASHED),
+            where=P.ValueIs(source=get_path(SERVICE_STATUS_PATH), condition=ResourceStatus.CRASHED),
         )
         await self.bus.on(
             topic=topic,
@@ -622,13 +613,13 @@ class ServiceWatcher(Resource):
             topic=topic,
             handler=self.on_service_running,
             name="hassette.service_watcher.on_service_running",
-            where=P.ValueIs(source=get_path("payload.data.status"), condition=ResourceStatus.RUNNING),
+            where=P.ValueIs(source=get_path(SERVICE_STATUS_PATH), condition=ResourceStatus.RUNNING),
         )
         await self.bus.on(
             topic=topic,
             handler=self.on_bus_service_running,
             name="hassette.service_watcher.on_bus_service_running",
-            where=P.ValueIs(source=get_path("payload.data.status"), condition=ResourceStatus.RUNNING),
+            where=P.ValueIs(source=get_path(SERVICE_STATUS_PATH), condition=ResourceStatus.RUNNING),
         )
 
     async def on_bus_service_running(self, event: HassetteServiceEvent) -> None:

--- a/src/hassette/core/service_watcher.py
+++ b/src/hassette/core/service_watcher.py
@@ -20,6 +20,8 @@ from hassette.types.types import LOG_LEVEL_TYPE
 if typing.TYPE_CHECKING:
     from hassette import Hassette
 
+DEFAULT_READINESS_TIMEOUT = 30.0
+
 
 class RestartBudget:
     """Sliding-window restart budget tracker.
@@ -121,6 +123,16 @@ class ServiceWatcher(Resource):
             self._budgets[key] = RestartBudget(spec.budget_intensity, spec.budget_period_seconds)
         return self._budgets[key]
 
+    def set_service_status(self, name: str, role: object, status: ResourceStatus, context: str) -> None:
+        """Find the service by name/role and set its status, warning if not found."""
+        services = self.get_service(name, role)
+        if not services:
+            self.logger.warning(
+                "No %s found for '%s' after %s, skipping %s status set", role, name, context, status.value
+            )
+            return
+        services[0].status = status
+
     async def shutdown_safe_sleep(self, duration: float) -> bool:
         """Sleep for duration seconds, waking early if shutdown is requested.
 
@@ -174,7 +186,7 @@ class ServiceWatcher(Resource):
         role: object,
         key: str,
         spec: RestartSpec,
-        original_data: ServiceStatusPayload,
+        status_payload: ServiceStatusPayload,
     ) -> None:
         """Handle budget exhaustion according to restart_type."""
         if spec.restart_type == RestartType.PERMANENT:
@@ -192,9 +204,9 @@ class ServiceWatcher(Resource):
                 role=role,
                 status=ResourceStatus.CRASHED,
                 previous_status=ResourceStatus.FAILED,
-                exception=original_data.exception,
-                exception_type=original_data.exception_type,
-                exception_traceback=original_data.exception_traceback,
+                exception=status_payload.exception,
+                exception_type=status_payload.exception_type,
+                exception_traceback=status_payload.exception_traceback,
             )
             await self.hassette.send_event(crashed_event)
             await self.hassette.shutdown()
@@ -213,17 +225,13 @@ class ServiceWatcher(Resource):
                 role=role,
                 status=ResourceStatus.EXHAUSTED_COOLING,
                 previous_status=ResourceStatus.FAILED,
-                exception=original_data.exception,
-                exception_type=original_data.exception_type,
-                exception_traceback=original_data.exception_traceback,
+                exception=status_payload.exception,
+                exception_type=status_payload.exception_type,
+                exception_traceback=status_payload.exception_traceback,
                 retry_at=retry_at,
             )
             await self.hassette.send_event(cooling_event)
-            services = self.get_service(name, role)
-            if not services:
-                self.logger.warning("No %s found for '%s' after EXHAUSTED_COOLING, skipping status set", role, name)
-            else:
-                services[0].status = ResourceStatus.EXHAUSTED_COOLING
+            self.set_service_status(name, role, ResourceStatus.EXHAUSTED_COOLING, "EXHAUSTED_COOLING")
             # Cancel existing cooldown for this service if any
             existing = self._cooldown_tasks.get(key)
             if existing and not existing.done():
@@ -245,16 +253,12 @@ class ServiceWatcher(Resource):
                 role=role,
                 status=ResourceStatus.EXHAUSTED_DEAD,
                 previous_status=ResourceStatus.FAILED,
-                exception=original_data.exception,
-                exception_type=original_data.exception_type,
-                exception_traceback=original_data.exception_traceback,
+                exception=status_payload.exception,
+                exception_type=status_payload.exception_type,
+                exception_traceback=status_payload.exception_traceback,
             )
             await self.hassette.send_event(dead_event)
-            services = self.get_service(name, role)
-            if not services:
-                self.logger.warning("No %s found for '%s' after EXHAUSTED_DEAD, skipping status set", role, name)
-            else:
-                services[0].status = ResourceStatus.EXHAUSTED_DEAD
+            self.set_service_status(name, role, ResourceStatus.EXHAUSTED_DEAD, "EXHAUSTED_DEAD")
 
     async def cooldown_and_retry(self, name: str, role: object, key: str, spec: RestartSpec) -> None:
         """Long-cooldown sleep followed by budget reset and restart attempt.
@@ -279,13 +283,7 @@ class ServiceWatcher(Resource):
                 previous_status=ResourceStatus.EXHAUSTED_COOLING,
             )
             await self.hassette.send_event(dead_event)
-            services = self.get_service(name, role)
-            if not services:
-                self.logger.warning(
-                    "No %s found for '%s' after cooldown cycle limit, skipping EXHAUSTED_DEAD status set", role, name
-                )
-            else:
-                services[0].status = ResourceStatus.EXHAUSTED_DEAD
+            self.set_service_status(name, role, ResourceStatus.EXHAUSTED_DEAD, "cooldown cycle limit")
             return
 
         self.logger.info(
@@ -320,9 +318,9 @@ class ServiceWatcher(Resource):
 
     async def restart_service(self, event: HassetteServiceEvent) -> None:
         """Restart a failed service using per-service RestartSpec-driven behavior."""
-        data = event.payload.data
-        name = data.resource_name
-        role = data.role
+        status_payload = event.payload.data
+        name = status_payload.resource_name
+        role = status_payload.role
 
         key = self.service_key(name, role)
 
@@ -336,37 +334,37 @@ class ServiceWatcher(Resource):
         spec = service.restart_spec
 
         # Step 1: Check fatal errors — immediate shutdown regardless of restart type
-        if data.exception_type and data.exception_type in spec.fatal_error_names:
+        if status_payload.exception_type and status_payload.exception_type in spec.fatal_error_names:
             self.logger.error(
                 "%s '%s' raised fatal error '%s', triggering immediate shutdown",
                 role,
                 name,
-                data.exception_type,
+                status_payload.exception_type,
             )
             # Record the fatal reason synchronously (see handle_exhaustion for rationale).
-            self.hassette.record_fatal_reason(f"{role} '{name}' raised fatal error '{data.exception_type}'")
+            self.hassette.record_fatal_reason(f"{role} '{name}' raised fatal error '{status_payload.exception_type}'")
             crashed_event = self.emit_service_status_event(
                 name=name,
                 role=role,
                 status=ResourceStatus.CRASHED,
                 previous_status=ResourceStatus.FAILED,
-                exception=data.exception,
-                exception_type=data.exception_type,
-                exception_traceback=data.exception_traceback,
+                exception=status_payload.exception,
+                exception_type=status_payload.exception_type,
+                exception_traceback=status_payload.exception_traceback,
             )
             await self.hassette.send_event(crashed_event)
             await self.hassette.shutdown()
             return
 
         # Step 2: Check non-retryable errors — skip restart, go to exhaustion handling
-        if data.exception_type and data.exception_type in spec.non_retryable_error_names:
+        if status_payload.exception_type and status_payload.exception_type in spec.non_retryable_error_names:
             self.logger.warning(
                 "%s '%s' raised non-retryable error '%s', skipping restart",
                 role,
                 name,
-                data.exception_type,
+                status_payload.exception_type,
             )
-            await self.handle_exhaustion(name, role, key, spec, data)
+            await self.handle_exhaustion(name, role, key, spec, status_payload)
             return
 
         # Step 3: In-restart guard — prevent double budget depletion from concurrent FAILED events
@@ -383,7 +381,7 @@ class ServiceWatcher(Resource):
         if budget.is_exhausted():
             # Clear any stale in-restart state before handling exhaustion
             self._restarting.discard(key)
-            await self.handle_exhaustion(name, role, key, spec, data)
+            await self.handle_exhaustion(name, role, key, spec, status_payload)
             return
 
         # Step 5: Mark in-restart and record the restart
@@ -478,9 +476,9 @@ class ServiceWatcher(Resource):
         makes a crash-driven exit non-zero to external supervisors (systemd Restart=on-failure,
         Docker healthcheck).
         """
-        data = event.payload.data
-        name = data.resource_name
-        role = data.role
+        status_payload = event.payload.data
+        name = status_payload.resource_name
+        role = status_payload.role
 
         try:
             self.logger.error(
@@ -488,11 +486,11 @@ class ServiceWatcher(Resource):
                 role,
                 name,
                 event.payload.event_id,
-                data.exception_traceback,
+                status_payload.exception_traceback,
             )
             reason = f"{role} '{name}' crashed"
-            if data.exception_type:
-                reason += f": {data.exception_type}"
+            if status_payload.exception_type:
+                reason += f": {status_payload.exception_type}"
             self.hassette.record_fatal_reason(reason)
             self.hassette.request_shutdown(reason)
         except Exception as e:
@@ -501,9 +499,9 @@ class ServiceWatcher(Resource):
 
     async def on_service_running(self, event: HassetteServiceEvent) -> None:
         """Reset restart budget when a service transitions to RUNNING and becomes ready."""
-        data = event.payload.data
-        name = data.resource_name
-        role = data.role
+        status_payload = event.payload.data
+        name = status_payload.resource_name
+        role = status_payload.role
 
         key = self.service_key(name, role)
         if key not in self._budgets and key not in self._restarting:
@@ -519,7 +517,7 @@ class ServiceWatcher(Resource):
 
         # Use per-service startup_timeout_seconds from restart_spec
         spec = service.restart_spec if isinstance(service, Service) else None
-        readiness_timeout = spec.startup_timeout_seconds if spec is not None else 30.0
+        readiness_timeout = spec.startup_timeout_seconds if spec is not None else DEFAULT_READINESS_TIMEOUT
 
         # Spawn readiness check as a detached task so this handler returns
         # immediately and releases its dispatch semaphore slot.
@@ -635,7 +633,7 @@ class ServiceWatcher(Resource):
 
     async def on_bus_service_running(self, event: HassetteServiceEvent) -> None:
         """Trigger reconciliation scan when BusService recovers."""
-        data = event.payload.data
-        if data.resource_name != BusService.__name__:
+        status_payload = event.payload.data
+        if status_payload.resource_name != BusService.__name__:
             return
         await self.reconcile_after_bus_recovery()

--- a/tests/integration/test_service_watcher.py
+++ b/tests/integration/test_service_watcher.py
@@ -22,6 +22,18 @@ from hassette.types import ResourceStatus, Topic
 from hassette.types.enums import RestartType
 
 
+def make_call_counts() -> dict[str, int]:
+    """Fresh cancel/start counters for get_dummy_service."""
+    return {"cancel": 0, "start": 0}
+
+
+def make_fast_spec(**overrides: object) -> RestartSpec:
+    """RestartSpec with zero backoff for test speed. Override any field via kwargs."""
+    defaults: dict[str, object] = {"backoff_base_seconds": 0}
+    defaults.update(overrides)
+    return RestartSpec(**defaults)  # pyright: ignore[reportCallIssue]
+
+
 @pytest.fixture
 async def get_service_watcher_mock(hassette_with_bus):
     """Return a fresh service watcher for each test."""
@@ -92,17 +104,12 @@ def get_dummy_service(
 
 async def test_restart_service_cancels_then_starts(get_service_watcher_mock: ServiceWatcher):
     """Restarting a failed service cancels and reinitializes it."""
-    call_counts = {"cancel": 0, "start": 0}
+    call_counts = make_call_counts()
 
     dummy_service = get_dummy_service(
         call_counts,
         get_service_watcher_mock.hassette,
-        restart_spec=RestartSpec(
-            restart_type=RestartType.TRANSIENT,
-            backoff_base_seconds=0,
-            budget_intensity=5,
-            budget_period_seconds=300,
-        ),
+        restart_spec=make_fast_spec(restart_type=RestartType.TRANSIENT, budget_intensity=5),
     )
     get_service_watcher_mock.hassette.children.append(dummy_service)
 
@@ -124,15 +131,10 @@ async def test_always_failing_service_stops_after_max_attempts(get_service_watch
     """A service that always fails on restart stops being restarted after budget exhaustion."""
     watcher = get_service_watcher_mock
     hassette = watcher.hassette
-    call_counts = {"cancel": 0, "start": 0}
+    call_counts = make_call_counts()
 
     # budget_intensity=3 means 3 restarts before exhaustion
-    spec = RestartSpec(
-        restart_type=RestartType.PERMANENT,
-        budget_intensity=3,
-        budget_period_seconds=300,
-        backoff_base_seconds=0,
-    )
+    spec = make_fast_spec(restart_type=RestartType.PERMANENT, budget_intensity=3)
     dummy_service = get_dummy_service(call_counts, hassette, fail=True, restart_spec=spec)
     hassette.children.append(dummy_service)
 
@@ -160,14 +162,9 @@ async def test_crashed_event_emitted_before_shutdown(get_service_watcher_mock: S
     """When budget is exhausted for PERMANENT service, a CRASHED event is emitted before shutdown."""
     watcher = get_service_watcher_mock
     hassette = watcher.hassette
-    call_counts = {"cancel": 0, "start": 0}
+    call_counts = make_call_counts()
 
-    spec = RestartSpec(
-        restart_type=RestartType.PERMANENT,
-        budget_intensity=1,  # exhaust on first restart
-        budget_period_seconds=300,
-        backoff_base_seconds=0,
-    )
+    spec = make_fast_spec(restart_type=RestartType.PERMANENT, budget_intensity=1)
     dummy_service = get_dummy_service(call_counts, hassette, fail=True, restart_spec=spec)
     hassette.children.append(dummy_service)
 
@@ -198,12 +195,11 @@ async def test_crashed_event_emitted_before_shutdown(get_service_watcher_mock: S
 async def test_exponential_backoff(get_service_watcher_mock: ServiceWatcher):
     """Backoff delay increases exponentially between restart attempts (using shutdown-safe sleep)."""
     watcher = get_service_watcher_mock
-    call_counts = {"cancel": 0, "start": 0}
+    call_counts = make_call_counts()
 
-    spec = RestartSpec(
+    spec = make_fast_spec(
         restart_type=RestartType.TRANSIENT,
         budget_intensity=10,
-        budget_period_seconds=300,
         backoff_base_seconds=1.0,
         backoff_multiplier=2.0,
         backoff_max_seconds=60.0,
@@ -232,15 +228,9 @@ async def test_exponential_backoff(get_service_watcher_mock: ServiceWatcher):
 async def test_budget_reset_on_recovery(get_service_watcher_mock: ServiceWatcher):
     """Budget resets when a service transitions to RUNNING and becomes ready."""
     watcher = get_service_watcher_mock
-    call_counts = {"cancel": 0, "start": 0}
+    call_counts = make_call_counts()
 
-    spec = RestartSpec(
-        restart_type=RestartType.TRANSIENT,
-        budget_intensity=5,
-        budget_period_seconds=300,
-        backoff_base_seconds=0,
-        startup_timeout_seconds=1.0,
-    )
+    spec = make_fast_spec(restart_type=RestartType.TRANSIENT, budget_intensity=5, startup_timeout_seconds=1.0)
     dummy_service = get_dummy_service(call_counts, watcher.hassette, fail=True, restart_spec=spec)
     watcher.hassette.children.append(dummy_service)
 
@@ -267,14 +257,9 @@ async def test_permanent_exhaustion_triggers_shutdown(get_service_watcher_mock: 
     """PERMANENT service: exhausting budget triggers hassette.shutdown()."""
     watcher = get_service_watcher_mock
     hassette = watcher.hassette
-    call_counts = {"cancel": 0, "start": 0}
+    call_counts = make_call_counts()
 
-    spec = RestartSpec(
-        restart_type=RestartType.PERMANENT,
-        budget_intensity=2,
-        budget_period_seconds=300,
-        backoff_base_seconds=0,
-    )
+    spec = make_fast_spec(restart_type=RestartType.PERMANENT, budget_intensity=2)
     dummy_service = get_dummy_service(call_counts, hassette, restart_spec=spec)
     hassette.children.append(dummy_service)
 
@@ -302,13 +287,8 @@ async def test_permanent_exhaustion_records_fatal_reason(get_service_watcher_moc
     hassette = watcher.hassette
     assert hassette._fatal_shutdown_reason is None
 
-    spec = RestartSpec(
-        restart_type=RestartType.PERMANENT,
-        budget_intensity=2,
-        budget_period_seconds=300,
-        backoff_base_seconds=0,
-    )
-    dummy_service = get_dummy_service({"cancel": 0, "start": 0}, hassette, restart_spec=spec)
+    spec = make_fast_spec(restart_type=RestartType.PERMANENT, budget_intensity=2)
+    dummy_service = get_dummy_service(make_call_counts(), hassette, restart_spec=spec)
     hassette.children.append(dummy_service)
 
     event = make_service_failed_event(dummy_service)
@@ -326,14 +306,12 @@ async def test_fatal_error_records_fatal_reason(get_service_watcher_mock: Servic
     hassette = watcher.hassette
     assert hassette._fatal_shutdown_reason is None
 
-    spec = RestartSpec(
+    spec = make_fast_spec(
         restart_type=RestartType.TRANSIENT,
         budget_intensity=5,
-        budget_period_seconds=300,
-        backoff_base_seconds=0,
         fatal_error_names=("RuntimeError",),
     )
-    dummy_service = get_dummy_service({"cancel": 0, "start": 0}, hassette, restart_spec=spec)
+    dummy_service = get_dummy_service(make_call_counts(), hassette, restart_spec=spec)
     hassette.children.append(dummy_service)
 
     event = make_service_failed_event(dummy_service, exception=RuntimeError("boom"))
@@ -347,13 +325,11 @@ async def test_transient_exhaustion_enters_cooldown(get_service_watcher_mock: Se
     """TRANSIENT service: exhausting budget emits EXHAUSTED_COOLING and schedules cooldown task."""
     watcher = get_service_watcher_mock
     hassette = watcher.hassette
-    call_counts = {"cancel": 0, "start": 0}
+    call_counts = make_call_counts()
 
-    spec = RestartSpec(
+    spec = make_fast_spec(
         restart_type=RestartType.TRANSIENT,
         budget_intensity=2,
-        budget_period_seconds=300,
-        backoff_base_seconds=0,
         cooldown_seconds=999,  # long cooldown so we can verify the task is created
     )
     dummy_service = get_dummy_service(call_counts, hassette, restart_spec=spec)
@@ -398,14 +374,9 @@ async def test_temporary_exhaustion_stays_dead(get_service_watcher_mock: Service
     """TEMPORARY service: exhausting budget emits EXHAUSTED_DEAD, no further restarts."""
     watcher = get_service_watcher_mock
     hassette = watcher.hassette
-    call_counts = {"cancel": 0, "start": 0}
+    call_counts = make_call_counts()
 
-    spec = RestartSpec(
-        restart_type=RestartType.TEMPORARY,
-        budget_intensity=2,
-        budget_period_seconds=300,
-        backoff_base_seconds=0,
-    )
+    spec = make_fast_spec(restart_type=RestartType.TEMPORARY, budget_intensity=2)
     dummy_service = get_dummy_service(call_counts, hassette, restart_spec=spec)
     hassette.children.append(dummy_service)
 
@@ -438,14 +409,12 @@ async def test_fatal_error_triggers_immediate_shutdown(get_service_watcher_mock:
     """Service with fatal_error_names: matching exception triggers immediate shutdown, no restart."""
     watcher = get_service_watcher_mock
     hassette = watcher.hassette
-    call_counts = {"cancel": 0, "start": 0}
+    call_counts = make_call_counts()
 
-    spec = RestartSpec(
+    spec = make_fast_spec(
         restart_type=RestartType.TRANSIENT,
         fatal_error_names=("FatalDbError", "SchemaVersionError"),
         budget_intensity=5,
-        budget_period_seconds=300,
-        backoff_base_seconds=0,
     )
     dummy_service = get_dummy_service(call_counts, hassette, restart_spec=spec)
     hassette.children.append(dummy_service)
@@ -494,14 +463,12 @@ async def test_non_retryable_error_skips_restart(get_service_watcher_mock: Servi
     """Service with non_retryable_error_names: matching exception skips restart, goes to exhaustion."""
     watcher = get_service_watcher_mock
     hassette = watcher.hassette
-    call_counts = {"cancel": 0, "start": 0}
+    call_counts = make_call_counts()
 
-    spec = RestartSpec(
+    spec = make_fast_spec(
         restart_type=RestartType.TEMPORARY,
         non_retryable_error_names=("NonRetryableError",),
         budget_intensity=5,
-        budget_period_seconds=300,
-        backoff_base_seconds=0,
     )
     dummy_service = get_dummy_service(call_counts, hassette, restart_spec=spec)
     hassette.children.append(dummy_service)
@@ -544,14 +511,9 @@ async def test_in_restart_guard_prevents_double_budget(get_service_watcher_mock:
     """Two FAILED events while restart is in progress only record one budget entry."""
     watcher = get_service_watcher_mock
     hassette = watcher.hassette
-    call_counts = {"cancel": 0, "start": 0}
+    call_counts = make_call_counts()
 
-    spec = RestartSpec(
-        restart_type=RestartType.TRANSIENT,
-        budget_intensity=10,
-        budget_period_seconds=300,
-        backoff_base_seconds=0,
-    )
+    spec = make_fast_spec(restart_type=RestartType.TRANSIENT, budget_intensity=10)
     dummy_service = get_dummy_service(call_counts, hassette, restart_spec=spec)
     hassette.children.append(dummy_service)
 
@@ -579,12 +541,11 @@ async def test_shutdown_safe_sleep_aborts_on_shutdown(get_service_watcher_mock: 
     """Backoff sleep aborts early when shutdown_event is set."""
     watcher = get_service_watcher_mock
     hassette = watcher.hassette
-    call_counts = {"cancel": 0, "start": 0}
+    call_counts = make_call_counts()
 
-    spec = RestartSpec(
+    spec = make_fast_spec(
         restart_type=RestartType.TRANSIENT,
         budget_intensity=10,
-        budget_period_seconds=300,
         backoff_base_seconds=5.0,  # real backoff that would be interrupted
         backoff_multiplier=1.0,
     )
@@ -608,15 +569,9 @@ async def test_shutdown_safe_sleep_aborts_on_shutdown(get_service_watcher_mock: 
 async def test_budget_reset_on_recovery_confirmed(get_service_watcher_mock: ServiceWatcher):
     """Budget resets when service reaches RUNNING and signals readiness."""
     watcher = get_service_watcher_mock
-    call_counts = {"cancel": 0, "start": 0}
+    call_counts = make_call_counts()
 
-    spec = RestartSpec(
-        restart_type=RestartType.TRANSIENT,
-        budget_intensity=5,
-        budget_period_seconds=300,
-        backoff_base_seconds=0,
-        startup_timeout_seconds=1.0,
-    )
+    spec = make_fast_spec(restart_type=RestartType.TRANSIENT, budget_intensity=5, startup_timeout_seconds=1.0)
     dummy_service = get_dummy_service(call_counts, watcher.hassette, fail=True, restart_spec=spec)
     watcher.hassette.children.append(dummy_service)
 
@@ -643,15 +598,9 @@ async def test_budget_reset_on_recovery_confirmed(get_service_watcher_mock: Serv
 async def test_readiness_timeout_no_budget_impact(get_service_watcher_mock: ServiceWatcher):
     """Readiness timeout after RUNNING does NOT increment restart budget."""
     watcher = get_service_watcher_mock
-    call_counts = {"cancel": 0, "start": 0}
+    call_counts = make_call_counts()
 
-    spec = RestartSpec(
-        restart_type=RestartType.TRANSIENT,
-        budget_intensity=5,
-        budget_period_seconds=300,
-        backoff_base_seconds=0,
-        startup_timeout_seconds=0.05,  # very short timeout
-    )
+    spec = make_fast_spec(restart_type=RestartType.TRANSIENT, budget_intensity=5, startup_timeout_seconds=0.05)
     dummy_service = get_dummy_service(call_counts, watcher.hassette, fail=True, restart_spec=spec)
     watcher.hassette.children.append(dummy_service)
 
@@ -682,13 +631,11 @@ async def test_cooldown_then_recovery(get_service_watcher_mock: ServiceWatcher):
     """TRANSIENT exhaustion → cooldown completes → budget reset → restart attempted."""
     watcher = get_service_watcher_mock
     hassette = watcher.hassette
-    call_counts = {"cancel": 0, "start": 0}
+    call_counts = make_call_counts()
 
-    spec = RestartSpec(
+    spec = make_fast_spec(
         restart_type=RestartType.TRANSIENT,
         budget_intensity=1,
-        budget_period_seconds=300,
-        backoff_base_seconds=0,
         cooldown_seconds=0.05,  # very short cooldown for test speed
     )
     dummy_service = get_dummy_service(call_counts, hassette, restart_spec=spec)
@@ -721,13 +668,11 @@ async def test_max_cooldown_cycles_exceeded(get_service_watcher_mock: ServiceWat
     """TRANSIENT with max_cooldown_cycles=1: second exhaustion → EXHAUSTED_DEAD."""
     watcher = get_service_watcher_mock
     hassette = watcher.hassette
-    call_counts = {"cancel": 0, "start": 0}
+    call_counts = make_call_counts()
 
-    spec = RestartSpec(
+    spec = make_fast_spec(
         restart_type=RestartType.TRANSIENT,
         budget_intensity=1,
-        budget_period_seconds=300,
-        backoff_base_seconds=0,
         cooldown_seconds=0.01,
         max_cooldown_cycles=1,
     )
@@ -763,15 +708,10 @@ async def test_concurrent_failures_independent_budgets(get_service_watcher_mock:
     watcher = get_service_watcher_mock
     hassette = watcher.hassette
 
-    counts_a = {"cancel": 0, "start": 0}
-    counts_b = {"cancel": 0, "start": 0}
+    counts_a = make_call_counts()
+    counts_b = make_call_counts()
 
-    spec = RestartSpec(
-        restart_type=RestartType.TRANSIENT,
-        budget_intensity=5,
-        budget_period_seconds=300,
-        backoff_base_seconds=0,
-    )
+    spec = make_fast_spec(restart_type=RestartType.TRANSIENT, budget_intensity=5)
 
     class _DummyA(Service):
         restart_spec: ClassVar[RestartSpec] = spec
@@ -829,14 +769,9 @@ async def test_restart_exception_caught_no_double_count(get_service_watcher_mock
     """service.restart() raises → exception caught and logged, budget not double-counted."""
     watcher = get_service_watcher_mock
     hassette = watcher.hassette
-    call_counts = {"cancel": 0, "start": 0}
+    call_counts = make_call_counts()
 
-    spec = RestartSpec(
-        restart_type=RestartType.TRANSIENT,
-        budget_intensity=10,
-        budget_period_seconds=300,
-        backoff_base_seconds=0,
-    )
+    spec = make_fast_spec(restart_type=RestartType.TRANSIENT, budget_intensity=10)
     dummy_service = get_dummy_service(call_counts, hassette, restart_spec=spec)
     hassette.children.append(dummy_service)
 
@@ -866,14 +801,9 @@ async def test_bus_recovery_reconciliation(get_service_watcher_mock: ServiceWatc
     """BusService restarts, another service is in FAILED state during blind window → reconciliation picks it up."""
     watcher = get_service_watcher_mock
     hassette = watcher.hassette
-    call_counts = {"cancel": 0, "start": 0}
+    call_counts = make_call_counts()
 
-    spec = RestartSpec(
-        restart_type=RestartType.TRANSIENT,
-        budget_intensity=5,
-        budget_period_seconds=300,
-        backoff_base_seconds=0,
-    )
+    spec = make_fast_spec(restart_type=RestartType.TRANSIENT, budget_intensity=5)
     dummy_service = get_dummy_service(call_counts, hassette, restart_spec=spec)
     hassette.children.append(dummy_service)
 

--- a/tests/integration/test_service_watcher.py
+++ b/tests/integration/test_service_watcher.py
@@ -5,6 +5,8 @@ Tests use RestartSpec-based per-service configuration rather than global config 
 
 import asyncio
 import time
+from collections.abc import Generator
+from contextlib import contextmanager
 from typing import ClassVar
 from unittest.mock import AsyncMock, patch
 
@@ -21,6 +23,8 @@ from hassette.test_utils.reset import reset_hassette_lifecycle
 from hassette.types import ResourceStatus, Topic
 from hassette.types.enums import RestartType
 
+AWAIT_TIMEOUT = 5.0
+
 
 def make_call_counts() -> dict[str, int]:
     """Fresh cancel/start counters for get_dummy_service."""
@@ -32,6 +36,22 @@ def make_fast_spec(**overrides: object) -> RestartSpec:
     defaults: dict[str, object] = {"backoff_base_seconds": 0}
     defaults.update(overrides)
     return RestartSpec(**defaults)  # pyright: ignore[reportCallIssue]
+
+
+@contextmanager
+def capture_events(hassette) -> Generator[list, None, None]:
+    """Temporarily replace hassette.send_event to capture emitted events."""
+    events: list = []
+    original = hassette.send_event
+
+    async def capture(ev):
+        events.append(ev)
+
+    hassette.send_event = capture  # pyright: ignore[reportAttributeAccessIssue]
+    try:
+        yield events
+    finally:
+        hassette.send_event = original  # pyright: ignore[reportAttributeAccessIssue]
 
 
 @pytest.fixture
@@ -61,7 +81,7 @@ async def restart_and_await(watcher: ServiceWatcher, event: HassetteServiceEvent
         await wait_for(
             lambda: key not in watcher._restarting,
             desc=f"execute_restart for {key} completed",
-            timeout=5.0,
+            timeout=AWAIT_TIMEOUT,
         )
 
 
@@ -71,7 +91,7 @@ async def on_running_and_await(watcher: ServiceWatcher, event: HassetteServiceEv
     await watcher.on_service_running(event)
     new_tasks = set(watcher.task_bucket.pending_tasks()) - pending_before
     for task in new_tasks:
-        await asyncio.wait_for(asyncio.shield(task), timeout=5.0)
+        await asyncio.wait_for(asyncio.shield(task), timeout=AWAIT_TIMEOUT)
 
 
 def get_dummy_service(
@@ -342,18 +362,9 @@ async def test_transient_exhaustion_enters_cooldown(get_service_watcher_mock: Se
     await restart_and_await(watcher, event)
     await restart_and_await(watcher, event)
 
-    # Capture events emitted on exhaustion
-    emitted_events: list = []
-
-    async def capture_event(ev):
-        emitted_events.append(ev)
-
-    hassette.send_event = capture_event  # pyright: ignore[reportAttributeAccessIssue]
-
     # Exhaust budget (budget check is synchronous — no spawn needed)
-    await watcher.restart_service(event)
-
-    hassette.send_event = hassette._event_stream_service.send_event  # pyright: ignore[reportAttributeAccessIssue]
+    with capture_events(hassette) as emitted_events:
+        await watcher.restart_service(event)
 
     assert not hassette.shutdown_event.is_set(), "TRANSIENT exhaustion should NOT trigger shutdown"
     assert len(emitted_events) >= 1
@@ -386,17 +397,9 @@ async def test_temporary_exhaustion_stays_dead(get_service_watcher_mock: Service
     await restart_and_await(watcher, event)
     await restart_and_await(watcher, event)
 
-    emitted_events: list = []
-
-    async def capture_event(ev):
-        emitted_events.append(ev)
-
-    hassette.send_event = capture_event  # pyright: ignore[reportAttributeAccessIssue]
-
     # Exhaust budget (budget check is synchronous — no spawn needed)
-    await watcher.restart_service(event)
-
-    hassette.send_event = hassette._event_stream_service.send_event  # pyright: ignore[reportAttributeAccessIssue]
+    with capture_events(hassette) as emitted_events:
+        await watcher.restart_service(event)
 
     assert not hassette.shutdown_event.is_set()
     assert len(emitted_events) == 1
@@ -437,18 +440,8 @@ async def test_fatal_error_triggers_immediate_shutdown(get_service_watcher_mock:
         ),
     )
 
-    emitted_events: list = []
-
-    async def capture_event(ev):
-        emitted_events.append(ev)
-        await hassette.shutdown()
-
-    original_send = hassette.send_event
-    hassette.send_event = capture_event  # pyright: ignore[reportAttributeAccessIssue]
-
-    await watcher.restart_service(fatal_event)
-
-    hassette.send_event = original_send  # pyright: ignore[reportAttributeAccessIssue]
+    with capture_events(hassette) as emitted_events:
+        await watcher.restart_service(fatal_event)
 
     # Should have emitted CRASHED and triggered shutdown
     assert hassette.shutdown_event.is_set()
@@ -489,16 +482,8 @@ async def test_non_retryable_error_skips_restart(get_service_watcher_mock: Servi
         ),
     )
 
-    emitted_events: list = []
-
-    async def capture_event(ev):
-        emitted_events.append(ev)
-
-    hassette.send_event = capture_event  # pyright: ignore[reportAttributeAccessIssue]
-
-    await watcher.restart_service(nr_event)
-
-    hassette.send_event = hassette._event_stream_service.send_event  # pyright: ignore[reportAttributeAccessIssue]
+    with capture_events(hassette) as emitted_events:
+        await watcher.restart_service(nr_event)
 
     # No restart attempt made
     assert call_counts["start"] == 0
@@ -620,7 +605,7 @@ async def test_readiness_timeout_no_budget_impact(get_service_watcher_mock: Serv
     await wait_for(
         lambda: watcher.task_bucket.pending_tasks() == [],
         desc="readiness timeout task completed",
-        timeout=5.0,
+        timeout=AWAIT_TIMEOUT,
     )
 
     budget.evict_expired()
@@ -687,17 +672,9 @@ async def test_max_cooldown_cycles_exceeded(get_service_watcher_mock: ServiceWat
     watcher._cooldown_cycles[key] = 2  # already exceeded max_cooldown_cycles=1
     dummy_service._status = ResourceStatus.EXHAUSTED_COOLING
 
-    emitted_events: list = []
-
-    async def capture_event(ev):
-        emitted_events.append(ev)
-
-    hassette.send_event = capture_event  # pyright: ignore[reportAttributeAccessIssue]
-
     # Run cooldown_and_retry directly — should detect exceeded cycles and emit EXHAUSTED_DEAD
-    await watcher.cooldown_and_retry(dummy_service.class_name, dummy_service.role, key, spec)
-
-    hassette.send_event = hassette._event_stream_service.send_event  # pyright: ignore[reportAttributeAccessIssue]
+    with capture_events(hassette) as emitted_events:
+        await watcher.cooldown_and_retry(dummy_service.class_name, dummy_service.role, key, spec)
 
     assert len(emitted_events) == 1
     assert emitted_events[0].payload.data.status == ResourceStatus.EXHAUSTED_DEAD

--- a/tests/unit/core/test_service_watcher_exhausted.py
+++ b/tests/unit/core/test_service_watcher_exhausted.py
@@ -59,7 +59,7 @@ async def test_exhausted_cooling_sets_status_on_instance():
             role=service.role,
             key=f"{service.class_name}:{service.role}",
             spec=spec,
-            original_data=payload,
+            status_payload=payload,
         )
 
     # Close captured coroutines to avoid "coroutine was never awaited" warnings
@@ -87,7 +87,7 @@ async def test_exhausted_dead_sets_status_on_instance():
         role=service.role,
         key=f"{service.class_name}:{service.role}",
         spec=spec,
-        original_data=payload,
+        status_payload=payload,
     )
 
     assert service.status == ResourceStatus.EXHAUSTED_DEAD, (
@@ -149,7 +149,7 @@ async def test_exhausted_status_skipped_when_service_not_found():
         role=ResourceRole.SERVICE,
         key="NonExistentService:service",
         spec=spec,
-        original_data=payload,
+        status_payload=payload,
     )
 
     hassette.send_event.assert_called()


### PR DESCRIPTION
### Service Watcher Cleanup

- Extract a `set_service_status()` helper on `ServiceWatcher` to consolidate three duplicated find-service-and-set-status blocks in `handle_exhaustion` and `cooldown_and_retry` — the same lookup/warn/set sequence was hand-rolled three times with slightly different log messages.
- Add a `DEFAULT_READINESS_TIMEOUT` constant (30.0) replacing a magic number used as the fallback when a service has no `restart_spec`.
- Rename the generic `data` variable to `status_payload` at every `ServiceStatusPayload` extraction site — `data` gave no hint about what was actually being unpacked (exception info, resource name, role).

### Test Cleanup

- Add `make_call_counts()` and `make_fast_spec()` helpers in `tests/integration/test_service_watcher.py` to eliminate repeated `RestartSpec(...)` and `{"cancel": 0, "start": 0}` boilerplate across 21+ test functions — each test now states only the fields it cares about.
- Update `tests/unit/core/test_service_watcher_exhausted.py` to use the renamed `status_payload` keyword argument, matching the source change.

Closes #1261
