### PR TITLE
fix: use MagicMock for invoke_error_handler in predicate failure test

### DIFF
--- a/tests/unit/core/test_bus_service_predicate_failure.py
+++ b/tests/unit/core/test_bus_service_predicate_failure.py
@@ -29,7 +29,7 @@ def make_bus_service() -> tuple[BusService, MagicMock]:
 
     executor = MagicMock()
     executor.enqueue_record = MagicMock()
-    executor.invoke_error_handler = AsyncMock()
+    executor.invoke_error_handler = MagicMock()
 
     bs = object.__new__(BusService)
     bs.hassette = hassette


### PR DESCRIPTION
### Notable Changes

- `test_invokes_per_listener_error_handler` was failing intermittently on Python 3.13 CI ([run 28990473179](https://github.com/NodeJSmith/hassette/actions/runs/28990473179)). The fixture mocked `executor.invoke_error_handler` as an `AsyncMock`, but `_record_predicate_failure` is synchronous and passes the resulting coroutine to `task_bucket.spawn()` without awaiting it. On Python 3.13+, garbage collecting that unawaited coroutine raised `PytestUnraisableExceptionWarning`, which pytest turns into a test failure. Switched the mock to `MagicMock`, since the test only asserts that `spawn` was called and never awaits the mock's return value itself.
