### PR TITLE
ci: add concurrency groups to cancel superseded workflow runs

### DIFF
--- a/.github/workflows/cancel-stale-pr-runs.yml
+++ b/.github/workflows/cancel-stale-pr-runs.yml
@@ -1,8 +1,10 @@
 name: Cancel Stale PR Runs
 
 # When a PR is closed (merged or not), cancel any in-progress or queued
-# workflow runs for that PR's head branch. Without this, merged PRs keep
-# consuming runners for checks nobody will look at.
+# workflow runs for that PR's head branch. The per-workflow concurrency
+# groups cancel superseded runs on the same ref while a PR is open; this
+# handles the different case where the PR closes and nobody needs the
+# result at all.
 on:
     pull_request:
         types: [closed]
@@ -20,13 +22,12 @@ jobs:
                   HEAD_BRANCH: ${{ github.head_ref }}
                   REPO: ${{ github.repository }}
               run: |
+                  # --status is a single-value flag; fetch all and filter client-side
                   gh run list \
                     --repo "$REPO" \
                     --branch "$HEAD_BRANCH" \
-                    --status in_progress \
-                    --status queued \
-                    --json databaseId \
-                    --jq '.[].databaseId' \
+                    --json databaseId,status \
+                    --jq '.[] | select(.status == "in_progress" or .status == "queued") | .databaseId' \
                   | while read -r run_id; do
                       echo "Cancelling run $run_id"
                       gh run cancel "$run_id" --repo "$REPO" || true

--- a/.github/workflows/cancel-stale-pr-runs.yml
+++ b/.github/workflows/cancel-stale-pr-runs.yml
@@ -1,0 +1,33 @@
+name: Cancel Stale PR Runs
+
+# When a PR is closed (merged or not), cancel any in-progress or queued
+# workflow runs for that PR's head branch. Without this, merged PRs keep
+# consuming runners for checks nobody will look at.
+on:
+    pull_request:
+        types: [closed]
+
+permissions:
+    actions: write
+
+jobs:
+    cancel:
+        runs-on: ubuntu-latest
+        timeout-minutes: 5
+        steps:
+            - env:
+                  GH_TOKEN: ${{ github.token }}
+                  HEAD_BRANCH: ${{ github.head_ref }}
+                  REPO: ${{ github.repository }}
+              run: |
+                  gh run list \
+                    --repo "$REPO" \
+                    --branch "$HEAD_BRANCH" \
+                    --status in_progress \
+                    --status queued \
+                    --json databaseId \
+                    --jq '.[].databaseId' \
+                  | while read -r run_id; do
+                      echo "Cancelling run $run_id"
+                      gh run cancel "$run_id" --repo "$REPO" || true
+                    done

--- a/.github/workflows/docker-tests.yml
+++ b/.github/workflows/docker-tests.yml
@@ -11,6 +11,10 @@ on:
       - "tests/test_docker_*.py"
       - ".github/workflows/docker-tests.yml"
 
+concurrency:
+    group: ${{ github.workflow }}-${{ github.ref }}
+    cancel-in-progress: true
+
 permissions:
     contents: read
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -18,6 +18,10 @@ on:
 
     workflow_dispatch:
 
+concurrency:
+    group: ${{ github.workflow }}-${{ github.ref }}
+    cancel-in-progress: true
+
 permissions:
     contents: read
 

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -7,6 +7,10 @@ on:
         branches: [main]
     workflow_dispatch:
 
+concurrency:
+    group: ${{ github.workflow }}-${{ github.ref }}
+    cancel-in-progress: true
+
 permissions:
     contents: read
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -7,6 +7,10 @@ on:
         branches: [main]
     workflow_dispatch:
 
+concurrency:
+    group: ${{ github.workflow }}-${{ github.ref }}
+    cancel-in-progress: true
+
 permissions:
     contents: read
 

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -4,6 +4,10 @@ on:
     pull_request:
         types: [opened, edited, synchronize]
 
+concurrency:
+    group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+    cancel-in-progress: true
+
 permissions:
     pull-requests: read
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,6 +7,10 @@ on:
         branches: [main]
     workflow_dispatch:
 
+concurrency:
+    group: ${{ github.workflow }}-${{ github.ref }}
+    cancel-in-progress: true
+
 permissions:
     contents: read
 


### PR DESCRIPTION
## Summary

Adds workflow-level concurrency groups to all push-triggered CI workflows, and a cleanup workflow for merged PRs.

**Problem:** When multiple PRs merge in quick succession, each push to main triggers a full set of CI runs. Earlier runs test a subset of what the latest commit includes, wasting runners and causing queue congestion. Similarly, when a PR merges, its in-progress checks keep running even though nobody will look at them.

**Fix:**

1. **Concurrency groups** (`workflow + ref`, `cancel-in-progress: true`) on tests, lint, e2e, docker-tests, docs, and pr-title workflows. A new push to the same ref cancels any in-progress run for that workflow.

2. **`cancel-stale-pr-runs.yml`** — fires on `pull_request: closed` and cancels all in-progress/queued runs for the PR's head branch via `gh run cancel`.

Workflows that already had concurrency groups (`build_and_publish_image`, `pr-screenshots`, `release-please`, `ha-version-drift`) are unchanged.