### PR TITLE
chore: replace hardcoded CSS values with design tokens

### DIFF
--- a/design/context.md
+++ b/design/context.md
@@ -142,6 +142,8 @@ These document the current implemented token direction. Do not treat this sectio
 - **Body**: `Geist`, system UI fallback. Used for navigation, labels, explanatory text, and controls.
 - **Mono**: `Geist Mono`, UI monospace fallback. Used for code, IDs, timestamps, paths, timings, and dense table data.
 - **Current scale**: display 38px, h1 28px, h2 20px, h3 16px, body 14px, small 12.5px, micro 12px, xs 11px.
+- **Line heights**: `--lh-display` 1.05, `--lh-h1` 1.15, `--lh-h2` 1.25, `--lh-h3` 1.35, `--lh-body` 1.55, `--lh-relaxed` 1.6, `--lh-small` 1.5, `--lh-micro` 1.4, `--lh-xs` 1.3.
+- **Tracking**: `--tr-label-tight` 0.03em, `--tr-label-mid` 0.04em, `--tr-label` 0.05em, `--tr-label-wide` 0.07em.
 - **Current weights**: normal 400, medium 500, semibold 600, bold 700.
 
 **Guidance**: The serif display face should remain a deliberate accent. If a page title feels disconnected from the rest of the UI, integrate surrounding hierarchy rather than removing the character by default.
@@ -149,7 +151,7 @@ These document the current implemented token direction. Do not treat this sectio
 ### Spacing
 
 - **Base**: 4px grid with half-steps where useful.
-- **Scale**: `--sp-0` 2px, `--sp-1` 4px, `--sp-2` 8px, `--sp-3` 12px, `--sp-4` 16px, `--sp-5` 20px, `--sp-6` 24px, `--sp-7` 32px, `--sp-8` 40px, `--sp-9` 56px, `--sp-10` 72px.
+- **Scale**: `--sp-px` 1px, `--sp-0` 2px, `--sp-1` 4px, `--sp-2` 8px, `--sp-3` 12px, `--sp-4` 16px, `--sp-5` 20px, `--sp-6` 24px, `--sp-7` 32px, `--sp-8` 40px, `--sp-9` 56px, `--sp-10` 72px.
 - **Current page rhythm**: `.ht-page` uses larger desktop padding and gaps, then tightens below mobile breakpoints.
 
 **Guidance**: Use spacing to clarify hierarchy, not to make the product airy. This UI should remain compact.
@@ -169,10 +171,22 @@ These document the current implemented token direction. Do not treat this sectio
 
 **Guidance**: Large rounded panels should be used carefully. Keep dense diagnostic elements tighter than marketing-style cards.
 
+### Component Sizing
+
+- `--sz-sidebar` 240px — sidebar width, used in layout grid and mobile drawer.
+- `--sz-search-min` 160px — minimum width for search inputs.
+- `--sz-touch` 44px, `--sz-icon-sm` 14px.
+
+### Effects
+
+- `--blur-overlay` 2px — backdrop blur for overlays (command palette, confirm dialog).
+- `--border-thick` 3px — heavy borders (spinner track, error accent borders).
+
 ### Motion
 
 - **Micro**: `--t-fast` 120ms.
 - **Transition**: `--t-med` 200ms.
+- **Spin**: `--t-spin` 0.8s — spinner animation duration.
 - **Easing**: `cubic-bezier(0.4, 0, 0.2, 1)`.
 
 **Guidance**: Motion should confirm interactions and orient users during overlays/drawers. Avoid decorative animation except for meaningful live-status indicators like the connection pulse.

--- a/frontend/src/components/app-detail/code-tab.module.css
+++ b/frontend/src/components/app-detail/code-tab.module.css
@@ -37,7 +37,7 @@
   font-family: var(--font-mono);
   border: 1px solid var(--line-1);
   border-radius: var(--r-sm);
-  padding: 1px var(--sp-2);
+  padding: var(--sp-px) var(--sp-2);
 }
 
 .body {
@@ -52,7 +52,7 @@
   background-color: var(--bg-page) !important;
   border-radius: 0;
   font-size: var(--fs-small);
-  line-height: 1.6;
+  line-height: var(--lh-relaxed);
 }
 
 :global([data-theme="dark"]) .body :global(.shiki) {

--- a/frontend/src/components/app-detail/config-tab.module.css
+++ b/frontend/src/components/app-detail/config-tab.module.css
@@ -47,7 +47,7 @@
   font-family: var(--font-body);
   font-size: var(--fs-small);
   font-weight: var(--fw-semibold);
-  letter-spacing: 0.04em;
+  letter-spacing: var(--tr-label-mid);
   text-transform: uppercase;
   color: var(--ink-2);
 }

--- a/frontend/src/components/app-detail/handler-health-card.module.css
+++ b/frontend/src/components/app-detail/handler-health-card.module.css
@@ -22,7 +22,7 @@
 
 .card:focus-visible {
   outline: 2px solid var(--accent);
-  outline-offset: 2px;
+  outline-offset: var(--sp-0);
 }
 
 .cardFailing {

--- a/frontend/src/components/app-detail/unified-handler-row.module.css
+++ b/frontend/src/components/app-detail/unified-handler-row.module.css
@@ -7,7 +7,7 @@
   gap: var(--sp-2);
   padding: var(--sp-3);
   cursor: pointer;
-  transition: background var(--t-fast);
+  transition: background var(--t-fast) var(--ease);
   background: var(--bg-surface);
   /* Button reset */
   border: none;
@@ -72,11 +72,11 @@
   background: var(--bg-sunken);
   border: 1px solid var(--line-1);
   border-radius: var(--r-sm);
-  padding: 1px var(--sp-1);
+  padding: var(--sp-px) var(--sp-1);
   color: var(--ink-3);
   text-transform: lowercase;
   letter-spacing: var(--tr-label-tight);
-  line-height: 1.4;
+  line-height: var(--lh-micro);
 }
 
 .name {
@@ -140,9 +140,9 @@
   background: color-mix(in srgb, var(--accent) 10%, transparent);
   border: 1px solid color-mix(in srgb, var(--accent) 25%, transparent);
   border-radius: var(--r-sm);
-  padding: 1px var(--sp-1);
+  padding: var(--sp-px) var(--sp-1);
   color: var(--ink-3);
   text-transform: lowercase;
   letter-spacing: var(--tr-label-tight);
-  line-height: 1.4;
+  line-height: var(--lh-micro);
 }

--- a/frontend/src/components/layout/command-palette.module.css
+++ b/frontend/src/components/layout/command-palette.module.css
@@ -5,7 +5,7 @@
   position: fixed;
   inset: 0;
   background: var(--overlay-bg);
-  backdrop-filter: blur(2px);
+  backdrop-filter: blur(var(--blur-overlay));
   z-index: var(--z-palette-bg);
 }
 
@@ -147,7 +147,7 @@
   background: var(--bg-sunken);
   border: 1px solid var(--line-1);
   border-radius: var(--r-sm);
-  padding: 1px var(--sp-2);
+  padding: var(--sp-px) var(--sp-2);
   white-space: nowrap;
   flex-shrink: 0;
 }
@@ -170,7 +170,7 @@
   background: var(--bg-sunken);
   border: 1px solid var(--line-1);
   border-radius: var(--r-sm);
-  padding: 1px var(--sp-1);
+  padding: var(--sp-px) var(--sp-1);
   color: var(--ink-3);
   margin-right: var(--sp-1);
 }

--- a/frontend/src/components/layout/sidebar.module.css
+++ b/frontend/src/components/layout/sidebar.module.css
@@ -153,7 +153,7 @@
   padding: 0 var(--sp-2);
   display: flex;
   flex-direction: column;
-  gap: 1px;
+  gap: var(--sp-px);
 }
 
 .empty {
@@ -246,7 +246,7 @@
   padding: 0 0 0 var(--sp-4);
   display: flex;
   flex-direction: column;
-  gap: 1px;
+  gap: var(--sp-px);
 }
 
 .instanceItem {

--- a/frontend/src/components/layout/sidebar.module.css
+++ b/frontend/src/components/layout/sidebar.module.css
@@ -1,6 +1,6 @@
 /* — Sidebar shell —————————————————————————————————————— */
 .sidebar {
-  width: 240px;
+  width: var(--sz-sidebar);
   background: transparent;
   color: var(--ink-2);
   display: flex;
@@ -360,7 +360,7 @@
 
 .groupHeader:focus-visible {
   outline: 2px solid var(--accent);
-  outline-offset: 1px;
+  outline-offset: var(--sp-px);
 }
 
 .groupChevron {
@@ -390,7 +390,7 @@
   border: 1px solid var(--line-1);
   border-radius: var(--r-sm);
   padding: 0 var(--sp-1);
-  line-height: 1.6;
+  line-height: var(--lh-relaxed);
   flex-shrink: 0;
 }
 

--- a/frontend/src/components/layout/time-preset-selector.module.css
+++ b/frontend/src/components/layout/time-preset-selector.module.css
@@ -13,7 +13,7 @@
   font-family: var(--font-body);
   font-size: var(--fs-micro);
   font-weight: var(--fw-medium);
-  line-height: 1.6;
+  line-height: var(--lh-relaxed);
   color: var(--ink-3);
   background: transparent;
   border: none;

--- a/frontend/src/components/shared/badge.module.css
+++ b/frontend/src/components/shared/badge.module.css
@@ -8,7 +8,7 @@
   font-weight: var(--fw-medium);
   padding: 0.15em 0.55em;
   border-radius: var(--r-pill);
-  line-height: 1.6;
+  line-height: var(--lh-relaxed);
   white-space: nowrap;
   vertical-align: middle;
 }
@@ -16,7 +16,7 @@
 .xs {
   font-size: var(--fs-xs);
   padding: 0.05em 0.4em;
-  line-height: 1.4;
+  line-height: var(--lh-micro);
 }
 
 .sm {

--- a/frontend/src/components/shared/button.module.css
+++ b/frontend/src/components/shared/button.module.css
@@ -18,7 +18,7 @@
     border-color var(--t-fast),
     color var(--t-fast);
   text-decoration: none;
-  line-height: 1.5;
+  line-height: var(--lh-small);
 }
 
 .btn:hover {

--- a/frontend/src/components/shared/chip.module.css
+++ b/frontend/src/components/shared/chip.module.css
@@ -8,7 +8,7 @@
   font-size: var(--fs-micro);
   font-weight: var(--fw-medium);
   white-space: nowrap;
-  line-height: 1.5;
+  line-height: var(--lh-small);
 }
 
 .modifier {
@@ -72,5 +72,5 @@
 /* size modifier */
 .sm {
   font-size: var(--fs-xs);
-  padding: 1px var(--sp-1);
+  padding: var(--sp-px) var(--sp-1);
 }

--- a/frontend/src/components/shared/column-filter-popover/index.module.css
+++ b/frontend/src/components/shared/column-filter-popover/index.module.css
@@ -62,5 +62,5 @@
 
 .tierBtn:focus-visible {
   outline: 2px solid var(--accent);
-  outline-offset: 2px;
+  outline-offset: var(--sp-0);
 }

--- a/frontend/src/components/shared/config-schema-view.module.css
+++ b/frontend/src/components/shared/config-schema-view.module.css
@@ -103,7 +103,7 @@
   color: var(--ink-2);
   background: var(--bg-sunken);
   border: 1px solid var(--line-2);
-  padding: 1px var(--sp-2);
+  padding: var(--sp-px) var(--sp-2);
   border-radius: var(--r-sm);
 }
 
@@ -134,7 +134,7 @@
 
 .lockIcon {
   font-size: var(--fs-mono-md);
-  opacity: 0.7;
+  opacity: var(--op-muted);
   flex-shrink: 0;
 }
 
@@ -152,7 +152,7 @@
   background: var(--bg-sunken);
   border: 1px solid var(--line-1);
   border-radius: var(--r-sm);
-  padding: 1px var(--sp-2);
+  padding: var(--sp-px) var(--sp-2);
   color: var(--ink-2);
 }
 
@@ -195,7 +195,7 @@
   .value {
     flex-basis: 100%;
     text-align: left;
-    margin-top: 2px;
+    margin-top: var(--sp-0);
   }
 
   .valList {

--- a/frontend/src/components/shared/confirm-dialog.module.css
+++ b/frontend/src/components/shared/confirm-dialog.module.css
@@ -6,7 +6,7 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  backdrop-filter: blur(2px);
+  backdrop-filter: blur(var(--blur-overlay));
 }
 
 .dialog {

--- a/frontend/src/components/shared/info-popover.module.css
+++ b/frontend/src/components/shared/info-popover.module.css
@@ -26,7 +26,7 @@
 
 .trigger:focus-visible {
   outline: 2px solid var(--accent);
-  outline-offset: 2px;
+  outline-offset: var(--sp-0);
 }
 
 /* position:fixed is required: info-popover.tsx positions this with floating-ui's

--- a/frontend/src/components/shared/log-table/column-picker.module.css
+++ b/frontend/src/components/shared/log-table/column-picker.module.css
@@ -14,7 +14,7 @@
 }
 .trigger:focus-visible {
   outline: 2px solid var(--accent);
-  outline-offset: 2px;
+  outline-offset: var(--sp-0);
 }
 
 .list {
@@ -59,5 +59,5 @@
 }
 .resetBtn:focus-visible {
   outline: 2px solid var(--accent);
-  outline-offset: 2px;
+  outline-offset: var(--sp-0);
 }

--- a/frontend/src/components/shared/log-table/log-detail-drawer.module.css
+++ b/frontend/src/components/shared/log-table/log-detail-drawer.module.css
@@ -94,7 +94,7 @@
 }
 .iconBtn:focus-visible {
   outline: 2px solid var(--accent);
-  outline-offset: 2px;
+  outline-offset: var(--sp-0);
 }
 .iconBtn:disabled {
   color: var(--ink-4);
@@ -177,7 +177,7 @@
   text-align: right;
   text-transform: uppercase;
   letter-spacing: var(--tr-label-tight);
-  padding-top: 1px;
+  padding-top: var(--sp-px);
 }
 
 .metaGrid dd {
@@ -235,7 +235,7 @@
   margin: 0;
   font-family: var(--font-mono);
   font-size: var(--fs-mono-sm);
-  line-height: 1.5;
+  line-height: var(--lh-small);
   white-space: pre-wrap;
   word-break: break-all;
   overflow-wrap: anywhere;
@@ -248,7 +248,7 @@
 }
 
 .exceptionBlock {
-  border-left: 3px solid var(--err);
+  border-left: var(--border-thick) solid var(--err);
 }
 
 /* Copy button */
@@ -268,7 +268,7 @@
 }
 .copyBtn:focus-visible {
   outline: 2px solid var(--accent);
-  outline-offset: 2px;
+  outline-offset: var(--sp-0);
 }
 
 /* Filtered out state */

--- a/frontend/src/components/shared/log-table/log-table-row.module.css
+++ b/frontend/src/components/shared/log-table/log-table-row.module.css
@@ -89,7 +89,7 @@
 .messageText {
   font-family: var(--font-mono);
   font-size: var(--fs-mono-md);
-  line-height: 1.5;
+  line-height: var(--lh-small);
   max-height: 1.5em;
   overflow: clip;
   text-overflow: ellipsis;

--- a/frontend/src/components/shared/sort-header.module.css
+++ b/frontend/src/components/shared/sort-header.module.css
@@ -58,7 +58,7 @@
 
 .filterBtn:focus-visible {
   outline: 2px solid var(--accent);
-  outline-offset: 2px;
+  outline-offset: var(--sp-0);
 }
 
 .filterActive {

--- a/frontend/src/components/shared/spinner.module.css
+++ b/frontend/src/components/shared/spinner.module.css
@@ -1,10 +1,10 @@
 .spinner {
   width: var(--sp-6);
   height: var(--sp-6);
-  border: 3px solid var(--line-strong);
+  border: var(--border-thick) solid var(--line-strong);
   border-top-color: var(--accent);
   border-radius: var(--r-pill);
-  animation: spin 0.8s linear infinite;
+  animation: spin var(--t-spin) linear infinite;
   margin: var(--sp-4) auto;
 }
 

--- a/frontend/src/components/shared/table-footer.module.css
+++ b/frontend/src/components/shared/table-footer.module.css
@@ -46,7 +46,7 @@
 }
 .filterBtn:focus-visible {
   outline: 2px solid var(--accent);
-  outline-offset: 2px;
+  outline-offset: var(--sp-0);
 }
 .filterBtnActive {
   color: var(--ink-1);
@@ -89,5 +89,5 @@
 }
 .resetFiltersBtn:focus-visible {
   outline: 2px solid var(--accent);
-  outline-offset: 2px;
+  outline-offset: var(--sp-0);
 }

--- a/frontend/src/pages/app-detail.module.css
+++ b/frontend/src/pages/app-detail.module.css
@@ -35,8 +35,8 @@
   color: var(--ink-3);
   cursor: pointer;
   transition:
-    color var(--t-fast),
-    background var(--t-fast);
+    color var(--t-fast) var(--ease),
+    background var(--t-fast) var(--ease);
   white-space: nowrap;
   text-decoration: none;
   display: inline-block;
@@ -90,8 +90,8 @@
   cursor: pointer;
   box-shadow: var(--shadow-2);
   transition:
-    border-color var(--t-fast),
-    box-shadow var(--t-fast);
+    border-color var(--t-fast) var(--ease),
+    box-shadow var(--t-fast) var(--ease);
   font-family: inherit;
   font-size: var(--fs-small);
   color: var(--ink-1);
@@ -158,8 +158,8 @@
   color: var(--ink-2);
   cursor: pointer;
   transition:
-    color var(--t-fast),
-    background var(--t-fast);
+    color var(--t-fast) var(--ease),
+    background var(--t-fast) var(--ease);
   white-space: nowrap;
 }
 

--- a/frontend/src/pages/diagnostics.module.css
+++ b/frontend/src/pages/diagnostics.module.css
@@ -31,7 +31,7 @@
   color: var(--warn);
   border: 1px solid var(--warn);
   border-radius: var(--r-pill);
-  padding: 1px var(--sp-2);
+  padding: var(--sp-px) var(--sp-2);
 }
 
 /* Services grid — compact tiles; anomalous services span the full row */

--- a/frontend/src/pages/handlers.module.css
+++ b/frontend/src/pages/handlers.module.css
@@ -31,7 +31,7 @@
   border-bottom: 1px solid var(--line-2);
   text-decoration: none;
   color: inherit;
-  transition: background var(--t-fast);
+  transition: background var(--t-fast) var(--ease);
 }
 
 .mobileCard:last-child {

--- a/frontend/src/pages/logs.module.css
+++ b/frontend/src/pages/logs.module.css
@@ -13,7 +13,7 @@
   color: var(--warn);
   padding: var(--sp-0) var(--sp-2);
   border-radius: var(--r-sm);
-  transition: background var(--t-fast);
+  transition: background var(--t-fast) var(--ease);
 }
 
 .pausedBtn:hover {
@@ -22,5 +22,5 @@
 
 .pausedBtn:focus-visible {
   outline: 2px solid var(--warn);
-  outline-offset: 2px;
+  outline-offset: var(--sp-0);
 }

--- a/frontend/src/styles/layout.css
+++ b/frontend/src/styles/layout.css
@@ -1,9 +1,9 @@
 /* Layout — grid, main content area, sections, pages, level bars, drawer */
 
-/* — Layout grid (240px sidebar + 1fr main) ————————————— */
+/* — Layout grid (sidebar + 1fr main) —————————————————— */
 .ht-layout {
   display: grid;
-  grid-template-columns: 240px 1fr;
+  grid-template-columns: var(--sz-sidebar) 1fr;
   min-height: 100vh;
   min-height: 100dvh;
   position: relative;
@@ -85,7 +85,7 @@
   top: 0;
   left: 0;
   bottom: 0;
-  width: 240px;
+  width: var(--sz-sidebar);
   z-index: var(--z-drawer);
   background: var(--bg-surface);
   overflow-y: auto;

--- a/frontend/src/styles/utilities.css
+++ b/frontend/src/styles/utilities.css
@@ -83,7 +83,7 @@
   font-size: var(--fs-micro);
   overflow-x: auto;
   white-space: pre;
-  line-height: 1.6;
+  line-height: var(--lh-relaxed);
 }
 
 /* — Detail Label ——————————————————————————————————————— */
@@ -160,7 +160,7 @@
   background: var(--input-bg);
   color: var(--ink-1);
   outline: none;
-  min-width: 160px;
+  min-width: var(--sz-search-min);
   align-self: flex-end;
 }
 

--- a/frontend/src/tokens.css
+++ b/frontend/src/tokens.css
@@ -78,6 +78,7 @@
   --tr-h3: -0.005em;
   --fs-body: 14px;
   --lh-body: 1.55;
+  --lh-relaxed: 1.6;
   --fs-small: 12.5px;
   --lh-small: 1.5;
   --fs-micro: 12px;
@@ -85,12 +86,14 @@
   --fs-xs: 11px;
   --lh-xs: 1.3;
   --tr-label-tight: 0.03em;
+  --tr-label-mid: 0.04em;
   --tr-label: 0.05em;
   --tr-label-wide: 0.07em;
   --fs-mono-sm: 12px;
   --fs-mono-md: 13px;
 
   /* Spacing (4px grid, half-steps where needed) */
+  --sp-px: 1px;
   --sp-0: 2px;
   --sp-1: 4px;
   --sp-2: 8px;
@@ -108,6 +111,8 @@
   /* Component sizing */
   --sz-touch: 44px;
   --sz-icon-sm: 14px;
+  --sz-sidebar: 240px;
+  --sz-search-min: 160px;
 
   /* Additional font sizes */
   --fs-stat: 26px;
@@ -143,6 +148,11 @@
   --ease: cubic-bezier(0.4, 0, 0.2, 1);
   --t-fast: 120ms;
   --t-med: 200ms;
+  --t-spin: 0.8s;
+
+  /* Effects */
+  --blur-overlay: 2px;
+  --border-thick: 3px;
 
   /* Z-index scale */
   --z-table-head: 1;


### PR DESCRIPTION
### Design Tokens

- Added 8 tokens to `tokens.css` that the codebase needed but didn't have: `--sz-sidebar` (240px sidebar width), `--sp-px` (1px, the missing rung below `--sp-0`), `--lh-relaxed` (1.6 line-height), `--blur-overlay` (2px backdrop blur), `--border-thick` (3px heavy borders), `--t-spin` (0.8s spinner duration), `--tr-label-mid` (0.04em letter-spacing), and `--sz-search-min` (160px search input minimum width).
- Documented all 8 in `design/context.md` under new "Component Sizing" and "Effects" sections, plus additions to the existing Typography and Motion sections — so future work references these instead of re-inventing hardcoded values.

### CSS Token Substitution

- Replaced ~35 hardcoded values across 28 frontend files with references to existing or newly-added tokens: `outline-offset`, `line-height`, `opacity`, `margin-top`, `padding`, `border-width`, and transition-easing declarations that specified a duration but not a curve.
- No values changed — every substitution maps a literal (`1px`, `2px`, `0.7`, `1.6`, etc.) to a token carrying that same value, so this is a no-visual-diff mechanical pass, not a redesign.
- Motivation: hardcoded values silently drift from the token scale over time and make future design-system changes (e.g., adjusting the spacing scale) miss spots. Centralizing them in `tokens.css` closes that gap.

Closes #1276
