### PR TITLE
refactor(ui): add component-level tokens for em-based padding values

### DIFF
--- a/design/context.md
+++ b/design/context.md
@@ -177,7 +177,7 @@ These document the current implemented token direction. Do not treat this sectio
 - `--sz-search-min` 160px — minimum width for search inputs.
 - `--sz-touch` 44px, `--sz-icon-sm` 14px.
 
-### Component Specifications
+### Component Padding & Gap
 
 Component-local custom properties for em-based padding and gap values. These scale with font-size and are prefixed per component to avoid collisions (CSS Modules scopes class selectors, not custom property names).
 

--- a/design/context.md
+++ b/design/context.md
@@ -177,6 +177,16 @@ These document the current implemented token direction. Do not treat this sectio
 - `--sz-search-min` 160px — minimum width for search inputs.
 - `--sz-touch` 44px, `--sz-icon-sm` 14px.
 
+### Component Specifications
+
+Component-local custom properties for em-based padding and gap values. These scale with font-size and are prefixed per component to avoid collisions (CSS Modules scopes class selectors, not custom property names).
+
+- **Button** (`button.module.css`): `--btn-pad-y` 0.4em (sm 0.25em, xs 0.15em), `--btn-pad-x` 0.85em (sm 0.6em, xs 0.45em), `--btn-gap` 0.35em.
+- **Badge** (`badge.module.css`): `--badge-pad-y` 0.15em (xs 0.05em, sm 0.1em, md 0.2em), `--badge-pad-x` 0.55em (xs 0.4em, sm 0.45em, md 0.65em), `--badge-gap` 0.25em.
+- **Inline Code** (`typography.css`): `--code-pad-y` 0.1em, `--code-pad-x` 0.35em.
+
+**Guidance**: These are em-based so they scale with the component's font-size across size variants. They are not global tokens — they live on the component's base selector and size variants override them via cascade.
+
 ### Effects
 
 - `--blur-overlay` 2px — backdrop blur for overlays (command palette, confirm dialog).

--- a/frontend/src/components/shared/badge.module.css
+++ b/frontend/src/components/shared/badge.module.css
@@ -1,12 +1,16 @@
 /* Badge — status indicators, size variants, semantic colors */
 
 .badge {
+  --badge-pad-y: 0.15em;
+  --badge-pad-x: 0.55em;
+  --badge-gap: 0.25em;
+
   display: inline-flex;
   align-items: center;
-  gap: 0.25em;
+  gap: var(--badge-gap);
   font-size: var(--fs-micro);
   font-weight: var(--fw-medium);
-  padding: 0.15em 0.55em;
+  padding: var(--badge-pad-y) var(--badge-pad-x);
   border-radius: var(--r-pill);
   line-height: var(--lh-relaxed);
   white-space: nowrap;
@@ -14,19 +18,25 @@
 }
 
 .xs {
+  --badge-pad-y: 0.05em;
+  --badge-pad-x: 0.4em;
+
   font-size: var(--fs-xs);
-  padding: 0.05em 0.4em;
   line-height: var(--lh-micro);
 }
 
 .sm {
+  --badge-pad-y: 0.1em;
+  --badge-pad-x: 0.45em;
+
   font-size: var(--fs-micro);
-  padding: 0.1em 0.45em;
 }
 
 .md {
+  --badge-pad-y: 0.2em;
+  --badge-pad-x: 0.65em;
+
   font-size: var(--fs-small);
-  padding: 0.2em 0.65em;
 }
 
 /* Semantic badge variants */

--- a/frontend/src/components/shared/button.module.css
+++ b/frontend/src/components/shared/button.module.css
@@ -1,13 +1,17 @@
 /* Button — base, sizes, variants */
 
 .btn {
+  --btn-pad-y: 0.4em;
+  --btn-pad-x: 0.85em;
+  --btn-gap: 0.35em;
+
   display: inline-flex;
   align-items: center;
-  gap: 0.35em;
+  gap: var(--btn-gap);
   font-family: var(--font-body);
   font-size: var(--fs-small);
   font-weight: var(--fw-medium);
-  padding: 0.4em 0.85em;
+  padding: var(--btn-pad-y) var(--btn-pad-x);
   border: 1px solid var(--line-strong);
   border-radius: var(--r-md);
   background: var(--bg-surface);
@@ -28,13 +32,17 @@
 }
 
 .sm {
+  --btn-pad-y: 0.25em;
+  --btn-pad-x: 0.6em;
+
   font-size: var(--fs-micro);
-  padding: 0.25em 0.6em;
 }
 
 .xs {
+  --btn-pad-y: 0.15em;
+  --btn-pad-x: 0.45em;
+
   font-size: var(--fs-micro);
-  padding: 0.15em 0.45em;
 }
 
 /* Icon-only button — square, centered icon, no text */

--- a/frontend/src/styles/typography.css
+++ b/frontend/src/styles/typography.css
@@ -58,9 +58,12 @@ kbd {
 }
 
 code {
+  --code-pad-y: 0.1em;
+  --code-pad-x: 0.35em;
+
   background: var(--code-bg);
   color: var(--ink-1);
-  padding: 0.1em 0.35em;
+  padding: var(--code-pad-y) var(--code-pad-x);
   border-radius: var(--r-sm);
 }
 


### PR DESCRIPTION
### Component tokens for em-based padding/gap

- Replaced the raw em values in `Button`, `Badge`, and inline `code` with component-scoped CSS custom properties (`--btn-pad-y`, `--btn-pad-x`, `--btn-gap`, `--badge-pad-y`, `--badge-pad-x`, `--badge-gap`, `--code-pad-y`, `--code-pad-x`). Each property is prefixed per component since CSS Modules only scopes class selectors, not custom property names.
- Size variants (`.xs`, `.sm`, `.md`) override the base declaration via cascade instead of repeating a bare `padding: ... em` value — same computed output, but the source of the value is now named instead of a magic number.
- Documented the new tokens in `design/context.md` under a renamed "Component Padding & Gap" section (was "Component Specifications"), with the full value table and guidance on why these stay component-local instead of becoming global tokens.
- No visual output changes — every custom property is set to the exact em value it replaces.

Closes #1277
