### PR TITLE
refactor(ui): replace hardcoded CSS values with design tokens and add /design style guide

### DIFF
--- a/.claude/skills/ui-qa/references/harness.md
+++ b/.claude/skills/ui-qa/references/harness.md
@@ -66,7 +66,7 @@ Feed analysis subagents these sources rather than letting them invent design opi
 |--------|-----------------|
 | `frontend/DESIGN_RULES.md` | Responsive rules, table behavior, density, hierarchy |
 | `frontend/src/tokens.css` | All design tokens — anything not derived from these is a finding |
-| `design/interface-design/` | Design system specification |
+| `design/context.md` | Design system reference: tokens, component specs, status system, layout patterns |
 
 ## Verification battery (after any fix)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -317,7 +317,7 @@ Internal design documents live in `design/`, not in `docs/` (which is the readth
 
 - **`design/adrs/`** — Architecture Decision Records. One per significant technical decision. Numbered sequentially (`001-short-name.md`). Created when a direction is chosen, not while still exploring.
 - **`design/audits/`** — Design and architecture audits, reviews, and post-hoc evaluations of existing decisions or implementations.
-- **`design/interface-design/`** — Design system specification (tokens, layout, component patterns) for the web UI.
+- **`design/context.md`** — Design system reference: brand context, design tokens, component specifications, status system, layout patterns, and do's/don'ts. Read by all i-* design skills as the canonical design context.
 - **`design/research/`** — Feasibility analysis and implementation planning. Organized as `YYYY-MM-DD-topic-name/` subfolders containing a main `research.md` brief and optional prereq breakdowns.
 
 See `design/README.md` for the full guide on what goes where.

--- a/design/README.md
+++ b/design/README.md
@@ -6,9 +6,9 @@ Internal project design artifacts. Not published to readthedocs — that lives i
 
 ```
 design/
+├── context.md             Design system reference (tokens, components, patterns)
 ├── adrs/                  Architecture Decision Records
 ├── audits/                Diagnostic snapshots (health, security, dependencies)
-├── interface-design/      Design system (tokens, layout, component specs)
 └── research/              Feasibility analysis and implementation planning
 ```
 
@@ -20,9 +20,9 @@ Architecture Decision Records — one file per significant decision. Created whe
 
 ADRs record: context, decision, consequences, and alternatives considered. They are append-only — superseded decisions get a `Superseded by: ADR-NNN` status, not deleted.
 
-### `interface-design/`
+### `context.md`
 
-Design system specification for the web UI. Tokens (colors, spacing, typography), component patterns, and layout rules. Referenced by frontend code and UI-related issues.
+Design system reference for the web UI. Brand context, design tokens, component specifications, status system, layout patterns, and do's/don'ts. Read by all i-* design skills as the canonical design context. Canonical source of truth for design decisions — token values live in `frontend/src/tokens.css`, component implementations in `frontend/src/components/shared/`.
 
 ### `audits/`
 

--- a/design/context.md
+++ b/design/context.md
@@ -1,9 +1,9 @@
 ---
 schema_version: 1
-updated_at: 2026-07-08
+updated_at: 2026-07-10
 ---
 
-# Hassette Frontend Design Context
+# Hassette Design System
 
 ## Users & Purpose
 
@@ -111,114 +111,673 @@ Healthy/running states should be calm. Failures, warnings, blocked states, and d
 
 Buttons, badges, chips, cards, table shells, sort headers, empty states, and popovers should encode visual decisions. Page code should assemble domain-specific content, not invent one-off UI language.
 
+---
+
 ## Design Tokens
 
-These document the current implemented token direction. Do not treat this section as a mandate that tokens are final; it records the baseline before visual QA.
+All tokens are defined in `frontend/src/tokens.css`. Light theme is the `:root` default; dark theme overrides live under `[data-theme="dark"]`. These values document the current implemented state — some remain open for revision (see Open Questions at the end of this file).
 
-### Color
+For prescriptive design rules on how to apply these tokens — typography hierarchy, spacing rhythm, contrast safety, data formatting, information density — see `frontend/DESIGN_RULES.md`.
+
+### Color Palette
+
+#### Surfaces
 
 | Token | Light | Dark | Role |
 |---|---|---|---|
 | `--bg-page` | `oklch(0.95 0.006 var(--accent-hue))` | `#0c0e11` | Outer page background |
-| `--bg-surface` | `oklch(0.995 0.002 var(--accent-hue))` | `#1a1c21` | Main panels and cards |
+| `--bg-surface` | `oklch(0.995 0.002 var(--accent-hue))` | `#1a1c21` | Main panels, cards, sidebar |
 | `--bg-sunken` | `oklch(0.955 0.006 var(--accent-hue))` | `#141619` | Table headers, recessed inputs, code regions |
-| `--bg-active` | `oklch(0.92 0.01 var(--accent-hue))` | `#22242a` | Active/hover surfaces |
+| `--bg-active` | `oklch(0.92 0.01 var(--accent-hue))` | `#22242a` | Hover and active surfaces |
 | `--bg-chrome` | `oklch(0.96 0.005 var(--accent-hue))` | `#131517` | Status bar and app chrome |
+
+Light-mode surfaces use oklch with accent-hue tinting for subtle warmth. Dark-mode surfaces use raw hex with no hue tinting.
+
+#### Ink (Text)
+
+| Token | Light | Dark | Role |
+|---|---|---|---|
 | `--ink-1` | `#16181c` | `#edeff3` | Primary text |
-| `--ink-2` | `#4a4d54` | `#b5b9c0` | Secondary text |
-| `--ink-3` | `#787c84` | `#888d97` | Muted metadata |
-| `--ink-4` | `#b0b3b8` | `#5a5e66` | Disabled/subtle metadata |
+| `--ink-2` | `#4a4d54` | `#b5b9c0` | Secondary text, descriptions |
+| `--ink-3` | `#787c84` | `#888d97` | Muted metadata, labels |
+| `--ink-4` | `#b0b3b8` | `#5a5e66` | Disabled/subtle metadata, placeholders |
+
+#### Lines (Borders)
+
+| Token | Light | Dark | Role |
+|---|---|---|---|
+| `--line-1` | `#e6e6e2` | `#272a30` | Subtle dividers, section borders |
+| `--line-2` | `#ecece8` | `#1f2227` | Softest dividers, internal borders |
+| `--line-strong` | `#d0d0cc` | `#3a3e46` | Card borders, table containers, prominent dividers |
+
+#### Accent
+
+| Token | Light | Dark | Role |
+|---|---|---|---|
 | `--accent` | `oklch(0.5 0.09 255)` | `oklch(0.72 0.09 255)` | Navigation, active state, primary emphasis |
-| `--ok` | `#1f7a4d` | `#5fb988` | Healthy/running/success |
-| `--warn` | `#9a6a12` | `#d9b36e` | Warning/degraded/blocked |
-| `--err` | `#b53024` | `#e08278` | Failure/error |
-| `--mute` | `#9097a0` | `#6a707a` | Inactive/unknown/disabled |
+| `--accent-hover` | `oklch(0.42 0.09 255)` | `oklch(0.8 0.09 255)` | Accent hover state |
+| `--accent-ink` | `oklch(0.98 0.005 255)` | `oklch(0.15 0.01 255)` | Text on accent background |
+| `--accent-soft` | `oklch(0.95 0.0225 255)` | `oklch(0.22 0.036 255)` | Active tab backgrounds, focus rings |
+| `--accent-border` | `oklch(0.65 0.054 255)` | `oklch(0.55 0.054 255)` | Instance switcher active border |
+| `--accent-bg` | `oklch(0.97 0.0135 255)` | `oklch(0.18 0.018 255)` | Instance switcher active background |
+
+Accent hue is `255` (blue-violet). Chroma is `0.09`. Both are CSS custom properties (`--accent-hue`, `--accent-chroma`) so the entire accent family shifts if the hue changes.
+
+#### Status
+
+| Token | Light | Dark | Role |
+|---|---|---|---|
+| `--ok` | `#1f7a4d` | `#5fb988` | Healthy, running, success |
+| `--ok-bg` | `#eaf3ee` | `#19241e` | Success background tint |
+| `--warn` | `#9a6a12` | `#d9b36e` | Warning, degraded, blocked |
+| `--warn-bg` | `#f5eedd` | `#272219` | Warning background tint |
+| `--err` | `#b53024` | `#e08278` | Failure, error, crashed |
+| `--err-bg` | `#f5dedc` | `#28191a` | Error background tint |
+| `--cancel` | `#1f6f9a` | `#6fb8d9` | Cancelled (no `--cancel-bg` token) |
+| `--mute` | `#9097a0` | `#6a707a` | Inactive, unknown, disabled |
+| `--mute-bg` | `#eff0ec` | `#1d1f23` | Muted background tint |
+
+#### Utility
+
+| Token | Light | Dark | Role |
+|---|---|---|---|
+| `--input-bg` | `#ffffff` | `#1f2227` | Input field backgrounds |
+| `--overlay-bg` | `rgba(0,0,0,0.45)` | `rgba(0,0,0,0.5)` | Modal/drawer backdrops |
+| `--err-dark` | `#9a2020` | `#7a1a1a` | Error emphasis variant |
+| `--code-bg` | `var(--bg-sunken)` | `var(--bg-sunken)` | Code block backgrounds |
+| `--code-comment` | `var(--ink-3)` | `var(--ink-3)` | Code comment text |
 
 **Rationale**: The palette supports a restrained operational console. Surfaces stay close together, status colors carry meaning, and accent color is used primarily for orientation rather than decoration.
 
 ### Typography
 
-- **Display**: `Newsreader`, `Source Serif Pro`, Georgia, serif. Used for page titles and product wordmark. Adds a human/editorial note to an otherwise technical interface.
-- **Body**: `Geist`, system UI fallback. Used for navigation, labels, explanatory text, and controls.
-- **Mono**: `Geist Mono`, UI monospace fallback. Used for code, IDs, timestamps, paths, timings, and dense table data.
-- **Current scale**: display 38px, h1 28px, h2 20px, h3 16px, body 14px, small 12.5px, micro 12px, xs 11px.
-- **Line heights**: `--lh-display` 1.05, `--lh-h1` 1.15, `--lh-h2` 1.25, `--lh-h3` 1.35, `--lh-body` 1.55, `--lh-relaxed` 1.6, `--lh-small` 1.5, `--lh-micro` 1.4, `--lh-xs` 1.3.
-- **Tracking**: `--tr-label-tight` 0.03em, `--tr-label-mid` 0.04em, `--tr-label` 0.05em, `--tr-label-wide` 0.07em.
-- **Current weights**: normal 400, medium 500, semibold 600, bold 700.
+#### Font Stacks
 
-**Guidance**: The serif display face should remain a deliberate accent. If a page title feels disconnected from the rest of the UI, integrate surrounding hierarchy rather than removing the character by default.
+| Token | Stack | Usage |
+|---|---|---|
+| `--font-display` | Newsreader, Source Serif Pro, Georgia, serif | Page titles, product wordmark |
+| `--font-body` | Geist, system-ui, -apple-system, sans-serif | Navigation, labels, explanatory text, controls |
+| `--font-mono` | Geist Mono, ui-monospace, SF Mono, Menlo, monospace | Code, IDs, timestamps, paths, timings, table data |
+
+The serif display face is a deliberate accent — an editorial note in an otherwise technical interface.
+
+#### Type Scale
+
+| Token | Size | Line Height | Tracking | Usage |
+|---|---|---|---|---|
+| `--fs-display` | 38px | `--lh-display` 1.05 | `--tr-display` -0.025em | Page titles (with `--font-display`) |
+| `--fs-h1` | 28px | `--lh-h1` 1.15 | `--tr-h1` -0.02em | Major section headings |
+| `--fs-h2` | 20px | `--lh-h2` 1.25 | `--tr-h2` -0.015em | Subsection headings |
+| `--fs-h3` | 16px | `--lh-h3` 1.35 | `--tr-h3` -0.005em | Card headings, sidebar wordmark |
+| `--fs-body` | 14px | `--lh-body` 1.55 | — | Body text, nav items |
+| `--fs-small` | 12.5px | `--lh-small` 1.5 | — | Table cells, app links |
+| `--fs-micro` | 12px | `--lh-micro` 1.4 | — | Badges, chips, inputs, metadata |
+| `--fs-xs` | 11px | `--lh-xs` 1.3 | — | Smallest labels |
+
+`--lh-relaxed` (1.6) is used for code blocks, tracebacks, and compact button rows where lines need more breathing room than `--lh-small` (1.5).
+| `--fs-stat` | 26px | — | — | StatsStrip values |
+| `--fs-badge` | 11.5px | — | — | Badge text (specific) |
+| `--fs-mono-sm` | 12px | — | — | Small monospace (inputs, code) |
+| `--fs-mono-md` | 13px | — | — | Medium monospace (tabs) |
+
+#### Letter Spacing
+
+| Token | Value | Usage |
+|---|---|---|
+| `--tr-label-tight` | 0.03em | Mobile filter labels |
+| `--tr-label-mid` | 0.04em | Diagnostics, config tab labels |
+| `--tr-label` | 0.05em | Uppercase table headers, sidebar labels |
+| `--tr-label-wide` | 0.07em | StatsStrip labels, section headers |
+
+#### Weights
+
+| Token | Value | Usage |
+|---|---|---|
+| `--fw-normal` | 400 | Body text, display titles |
+| `--fw-medium` | 500 | Buttons, badges, chips, stat values, active nav |
+| `--fw-semibold` | 600 | Active sort columns, dialog titles, tab badges |
+| `--fw-bold` | 700 | Rare emphasis |
 
 ### Spacing
 
-- **Base**: 4px grid with half-steps where useful.
-- **Scale**: `--sp-px` 1px, `--sp-0` 2px, `--sp-1` 4px, `--sp-2` 8px, `--sp-3` 12px, `--sp-4` 16px, `--sp-5` 20px, `--sp-6` 24px, `--sp-7` 32px, `--sp-8` 40px, `--sp-9` 56px, `--sp-10` 72px.
-- **Current page rhythm**: `.ht-page` uses larger desktop padding and gaps, then tightens below mobile breakpoints.
+4px base grid with half-steps where useful.
 
-**Guidance**: Use spacing to clarify hierarchy, not to make the product airy. This UI should remain compact.
-
-### Depth
-
-- **Strategy**: subtle shadows plus visible borders.
-- **Current levels**: `--shadow-1`, `--shadow-2`, `--shadow-3`.
-- **Current card baseline**: `var(--bg-surface)`, `1px solid var(--line-strong)`, `var(--r-md)`, `var(--shadow-2)`.
-
-**Guidance**: Depth should separate working surfaces from the page, especially tables and diagnostic cards. Avoid dramatic elevation.
+| Token | Value | Usage examples |
+|---|---|---|
+| `--sp-px` | 1px | Sub-grid vertical padding (chips, compact badges) |
+| `--sp-0` | 2px | Focus outline offset, micro margins |
+| `--sp-1` | 4px | Icon button padding, tight gaps |
+| `--sp-1h` | 6px | Input vertical padding (half-step) |
+| `--sp-2` | 8px | Shell gap, table cell padding, inner gaps |
+| `--sp-3` | 12px | Card compact padding, section gaps, nav item padding |
+| `--sp-3h` | 14px | StatsStrip cell padding (half-step) |
+| `--sp-4` | 16px | Page header gaps, command palette padding |
+| `--sp-5` | 20px | Card default padding |
+| `--sp-6` | 24px | Card error padding, dialog padding, empty state padding |
+| `--sp-7` | 32px | Page padding and gap, status bar horizontal padding |
+| `--sp-8` | 40px | Dialog width margin |
+| `--sp-9` | 56px | (Reserved) |
+| `--sp-10` | 72px | (Reserved) |
 
 ### Border Radius
 
-- **Scale**: `--r-sm` 6px, `--r-md` 8px, `--r-lg` 12px, `--r-xl` 20px, `--r-pill` 999px.
-- **Character**: moderately technical, not sharp-industrial and not bubbly.
+| Token | Value | Mobile | Character |
+|---|---|---|---|
+| `--r-sm` | 6px | — | Chips, filter buttons, focus outlines |
+| `--r-md` | 8px | — | Cards, buttons, inputs, table containers, popovers |
+| `--r-lg` | 12px | 10px | Main content area top corners |
+| `--r-xl` | 20px | 16px | Dialogs, command palette |
+| `--r-pill` | 999px | — | Badges, pulse dots, spinner |
 
-**Guidance**: Large rounded panels should be used carefully. Keep dense diagnostic elements tighter than marketing-style cards.
+Moderately technical — not sharp-industrial and not bubbly.
 
-### Component Sizing
+### Elevation & Shadows
 
-- `--sz-sidebar` 240px — sidebar width, used in layout grid and mobile drawer.
-- `--sz-search-min` 160px — minimum width for search inputs.
-- `--sz-touch` 44px, `--sz-icon-sm` 14px.
-- `--sz-popover-min` 200px — minimum width for popovers (column filter, mobile filter panel).
-- `--sz-popover-max` 280px — maximum width for popovers (column filter, info popover).
-- `--sz-content-narrow` 320px — maximum width for narrow centered content (empty state body text).
-- `--sz-dialog-min` 320px — minimum width for dialogs (confirm dialog).
-- `--sz-dialog-max` 480px — maximum width for dialogs (confirm dialog).
-- `--sz-drawer` 400px — log detail drawer width (grid column + fixed panel).
-- `--sz-palette` 620px — command palette width (clamped to 90% on small screens).
+| Token | Light | Dark | Usage |
+|---|---|---|---|
+| `--shadow-1` | `0 1px 2px rgba(20,22,26,0.04)` | `0 1px 2px rgba(0,0,0,0.3)` | Subtle, mobile cards |
+| `--shadow-2` | `0 2px 8px rgba(20,22,26,0.06), 0 1px 2px rgba(20,22,26,0.04)` | `0 2px 8px rgba(0,0,0,0.4), 0 1px 2px rgba(0,0,0,0.3)` | Cards, table containers, stats strips |
+| `--shadow-3` | `0 8px 24px rgba(20,22,26,0.08), 0 2px 6px rgba(20,22,26,0.04)` | `0 8px 24px rgba(0,0,0,0.5), 0 2px 6px rgba(0,0,0,0.3)` | Dialogs, command palette, elevated popovers |
+
+Dark mode shadows use stronger opacity for definition against dark backgrounds. Strategy is subtle shadows plus visible borders — depth separates working surfaces from the page without dramatic elevation.
 
 ### Component Padding & Gap
 
 Component-local custom properties for em-based padding and gap values. These scale with font-size and are prefixed per component to avoid collisions (CSS Modules scopes class selectors, not custom property names).
 
-- **Button** (`button.module.css`): `--btn-pad-y` 0.4em (sm 0.25em, xs 0.15em), `--btn-pad-x` 0.85em (sm 0.6em, xs 0.45em), `--btn-gap` 0.35em.
-- **Badge** (`badge.module.css`): `--badge-pad-y` 0.15em (xs 0.05em, sm 0.1em, md 0.2em), `--badge-pad-x` 0.55em (xs 0.4em, sm 0.45em, md 0.65em), `--badge-gap` 0.25em.
-- **Inline Code** (`typography.css`): `--code-pad-y` 0.1em, `--code-pad-x` 0.35em.
+| Component | Pad Y | Pad X | Gap | Defined in |
+|---|---|---|---|---|
+| **Button** (default) | `--btn-pad-y` 0.4em | `--btn-pad-x` 0.85em | `--btn-gap` 0.35em | `button.module.css` |
+| Button sm | 0.25em | 0.6em | — | |
+| Button xs | 0.15em | 0.45em | — | |
+| **Badge** (default) | `--badge-pad-y` 0.15em | `--badge-pad-x` 0.55em | `--badge-gap` 0.25em | `badge.module.css` |
+| Badge xs | 0.05em | 0.4em | — | |
+| Badge sm | 0.1em | 0.45em | — | |
+| Badge md | 0.2em | 0.65em | — | |
+| **Inline Code** | `--code-pad-y` 0.1em | `--code-pad-x` 0.35em | — | `typography.css` |
 
-**Guidance**: These are em-based so they scale with the component's font-size across size variants. They are not global tokens — they live on the component's base selector and size variants override them via cascade.
+These are em-based so they scale with the component's font-size across size variants. They are not global tokens — they live on the component's base selector and size variants override them via cascade.
 
 ### Effects
 
-- `--blur-overlay` 2px — backdrop blur for overlays (command palette, confirm dialog).
-- `--border-thick` 3px — heavy borders (spinner track, error accent borders).
+| Token | Value | Usage |
+|---|---|---|
+| `--blur-overlay` | 2px | Backdrop blur for overlays (command palette, confirm dialog) |
+| `--border-thick` | 3px | Heavy borders (spinner track, error accent borders) |
 
 ### Motion
 
-- **Micro**: `--t-fast` 120ms.
-- **Transition**: `--t-med` 200ms.
-- **Spin**: `--t-spin` 0.8s — spinner animation duration.
-- **Easing**: `cubic-bezier(0.4, 0, 0.2, 1)`.
+| Token | Value | Usage |
+|---|---|---|
+| `--t-fast` | 120ms | Hover, color, background transitions |
+| `--t-med` | 200ms | Drawer slide, layout shifts |
+| `--t-spin` | 0.8s | Spinner animation duration |
+| `--ease` | `cubic-bezier(0.4, 0, 0.2, 1)` | All transitions |
 
-**Guidance**: Motion should confirm interactions and orient users during overlays/drawers. Avoid decorative animation except for meaningful live-status indicators like the connection pulse.
+The breathing animation (connection pulse) cycles opacity `--op-ghost` to 1.0 over 2.5s, ease-in-out, infinite. No spring or bounce curves anywhere.
 
-## Anti-Patterns
+Motion confirms interactions and orients users during overlays/drawers. No decorative animation except the connection pulse.
 
-- Showing every value with equal emphasis.
-- Adding charts when a table, count, or linked evidence trail answers the question better.
-- Making successful states visually louder than failures.
-- Using red/green only as decoration without text or context.
-- Creating page-specific table/filter behavior when a shared pattern already exists.
-- Hiding important diagnostic details behind tabs or collapsed panels without a strong reason.
-- Treating configuration and logs as raw dumps with no hierarchy or affordances.
+### Z-Index
 
-## Current Open Questions
+| Token | Value | Layer |
+|---|---|---|
+| `--z-table-head` | 1 | Sticky table headers |
+| `--z-tooltip` | 15 | Tooltips, info popovers |
+| `--z-sidebar` | 30 | Desktop sidebar |
+| `--z-drawer-bg` | 55 | Mobile drawer backdrop |
+| `--z-drawer` | 60 | Mobile drawer, column filter popovers |
+| `--z-status-bar` | 65 | Fixed mobile status bar |
+| `--z-dialog` | 100 | Modal dialogs (backdrop + 1 for content) |
+| `--z-palette-bg` | 200 | Command palette backdrop |
+| `--z-palette` | 201 | Command palette panel |
+| `--z-skip` | 1000 | Accessibility skip link |
+
+### Opacity
+
+| Token | Value | Usage |
+|---|---|---|
+| `--op-ghost` | 0.35 | Breathing animation low point |
+| `--op-disabled` | 0.5 | Disabled elements |
+| `--op-muted` | 0.7 | Muted overlays |
+| `--op-subtle` | 0.9 | Hover dimming (brand link, primary button) |
+
+### Component Sizing
+
+| Token | Value | Usage |
+|---|---|---|
+| `--sz-sidebar` | 240px | Sidebar width, layout grid and mobile drawer |
+| `--sz-search-min` | 160px | Minimum width for search inputs |
+| `--sz-touch` | 44px | WCAG touch target minimum (applied at ≤900px) |
+| `--sz-icon-sm` | 14px | Standard inline icon size |
+| `--sz-popover-min` | 200px | Minimum width for popovers (column filter, mobile filter panel) |
+| `--sz-popover-max` | 280px | Maximum width for popovers (column filter, info popover) |
+| `--sz-content-narrow` | 320px | Maximum width for narrow centered content (empty state body) |
+| `--sz-dialog-min` | 320px | Minimum width for dialogs (confirm dialog) |
+| `--sz-dialog-max` | 480px | Maximum width for dialogs (confirm dialog) |
+| `--sz-drawer` | 400px | Log detail drawer width |
+| `--sz-palette` | 620px | Command palette width (clamped to 90% on small screens) |
+
+### Effects
+
+| Token | Value | Usage |
+|---|---|---|
+| `--blur-overlay` | 2px | Backdrop blur for overlays (command palette, confirm dialog) |
+| `--border-thick` | 3px | Heavy borders (spinner track, error accent borders) |
+
+---
+
+## Layout
+
+### Shell Structure
+
+The app shell is a CSS grid: 240px sidebar + 1fr main content area. The main area has rounded top corners (`--r-lg`), `--shadow-2`, and scrolls independently.
+
+```
+.ht-layout (grid: 240px 1fr, gap --sp-2, padded right/top/bottom)
+  Sidebar (sticky, full height)
+  .ht-main (scrollable, --bg-surface, rounded top)
+    StatusBar (inline on desktop, fixed on mobile)
+    .ht-page (content, --sp-7 padding and gap)
+```
+
+### Sidebar
+
+Width: `--sz-sidebar`, `position: sticky; top: 0`, `--bg-page` background.
+
+**Sections top to bottom:**
+1. **Brand** — Newsreader wordmark (`--fs-h3`), version in mono (`--fs-micro`, `--ink-3`), bordered bottom
+2. **Cmd-K trigger** — button styled as a sunken pill (`--bg-sunken`, `--line-1` border, `--r-md`)
+3. **Main navigation** — links with icons, `--fs-body`, `--r-md` radius. Active: `--accent-soft` background, `--accent` text, `--fw-medium`
+4. **App navigation** — scrollable section with search input, collapsible status groups, app links
+
+**Status groups** in sidebar: collapsible headers with StatusShape indicator, uppercase mono label, count badge. Groups with errors/warnings use `--err`/`--warn` on the label.
+
+**App links:** `--font-mono`, `--fs-small`. Hover: `--accent` color.
+
+### Status Bar
+
+Horizontal bar at top of main area. `--bg-chrome` background, `--line-1` bottom border.
+
+**Contents:** time preset selector (left), WebSocket status pulse + optional indicators + theme toggle (right).
+
+**Pulse dot:** 8px circle, `--r-pill`. Colors: connected = `--ok` with breathing animation, connecting = `--mute`, disconnected = `--err`, degraded = `--warn`.
+
+**Time preset selector (desktop):** segmented button row with `--line-1` border, `--r-md` radius. Active preset: `--accent-soft` background, `--accent` text. Mobile: native `<select>` dropdown.
+
+### Responsive Breakpoints
+
+| Breakpoint | Constant | Changes |
+|---|---|---|
+| **≤900px** | `BREAKPOINT_SIDEBAR` | Sidebar hidden, hamburger menu shown, grid collapses to single column, main area loses border-radius and shadow, touch targets enlarged to `--sz-touch` |
+| **≤768px** | `BREAKPOINT_MOBILE` | Status bar becomes fixed, page padding reduces to `--sp-3`, search inputs go full-width, stats strip drops to 3 columns, handler table replaced by card layout, tab strip scrolls horizontally, column filters consolidate into footer |
+| **≤480px** | `BREAKPOINT_SMALL_MOBILE` | Page padding reduces to `--sp-2`, uptime display hidden |
+
+These constants are synced between CSS media queries and `use-media-query.ts`.
+
+### Page Patterns
+
+#### Standard Table Page (Apps, Handlers)
+
+```
+.ht-page
+  .ht-page-header > h1.ht-display
+  .ht-table-section
+    StatsStrip? (optional summary stats)
+    input.ht-search (align-self: flex-end)
+    TableCard
+      table.ht-table.ht-table--fixed
+        colgroup (explicit column widths)
+        thead > SortHeader per column
+        tbody > rows
+      TableFooter (count + mobile filters)
+```
+
+Page gap: `--sp-7`. Table section gap: `--sp-3`. Display heading: `--font-display`, `--fs-h1`.
+
+Column widths are set per-page via `<colgroup>`. Mobile (≤900px) hides lower-priority columns and reallocates widths.
+
+#### Detail Page (App Detail)
+
+```
+.ht-page
+  Identity section (instance switcher + header + tab strip)
+  Tab panel (active tab content)
+```
+
+**Tab strip:** inline row of links, `--line-1` border, `--r-sm` radius. Active tab: gradient fade to `--accent-soft`. Tabs: overview, handlers, code, logs, config.
+
+**Multi-instance:** grid `repeat(auto-fill, minmax(280px, 1fr))` of instance cards. Active instance: `--accent-bg` background, `--accent-border` border.
+
+---
+
+## Components
+
+All shared components live in `frontend/src/components/shared/`. Use these instead of raw CSS class strings.
+
+### Button
+
+**Variants:** `default`, `primary`, `success`, `warning`, `info`, `danger`
+**Sizes:** default, `sm`, `xs`
+**Modifiers:** `ghost` (transparent bg/border), `icon` (square padding for icon-only)
+
+| Variant | Background | Border | Text | Hover |
+|---|---|---|---|---|
+| default | `--bg-surface` | `--line-strong` | `--ink-1` | bg: `--bg-sunken` |
+| primary | `--accent` | `--accent` | `--accent-ink` | opacity: `--op-subtle` |
+| success | `--bg-surface` | `--ok` | `--ok` | bg: `--ok-bg` |
+| warning | `--bg-surface` | `--warn` | `--warn` | bg: `--warn-bg` |
+| info | `--bg-surface` | `--line-strong` | `--accent` | bg: `--bg-sunken`, text: `--accent-hover` |
+| danger | transparent | `--err` | `--err` | bg: `--err-bg` |
+
+**Ghost modifier:** border and background become transparent. Hover shows `--bg-sunken` (or status-bg for semantic variants).
+
+**Base:** `--font-body`, `--fs-small`, `--fw-medium`, `--r-md` radius, `--t-fast` transitions. Padding: `--btn-pad-y` / `--btn-pad-x` (em-based, scales with font size). Icon mode: `--sp-1` padding, SVG sized `--sp-4`.
+
+**Sizes:** `sm` and `xs` use `--fs-micro` and override `--btn-pad-y` / `--btn-pad-x` to tighter values.
+
+**Responsive (≤900px):** `sm`, `xs`, and `icon` variants get min-height `--sz-touch` for WCAG touch targets.
+
+### Badge
+
+**Variants:** `success`, `danger`, `warning`, `neutral`, `info`
+**Sizes:** `xs`, `sm`, default, `md`
+
+| Variant | Text | Background |
+|---|---|---|
+| success | `--ok` | `--ok-bg` |
+| danger | `--err` | `--err-bg` |
+| warning | `--warn` | `--warn-bg` |
+| neutral | `--ink-3` | `--bg-sunken` |
+| info | `--accent` | `--accent-soft` |
+
+**Base:** `--r-pill` (full pill shape), `--fs-micro`, `--fw-medium`, `--badge-pad-y` / `--badge-pad-x` padding. No interactive states (static display element).
+
+`BadgeVariant` extends `StatusVariant` with `"info"` — the info variant is used directly by components, not derived from status mapping functions.
+
+### Card
+
+**Variants:** default, `compact`, `config`, `error`
+
+| Variant | Padding | Notes |
+|---|---|---|
+| default | `--sp-5` | Standard card |
+| compact | `--sp-3` | Tighter padding, same border/shadow |
+| config | 0 | Flush inner content, overflow hidden |
+| error | `--sp-6` | Standalone error display, centered text |
+
+**Base:** `--bg-surface`, `1px solid --line-strong`, `--r-md`, `--shadow-2`.
+
+**Responsive (≤768px):** shadow reduces to `--shadow-1`, border softens to `--line-1`. At ≤480px: padding reduces to `--sp-3`.
+
+### Chip
+
+**Variants:** `modifier`, `schedule`, `kind`, `origin`, `muted`
+**Sizes:** default, `sm`
+
+| Variant | Font | Border | Background | Text |
+|---|---|---|---|---|
+| modifier | `--font-mono` | `color-mix(--accent 30%)` | `color-mix(--accent 12%)` | `--ink-1` |
+| schedule | `--font-mono` | `color-mix(--ok 25%)` | `color-mix(--ok 10%)` | `--ink-3` |
+| kind | `--font-body` | per-kind color | transparent | per-kind color |
+| origin | `--font-mono` | `--line-2` | transparent | `--ink-3` |
+| muted | `--font-mono` | `--line-1` | `--bg-sunken` | `--ink-3` |
+
+**Kind sub-variants** (when `variant="kind"`):
+
+| Kind | Border/Text Color |
+|---|---|
+| ok | `--ok` |
+| warn | `--warn` |
+| err | `--err` |
+| cancel | `--cancel` |
+| mute | `--ink-4` |
+
+**Base:** `--r-sm`, `--fs-micro`, `--fw-medium`. No interactive states.
+
+Origin variant uses uppercase + `--tr-label` letter spacing.
+
+### StatusShape
+
+SVG geometric indicators for inline status display. Each kind maps to a distinct shape:
+
+| Kind | Shape | Fill | Notes |
+|---|---|---|---|
+| ok | Circle | `--ok` | Filled |
+| warn | Triangle | `--warn` | Filled |
+| err | Rounded square | `--err` | Filled |
+| cancel | Diamond | `--cancel` | Filled |
+| mute | Ring | `--mute` | Stroke-only (hollow) |
+
+Used in sidebar app groups, table rows, and command palette results. Sized by the parent context. No interactive states.
+
+### StatsStrip
+
+Grid of labeled stat cells. Columns set via `cols` prop (default 7).
+
+**Structure:** `--bg-surface`, `--line-strong` border, `--r-md` radius, `--shadow-2`.
+
+**Cell:** label in `--font-mono`, uppercase, `--fs-micro`, `--tr-label-wide`, `--ink-3`. Value in `--font-body`, `--fs-stat`, `--fw-medium`.
+
+**Tone colors:** cells accept a tone (ok, warn, err, cancel, mute) that colors the value. Zero-value cells dim both label and value to `--ink-4`.
+
+**Responsive (≤768px):** grid drops to 3 columns; overflow cells get a top border.
+
+### Tooltip
+
+CSS-only via `::after` pseudo-element on a wrapper. No JavaScript positioning.
+
+**Appearance:** `--ink-1` background (inverted), `--bg-page` text, `--r-sm` radius, `--shadow-2`. Positioned above trigger with `--sp-1` gap.
+
+**Activation:** hover or focus-visible → opacity 1 with `--t-fast` transition.
+
+### InfoPopover
+
+JavaScript-positioned floating panel for contextual help. Uses floating-ui.
+
+**Trigger:** 18×18px button, `--ink-4` text → `--accent` on hover/expanded.
+
+**Panel:** `--bg-surface`, `--line-strong` border, `--r-md` radius, `--shadow-3`. Max `--sz-popover-max` wide, 60vh tall. `--font-body`, `--fs-micro`, `--ink-2` text.
+
+**Dismiss:** Escape, click outside.
+
+### ConfirmDialog
+
+Modal dialog with backdrop blur.
+
+**Backdrop:** `--overlay-bg`, `backdrop-filter: blur(--blur-overlay)`, `--z-dialog`.
+
+**Dialog:** `--bg-surface`, `--line-1` border, `--r-xl` radius, `--shadow-3`. Min `--sz-dialog-min`, max `--sz-dialog-max` wide, `--sp-6` padding. Title: `--fs-h3`, `--fw-semibold`. Body: `--fs-body`, `--ink-2`.
+
+**Actions:** flex-end, `--sp-3` gap. Cancel button is default variant; confirm is `primary` or `danger` based on tone prop.
+
+**Behavior:** focus trap, Escape dismisses, focus returns to trigger on unmount.
+
+### Spinner
+
+Rotating border circle. `--sp-6` width/height, `--border-thick` border in `--line-strong` with `--accent` top edge. `--t-spin` linear infinite rotation.
+
+ARIA: `role="status"`, `aria-label="Loading"`.
+
+### EmptyState
+
+Centered placeholder for empty data views.
+
+**Structure:** icon (`--fs-h1`, `--ink-4`), title (`--fs-small`, `--fw-medium`, `--ink-2`), optional body (`--fs-micro`, `--ink-3`, max `--sz-content-narrow`), optional children slot for action buttons.
+
+### AppLink
+
+Monospace link to app detail pages. `--font-mono`, `--fs-small`, `--ink-1`. Hover: `--accent` with underline.
+
+### Icons
+
+Inline SVGs at `--sz-icon-sm` (14px). All use `currentColor` and `aria-hidden="true"`.
+
+**Stroke icons** (navigation, actions): 24×24 viewBox, stroke-width 2, round caps/joins.
+
+**Fill icons** (sidebar): 24×24 viewBox, path-based.
+
+**Chevron:** separate sizing via `size` prop, rotates based on `open` prop.
+
+---
+
+## Status System
+
+### Two Visual Channels
+
+The UI uses two parallel status systems that intentionally diverge for some states. They serve different questions:
+
+- **StatusVariant** (Badge) → "What should the user do about this?" Warning = needs attention. Neutral = no action needed.
+- **StatusKind** (Shape/Chip) → "What is the current health state?" Ok = healthy. Warn = transitional. Mute = inactive.
+
+| Status | Badge (StatusVariant) | Shape (StatusKind) | Why they differ |
+|---|---|---|---|
+| running | success | ok | — |
+| starting | neutral | ok | No action needed, but healthy progress |
+| stopped | warning | mute | Needs attention (badge) but not broken (shape) |
+| blocked | warning | warn | — |
+| stopping / shutting_down | neutral | warn | No action needed, but transitional |
+| failed / crashed | danger | err | — |
+| exhausted_dead | danger | err | — |
+| exhausted_cooling | warning | warn | — |
+| disabled / not_started | neutral | mute | — |
+
+Use the mapping functions in `frontend/src/utils/status.ts` — do not map status strings to colors directly. New status values must be added to both maps.
+
+### StatusVariant
+
+`"success" | "danger" | "warning" | "neutral"`
+
+Used by Badge (via `statusToVariant()`), log levels (via `levelToVariant()`), and readiness display (via `readinessVariant()`).
+
+### StatusKind
+
+`"ok" | "warn" | "err" | "cancel" | "mute"`
+
+Used by StatusShape SVG indicators (via `statusToKind()`), Chip kind variant, execution status (via `executionStatusKind()`), and log levels (via `levelToKind()`).
+
+`cancel` exists as a Kind but not a Variant — it maps to the diamond shape for cancelled executions.
+
+### Execution Status Mapping
+
+| Execution status | StatusKind |
+|---|---|
+| success | ok |
+| timed_out | warn |
+| cancelled | cancel |
+| error | err |
+| skipped | mute |
+
+### Log Level Mapping
+
+| Level | Badge (StatusVariant) | Shape (StatusKind) |
+|---|---|---|
+| DEBUG | neutral | mute |
+| INFO | success | mute |
+| WARNING | warning | warn |
+| ERROR / CRITICAL | danger | err |
+
+---
+
+## Patterns
+
+### Focus
+
+**Global baseline** (`:where(:focus-visible)`): `outline: 2px solid var(--accent)`, `outline-offset: var(--sp-0)`. The `:where()` wrapper gives zero specificity so component-level rules win cleanly.
+
+**Inputs** suppress the outline and use border + box-shadow ring instead: `border-color: var(--accent)`, `box-shadow: 0 0 0 2px var(--accent-soft)`.
+
+**Popover inputs** use a simpler focus: `border-color: var(--accent)` only (no box-shadow).
+
+### Inputs
+
+No shared `<Input>` component exists. Inputs are styled via two patterns:
+
+**`.ht-search`** (global class, primary pattern): `--font-body`, `--fs-mono-sm`, `--sp-1h`/`--sp-2` padding, `1px solid --line-strong`, `--r-md`, `--input-bg`. Placeholder: `--ink-4`. Mobile: stretches full width.
+
+**Popover inputs** (scoped CSS): similar but smaller padding (`--sp-1`/`--sp-2`), `--line-1` border (softer), `--r-sm` radius.
+
+### Tables
+
+All data tables follow the same structural pattern:
+
+```
+TableCard (scroll container + footer slot)
+  table.ht-table[.ht-table--fixed|.ht-table--compact]
+    colgroup (explicit column widths, set per page)
+    thead > SortHeader per column
+    tbody > rows
+  TableFooter (count + mobile filter consolidation)
+```
+
+**Table headers:** `--font-mono`, `--fw-medium`, `--fs-micro`, uppercase, `--tr-label` tracking, `--ink-3`.
+
+**Table cells:** `--fs-small`, `--sp-2`/`--sp-3` padding, `--line-1` bottom border. Row hover: `--bg-sunken`.
+
+**Scroll container:** `--line-strong` border, `--r-md` radius, max-height defaults to `calc(100vh - 310px)`, overridable via `scrollHeight` prop.
+
+**Sort headers:** click cycles asc/desc. Active: `--ink-1`, `--fw-semibold`. Arrow indicators: Unicode ↑/↓.
+
+**Column filters:** desktop: popover per column header. Mobile: consolidated into footer panel.
+
+**Compact variant:** tighter padding (`--sp-1`/`--sp-2`), `table-layout: fixed`, text-overflow ellipsis. Has predefined column-width classes for status/time/duration columns.
+
+### Command Palette
+
+Cmd-K / Ctrl-K global search. `--r-xl` radius, `--shadow-3`, positioned at 15vh from top.
+
+**Structure:** search input → grouped results (sections with uppercase mono headers) → keyboard hint footer.
+
+**Result rows:** `--fs-body`, hover: `--bg-active`. Active: `--fw-semibold`. Kind chips per result.
+
+**Responsive (≤768px):** footer hidden.
+
+### Dark Mode
+
+Token-driven — almost no component-level overrides. The only structural dark-mode override is the Shiki code syntax highlighter, which needs `!important` to override inline styles.
+
+Key dark-mode differences in token values:
+- Accent lightness inverts (0.5 → 0.72) for contrast on dark backgrounds
+- Shadow opacity increases significantly for definition
+- Light-mode surfaces use oklch with accent-hue tinting; dark-mode uses raw hex
+
+---
+
+## Do's and Don'ts
+
+These are implementation-level rules for agents working on the frontend. For higher-level design constraints, see Concrete Constraints above.
+
+### Do
+
+- Use shared components (Button, Badge, Card, Chip) instead of raw CSS classes
+- Use CSS Modules for all component-specific styles
+- Reference tokens for all visual values — no raw hex, pixel, or rem values in component CSS
+- Follow the table pattern: TableCard + SortHeader + TableFooter
+- Use StatusShape for inline status indicators, Badge for labeled status
+- Use the status mapping functions from `status.ts` — never map status strings to colors directly
+- Follow the standard table page or detail page pattern when creating new pages
+- Let tokens handle dark mode — avoid component-level `[data-theme="dark"]` overrides
+- Enlarge touch targets to `--sz-touch` at the sidebar breakpoint (≤900px)
+- Use `--font-mono` for data that benefits from fixed-width alignment (IDs, timestamps, paths)
+
+### Don't
+
+- Show every value with equal visual emphasis — use ink hierarchy (`--ink-1` through `--ink-4`)
+- Add charts when a table, count, or linked evidence trail answers the question better
+- Make successful states visually louder than failures
+- Use status colors as decoration without text or context
+- Create page-specific table or filter behavior when the shared pattern exists
+- Hide diagnostic details behind tabs or collapsed panels without strong reason
+- Treat config and logs as raw dumps with no hierarchy or affordances
+- Add new `.ht-*` global classes without updating the CSS allowlist
+- Create new status colors or invent a third status mapping system
+- Use inline styles for colors, spacing, or typography
+- Style inputs inconsistently — follow `.ht-search` or the popover input pattern
+- Add new page layouts that deviate from the standard table page or detail page pattern
+
+---
+
+## Open Questions
 
 - Should the serif display treatment stay as-is, become more integrated, or be reduced?
 - Should the accent remain blue-violet in tokens while operational status remains green, or should the product identity move closer to Graphite/Emerald?

--- a/design/context.md
+++ b/design/context.md
@@ -244,7 +244,7 @@ The serif display face is a deliberate accent — an editorial note in an otherw
 
 | Token | Value | Usage examples |
 |---|---|---|
-| `--sp-px` | 1px | Sub-grid vertical padding (chips, compact badges) |
+| `--sp-px` | 1px | Hairline border width, sub-grid vertical padding (chips, compact badges) |
 | `--sp-0` | 2px | Focus outline offset, micro margins |
 | `--sp-1` | 4px | Icon button padding, tight gaps |
 | `--sp-1h` | 6px | Input vertical padding (half-step) |
@@ -303,6 +303,7 @@ These are em-based so they scale with the component's font-size across size vari
 | Token | Value | Usage |
 |---|---|---|
 | `--blur-overlay` | 2px | Backdrop blur for overlays (command palette, confirm dialog) |
+| `--border-med` | 2px | Focus-visible outlines, failing-state accent borders |
 | `--border-thick` | 3px | Heavy borders (spinner track, error accent borders) |
 
 ### Motion
@@ -363,6 +364,7 @@ Motion confirms interactions and orients users during overlays/drawers. No decor
 | Token | Value | Usage |
 |---|---|---|
 | `--blur-overlay` | 2px | Backdrop blur for overlays (command palette, confirm dialog) |
+| `--border-med` | 2px | Focus-visible outlines, failing-state accent borders |
 | `--border-thick` | 3px | Heavy borders (spinner track, error accent borders) |
 
 ---

--- a/design/context.md
+++ b/design/context.md
@@ -213,12 +213,12 @@ The serif display face is a deliberate accent — an editorial note in an otherw
 | `--fs-small` | 12.5px | `--lh-small` 1.5 | — | Table cells, app links |
 | `--fs-micro` | 12px | `--lh-micro` 1.4 | — | Badges, chips, inputs, metadata |
 | `--fs-xs` | 11px | `--lh-xs` 1.3 | — | Smallest labels |
-
-`--lh-relaxed` (1.6) is used for code blocks, tracebacks, and compact button rows where lines need more breathing room than `--lh-small` (1.5).
 | `--fs-stat` | 26px | — | — | StatsStrip values |
 | `--fs-badge` | 11.5px | — | — | Badge text (specific) |
 | `--fs-mono-sm` | 12px | — | — | Small monospace (inputs, code) |
 | `--fs-mono-md` | 13px | — | — | Medium monospace (tabs) |
+
+`--lh-relaxed` (1.6) is used for code blocks, tracebacks, and compact button rows where lines need more breathing room than `--lh-small` (1.5).
 
 #### Letter Spacing
 
@@ -358,14 +358,6 @@ Motion confirms interactions and orients users during overlays/drawers. No decor
 | `--sz-dialog-max` | 480px | Maximum width for dialogs (confirm dialog) |
 | `--sz-drawer` | 400px | Log detail drawer width |
 | `--sz-palette` | 620px | Command palette width (clamped to 90% on small screens) |
-
-### Effects
-
-| Token | Value | Usage |
-|---|---|---|
-| `--blur-overlay` | 2px | Backdrop blur for overlays (command palette, confirm dialog) |
-| `--border-med` | 2px | Focus-visible outlines, failing-state accent borders |
-| `--border-thick` | 3px | Heavy borders (spinner track, error accent borders) |
 
 ---
 

--- a/frontend/DESIGN_RULES.md
+++ b/frontend/DESIGN_RULES.md
@@ -4,6 +4,8 @@ Concrete visual rules for hassette's web UI. Claude reads this when making front
 
 These rules codify what's already working and fix what's inconsistent. They reference the existing token system in `src/styles/tokens.css`. Every rule uses specific tokens or values — no subjective judgment required.
 
+For the token catalog, component specifications, and status system reference, see `design/context.md`.
+
 ## Typography Hierarchy
 
 The UI uses two font families: Newsreader (serif, display) and Geist (sans, body). The rule is: **Newsreader is for page identity only. Geist does everything else.**

--- a/frontend/src/app.tsx
+++ b/frontend/src/app.tsx
@@ -15,6 +15,7 @@ import { createQueryClient } from "./lib/query-client";
 import { AppDetailPage } from "./pages/app-detail";
 import { AppsPage } from "./pages/apps";
 import { ConfigPage } from "./pages/config";
+import { DesignPage } from "./pages/design";
 import { DiagnosticsPage } from "./pages/diagnostics";
 import { HandlersPage } from "./pages/handlers";
 import { LogsPage } from "./pages/logs";
@@ -148,6 +149,7 @@ export function App() {
                   <Route path="/diagnostics" component={DiagnosticsPage} />
                   <Route path="/logs" component={LogsPage} />
                   <Route path="/config" component={ConfigPage} />
+                  <Route path="/design" component={DesignPage} />
                   <Route component={NotFoundPage} />
                 </Switch>
               </ErrorBoundary>

--- a/frontend/src/components/app-detail/code-tab.module.css
+++ b/frontend/src/components/app-detail/code-tab.module.css
@@ -1,7 +1,7 @@
 /* Code tab — component-scoped styles */
 
 .codeTab {
-  border: 1px solid var(--line-1);
+  border: var(--sp-px) solid var(--line-1);
   border-radius: var(--r-md);
   overflow: hidden;
   background: var(--bg-surface);
@@ -12,7 +12,7 @@
   align-items: center;
   justify-content: space-between;
   padding: var(--sp-2) var(--sp-4);
-  border-bottom: 1px solid var(--line-1);
+  border-bottom: var(--sp-px) solid var(--line-1);
   background: var(--bg-sunken);
   gap: var(--sp-3);
   flex-wrap: wrap;
@@ -35,7 +35,7 @@
   font-size: var(--fs-micro);
   color: var(--ink-4);
   font-family: var(--font-mono);
-  border: 1px solid var(--line-1);
+  border: var(--sp-px) solid var(--line-1);
   border-radius: var(--r-sm);
   padding: var(--sp-px) var(--sp-2);
 }
@@ -87,7 +87,7 @@
   padding: 0 var(--sp-3);
   user-select: none;
   flex-shrink: 0;
-  border-right: 1px solid var(--line-1);
+  border-right: var(--sp-px) solid var(--line-1);
   margin-right: var(--sp-3);
 }
 

--- a/frontend/src/components/app-detail/config-tab.module.css
+++ b/frontend/src/components/app-detail/config-tab.module.css
@@ -43,7 +43,7 @@
 .instanceHeading {
   margin: 0 0 var(--sp-3);
   padding-bottom: var(--sp-2);
-  border-bottom: 1px solid var(--line-strong);
+  border-bottom: var(--sp-px) solid var(--line-strong);
   font-family: var(--font-body);
   font-size: var(--fs-small);
   font-weight: var(--fw-semibold);
@@ -74,7 +74,7 @@
   margin-top: var(--sp-2);
   padding: var(--sp-3);
   background: var(--bg-sunken);
-  border: 1px dashed var(--line-1);
+  border: var(--sp-px) dashed var(--line-1);
   border-radius: var(--r-sm);
   font-family: var(--font-mono);
   font-size: var(--fs-xs);

--- a/frontend/src/components/app-detail/handler-detail-layout.module.css
+++ b/frontend/src/components/app-detail/handler-detail-layout.module.css
@@ -7,7 +7,7 @@
 .content {
   padding: var(--sp-4);
   background: var(--bg-surface);
-  border: 1px solid var(--line-1);
+  border: var(--sp-px) solid var(--line-1);
   border-radius: var(--r-md);
 }
 
@@ -46,7 +46,7 @@
 .executionsPanel {
   padding: var(--sp-4);
   background: var(--bg-surface);
-  border: 1px solid var(--line-1);
+  border: var(--sp-px) solid var(--line-1);
   border-radius: var(--r-md);
 }
 

--- a/frontend/src/components/app-detail/handler-health-card.module.css
+++ b/frontend/src/components/app-detail/handler-health-card.module.css
@@ -2,7 +2,7 @@
 
 .card {
   background: var(--bg-surface);
-  border: 1px solid var(--line-strong);
+  border: var(--sp-px) solid var(--line-strong);
   border-radius: var(--r-md);
   padding: var(--sp-3);
   cursor: pointer;
@@ -21,12 +21,12 @@
 }
 
 .card:focus-visible {
-  outline: 2px solid var(--accent);
+  outline: var(--border-med) solid var(--accent);
   outline-offset: var(--sp-0);
 }
 
 .cardFailing {
-  border-top: 2px solid var(--err);
+  border-top: var(--border-med) solid var(--err);
 }
 
 .cardFailing:hover {

--- a/frontend/src/components/app-detail/handler-list.module.css
+++ b/frontend/src/components/app-detail/handler-list.module.css
@@ -1,7 +1,7 @@
 /* Handler list — component-scoped styles */
 
 .itemList {
-  border: 1px solid var(--line-strong);
+  border: var(--sp-px) solid var(--line-strong);
   box-shadow: var(--shadow-2);
   border-radius: var(--r-md);
   overflow: hidden;

--- a/frontend/src/components/app-detail/handlers-tab.module.css
+++ b/frontend/src/components/app-detail/handlers-tab.module.css
@@ -25,7 +25,7 @@
   overflow-y: auto;
   max-height: var(--master-max-height);
   background: var(--bg-surface);
-  border: 1px solid var(--line-1);
+  border: var(--sp-px) solid var(--line-1);
   border-radius: var(--r-md);
 }
 

--- a/frontend/src/components/app-detail/overview-tab.module.css
+++ b/frontend/src/components/app-detail/overview-tab.module.css
@@ -18,7 +18,7 @@
   flex-direction: column;
   gap: var(--sp-3);
   padding-top: var(--sp-6);
-  border-top: 1px solid var(--line-1);
+  border-top: var(--sp-px) solid var(--line-1);
 }
 
 .section:first-child {
@@ -48,7 +48,7 @@
   gap: var(--sp-2);
   padding: var(--sp-3);
   background: var(--bg-surface);
-  border: 1px solid var(--line-1);
+  border: var(--sp-px) solid var(--line-1);
   border-radius: var(--r-md);
 }
 

--- a/frontend/src/components/app-detail/unified-handler-row.module.css
+++ b/frontend/src/components/app-detail/unified-handler-row.module.css
@@ -11,7 +11,7 @@
   background: var(--bg-surface);
   /* Button reset */
   border: none;
-  border-bottom: 1px solid var(--line-1);
+  border-bottom: var(--sp-px) solid var(--line-1);
   font: inherit;
   color: inherit;
   text-align: left;
@@ -27,7 +27,7 @@
 }
 
 .row:focus-visible {
-  outline: 2px solid var(--accent);
+  outline: var(--border-med) solid var(--accent);
   outline-offset: calc(-1 * var(--sp-0));
 }
 
@@ -37,7 +37,7 @@
 }
 
 .status {
-  padding-top: 3px;
+  padding-top: var(--sp-1);
   flex-shrink: 0;
 }
 
@@ -70,7 +70,7 @@
   font-size: var(--fs-xs);
   font-weight: var(--fw-medium);
   background: var(--bg-sunken);
-  border: 1px solid var(--line-1);
+  border: var(--sp-px) solid var(--line-1);
   border-radius: var(--r-sm);
   padding: var(--sp-px) var(--sp-1);
   color: var(--ink-3);
@@ -138,7 +138,7 @@
   font-size: var(--fs-xs);
   font-weight: var(--fw-medium);
   background: color-mix(in srgb, var(--accent) 10%, transparent);
-  border: 1px solid color-mix(in srgb, var(--accent) 25%, transparent);
+  border: var(--sp-px) solid color-mix(in srgb, var(--accent) 25%, transparent);
   border-radius: var(--r-sm);
   padding: var(--sp-px) var(--sp-1);
   color: var(--ink-3);

--- a/frontend/src/components/design/color-tokens.module.css
+++ b/frontend/src/components/design/color-tokens.module.css
@@ -1,0 +1,24 @@
+.grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(140px, 1fr));
+  gap: var(--sp-3);
+}
+
+.swatch {
+  display: flex;
+  flex-direction: column;
+  gap: var(--sp-1);
+}
+
+.swatchColor {
+  height: var(--sp-9);
+  border-radius: var(--r-md);
+  border: var(--sp-px) solid var(--line-1);
+}
+
+.swatchName {
+  font-family: var(--font-body);
+  font-size: var(--fs-small);
+  font-weight: var(--fw-medium);
+  color: var(--ink-1);
+}

--- a/frontend/src/components/design/color-tokens.tsx
+++ b/frontend/src/components/design/color-tokens.tsx
@@ -1,0 +1,84 @@
+import styles from "./color-tokens.module.css";
+import s from "./section.module.css";
+
+interface SwatchGroup {
+  label: string;
+  tokens: { name: string; cssVar: string }[];
+}
+
+const GROUPS: SwatchGroup[] = [
+  {
+    label: "Surfaces",
+    tokens: [
+      { name: "page", cssVar: "--bg-page" },
+      { name: "surface", cssVar: "--bg-surface" },
+      { name: "sunken", cssVar: "--bg-sunken" },
+      { name: "active", cssVar: "--bg-active" },
+      { name: "chrome", cssVar: "--bg-chrome" },
+    ],
+  },
+  {
+    label: "Ink",
+    tokens: [
+      { name: "ink-1", cssVar: "--ink-1" },
+      { name: "ink-2", cssVar: "--ink-2" },
+      { name: "ink-3", cssVar: "--ink-3" },
+      { name: "ink-4", cssVar: "--ink-4" },
+    ],
+  },
+  {
+    label: "Lines",
+    tokens: [
+      { name: "line-1", cssVar: "--line-1" },
+      { name: "line-2", cssVar: "--line-2" },
+      { name: "line-strong", cssVar: "--line-strong" },
+    ],
+  },
+  {
+    label: "Accent",
+    tokens: [
+      { name: "accent", cssVar: "--accent" },
+      { name: "hover", cssVar: "--accent-hover" },
+      { name: "ink", cssVar: "--accent-ink" },
+      { name: "soft", cssVar: "--accent-soft" },
+      { name: "border", cssVar: "--accent-border" },
+      { name: "bg", cssVar: "--accent-bg" },
+    ],
+  },
+  {
+    label: "Status",
+    tokens: [
+      { name: "ok", cssVar: "--ok" },
+      { name: "ok-bg", cssVar: "--ok-bg" },
+      { name: "warn", cssVar: "--warn" },
+      { name: "warn-bg", cssVar: "--warn-bg" },
+      { name: "err", cssVar: "--err" },
+      { name: "err-bg", cssVar: "--err-bg" },
+      { name: "cancel", cssVar: "--cancel" },
+      { name: "mute", cssVar: "--mute" },
+      { name: "mute-bg", cssVar: "--mute-bg" },
+    ],
+  },
+];
+
+export function ColorTokens() {
+  return (
+    <section class={s.section}>
+      <h2 class={s.heading}>Color Palette</h2>
+      {GROUPS.map((group) => (
+        <div key={group.label} class={s.group}>
+          <h3 class={s.groupLabel}>{group.label}</h3>
+          <div class={styles.grid}>
+            {group.tokens.map((token) => (
+              <div key={token.cssVar} class={styles.swatch}>
+                <div class={styles.swatchColor} style={{ backgroundColor: `var(${token.cssVar})` }} />
+                <span class={styles.swatchName}>{token.name}</span>
+                <code class={s.tokenCode}>{token.cssVar}</code>
+              </div>
+            ))}
+          </div>
+        </div>
+      ))}
+    </section>
+  );
+}

--- a/frontend/src/components/design/component-showcase.module.css
+++ b/frontend/src/components/design/component-showcase.module.css
@@ -1,0 +1,28 @@
+.row {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--sp-2);
+}
+
+.cardGrid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
+  gap: var(--sp-3);
+}
+
+.cardContent {
+  display: flex;
+  flex-direction: column;
+  gap: var(--sp-1);
+  padding: var(--sp-4);
+  font-family: var(--font-body);
+  font-size: var(--fs-small);
+  color: var(--ink-2);
+}
+
+.cardContent strong {
+  font-size: var(--fs-body);
+  font-weight: var(--fw-semibold);
+  color: var(--ink-1);
+}

--- a/frontend/src/components/design/component-showcase.tsx
+++ b/frontend/src/components/design/component-showcase.tsx
@@ -1,0 +1,115 @@
+import { Badge } from "../shared/badge";
+import { Button } from "../shared/button";
+import { Card } from "../shared/card";
+import { Chip } from "../shared/chip";
+import { Spinner } from "../shared/spinner";
+import { StatusShape } from "../shared/status-shape";
+import styles from "./component-showcase.module.css";
+import s from "./section.module.css";
+
+export function ComponentShowcase() {
+  return (
+    <section class={s.section}>
+      <h2 class={s.heading}>Components</h2>
+
+      <div class={s.group}>
+        <h3 class={s.groupLabel}>Button</h3>
+        <div class={styles.row}>
+          <Button>Default</Button>
+          <Button variant="primary">Primary</Button>
+          <Button variant="success">Success</Button>
+          <Button variant="warning">Warning</Button>
+          <Button variant="danger">Danger</Button>
+          <Button variant="info">Info</Button>
+        </div>
+        <div class={styles.row}>
+          <Button size="sm">Small</Button>
+          <Button size="xs">Extra Small</Button>
+          <Button disabled>Disabled</Button>
+        </div>
+      </div>
+
+      <div class={s.group}>
+        <h3 class={s.groupLabel}>Badge</h3>
+        <div class={styles.row}>
+          <Badge variant="success">Running</Badge>
+          <Badge variant="warning">Degraded</Badge>
+          <Badge variant="danger">Failed</Badge>
+          <Badge variant="neutral">Stopped</Badge>
+          <Badge variant="info">Info</Badge>
+        </div>
+        <div class={styles.row}>
+          <Badge variant="success" size="sm">
+            Small
+          </Badge>
+          <Badge variant="success" size="xs">
+            XS
+          </Badge>
+          <Badge variant="success" size="md">
+            Medium
+          </Badge>
+        </div>
+      </div>
+
+      <div class={s.group}>
+        <h3 class={s.groupLabel}>Chip</h3>
+        <div class={styles.row}>
+          <Chip variant="modifier">Modifier</Chip>
+          <Chip variant="schedule">Schedule</Chip>
+          <Chip variant="kind" kind="ok">
+            Kind
+          </Chip>
+          <Chip variant="origin">Origin</Chip>
+          <Chip variant="muted">Muted</Chip>
+        </div>
+        <div class={styles.row}>
+          <Chip variant="modifier" size="sm">
+            Small
+          </Chip>
+        </div>
+      </div>
+
+      <div class={s.group}>
+        <h3 class={s.groupLabel}>StatusShape</h3>
+        <div class={styles.row}>
+          <StatusShape kind="ok" />
+          <StatusShape kind="warn" />
+          <StatusShape kind="err" />
+          <StatusShape kind="cancel" />
+          <StatusShape kind="mute" />
+        </div>
+      </div>
+
+      <div class={s.group}>
+        <h3 class={s.groupLabel}>Card</h3>
+        <div class={styles.cardGrid}>
+          <Card>
+            <div class={styles.cardContent}>
+              <strong>Default</strong>
+              <span>Standard card surface</span>
+            </div>
+          </Card>
+          <Card variant="compact">
+            <div class={styles.cardContent}>
+              <strong>Compact</strong>
+              <span>Reduced padding</span>
+            </div>
+          </Card>
+          <Card variant="error">
+            <div class={styles.cardContent}>
+              <strong>Error</strong>
+              <span>Error state card</span>
+            </div>
+          </Card>
+        </div>
+      </div>
+
+      <div class={s.group}>
+        <h3 class={s.groupLabel}>Spinner</h3>
+        <div class={styles.row}>
+          <Spinner />
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/frontend/src/components/design/section.module.css
+++ b/frontend/src/components/design/section.module.css
@@ -1,0 +1,37 @@
+.section {
+  display: flex;
+  flex-direction: column;
+  gap: var(--sp-6);
+}
+
+.heading {
+  font-family: var(--font-display);
+  font-size: var(--fs-h2);
+  font-weight: var(--fw-semibold);
+  line-height: var(--lh-h2);
+  letter-spacing: var(--tr-h2);
+  color: var(--ink-1);
+  margin: 0;
+}
+
+.group {
+  display: flex;
+  flex-direction: column;
+  gap: var(--sp-3);
+}
+
+.groupLabel {
+  font-family: var(--font-body);
+  font-size: var(--fs-small);
+  font-weight: var(--fw-semibold);
+  text-transform: uppercase;
+  letter-spacing: var(--tr-label);
+  color: var(--ink-3);
+  margin: 0;
+}
+
+.tokenCode {
+  font-family: var(--font-mono);
+  font-size: var(--fs-xs);
+  color: var(--ink-3);
+}

--- a/frontend/src/components/design/spacing-tokens.module.css
+++ b/frontend/src/components/design/spacing-tokens.module.css
@@ -1,0 +1,90 @@
+.spacingList {
+  display: flex;
+  flex-direction: column;
+  gap: var(--sp-2);
+}
+
+.spacingRow {
+  display: grid;
+  grid-template-columns: 100px 40px 1fr;
+  align-items: center;
+  gap: var(--sp-3);
+}
+
+.spacingValue {
+  font-family: var(--font-mono);
+  font-size: var(--fs-xs);
+  color: var(--ink-2);
+  text-align: right;
+}
+
+.spacingBarTrack {
+  height: var(--sp-2);
+  background: var(--bg-sunken);
+  border-radius: var(--r-sm);
+  overflow: hidden;
+}
+
+.spacingBar {
+  height: 100%;
+  background: var(--accent);
+  border-radius: var(--r-sm);
+  min-width: var(--sp-px);
+}
+
+.radiiGrid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(100px, 1fr));
+  gap: var(--sp-4);
+}
+
+.radiusItem {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--sp-1);
+}
+
+.radiusBox {
+  width: var(--sp-9);
+  height: var(--sp-9);
+  background: var(--accent-soft);
+  border: var(--sp-px) solid var(--accent-border);
+}
+
+.radiusLabel {
+  font-family: var(--font-body);
+  font-size: var(--fs-small);
+  font-weight: var(--fw-medium);
+  color: var(--ink-1);
+}
+
+.shadowGrid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: var(--sp-7);
+  padding: var(--sp-6) var(--sp-4);
+  background: var(--bg-sunken);
+  border-radius: var(--r-lg);
+}
+
+.shadowItem {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--sp-3);
+}
+
+.shadowBox {
+  width: 100%;
+  aspect-ratio: 3 / 2;
+  background: var(--bg-surface);
+  border-radius: var(--r-md);
+}
+
+.shadowLabel {
+  font-family: var(--font-body);
+  font-size: var(--fs-small);
+  font-weight: var(--fw-medium);
+  color: var(--ink-1);
+}

--- a/frontend/src/components/design/spacing-tokens.tsx
+++ b/frontend/src/components/design/spacing-tokens.tsx
@@ -1,0 +1,92 @@
+import s from "./section.module.css";
+import styles from "./spacing-tokens.module.css";
+
+interface SpacingToken {
+  name: string;
+  cssVar: string;
+  px: number;
+}
+
+const SPACING: SpacingToken[] = [
+  { name: "px", cssVar: "--sp-px", px: 1 },
+  { name: "0", cssVar: "--sp-0", px: 2 },
+  { name: "1", cssVar: "--sp-1", px: 4 },
+  { name: "1h", cssVar: "--sp-1h", px: 6 },
+  { name: "2", cssVar: "--sp-2", px: 8 },
+  { name: "3", cssVar: "--sp-3", px: 12 },
+  { name: "3h", cssVar: "--sp-3h", px: 14 },
+  { name: "4", cssVar: "--sp-4", px: 16 },
+  { name: "5", cssVar: "--sp-5", px: 20 },
+  { name: "6", cssVar: "--sp-6", px: 24 },
+  { name: "7", cssVar: "--sp-7", px: 32 },
+  { name: "8", cssVar: "--sp-8", px: 40 },
+  { name: "9", cssVar: "--sp-9", px: 56 },
+  { name: "10", cssVar: "--sp-10", px: 72 },
+];
+
+const MAX_SPACING_PX = SPACING[SPACING.length - 1].px;
+
+const RADII = [
+  { name: "sm", cssVar: "--r-sm", px: 6 },
+  { name: "md", cssVar: "--r-md", px: 8 },
+  { name: "lg", cssVar: "--r-lg", px: 12 },
+  { name: "xl", cssVar: "--r-xl", px: 20 },
+  { name: "pill", cssVar: "--r-pill", px: 999 },
+];
+
+const SHADOWS = [
+  { name: "shadow-1", cssVar: "--shadow-1", label: "Subtle" },
+  { name: "shadow-2", cssVar: "--shadow-2", label: "Medium" },
+  { name: "shadow-3", cssVar: "--shadow-3", label: "Elevated" },
+];
+
+export function SpacingTokens() {
+  return (
+    <section class={s.section}>
+      <h2 class={s.heading}>Spacing, Radii & Shadows</h2>
+
+      <div class={s.group}>
+        <h3 class={s.groupLabel}>Spacing Scale</h3>
+        <div class={styles.spacingList}>
+          {SPACING.map((token) => (
+            <div key={token.cssVar} class={styles.spacingRow}>
+              <code class={s.tokenCode}>{token.cssVar}</code>
+              <span class={styles.spacingValue}>{token.px}px</span>
+              <div class={styles.spacingBarTrack}>
+                <div class={styles.spacingBar} style={{ width: `${(token.px / MAX_SPACING_PX) * 100}%` }} />
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      <div class={s.group}>
+        <h3 class={s.groupLabel}>Border Radius</h3>
+        <div class={styles.radiiGrid}>
+          {RADII.map((r) => (
+            <div key={r.cssVar} class={styles.radiusItem}>
+              <div class={styles.radiusBox} style={{ borderRadius: `var(${r.cssVar})` }} />
+              <span class={styles.radiusLabel}>{r.name}</span>
+              <code class={s.tokenCode}>
+                {r.cssVar} ({r.px}px)
+              </code>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      <div class={s.group}>
+        <h3 class={s.groupLabel}>Elevation</h3>
+        <div class={styles.shadowGrid}>
+          {SHADOWS.map((shadow) => (
+            <div key={shadow.cssVar} class={styles.shadowItem}>
+              <div class={styles.shadowBox} style={{ boxShadow: `var(${shadow.cssVar})` }} />
+              <span class={styles.shadowLabel}>{shadow.label}</span>
+              <code class={s.tokenCode}>{shadow.cssVar}</code>
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/frontend/src/components/design/typography-tokens.module.css
+++ b/frontend/src/components/design/typography-tokens.module.css
@@ -1,0 +1,71 @@
+.stackList {
+  display: flex;
+  flex-direction: column;
+  gap: var(--sp-4);
+}
+
+.stackRow {
+  display: flex;
+  flex-direction: column;
+  gap: var(--sp-1);
+}
+
+.stackSample {
+  font-size: var(--fs-h2);
+  color: var(--ink-1);
+}
+
+.scaleList {
+  display: flex;
+  flex-direction: column;
+  gap: var(--sp-5);
+}
+
+.scaleRow {
+  display: flex;
+  flex-direction: column;
+  gap: var(--sp-1);
+  padding-bottom: var(--sp-5);
+  border-bottom: var(--sp-px) solid var(--line-2);
+}
+
+.scaleRow:last-child {
+  border-bottom: none;
+  padding-bottom: 0;
+}
+
+.scaleMeta {
+  display: flex;
+  align-items: baseline;
+  gap: var(--sp-3);
+}
+
+.scaleLabel {
+  font-family: var(--font-body);
+  font-size: var(--fs-small);
+  font-weight: var(--fw-semibold);
+  color: var(--ink-2);
+}
+
+.scaleSample {
+  font-family: var(--font-body);
+  color: var(--ink-1);
+}
+
+.weightList {
+  display: flex;
+  flex-direction: column;
+  gap: var(--sp-3);
+}
+
+.weightRow {
+  display: flex;
+  align-items: baseline;
+  gap: var(--sp-4);
+}
+
+.weightSample {
+  font-family: var(--font-body);
+  font-size: var(--fs-h3);
+  color: var(--ink-1);
+}

--- a/frontend/src/components/design/typography-tokens.tsx
+++ b/frontend/src/components/design/typography-tokens.tsx
@@ -1,0 +1,105 @@
+import s from "./section.module.css";
+import styles from "./typography-tokens.module.css";
+
+interface TypeSpec {
+  label: string;
+  sizeVar: string;
+  lineHeightVar: string;
+  trackingVar?: string;
+  sample: string;
+}
+
+const TYPE_SCALE: TypeSpec[] = [
+  {
+    label: "Display",
+    sizeVar: "--fs-display",
+    lineHeightVar: "--lh-display",
+    trackingVar: "--tr-display",
+    sample: "Hassette",
+  },
+  { label: "H1", sizeVar: "--fs-h1", lineHeightVar: "--lh-h1", trackingVar: "--tr-h1", sample: "Page heading" },
+  { label: "H2", sizeVar: "--fs-h2", lineHeightVar: "--lh-h2", trackingVar: "--tr-h2", sample: "Section heading" },
+  { label: "H3", sizeVar: "--fs-h3", lineHeightVar: "--lh-h3", trackingVar: "--tr-h3", sample: "Card heading" },
+  {
+    label: "Body",
+    sizeVar: "--fs-body",
+    lineHeightVar: "--lh-body",
+    sample: "Default paragraph text for descriptions and content.",
+  },
+  { label: "Small", sizeVar: "--fs-small", lineHeightVar: "--lh-small", sample: "Secondary labels and metadata" },
+  { label: "Micro", sizeVar: "--fs-micro", lineHeightVar: "--lh-micro", sample: "Timestamps, footnotes" },
+  { label: "XS", sizeVar: "--fs-xs", lineHeightVar: "--lh-xs", sample: "BADGE LABELS" },
+];
+
+const FONT_STACKS = [
+  { label: "Display", cssVar: "--font-display", sample: "Newsreader — The quick brown fox" },
+  { label: "Body", cssVar: "--font-body", sample: "Geist — The quick brown fox jumps over the lazy dog" },
+  { label: "Mono", cssVar: "--font-mono", sample: "Geist Mono — 0123456789 => {}" },
+];
+
+const WEIGHTS = [
+  { label: "Normal", cssVar: "--fw-normal", value: "400" },
+  { label: "Medium", cssVar: "--fw-medium", value: "500" },
+  { label: "Semibold", cssVar: "--fw-semibold", value: "600" },
+  { label: "Bold", cssVar: "--fw-bold", value: "700" },
+];
+
+export function TypographyTokens() {
+  return (
+    <section class={s.section}>
+      <h2 class={s.heading}>Typography</h2>
+
+      <div class={s.group}>
+        <h3 class={s.groupLabel}>Font Stacks</h3>
+        <div class={styles.stackList}>
+          {FONT_STACKS.map((stack) => (
+            <div key={stack.cssVar} class={styles.stackRow}>
+              <code class={s.tokenCode}>{stack.cssVar}</code>
+              <span class={styles.stackSample} style={{ fontFamily: `var(${stack.cssVar})` }}>
+                {stack.sample}
+              </span>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      <div class={s.group}>
+        <h3 class={s.groupLabel}>Type Scale</h3>
+        <div class={styles.scaleList}>
+          {TYPE_SCALE.map((spec) => (
+            <div key={spec.sizeVar} class={styles.scaleRow}>
+              <div class={styles.scaleMeta}>
+                <span class={styles.scaleLabel}>{spec.label}</span>
+                <code class={s.tokenCode}>{spec.sizeVar}</code>
+              </div>
+              <span
+                class={styles.scaleSample}
+                style={{
+                  fontSize: `var(${spec.sizeVar})`,
+                  lineHeight: `var(${spec.lineHeightVar})`,
+                  letterSpacing: spec.trackingVar ? `var(${spec.trackingVar})` : undefined,
+                }}
+              >
+                {spec.sample}
+              </span>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      <div class={s.group}>
+        <h3 class={s.groupLabel}>Weights</h3>
+        <div class={styles.weightList}>
+          {WEIGHTS.map((w) => (
+            <div key={w.cssVar} class={styles.weightRow}>
+              <code class={s.tokenCode}>{w.cssVar}</code>
+              <span class={styles.weightSample} style={{ fontWeight: `var(${w.cssVar})` }}>
+                {w.label} ({w.value})
+              </span>
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/frontend/src/components/layout/alert-banner.module.css
+++ b/frontend/src/components/layout/alert-banner.module.css
@@ -17,13 +17,13 @@
 
 .alertWarning {
   background: var(--warn-bg);
-  border: 1px solid var(--warn);
+  border: var(--sp-px) solid var(--warn);
   color: var(--warn);
 }
 
 .alertDanger {
   background: var(--err-bg);
-  border: 1px solid var(--err);
+  border: var(--sp-px) solid var(--err);
   color: var(--err);
   flex-direction: column;
   align-items: stretch;
@@ -51,7 +51,7 @@
   border-radius: var(--r-md);
   margin-bottom: var(--sp-4);
   font-size: var(--fs-body);
-  border: 1px solid transparent;
+  border: var(--sp-px) solid transparent;
 }
 
 .degradedBannerWarn {

--- a/frontend/src/components/layout/command-palette.module.css
+++ b/frontend/src/components/layout/command-palette.module.css
@@ -20,7 +20,7 @@
   display: flex;
   flex-direction: column;
   background: var(--bg-surface);
-  border: 1px solid var(--line-1);
+  border: var(--sp-px) solid var(--line-1);
   border-radius: var(--r-xl);
   box-shadow: var(--shadow-3);
   z-index: var(--z-palette);
@@ -33,7 +33,7 @@
   align-items: center;
   gap: var(--sp-3);
   padding: var(--sp-3) var(--sp-4);
-  border-bottom: 1px solid var(--line-1);
+  border-bottom: var(--sp-px) solid var(--line-1);
   flex-shrink: 0;
 }
 
@@ -145,7 +145,7 @@
   font-size: var(--fs-micro);
   color: var(--ink-4);
   background: var(--bg-sunken);
-  border: 1px solid var(--line-1);
+  border: var(--sp-px) solid var(--line-1);
   border-radius: var(--r-sm);
   padding: var(--sp-px) var(--sp-2);
   white-space: nowrap;
@@ -158,7 +158,7 @@
   align-items: center;
   gap: var(--sp-4);
   padding: var(--sp-2) var(--sp-4);
-  border-top: 1px solid var(--line-1);
+  border-top: var(--sp-px) solid var(--line-1);
   font-size: var(--fs-micro);
   color: var(--ink-4);
   flex-shrink: 0;
@@ -168,7 +168,7 @@
   font-family: var(--font-mono);
   font-size: var(--fs-micro);
   background: var(--bg-sunken);
-  border: 1px solid var(--line-1);
+  border: var(--sp-px) solid var(--line-1);
   border-radius: var(--r-sm);
   padding: var(--sp-px) var(--sp-1);
   color: var(--ink-3);

--- a/frontend/src/components/layout/sidebar.module.css
+++ b/frontend/src/components/layout/sidebar.module.css
@@ -20,7 +20,7 @@
   flex-direction: column;
   align-items: flex-start;
   padding: var(--sp-4) 0 var(--sp-2);
-  border-bottom: 1px solid var(--line-2);
+  border-bottom: var(--sp-px) solid var(--line-2);
   flex-shrink: 0;
 }
 
@@ -52,7 +52,7 @@
   justify-content: space-between;
   margin: var(--sp-2) var(--sp-3);
   padding: var(--sp-2) var(--sp-3);
-  border: 1px solid var(--line-1);
+  border: var(--sp-px) solid var(--line-1);
   border-radius: var(--r-md);
   background: var(--bg-sunken);
   color: var(--ink-3);
@@ -112,7 +112,7 @@
 /* — App search ————————————————————————————————————————— */
 .searchWrap {
   padding: var(--sp-2) var(--sp-3);
-  border-top: 1px solid var(--line-2);
+  border-top: var(--sp-px) solid var(--line-2);
   margin-top: var(--sp-1);
 }
 
@@ -123,7 +123,7 @@
   font-size: var(--fs-small);
   color: var(--ink-1);
   background: var(--bg-sunken);
-  border: 1px solid var(--line-1);
+  border: var(--sp-px) solid var(--line-1);
   border-radius: var(--r-md);
   outline: none;
   transition:
@@ -359,7 +359,7 @@
 }
 
 .groupHeader:focus-visible {
-  outline: 2px solid var(--accent);
+  outline: var(--border-med) solid var(--accent);
   outline-offset: var(--sp-px);
 }
 
@@ -387,7 +387,7 @@
   font-size: var(--fs-micro);
   color: var(--ink-4);
   background: var(--bg-sunken);
-  border: 1px solid var(--line-1);
+  border: var(--sp-px) solid var(--line-1);
   border-radius: var(--r-sm);
   padding: 0 var(--sp-1);
   line-height: var(--lh-relaxed);

--- a/frontend/src/components/layout/status-bar.module.css
+++ b/frontend/src/components/layout/status-bar.module.css
@@ -40,7 +40,7 @@
   justify-content: center;
   width: var(--sp-7);
   height: var(--sp-7);
-  border: 1px solid var(--line-1);
+  border: var(--sp-px) solid var(--line-1);
   border-radius: var(--r-md);
   background: transparent;
   color: var(--ink-3);
@@ -75,7 +75,7 @@
   align-items: center;
   padding: var(--sp-2) var(--sp-7);
   background: var(--bg-chrome);
-  border-bottom: 1px solid var(--line-1);
+  border-bottom: var(--sp-px) solid var(--line-1);
   gap: var(--sp-3);
   flex-shrink: 0;
 }
@@ -100,7 +100,7 @@
   justify-content: center;
   width: var(--sz-touch);
   height: var(--sz-touch);
-  border: 1px solid var(--line-1);
+  border: var(--sp-px) solid var(--line-1);
   border-radius: var(--r-md);
   background: transparent;
   color: var(--ink-2);

--- a/frontend/src/components/layout/time-preset-selector.module.css
+++ b/frontend/src/components/layout/time-preset-selector.module.css
@@ -2,7 +2,7 @@
   display: flex;
   align-items: center;
   gap: var(--sp-0);
-  border: 1px solid var(--line-1);
+  border: var(--sp-px) solid var(--line-1);
   border-radius: var(--r-md);
   overflow: hidden;
   background: var(--bg-surface);
@@ -17,7 +17,7 @@
   color: var(--ink-3);
   background: transparent;
   border: none;
-  border-right: 1px solid var(--line-2);
+  border-right: var(--sp-px) solid var(--line-2);
   cursor: pointer;
   transition:
     background var(--t-fast) var(--ease),
@@ -44,7 +44,7 @@
   font-size: var(--fs-micro);
   color: var(--ink-4);
   font-family: var(--font-mono);
-  border-left: 1px solid var(--line-2);
+  border-left: var(--sp-px) solid var(--line-2);
 }
 
 .select {

--- a/frontend/src/components/shared/button.module.css
+++ b/frontend/src/components/shared/button.module.css
@@ -12,15 +12,15 @@
   font-size: var(--fs-small);
   font-weight: var(--fw-medium);
   padding: var(--btn-pad-y) var(--btn-pad-x);
-  border: 1px solid var(--line-strong);
+  border: var(--sp-px) solid var(--line-strong);
   border-radius: var(--r-md);
   background: var(--bg-surface);
   color: var(--ink-1);
   cursor: pointer;
   transition:
-    background var(--t-fast),
-    border-color var(--t-fast),
-    color var(--t-fast);
+    background var(--t-fast) var(--ease),
+    border-color var(--t-fast) var(--ease),
+    color var(--t-fast) var(--ease);
   text-decoration: none;
   line-height: var(--lh-small);
 }

--- a/frontend/src/components/shared/card.module.css
+++ b/frontend/src/components/shared/card.module.css
@@ -2,7 +2,7 @@
 
 .card {
   background: var(--bg-surface);
-  border: 1px solid var(--line-strong);
+  border: var(--sp-px) solid var(--line-strong);
   border-radius: var(--r-md);
   padding: var(--sp-5);
   box-shadow: var(--shadow-2);
@@ -25,7 +25,7 @@
    separate base class alongside it. */
 .error {
   background: var(--bg-surface);
-  border: 1px solid var(--line-strong);
+  border: var(--sp-px) solid var(--line-strong);
   border-radius: var(--r-md);
   padding: var(--sp-6);
   text-align: center;

--- a/frontend/src/components/shared/chip.module.css
+++ b/frontend/src/components/shared/chip.module.css
@@ -14,21 +14,21 @@
 .modifier {
   background: color-mix(in srgb, var(--accent) 12%, transparent);
   color: var(--ink-1);
-  border: 1px solid color-mix(in srgb, var(--accent) 30%, transparent);
+  border: var(--sp-px) solid color-mix(in srgb, var(--accent) 30%, transparent);
   font-family: var(--font-mono);
 }
 
 .schedule {
   background: color-mix(in srgb, var(--ok) 10%, transparent);
   color: var(--ink-3);
-  border: 1px solid color-mix(in srgb, var(--ok) 25%, transparent);
+  border: var(--sp-px) solid color-mix(in srgb, var(--ok) 25%, transparent);
   font-family: var(--font-mono);
 }
 
 /* kind variant: base styles shared across all kind sub-colors */
 .kind {
   gap: var(--sp-1);
-  border: 1px solid;
+  border: var(--sp-px) solid;
 }
 
 /* kind variant: per-color overrides */
@@ -58,7 +58,7 @@
   font-family: var(--font-mono);
   color: var(--ink-3);
   background: var(--bg-sunken);
-  border: 1px solid var(--line-1);
+  border: var(--sp-px) solid var(--line-1);
 }
 
 .origin {
@@ -66,7 +66,7 @@
   text-transform: uppercase;
   letter-spacing: var(--tr-label);
   color: var(--ink-3);
-  border: 1px solid var(--line-2);
+  border: var(--sp-px) solid var(--line-2);
 }
 
 /* size modifier */

--- a/frontend/src/components/shared/column-filter-popover/index.module.css
+++ b/frontend/src/components/shared/column-filter-popover/index.module.css
@@ -2,7 +2,7 @@
   position: fixed;
   z-index: var(--z-drawer);
   background: var(--bg-surface);
-  border: 1px solid var(--line-1);
+  border: var(--sp-px) solid var(--line-1);
   border-radius: var(--r-md);
   box-shadow: var(--shadow-2);
   padding: var(--sp-2);
@@ -19,7 +19,7 @@
   font-family: var(--font-body);
   font-size: var(--fs-small);
   padding: var(--sp-1) var(--sp-2);
-  border: 1px solid var(--line-1);
+  border: var(--sp-px) solid var(--line-1);
   border-radius: var(--r-sm);
   background: var(--input-bg);
   color: var(--ink-1);
@@ -46,7 +46,7 @@
   padding: var(--sp-0) var(--sp-2);
   border-radius: var(--r-sm);
   color: var(--ink-3);
-  transition: all var(--t-fast);
+  transition: all var(--t-fast) var(--ease);
 }
 
 .tierBtn:hover {
@@ -61,6 +61,6 @@
 }
 
 .tierBtn:focus-visible {
-  outline: 2px solid var(--accent);
+  outline: var(--border-med) solid var(--accent);
   outline-offset: var(--sp-0);
 }

--- a/frontend/src/components/shared/config-schema-view.module.css
+++ b/frontend/src/components/shared/config-schema-view.module.css
@@ -18,7 +18,7 @@
   align-items: baseline;
   gap: var(--sp-2);
   padding: var(--sp-3) var(--sp-4);
-  border-bottom: 1px solid var(--line-2);
+  border-bottom: var(--sp-px) solid var(--line-2);
 }
 
 .sectionTitle {
@@ -47,7 +47,7 @@
   flex-wrap: wrap;
   gap: var(--sp-2);
   padding: var(--sp-3) var(--sp-4);
-  border-bottom: 1px solid var(--line-2);
+  border-bottom: var(--sp-px) solid var(--line-2);
 }
 
 .row:last-child {
@@ -77,7 +77,7 @@
 .spacer {
   flex: 1 1 var(--sp-4);
   min-width: var(--sp-4);
-  border-bottom: 1px dotted var(--line-strong);
+  border-bottom: var(--sp-px) dotted var(--line-strong);
   transform: translateY(-3px);
   opacity: 0.55;
 }
@@ -102,7 +102,7 @@
   font-size: var(--fs-mono-sm);
   color: var(--ink-2);
   background: var(--bg-sunken);
-  border: 1px solid var(--line-2);
+  border: var(--sp-px) solid var(--line-2);
   padding: var(--sp-px) var(--sp-2);
   border-radius: var(--r-sm);
 }
@@ -125,7 +125,7 @@
 }
 
 /* The mask glyphs (••••) render visually small, so the secret value is sized up
-   a touch above the body size for legibility. 15px has no exact token. */
+   a touch above the body size for legibility. 15px and 2px have no exact tokens. */
 .valSecretMasked {
   font-style: italic;
   letter-spacing: 2px;
@@ -150,7 +150,7 @@
   font-family: var(--font-mono);
   font-size: var(--fs-xs);
   background: var(--bg-sunken);
-  border: 1px solid var(--line-1);
+  border: var(--sp-px) solid var(--line-1);
   border-radius: var(--r-sm);
   padding: var(--sp-px) var(--sp-2);
   color: var(--ink-2);

--- a/frontend/src/components/shared/confirm-dialog.module.css
+++ b/frontend/src/components/shared/confirm-dialog.module.css
@@ -16,7 +16,7 @@
   transform: translate(-50%, -50%);
   z-index: calc(var(--z-dialog) + 1);
   background: var(--bg-surface);
-  border: 1px solid var(--line-1);
+  border: var(--sp-px) solid var(--line-1);
   border-radius: var(--r-xl);
   box-shadow: var(--shadow-3);
   padding: var(--sp-6);

--- a/frontend/src/components/shared/detail-panel.module.css
+++ b/frontend/src/components/shared/detail-panel.module.css
@@ -2,7 +2,7 @@
 
 .panel {
   padding: var(--sp-3) var(--sp-4);
-  border-bottom: 1px solid var(--line-1);
+  border-bottom: var(--sp-px) solid var(--line-1);
 }
 
 .label {
@@ -31,7 +31,7 @@
 
 .tracebackSection {
   margin-top: var(--sp-3);
-  border-top: 1px solid var(--line-1);
+  border-top: var(--sp-px) solid var(--line-1);
   padding-top: var(--sp-3);
 }
 
@@ -68,7 +68,7 @@
 
 .logsWrapper {
   margin-top: var(--sp-3);
-  border-top: 1px solid var(--line-1);
+  border-top: var(--sp-px) solid var(--line-1);
   padding-top: var(--sp-3);
 }
 

--- a/frontend/src/components/shared/detail-stats.module.css
+++ b/frontend/src/components/shared/detail-stats.module.css
@@ -3,8 +3,8 @@
   gap: var(--sp-6);
   flex-wrap: wrap;
   padding: var(--sp-3) 0;
-  border-top: 1px solid var(--line-1);
-  border-bottom: 1px solid var(--line-1);
+  border-top: var(--sp-px) solid var(--line-1);
+  border-bottom: var(--sp-px) solid var(--line-1);
   margin-bottom: var(--sp-4);
 }
 

--- a/frontend/src/components/shared/error-banner.module.css
+++ b/frontend/src/components/shared/error-banner.module.css
@@ -1,6 +1,6 @@
 .banner {
   background: var(--err-bg);
-  border: 1px solid color-mix(in srgb, var(--err) 30%, transparent);
+  border: var(--sp-px) solid color-mix(in srgb, var(--err) 30%, transparent);
   border-radius: var(--r-md);
   padding: var(--sp-3) var(--sp-4);
   margin-bottom: var(--sp-4);

--- a/frontend/src/components/shared/info-popover.module.css
+++ b/frontend/src/components/shared/info-popover.module.css
@@ -25,7 +25,7 @@
 }
 
 .trigger:focus-visible {
-  outline: 2px solid var(--accent);
+  outline: var(--border-med) solid var(--accent);
   outline-offset: var(--sp-0);
 }
 
@@ -43,8 +43,8 @@
   color: var(--ink-2);
   font-family: var(--font-body);
   font-size: var(--fs-micro);
-  line-height: 1.45;
-  border: 1px solid var(--line-strong);
+  line-height: var(--lh-small);
+  border: var(--sp-px) solid var(--line-strong);
   border-radius: var(--r-md);
   box-shadow: var(--shadow-3);
 }

--- a/frontend/src/components/shared/log-table/column-picker.module.css
+++ b/frontend/src/components/shared/log-table/column-picker.module.css
@@ -6,14 +6,14 @@
   padding: var(--sp-1);
   border-radius: var(--r-sm);
   color: var(--ink-3);
-  transition: color var(--t-fast);
+  transition: color var(--t-fast) var(--ease);
 }
 
 .trigger:hover {
   color: var(--ink-1);
 }
 .trigger:focus-visible {
-  outline: 2px solid var(--accent);
+  outline: var(--border-med) solid var(--accent);
   outline-offset: var(--sp-0);
 }
 
@@ -51,13 +51,13 @@
   font-size: var(--fs-micro);
   color: var(--ink-3);
   padding: var(--sp-1) 0;
-  transition: color var(--t-fast);
+  transition: color var(--t-fast) var(--ease);
 }
 
 .resetBtn:hover {
   color: var(--ink-1);
 }
 .resetBtn:focus-visible {
-  outline: 2px solid var(--accent);
+  outline: var(--border-med) solid var(--accent);
   outline-offset: var(--sp-0);
 }

--- a/frontend/src/components/shared/log-table/log-detail-drawer.module.css
+++ b/frontend/src/components/shared/log-table/log-detail-drawer.module.css
@@ -22,7 +22,7 @@
   top: 0;
   height: 100vh;
   width: var(--sz-drawer);
-  border-left: 1px solid var(--line-1);
+  border-left: var(--sp-px) solid var(--line-1);
   box-shadow: var(--shadow-3);
   animation: slideInRight var(--t-med) var(--ease);
 }
@@ -33,7 +33,7 @@
   left: 0;
   width: 100%;
   max-height: 70vh;
-  border-top: 1px solid var(--line-1);
+  border-top: var(--sp-px) solid var(--line-1);
   border-radius: var(--r-lg) var(--r-lg) 0 0;
   box-shadow: var(--shadow-3);
   animation: slideInUp var(--t-med) var(--ease);
@@ -63,7 +63,7 @@
   align-items: center;
   justify-content: space-between;
   padding: var(--sp-2) var(--sp-3);
-  border-bottom: 1px solid var(--line-2);
+  border-bottom: var(--sp-px) solid var(--line-2);
   flex-shrink: 0;
 }
 
@@ -84,8 +84,8 @@
   font-size: var(--fs-body);
   color: var(--ink-3);
   transition:
-    color var(--t-fast),
-    background-color var(--t-fast);
+    color var(--t-fast) var(--ease),
+    background-color var(--t-fast) var(--ease);
 }
 
 .iconBtn:hover {
@@ -93,7 +93,7 @@
   background: var(--bg-sunken);
 }
 .iconBtn:focus-visible {
-  outline: 2px solid var(--accent);
+  outline: var(--border-med) solid var(--accent);
   outline-offset: var(--sp-0);
 }
 .iconBtn:disabled {
@@ -259,7 +259,7 @@
   color: var(--ink-4);
   padding: var(--sp-0);
   border-radius: var(--r-sm);
-  transition: color var(--t-fast);
+  transition: color var(--t-fast) var(--ease);
   flex-shrink: 0;
 }
 
@@ -267,7 +267,7 @@
   color: var(--ink-2);
 }
 .copyBtn:focus-visible {
-  outline: 2px solid var(--accent);
+  outline: var(--border-med) solid var(--accent);
   outline-offset: var(--sp-0);
 }
 

--- a/frontend/src/components/shared/log-table/log-table-row.module.css
+++ b/frontend/src/components/shared/log-table/log-table-row.module.css
@@ -1,7 +1,7 @@
 .row {
   cursor: pointer;
   outline: none;
-  transition: background var(--t-fast);
+  transition: background var(--t-fast) var(--ease);
 }
 
 .row:hover,

--- a/frontend/src/components/shared/registration-source.module.css
+++ b/frontend/src/components/shared/registration-source.module.css
@@ -6,7 +6,7 @@
   margin: var(--sp-1) 0 0;
   padding: var(--sp-3);
   background: var(--bg-sunken);
-  border: 1px dashed var(--line-1);
+  border: var(--sp-px) dashed var(--line-1);
   border-radius: var(--r-sm);
   font-family: var(--font-mono);
   font-size: var(--fs-micro);

--- a/frontend/src/components/shared/sort-header.module.css
+++ b/frontend/src/components/shared/sort-header.module.css
@@ -17,7 +17,7 @@
 }
 
 .sortHeader:focus-visible {
-  outline: 2px solid var(--accent);
+  outline: var(--border-med) solid var(--accent);
   outline-offset: var(--sp-0);
   border-radius: var(--r-sm);
 }
@@ -45,7 +45,7 @@
   padding: var(--sp-0);
   border-radius: var(--r-sm);
   color: var(--ink-4);
-  transition: color var(--t-fast);
+  transition: color var(--t-fast) var(--ease);
 }
 
 .filterBtn svg {
@@ -57,7 +57,7 @@
 }
 
 .filterBtn:focus-visible {
-  outline: 2px solid var(--accent);
+  outline: var(--border-med) solid var(--accent);
   outline-offset: var(--sp-0);
 }
 

--- a/frontend/src/components/shared/stats-strip.module.css
+++ b/frontend/src/components/shared/stats-strip.module.css
@@ -3,7 +3,7 @@
   grid-template-columns: repeat(var(--stats-cols, 7), 1fr);
   gap: 0;
   background: var(--bg-surface);
-  border: 1px solid var(--line-strong);
+  border: var(--sp-px) solid var(--line-strong);
   border-radius: var(--r-md);
   box-shadow: var(--shadow-2);
   overflow: hidden;
@@ -30,7 +30,7 @@
   font-family: var(--font-body);
   font-size: var(--fs-stat);
   font-weight: var(--fw-medium);
-  line-height: 1.1;
+  line-height: var(--lh-h1);
   color: var(--ink-1);
 }
 
@@ -61,6 +61,6 @@
   }
 
   .cell:nth-child(n + 4) {
-    border-top: 1px solid var(--line-2);
+    border-top: var(--sp-px) solid var(--line-2);
   }
 }

--- a/frontend/src/components/shared/table-footer.module.css
+++ b/frontend/src/components/shared/table-footer.module.css
@@ -4,7 +4,7 @@
   justify-content: space-between;
   gap: var(--sp-3);
   padding: var(--sp-2) var(--sp-3);
-  border-top: 1px solid var(--line-2);
+  border-top: var(--sp-px) solid var(--line-2);
   background: var(--bg-surface);
   flex-shrink: 0;
 }
@@ -38,14 +38,14 @@
   padding: var(--sp-1);
   border-radius: var(--r-sm);
   color: var(--ink-3);
-  transition: color var(--t-fast);
+  transition: color var(--t-fast) var(--ease);
 }
 
 .filterBtn:hover {
   color: var(--ink-1);
 }
 .filterBtn:focus-visible {
-  outline: 2px solid var(--accent);
+  outline: var(--border-med) solid var(--accent);
   outline-offset: var(--sp-0);
 }
 .filterBtnActive {
@@ -81,13 +81,13 @@
   font-size: var(--fs-micro);
   color: var(--ink-3);
   padding: var(--sp-1) 0;
-  transition: color var(--t-fast);
+  transition: color var(--t-fast) var(--ease);
 }
 
 .resetFiltersBtn:hover {
   color: var(--ink-1);
 }
 .resetFiltersBtn:focus-visible {
-  outline: 2px solid var(--accent);
+  outline: var(--border-med) solid var(--accent);
   outline-offset: var(--sp-0);
 }

--- a/frontend/src/pages/app-detail.module.css
+++ b/frontend/src/pages/app-detail.module.css
@@ -20,7 +20,7 @@
   display: flex;
   gap: 0;
   background: var(--bg-surface);
-  border: 1px solid var(--line-1);
+  border: var(--sp-px) solid var(--line-1);
   border-radius: var(--r-sm);
   overflow: hidden;
 }
@@ -48,7 +48,7 @@
 }
 
 .tabBtn:focus-visible {
-  outline: 2px solid var(--accent);
+  outline: var(--border-med) solid var(--accent);
   outline-offset: var(--sp-0);
   border-radius: var(--r-sm);
 }
@@ -84,7 +84,7 @@
   gap: var(--sp-2);
   padding: var(--sp-4);
   background: var(--bg-surface);
-  border: 1px solid var(--line-strong);
+  border: var(--sp-px) solid var(--line-strong);
   border-radius: var(--r-md);
   text-align: left;
   cursor: pointer;
@@ -102,7 +102,7 @@
 }
 
 .instanceCard:focus-visible {
-  outline: 2px solid var(--accent);
+  outline: var(--border-med) solid var(--accent);
   outline-offset: var(--sp-0);
 }
 
@@ -151,7 +151,7 @@
   gap: var(--sp-2);
   padding: var(--sp-1) var(--sp-3);
   background: none;
-  border: 1px solid var(--line-1);
+  border: var(--sp-px) solid var(--line-1);
   border-radius: var(--r-sm);
   font-family: var(--font-mono);
   font-size: var(--fs-micro);
@@ -177,7 +177,7 @@
 }
 
 .instanceSwitcherBtn:focus-visible {
-  outline: 2px solid var(--accent);
+  outline: var(--border-med) solid var(--accent);
   outline-offset: var(--sp-0);
 }
 

--- a/frontend/src/pages/apps.module.css
+++ b/frontend/src/pages/apps.module.css
@@ -116,7 +116,7 @@
 }
 
 .expand:focus-visible {
-  outline: 2px solid var(--accent);
+  outline: var(--border-med) solid var(--accent);
   outline-offset: var(--sp-0);
 }
 

--- a/frontend/src/pages/design.module.css
+++ b/frontend/src/pages/design.module.css
@@ -1,0 +1,7 @@
+.content {
+  display: flex;
+  flex-direction: column;
+  gap: var(--sp-10);
+  padding: var(--sp-6);
+  max-width: 960px;
+}

--- a/frontend/src/pages/design.test.tsx
+++ b/frontend/src/pages/design.test.tsx
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+
+import { renderWithAppState } from "../test/render-helpers";
+import { DesignPage } from "./design";
+
+describe("DesignPage", () => {
+  it("renders the page heading", () => {
+    const { getByRole } = renderWithAppState(<DesignPage />);
+    expect(getByRole("heading", { name: /design system/i })).toBeDefined();
+  });
+
+  it("renders all four token sections", () => {
+    const { getByRole } = renderWithAppState(<DesignPage />);
+    expect(getByRole("heading", { name: /color palette/i })).toBeDefined();
+    expect(getByRole("heading", { name: /typography/i })).toBeDefined();
+    expect(getByRole("heading", { name: /spacing, radii & shadows/i })).toBeDefined();
+    expect(getByRole("heading", { name: /components/i })).toBeDefined();
+  });
+});

--- a/frontend/src/pages/design.tsx
+++ b/frontend/src/pages/design.tsx
@@ -1,0 +1,24 @@
+import { ColorTokens } from "../components/design/color-tokens";
+import { ComponentShowcase } from "../components/design/component-showcase";
+import { SpacingTokens } from "../components/design/spacing-tokens";
+import { TypographyTokens } from "../components/design/typography-tokens";
+import { useDocumentTitle } from "../hooks/use-document-title";
+import styles from "./design.module.css";
+
+export function DesignPage() {
+  useDocumentTitle("Design System");
+
+  return (
+    <div class="ht-page">
+      <header class="ht-page-header">
+        <h1>Design System</h1>
+      </header>
+      <div class={styles.content}>
+        <ColorTokens />
+        <TypographyTokens />
+        <SpacingTokens />
+        <ComponentShowcase />
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/diagnostics.module.css
+++ b/frontend/src/pages/diagnostics.module.css
@@ -29,7 +29,7 @@
   text-transform: uppercase;
   letter-spacing: var(--tr-label);
   color: var(--warn);
-  border: 1px solid var(--warn);
+  border: var(--sp-px) solid var(--warn);
   border-radius: var(--r-pill);
   padding: var(--sp-px) var(--sp-2);
 }
@@ -153,7 +153,7 @@
 
 .degradedBanner {
   background: var(--warn-bg);
-  border: 1px solid var(--warn);
+  border: var(--sp-px) solid var(--warn);
   border-radius: var(--r-sm);
   padding: var(--sp-3) var(--sp-4);
   font-size: var(--fs-small);
@@ -173,7 +173,7 @@
   align-items: center;
   gap: var(--sp-3);
   padding: var(--sp-2) 0;
-  border-bottom: 1px solid var(--line-2);
+  border-bottom: var(--sp-px) solid var(--line-2);
 }
 
 .dropRow:last-child {

--- a/frontend/src/pages/handlers.module.css
+++ b/frontend/src/pages/handlers.module.css
@@ -28,7 +28,7 @@
   flex-direction: column;
   gap: var(--sp-1);
   padding: var(--sp-3) var(--sp-4);
-  border-bottom: 1px solid var(--line-2);
+  border-bottom: var(--sp-px) solid var(--line-2);
   text-decoration: none;
   color: inherit;
   transition: background var(--t-fast) var(--ease);

--- a/frontend/src/pages/logs.module.css
+++ b/frontend/src/pages/logs.module.css
@@ -21,6 +21,6 @@
 }
 
 .pausedBtn:focus-visible {
-  outline: 2px solid var(--warn);
+  outline: var(--border-med) solid var(--warn);
   outline-offset: var(--sp-0);
 }

--- a/frontend/src/styles/reset.css
+++ b/frontend/src/styles/reset.css
@@ -58,7 +58,7 @@ table {
 /* — Global Focus Indicator ————————————————————————————— */
 /* Zero specificity via :where() — component-level overrides win cleanly */
 :where(:focus-visible) {
-  outline: 2px solid var(--accent);
+  outline: var(--border-med) solid var(--accent);
   outline-offset: var(--sp-0);
 }
 

--- a/frontend/src/styles/tables.css
+++ b/frontend/src/styles/tables.css
@@ -23,13 +23,13 @@
   letter-spacing: var(--tr-label);
   color: var(--ink-3);
   padding: var(--sp-2) var(--sp-3);
-  border-bottom: 1px solid var(--line-1);
+  border-bottom: var(--sp-px) solid var(--line-1);
   white-space: nowrap;
 }
 
 .ht-table td {
   padding: var(--sp-2) var(--sp-3);
-  border-bottom: 1px solid var(--line-1);
+  border-bottom: var(--sp-px) solid var(--line-1);
   vertical-align: top;
   font-size: var(--fs-small);
 }
@@ -108,6 +108,6 @@
 .ht-table-card-scroll {
   overflow: auto;
   max-height: var(--table-scroll-height, calc(100vh - 310px));
-  border: 1px solid var(--line-strong);
+  border: var(--sp-px) solid var(--line-strong);
   border-radius: var(--r-md);
 }

--- a/frontend/src/styles/utilities.css
+++ b/frontend/src/styles/utilities.css
@@ -103,7 +103,7 @@
   padding: var(--sp-3) var(--sp-4);
   border-radius: var(--r-md);
   font-size: var(--fs-small);
-  border: 1px solid transparent;
+  border: var(--sp-px) solid transparent;
 }
 
 .ht-alert--danger {
@@ -144,7 +144,7 @@
   padding: var(--sp-2) var(--sp-4);
   background: var(--bg-surface);
   color: var(--ink-1);
-  border: 2px solid var(--accent);
+  border: var(--border-med) solid var(--accent);
   border-radius: var(--r-md);
   font-family: var(--font-body);
   font-size: var(--fs-body);
@@ -155,7 +155,7 @@
   font-family: var(--font-body);
   font-size: var(--fs-mono-sm);
   padding: var(--sp-1h) var(--sp-2);
-  border: 1px solid var(--line-strong);
+  border: var(--sp-px) solid var(--line-strong);
   border-radius: var(--r-md);
   background: var(--input-bg);
   color: var(--ink-1);

--- a/frontend/src/tokens.css
+++ b/frontend/src/tokens.css
@@ -159,6 +159,7 @@
 
   /* Effects */
   --blur-overlay: 2px;
+  --border-med: 2px;
   --border-thick: 3px;
 
   /* Z-index scale */


### PR DESCRIPTION
### `design/context.md` — comprehensive design system reference

- Rewrote `design/context.md` from a ~200-line design direction doc into a ~640-line reference following the Refero template, adding Layout, Components, Status System, and Patterns sections plus a Do's/Don'ts list. Preserves all required `i-*` skill sections (Users & Purpose, Brand Personality, Aesthetic Direction, Concrete Constraints, Design Principles, Design Tokens).
- Motivation: agents currently produce inconsistent frontend output because the design file leaves too much to be invented on the fly. The rewrite over-specifies component states, spacing rules, and status mapping so agents have one canonical source to check instead of guessing from existing code.
- Replaced stale `design/interface-design/` references in `CLAUDE.md`, `design/README.md`, and `.claude/skills/ui-qa/references/harness.md`, and cross-linked `design/context.md` with `frontend/DESIGN_RULES.md`.
- Fixed a duplicated Effects section and a broken table that slipped into the first draft.

### Design token sweep

- Replaced hardcoded CSS values across the frontend with their matching design tokens: `1px` → `var(--sp-px)` (34 files), `2px` → a new `var(--border-med)` token (19 files), and added the missing `var(--ease)` timing function to 13 transitions.
- Snapped a few line-height, letter-spacing, and padding edge cases to the nearest token.
- Left some values hardcoded on purpose — secret-mask glyphs, section-title tracking, and component sizing that only coincidentally matches popover/drawer tokens — where forcing a token would create the wrong semantic coupling.
- This is a value-only swap; rendered output is unchanged.

### `/design` living style guide page

- Added a hidden route (`/design`, no sidebar link) that renders design tokens and shared components live from CSS: color palette, typography scale, spacing scale, border radii, elevation/shadows, and a component showcase (Button, Badge, Chip, Card, StatusShape, Spinner).
- Shared section layout extracted into `section.module.css` to avoid duplicating the same wrapper styles across the four section components.
- Because it reads tokens straight from CSS, this page doubles as a live check that the design system doc and the actual styles agree — drift becomes visually obvious instead of silent.

### Screenshots

Verified the new `/design` page against the running demo stack (`http://localhost:<vite-port>/design`) via Playwright. All sections render correctly: color palette swatches (surfaces, ink, liner, accent, status, gauge), the type scale with weight variants, the spacing/radius/elevation scale, and the component showcase (Button variants, Badge, Chip, StatusShape, Card, Spinner). No console errors.

The CSS token sweep is a value-only substitution (e.g. `1px` → `var(--sp-px)`, which resolves to the same `1px`), so it produces no visible change on existing pages — spot-checked the app-detail and layout components touched by the sweep against current tokens.css values to confirm the substituted tokens resolve identically to the hardcoded values they replaced.
