### PR TITLE
fix(cli): fix --since flag crash on all commands

### DIFF
--- a/design/research/2026-07-10-cli-testing-patterns/research.md
+++ b/design/research/2026-07-10-cli-testing-patterns/research.md
@@ -1,0 +1,111 @@
+---
+topic: "CLI testing patterns — subprocess vs dispatch vs direct calls"
+date: 2026-07-10
+status: Draft
+---
+
+# Prior Art: CLI Testing Patterns
+
+## The Problem
+
+CLI frameworks add a wiring layer between user input and business logic: flag parsing, type conversion, subcommand routing, global option injection. When tests call the underlying function directly with pre-converted values, that wiring layer is untested. This is exactly how a `--since 7d` bug shipped — the converter worked in isolation, but the cyclopts adapter that bridges Token objects to the converter was never exercised.
+
+The question: what's the right testing level for CLI wiring, and how do mature projects handle it?
+
+## How We Do It Today
+
+All hassette CLI tests call command functions directly (e.g., `cmd_log(since=1700000000.0)`). The HTTP layer is mocked via `MockTransport`, but cyclopts never parses a single flag string. Two recent tests (`test_context.py`, `test_since_converter.py`) dispatch through toy cyclopts `App()` instances, but nobody tests the real `app` from `__init__.py`. System smoke tests also bypass dispatch — they call `client.get()` directly.
+
+## Patterns Found
+
+### Pattern 1: Parse-Without-Execute (cyclopts `parse_args`)
+
+**Used by**: Cyclopts projects, argparse projects (via `parse_args(args)`)
+**How it works**: `app.parse_args(["--flag", "value"])` performs all argument parsing, type conversion, env var resolution, and config loading, then returns `(command_function, BoundArguments, _)` without calling the command. Tests assert the right command was selected and arguments were parsed/converted correctly. No side effects, no mocking needed.
+
+For argparse, the equivalent is `parser.parse_args(["--flag"])` returning a `Namespace`. Click/Typer have no equivalent — `invoke()` always executes.
+
+**Strengths**: Fastest wiring test. No mocking. Catches broken converters, wrong flag names, missing defaults, env var misconfiguration. Tests the actual parsing code path.
+**Weaknesses**: Doesn't test command behavior, exit codes, or output formatting. Doesn't test error messages for invalid input (those need `app()` with `pytest.raises`).
+**Example**: https://cyclopts.readthedocs.io/en/latest/cookbook/unit_testing.html
+
+### Pattern 2: In-Process Dispatch (Click CliRunner / `app()` invocation)
+
+**Used by**: Click, Typer, cyclopts (via `app("arg")` or `app("arg", result_action="return_value")`)
+**How it works**: Full CLI dispatch pipeline runs in-process. Click/Typer use `CliRunner.invoke(app, ["--flag"])` with captured stdout/stderr. Cyclopts uses `app("arg")` (calls `sys.exit`) or `app("arg", result_action="return_value")` (returns directly). Tests the complete pipeline: parsing → dispatch → execution → output → exit code.
+
+**Strengths**: Tests full user-facing behavior. Fast. Mocking is easy. Can test error messages, help text, output formatting.
+**Weaknesses**: Click's CliRunner is not thread-safe and changes interpreter state. Cyclopts' `app()` calls `sys.exit()` requiring `pytest.raises(SystemExit)`. `result_action="return_value"` avoids this.
+**Example**: https://click.palletsprojects.com/en/stable/testing/
+
+### Pattern 3: Subprocess / Black-Box Testing
+
+**Used by**: Rust projects (assert_cmd), Node.js (CLI Testing Library), projects needing true e2e confidence
+**How it works**: Spawns the CLI as a child process, captures stdout/stderr, checks exit codes. CLI treated as a black box. Output normalization is critical (strip ANSI, replace paths).
+
+**Strengths**: Tests exactly what users experience. Catches import errors, entry point misconfiguration, missing dependencies.
+**Weaknesses**: Slow (process spawn per test). Output normalization is tedious. Mocking is harder. Cannot inspect internal state.
+**Example**: https://alexwlchan.net/2025/testing-rust-cli-apps-with-assert-cmd/
+
+### Pattern 4: Separated Architecture (Business Logic + CLI Shell)
+
+**Used by**: Nearly every source recommends this. The single most cited pattern.
+**How it works**: Two layers: (1) business logic functions with no CLI awareness, (2) thin CLI shell that parses and dispatches. Test both independently. Business logic gets normal unit tests. CLI shell gets parse_args or mocked dispatch tests.
+
+**Strengths**: Business logic tests are fast and framework-independent. CLI tests focus on wiring. Changing frameworks doesn't break logic tests.
+**Weaknesses**: Requires disciplined architecture. The "thin shell" can grow complex (formatting, error handling) and needs its own tests. Over-separation can miss integration bugs.
+**Example**: https://rust-cli.github.io/book/tutorial/testing.html
+
+### Pattern 5: Snapshot / Golden File Testing
+
+**Used by**: Rust CLI ecosystem (trycmd, snapbox), shelltestrunner (Haskell)
+**How it works**: Run CLI, compare output against saved baseline. Update snapshots when output intentionally changes.
+
+**Strengths**: Low maintenance. Catches formatting regressions. Makes output changes visible in review.
+**Weaknesses**: Brittle to incidental changes (timestamps, paths). Can obscure what the test checks. Snapshot bloat.
+**Example**: https://docs.rs/trycmd
+
+## Anti-Patterns
+
+1. **Testing auto-generated output like `--help` formatting** — help text is framework-generated and changes with upgrades. Test that help displays (exit code), don't assert layout. (Source: Rust CLI book)
+2. **Calling `parse_args()` with no arguments** — reads from `sys.argv`, producing confusing failures. Always pass an explicit list. (Source: cyclopts docs)
+3. **Only testing the business logic function directly** — converters, validators, flag names, and defaults are all untested. The `--since 7d` bug is this anti-pattern. (Synthesized from sources)
+4. **Mocking at the wrong level** — mock your business logic, not the framework's internals. (Source: Smashing Magazine)
+
+## Relevance to Us
+
+Hassette's CLI tests are almost entirely Anti-Pattern #3 — every test calls the command function directly with pre-converted values. The `SinceArg` converter bug proved this gap is real.
+
+Cyclopts' `parse_args()` (Pattern 1) is purpose-built for the exact gap we have. It's already available — we just aren't using it. It fills the space between "test the function" (no wiring coverage) and "test the full dispatch" (requires mocking the HTTP layer and handling `sys.exit`).
+
+Our architecture already follows Pattern 4 (separated architecture) — command functions are thin shells that call `make_client` and forward parsed args. The existing direct-call tests cover the business logic side well. What's missing is the wiring side.
+
+Subprocess testing (Pattern 3) would add little value here — the entry point works, and the HTTP client needs mocking regardless. The overhead isn't worth it for a framework that provides `parse_args()`.
+
+## Recommendation
+
+**Use `parse_args()` for wiring tests.** For each command, add tests that call `app.parse_args(["subcommand", "--flag", "value"])` on the real `app` object and verify:
+- The right command function was selected
+- Arguments arrive with the right types (converter wiring)
+- Global options (`--json`, `--debug`) propagate correctly
+
+Keep the existing direct-call tests — they cover the function logic (param forwarding, HTTP routing, output rendering). The `parse_args` tests are complementary, not replacement.
+
+For error cases (invalid `--since`, `--source-tier bogus`), `parse_args` raises `SystemExit` directly (cyclopts defaults `exit_on_error=True`), so the same `app.parse_args()` pattern works for both success and error-case wiring tests.
+
+**Don't add subprocess tests.** The ROI is low when `parse_args()` covers the wiring layer and the HTTP layer needs mocking anyway.
+
+## Sources
+
+### Documentation & standards
+- https://cyclopts.readthedocs.io/en/latest/cookbook/unit_testing.html — cyclopts official testing guide (parse_args, app invocation, result_action)
+- https://click.palletsprojects.com/en/stable/testing/ — Click CliRunner documentation
+- https://typer.tiangolo.com/tutorial/testing/ — Typer testing (re-exports Click's CliRunner)
+- https://rust-cli.github.io/book/tutorial/testing.html — Rust CLI book testing chapter
+
+### Blog posts & writeups
+- https://www.smashingmagazine.com/2022/04/testing-cli-way-people-use-it/ — testing CLIs the way people use them
+- https://alexwlchan.net/2025/testing-rust-cli-apps-with-assert-cmd/ — black-box CLI testing in Rust
+- https://pytest-with-eric.com/pytest-advanced/pytest-argparse-typer/ — pytest + argparse/typer patterns
+- https://til.simonwillison.net/pytest/pytest-argparse — Simon Willison's argparse testing TIL
+- https://pythontest.com/testing-argparse-apps/ — three-tier argparse testing architecture

--- a/src/hassette/cli/types.py
+++ b/src/hassette/cli/types.py
@@ -82,7 +82,8 @@ SinceArg = Annotated[
     float | None,
     Parameter(
         name=["--since"],
-        converter=lambda _, value: convert_since(value),
+        # cyclopts passes (type, tuple[Token, ...]) — one Token per flag occurrence
+        converter=lambda _, tokens: convert_since(tokens[0].value),
         help=SINCE_HELP,
     ),
 ]

--- a/tests/unit/cli/CLAUDE.md
+++ b/tests/unit/cli/CLAUDE.md
@@ -1,0 +1,60 @@
+# CLI Tests
+
+## Two-layer testing
+
+CLI tests cover two distinct layers. Both are required.
+
+### 1. Wiring tests (`test_parse_args.py`)
+
+Test through cyclopts dispatch via `app.parse_args(argv)`. This exercises flag parsing, type conversion, subcommand routing, and converter lambdas — the layer between user input and your function. No mocking needed; no command execution.
+
+```python
+from hassette.cli import app
+
+cmd, bound, _ = app.parse_args(["log", "--since", "7d"])
+assert cmd.__name__ == "cmd_log"
+assert isinstance(bound.arguments["since"], float)
+```
+
+For global flags (`--json`, `--debug`, `--config-file`), use `app.meta.parse_args(argv)`.
+
+When adding a new command or flag, add a `parse_args` test for it. When adding a custom `converter=` on a `Parameter`, add a test that dispatches through `parse_args` with the real `app` — not a toy `App()`.
+
+### 2. Function tests (`test_commands_*.py`)
+
+Test command logic by calling the function directly with pre-converted values. These use `MockTransport` to mock the HTTP layer and verify endpoint routing, param forwarding, and output rendering.
+
+```python
+cmd_log(since=1700000000.0, limit=20)  # pre-converted epoch float
+```
+
+These tests do not exercise cyclopts at all. They exist to test that the function does the right thing with its arguments.
+
+### Why both layers exist
+
+A `--since 7d` bug shipped because every test called `cmd_log(since=<float>)` directly. The cyclopts converter lambda — the only code that bridges user input to the function — was never executed by any test. The converter received a tuple of `Token` objects, not a string, and nobody knew until a user hit it.
+
+Direct function calls test function logic. `parse_args` tests prove the wiring is correct. Neither substitutes for the other.
+
+## Fixtures and helpers
+
+`conftest.py` provides:
+- `CLIClientFactory` — builds `HassetteCLIClient` instances backed by `MockTransport`
+- `MockTransportBuilder` — route table for mock HTTP responses
+- `GetSpy` — wraps `client.get` to record paths and params
+- `capture_stdout()` / `capture_stderr()` / `capture_json_stdout()` — Rich console capture
+- `capture_human(func, *args)` — returns `(stdout, stderr)` strings
+- `SINCE_EPOCH` — pre-computed epoch float for direct-call tests
+
+## File layout
+
+| File | What it tests |
+|---|---|
+| `test_parse_args.py` | Cyclopts dispatch: routing, converters, flag combos, global flags, invalid input |
+| `test_commands_*.py` | Command function logic: endpoint routing, param forwarding, output |
+| `test_since_converter.py` | `convert_since()` unit tests: relative durations, ISO formats, invalid inputs |
+| `test_client.py` | `HassetteCLIClient` HTTP handling, error formatting |
+| `test_context.py` | `CLIContext` and launcher meta-command pattern |
+| `test_output.py` | Table rendering, formatters, JSON mode |
+| `test_output_detail.py` | Detail/panel rendering |
+| `test_completion.py` | Shell completion generation |

--- a/tests/unit/cli/conftest.py
+++ b/tests/unit/cli/conftest.py
@@ -16,6 +16,7 @@ from hassette.cli.client import HassetteCLIClient
 from hassette.config.config import HassetteConfig
 
 SINCE_EPOCH = 1_700_000_000.0
+NOW_EPOCH = 1_748_000_000.0
 
 
 class GetSpy:

--- a/tests/unit/cli/test_parse_args.py
+++ b/tests/unit/cli/test_parse_args.py
@@ -14,8 +14,7 @@ from whenever import Instant
 
 from hassette.cli import app
 from hassette.const.misc import SECONDS_PER_DAY, SECONDS_PER_HOUR, SECONDS_PER_MINUTE
-
-NOW_EPOCH = 1_748_000_000.0
+from tests.unit.cli.conftest import NOW_EPOCH
 
 
 def _fixed_now() -> float:

--- a/tests/unit/cli/test_parse_args.py
+++ b/tests/unit/cli/test_parse_args.py
@@ -1,0 +1,148 @@
+"""Tests that dispatch through cyclopts' real ``parse_args`` — not direct function calls.
+
+These tests exist because a bug (``--since 7d`` failing) went undetected: every existing
+test called command functions directly with pre-converted values, so nothing exercised
+cyclopts' flag parsing, type conversion, and subcommand routing end to end. ``app.parse_args``
+performs the full pipeline and returns the resolved command function plus bound arguments
+without executing the command.
+"""
+
+from unittest.mock import patch
+
+import pytest
+from whenever import Instant
+
+from hassette.cli import app
+
+NOW_EPOCH = 1_748_000_000.0
+SECONDS_PER_MINUTE = 60
+SECONDS_PER_HOUR = 3600
+SECONDS_PER_DAY = 86400
+
+
+def _fixed_now() -> float:
+    return NOW_EPOCH
+
+
+class TestSubcommandRouting:
+    @pytest.mark.parametrize(
+        ("argv", "expected_name"),
+        [
+            pytest.param(["app"], "cmd_app", id="app"),
+            pytest.param(["app", "health", "test-app"], "cmd_app_health", id="app-health"),
+            pytest.param(["app", "activity", "test-app"], "cmd_app_activity", id="app-activity"),
+            pytest.param(["app", "config", "test-app"], "cmd_app_config", id="app-config"),
+            pytest.param(["app", "source", "test-app"], "cmd_app_source", id="app-source"),
+            pytest.param(["config"], "cmd_config", id="config"),
+            pytest.param(["dashboard"], "cmd_dashboard", id="dashboard"),
+            pytest.param(["execution", "some-uuid"], "cmd_execution", id="execution"),
+            pytest.param(["job"], "cmd_job", id="job"),
+            pytest.param(["listener"], "cmd_listener", id="listener"),
+            pytest.param(["log"], "cmd_log", id="log"),
+            pytest.param(["run"], "cmd_run", id="run"),
+            pytest.param(["status"], "cmd_status", id="status"),
+            pytest.param(["telemetry"], "cmd_telemetry", id="telemetry"),
+        ],
+    )
+    def test_routes_to_expected_function(self, argv: list[str], expected_name: str) -> None:
+        cmd, _bound, _ = app.parse_args(argv)
+        assert cmd.__name__ == expected_name
+
+
+class TestSinceConverterWiring:
+    @pytest.mark.parametrize(
+        ("argv", "expected_seconds_ago"),
+        [
+            pytest.param(["log", "--since", "7d"], 7 * SECONDS_PER_DAY, id="log-7d"),
+            pytest.param(["listener", "--since", "1h"], SECONDS_PER_HOUR, id="listener-1h"),
+            pytest.param(["job", "--since", "30m"], 30 * SECONDS_PER_MINUTE, id="job-30m"),
+            pytest.param(["app", "health", "test-app", "--since", "2w"], 14 * SECONDS_PER_DAY, id="app-health-2w"),
+            pytest.param(["app", "activity", "test-app", "--since", "7d"], 7 * SECONDS_PER_DAY, id="app-activity-7d"),
+        ],
+    )
+    def test_relative_since_through_dispatch(self, argv: list[str], expected_seconds_ago: int) -> None:
+        with patch("hassette.cli.types.now_epoch", _fixed_now):
+            _cmd, bound, _ = app.parse_args(argv)
+
+        since = bound.arguments["since"]
+        assert isinstance(since, float)
+        assert since == pytest.approx(NOW_EPOCH - expected_seconds_ago, abs=1)
+
+    def test_absolute_since_through_dispatch(self) -> None:
+        _cmd, bound, _ = app.parse_args(["log", "--since", "2026-05-22T18:00:00Z"])
+
+        since = bound.arguments["since"]
+        assert since == pytest.approx(Instant.parse_iso("2026-05-22T18:00:00Z").timestamp(), abs=1)
+
+    def test_omitted_since_is_none(self) -> None:
+        _cmd, bound, _ = app.parse_args(["log"])
+
+        assert bound.arguments.get("since") is None
+
+
+class TestFlagCombinations:
+    def test_listener_app_since_limit(self) -> None:
+        with patch("hassette.cli.types.now_epoch", _fixed_now):
+            _cmd, bound, _ = app.parse_args(["listener", "--app", "my-app", "--since", "1h", "--limit", "50"])
+
+        assert bound.arguments["app"] == "my-app"
+        assert bound.arguments["since"] == pytest.approx(NOW_EPOCH - SECONDS_PER_HOUR, abs=1)
+        assert bound.arguments["limit"] == 50
+
+    def test_job_app_source_tier(self) -> None:
+        _cmd, bound, _ = app.parse_args(["job", "--app", "my-app", "--source-tier", "framework"])
+
+        assert bound.arguments["app"] == "my-app"
+        assert bound.arguments["source_tier"] == "framework"
+
+    def test_app_health_instance_since(self) -> None:
+        with patch("hassette.cli.types.now_epoch", _fixed_now):
+            _cmd, bound, _ = app.parse_args(["app", "health", "test-app", "--instance", "office", "--since", "7d"])
+
+        assert bound.arguments["instance"] == "office"
+        assert bound.arguments["since"] == pytest.approx(NOW_EPOCH - 7 * SECONDS_PER_DAY, abs=1)
+
+    def test_execution_uuid_limit(self) -> None:
+        _cmd, bound, _ = app.parse_args(["execution", "abc-123-def", "--limit", "100"])
+
+        assert bound.arguments["uuid"] == "abc-123-def"
+        assert bound.arguments["limit"] == 100
+
+
+class TestInvalidInputRejection:
+    @pytest.mark.parametrize(
+        "argv",
+        [
+            pytest.param(["log", "--since", "banana"], id="invalid-since"),
+            pytest.param(["log", "--source-tier", "bogus"], id="invalid-source-tier"),
+            pytest.param(["execution"], id="missing-required-arg"),
+        ],
+    )
+    def test_raises_system_exit(self, argv: list[str]) -> None:
+        with pytest.raises(SystemExit):
+            app.parse_args(argv)
+
+
+class TestGlobalFlagWiring:
+    def test_json_flag(self) -> None:
+        cmd, bound, _ = app.meta.parse_args(["--json", "log"])
+
+        assert cmd.__name__ == "launcher"
+        assert bound.arguments["json"] is True
+        assert "log" in bound.arguments["tokens"]
+
+    def test_debug_flag(self) -> None:
+        _cmd, bound, _ = app.meta.parse_args(["--debug", "status"])
+
+        assert bound.arguments["debug"] is True
+
+    def test_config_file_flag(self) -> None:
+        _cmd, bound, _ = app.meta.parse_args(["--config-file", "/some/path.toml", "status"])
+
+        assert bound.arguments["config_file"] == "/some/path.toml"
+
+    def test_no_global_flags(self) -> None:
+        _cmd, bound, _ = app.meta.parse_args(["log"])
+
+        assert not bound.arguments.get("json", False)
+        assert not bound.arguments.get("debug", False)

--- a/tests/unit/cli/test_parse_args.py
+++ b/tests/unit/cli/test_parse_args.py
@@ -13,11 +13,9 @@ import pytest
 from whenever import Instant
 
 from hassette.cli import app
+from hassette.const.misc import SECONDS_PER_DAY, SECONDS_PER_HOUR, SECONDS_PER_MINUTE
 
 NOW_EPOCH = 1_748_000_000.0
-SECONDS_PER_MINUTE = 60
-SECONDS_PER_HOUR = 3600
-SECONDS_PER_DAY = 86400
 
 
 def _fixed_now() -> float:

--- a/tests/unit/cli/test_since_converter.py
+++ b/tests/unit/cli/test_since_converter.py
@@ -6,8 +6,7 @@ import pytest
 from whenever import Instant, OffsetDateTime, PlainDateTime
 
 from hassette.cli.types import convert_since
-
-NOW_EPOCH = 1_748_000_000.0
+from tests.unit.cli.conftest import NOW_EPOCH
 
 
 def _fixed_now() -> float:


### PR DESCRIPTION
### Bug Fix

- Fixed `--since` crashing on every CLI command that accepts it (`log`, `listener`, `job`, `app health`, `execution`) with `TypeError: expected string or bytes-like object, got 'tuple'`. Cyclopts passes the converter a `(type, tuple[Token, ...])` pair — one `Token` per flag occurrence — not a raw string. The converter lambda in `src/hassette/cli/types.py` was calling `convert_since(value)` on the raw tuple instead of extracting `tokens[0].value`. One-line fix.

### Test Coverage

- Root cause: every existing CLI test called command functions directly with pre-converted values (e.g. `cmd_log(since=1700000000.0)`), so the cyclopts converter lambda — the only code that bridges user input to the function — was never exercised by any test. The bug shipped invisibly.
- Added `tests/unit/cli/test_parse_args.py` (32 test cases via `app.parse_args(...)`) that dispatch through the real cyclopts `app`, covering subcommand routing, the `--since` converter (relative and absolute forms), flag combinations, invalid-input rejection, and global flag wiring (`--json`, `--debug`, `--config-file`).
- Added `tests/unit/cli/CLAUDE.md` documenting the two-layer testing approach going forward: `parse_args` wiring tests prove cyclopts dispatch is correct; direct function calls prove command logic is correct. Neither substitutes for the other — this is the convention that would have caught the bug.
- Added a prior-art research brief (`design/research/2026-07-10-cli-testing-patterns/`) surveying how other CLI frameworks (cyclopts, argparse, Click/Typer) support parse-without-execute testing, which informed the wiring-test approach adopted here.

### Housekeeping

- Deduplicated `NOW_EPOCH` into `tests/unit/cli/conftest.py` so `test_since_converter.py` and the new `test_parse_args.py` share one source of truth instead of redefining it.
- Imported shared time constants from `hassette.const.misc` in `test_parse_args.py` instead of redefining them locally.
