### PR TITLE
fix: preserve telemetry data during schema migrations

### DIFF
--- a/src/hassette/core/database_service.py
+++ b/src/hassette/core/database_service.py
@@ -458,8 +458,10 @@ class DatabaseService(Service):
 
         If the DB file does not exist yet, does nothing (migrations will create it).
         If the DB version matches the expected head, does nothing.
-        If the DB version is older than head, logs a WARNING and deletes the DB file
-        so that migrations recreate it cleanly.
+        If the DB version is behind head (0 < current < head), does nothing —
+        run_migrations() will apply pending migrations incrementally, preserving data.
+        If the DB version is 0 on an existing file (pre-PRAGMA-era or fresh DB with
+        no migrations applied), deletes the file so migrations recreate it cleanly.
         If the DB version is *ahead* of head (newer DB on older binary), logs an ERROR
         and raises SchemaVersionError — auto-delete is refused in this case.
 
@@ -479,15 +481,7 @@ class DatabaseService(Service):
         if current_version == expected_head:
             return
 
-        if current_version == 0:
-            # PRAGMA user_version = 0 on an existing file means either a fresh DB
-            # (no migrations applied) or a pre-PRAGMA-era Alembic-managed DB.
-            # Treat as stale schema needing recreation.
-            self.logger.warning(
-                "Database has no schema version (expected %d) — recreating database (no production data to preserve).",
-                expected_head,
-            )
-        elif current_version > expected_head:
+        if current_version > expected_head:
             self.logger.error(
                 "Database schema version %d is ahead of the code's expected head %d. "
                 "This usually means a newer binary created this database. "
@@ -499,23 +493,28 @@ class DatabaseService(Service):
                 f"Database schema version {current_version} is ahead of expected head "
                 f"{expected_head}. Cannot start safely."
             )
-        else:
-            self.logger.warning(
-                "Database schema version mismatch (current=%d, expected=%d) — "
-                "recreating database (no production data to preserve).",
+
+        if current_version > 0:
+            self.logger.info(
+                "Database schema version %d is behind head %d — pending migrations will be applied.",
                 current_version,
                 expected_head,
             )
+            return
 
-        try:
-            db_path.unlink(missing_ok=True)
-            # Also remove WAL and SHM side-car files if present
-            for suffix in ("-wal", "-shm"):
-                Path(str(db_path) + suffix).unlink(missing_ok=True)
-        except PermissionError as exc:
-            raise RuntimeError(
-                f"Cannot delete stale database file {db_path}: {exc}. Please remove it manually and restart."
-            ) from exc
+        if current_version == 0:
+            self.logger.warning(
+                "Database has no schema version (expected %d) — recreating database (no production data to preserve).",
+                expected_head,
+            )
+            try:
+                db_path.unlink(missing_ok=True)
+                for suffix in ("-wal", "-shm"):
+                    Path(str(db_path) + suffix).unlink(missing_ok=True)
+            except PermissionError as exc:
+                raise RuntimeError(
+                    f"Cannot delete stale database file {db_path}: {exc}. Please remove it manually and restart."
+                ) from exc
 
     def run_migrations(self) -> None:
         """Run PRAGMA user_version migrations to the latest version (synchronous, called via to_thread).

--- a/tests/integration/database/test_database_service_migrations.py
+++ b/tests/integration/database/test_database_service_migrations.py
@@ -1,8 +1,11 @@
 """Integration tests for the PRAGMA user_version migration runner and schema correctness."""
 
+import asyncio
 import sqlite3
 from pathlib import Path
+from unittest.mock import MagicMock
 
+from hassette.core.database_service import DatabaseService
 from hassette.core.migration_runner import run_migrations
 
 EXPECTED_TABLES = {
@@ -200,6 +203,43 @@ def test_auto_vacuum_set_on_fresh_db(tmp_path: Path) -> None:
         conn.close()
 
     assert mode == 2, f"Expected auto_vacuum = 2 (INCREMENTAL), got {mode}"
+
+
+def test_handle_schema_version_then_migrate_preserves_data(tmp_path: Path) -> None:
+    """Full upgrade path: handle_schema_version + run_migrations preserves existing rows."""
+    db_path = tmp_path / "test.db"
+    run_migrations(db_path, target=5)
+
+    conn = sqlite3.connect(db_path)
+    try:
+        conn.execute("INSERT INTO sessions (started_at, last_heartbeat_at, status) VALUES (1.0, 1.0, 'running')")
+        conn.execute(
+            "INSERT INTO listeners "
+            "(app_key, instance_index, name, handler_method, topic, source_location) "
+            "VALUES ('my_app', 0, 'kitchen_light', 'on_change', 'light.kitchen', 'app.py:10')"
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    svc = DatabaseService.__new__(DatabaseService)
+    svc.logger = MagicMock()
+    asyncio.run(svc.handle_schema_version(db_path))
+
+    run_migrations(db_path)
+
+    conn = sqlite3.connect(db_path)
+    try:
+        version = conn.execute("PRAGMA user_version").fetchone()[0]
+        assert version == 9, f"Expected schema version 9 after upgrade, got {version}"
+
+        session_count = conn.execute("SELECT COUNT(*) FROM sessions").fetchone()[0]
+        assert session_count == 1, "Session row lost during upgrade"
+
+        listener = conn.execute("SELECT name, app_key FROM listeners WHERE name = 'kitchen_light'").fetchone()
+        assert listener == ("kitchen_light", "my_app"), "Listener row lost during upgrade"
+    finally:
+        conn.close()
 
 
 def test_no_alembic_version_table(tmp_path: Path) -> None:

--- a/tests/unit/test_schema_migration.py
+++ b/tests/unit/test_schema_migration.py
@@ -358,8 +358,8 @@ class TestFreshMigration:
 
 
 class TestDbVersionMismatch:
-    def test_db_version_mismatch_recreates(self, tmp_path: Path) -> None:
-        """When DB version != expected head, DatabaseService deletes and recreates the DB."""
+    def test_version_zero_deletes_db(self, tmp_path: Path) -> None:
+        """When DB version is 0 (pre-PRAGMA era), DatabaseService deletes and recreates the DB."""
         db_path = tmp_path / "test.db"
         db_path.touch()  # Simulate existing DB file
 
@@ -387,6 +387,34 @@ class TestDbVersionMismatch:
             asyncio.run(svc.handle_schema_version(db_path))
             # DB file should have been deleted (on_initialize handles re-running migrations)
             assert not db_path.exists()
+
+
+class TestSchemaUpgradePreservesData:
+    def test_existing_db_not_deleted_when_behind_head(self, tmp_path: Path) -> None:
+        """When 0 < current_version < expected_head, handle_schema_version preserves the DB file and data."""
+        db_path = tmp_path / "test.db"
+        run_migrations(db_path, target=5)
+
+        conn = sqlite3.connect(db_path)
+        try:
+            conn.execute("INSERT INTO sessions (started_at, last_heartbeat_at, status) VALUES (1.0, 1.0, 'running')")
+            conn.commit()
+        finally:
+            conn.close()
+
+        svc = DatabaseService.__new__(DatabaseService)
+        svc.logger = MagicMock()
+
+        asyncio.run(svc.handle_schema_version(db_path))
+
+        assert db_path.exists(), "Database file was deleted despite having valid schema version > 0"
+
+        conn = sqlite3.connect(db_path)
+        try:
+            count = conn.execute("SELECT COUNT(*) FROM sessions").fetchone()[0]
+        finally:
+            conn.close()
+        assert count == 1, "Session data was lost during schema version check"
 
 
 class TestHassetteConfigTelemetryQueueMax:


### PR DESCRIPTION
### Fix data loss on schema upgrade

`DatabaseService.handle_schema_version()` deleted the on-disk database file any time the schema version was behind the expected head — not just when the version was `0`. That meant every upgrade past migration 002 wiped all telemetry data (sessions, listeners, invocations) on a valid, existing installation, because `run_migrations()` was never given the chance to apply the incremental migrations it already supports.

The fix narrows the delete-and-recreate path to `current_version == 0` only (a genuinely fresh DB or a pre-PRAGMA-era Alembic-managed DB with no data worth preserving). For `0 < current_version < expected_head`, the method now logs and returns early, letting `run_migrations()` apply pending migrations in place and preserve every existing row.

- Unit test (`TestSchemaUpgradePreservesData`) proves the DB file and its data survive `handle_schema_version()` when behind head
- Integration test (`test_handle_schema_version_then_migrate_preserves_data`) proves the full upgrade path — `handle_schema_version()` followed by `run_migrations()` — lands at the current schema version with seeded `sessions` and `listeners` rows intact
- Renamed the existing `test_db_version_mismatch_recreates` test to `test_version_zero_deletes_db` to reflect that recreation is now scoped to version `0`, not any mismatch

Closes #1297
