### PR TITLE
chore: add 5 new linters and enable ruff C4 comprehension family

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -115,6 +115,10 @@ jobs:
             - name: Check coordinator-internal annotations in core tests
               run: uv run python tools/check_coordinator_internal.py
 
+            - name: Check file sizes (non-blocking)
+              continue-on-error: true
+              run: uv run python tools/check_file_size.py
+
     frontend:
         needs: changes
         if: needs.changes.outputs.frontend == 'true' || github.event_name == 'workflow_dispatch'
@@ -165,6 +169,9 @@ jobs:
 
             - name: Check dead global CSS (blocking)
               run: uv run python tools/frontend/check_dead_global_css.py
+
+            - name: Check for dead CSS tokens
+              run: uv run python tools/frontend/check_dead_tokens.py
 
             - name: Check undefined CSS refs in TSX (blocking)
               run: uv run python tools/frontend/check_undefined_css_refs.py

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -171,6 +171,27 @@ repos:
         files: ^(src|tests|scripts|tools|codegen|docs|examples)/.*\.py$
         stages: [pre-commit, pre-push]
 
+      - id: check-exception-names
+        name: Enforce 'exc' naming in except handlers
+        language: system
+        entry: ./tools/check_exception_names.py
+        files: ^(src|tests|scripts|tools|codegen|docs|examples)/.*\.py$
+        stages: [pre-commit, pre-push]
+
+      - id: check-type-checking-position
+        name: Ensure TYPE_CHECKING blocks sit after all regular imports
+        language: system
+        entry: ./tools/check_type_checking_position.py
+        files: ^(src|tests|scripts|tools|codegen|docs|examples)/.*\.py$
+        stages: [pre-commit, pre-push]
+
+      - id: check-constants-position
+        name: Flag UPPER_CASE constants defined after first class/function
+        language: system
+        entry: ./tools/check_constants_position.py
+        files: ^(src|tests|scripts|tools|codegen|docs|examples)/.*\.py$
+        stages: [pre-commit, pre-push]
+
       - id: check-spec-tokens
         name: Ban leaked spec-artifact tokens (AC#/FR#/T##/WP#)
         language: system
@@ -236,6 +257,15 @@ repos:
         name: Check for unused global CSS selectors
         language: system
         entry: ./tools/frontend/check_dead_global_css.py
+        pass_filenames: false
+        types_or: [ts, tsx, css]
+        files: ^frontend/src/
+        stages: [pre-commit, pre-push]
+
+      - id: check-dead-tokens
+        name: Check for unused CSS tokens
+        language: system
+        entry: ./tools/frontend/check_dead_tokens.py
         pass_filenames: false
         types_or: [ts, tsx, css]
         files: ^frontend/src/

--- a/codegen/src/hassette_codegen/__main__.py
+++ b/codegen/src/hassette_codegen/__main__.py
@@ -32,8 +32,8 @@ def _run_sync_facade(args: argparse.Namespace) -> int:
     argv = ["--check"] if args.check else []
     try:
         sf_main(argv)
-    except SystemExit as e:
-        return e.code if isinstance(e.code, int) else 1
+    except SystemExit as exc:
+        return exc.code if isinstance(exc.code, int) else 1
     return 0
 
 

--- a/codegen/src/hassette_codegen/overrides.py
+++ b/codegen/src/hassette_codegen/overrides.py
@@ -7,6 +7,8 @@ from pathlib import Path
 
 from hassette_codegen.extractors.properties import ExtractedProperty
 
+_OVERRIDES_DIR = Path(__file__).resolve().parent / "overrides"
+
 
 @dataclass
 class PropertyOverride:
@@ -26,9 +28,6 @@ class DomainOverride:
     extra_imports: dict[str, list[str]] = field(default_factory=dict)
     param_type_overrides: dict[str, str] = field(default_factory=dict)
     state_base_class: str | None = None
-
-
-_OVERRIDES_DIR = Path(__file__).resolve().parent / "overrides"
 
 
 def load_overrides(overrides_dir: Path | None = None) -> dict[str, DomainOverride]:

--- a/codegen/src/hassette_codegen/sync_facade/ast_utils.py
+++ b/codegen/src/hassette_codegen/sync_facade/ast_utils.py
@@ -63,12 +63,40 @@ INTERNAL_METHODS = frozenset(
 """Public sync methods that are framework-internal plumbing, not user-facing."""
 
 
+# The async sentence opens the body paragraph (preceded by a blank line). Replace with the
+# blank line so the one-line summary stays separated from the body.
+_ASYNC_SENTENCE_AT_PARAGRAPH_START = re.compile(r"\n\nThis method is\s+``async`` and must be awaited\.\s*")
+# The async sentence sits mid-paragraph. Replace with a newline, not a space: the source
+# often breaks a line mid-phrase, so collapsing to a space would join two partial lines
+# into one that exceeds the 120-char limit and fail ruff validation.
+_ASYNC_SENTENCE_MID_PARAGRAPH = re.compile(r"\s*This method is\s+``async`` and must be awaited\.\s*")
+# A phrase mutation, not a sentence removal: rewrite the scheduler's "awaited inline" wording.
+_AWAITED_INLINE_PHRASE = re.compile(r"is awaited inline")
+# Api variant: entire standalone paragraph "Must be awaited — a forgotten ``await`` is
+# reported per ``forgotten_await_behavior`` (default: warn)." Consume the surrounding blank
+# lines so no extra blank line is left behind; the trailing group handles the last-paragraph case.
+_MUST_BE_AWAITED_FORGOTTEN_AWAIT = re.compile(
+    r"\n\n\s*Must be awaited — a forgotten\s+``await``\s+is reported per\s+"
+    r"``forgotten_await_behavior``\s+\(default: warn\)\."
+    r"(?:\s*\n\n|\s*$)"
+)
+# Bus/Scheduler variant: "Must be awaited. Registration/Scheduling completes …" — strip only
+# the leading "Must be awaited. " so the informative completion sentence is kept (it remains
+# true for sync callers).  The positive lookahead ensures we only strip this prefix when
+# followed immediately by an uppercase continuation word.
+_MUST_BE_AWAITED_PREFIX = re.compile(r"Must be awaited\.\s+(?=[A-Z])")
+# Bus 'on' variant: "...raw topic subscriptions. Must be awaited.\n" — "Must be awaited."
+# is appended to the end of an existing sentence rather than starting a new one.  Replace
+# ". Must be awaited." with "." to leave the host sentence intact.
+_MUST_BE_AWAITED_SENTENCE_SUFFIX = re.compile(r"\. Must be awaited\.")
+
+
 def safe_parse(source: str, filename: str) -> ast.Module:
     """Parse Python source, raising SystemExit with a clean message on SyntaxError."""
     try:
         return ast.parse(source, filename=filename)
-    except SyntaxError as e:
-        raise SystemExit(f"Syntax error in {filename}: {e}") from e
+    except SyntaxError as exc:
+        raise SystemExit(f"Syntax error in {filename}: {exc}") from exc
 
 
 def is_overload(func: ast.FunctionDef | ast.AsyncFunctionDef) -> bool:
@@ -154,36 +182,9 @@ def format_signature_and_call(func: ast.FunctionDef | ast.AsyncFunctionDef) -> t
 # the drift gate only detects changes to generated output, not phrasings the regex misses.
 # When adding such wording to Bus/Scheduler/Api, add a matching pattern here.
 
-# The async sentence opens the body paragraph (preceded by a blank line). Replace with the
-# blank line so the one-line summary stays separated from the body.
-_ASYNC_SENTENCE_AT_PARAGRAPH_START = re.compile(r"\n\nThis method is\s+``async`` and must be awaited\.\s*")
-# The async sentence sits mid-paragraph. Replace with a newline, not a space: the source
-# often breaks a line mid-phrase, so collapsing to a space would join two partial lines
-# into one that exceeds the 120-char limit and fail ruff validation.
-_ASYNC_SENTENCE_MID_PARAGRAPH = re.compile(r"\s*This method is\s+``async`` and must be awaited\.\s*")
-# A phrase mutation, not a sentence removal: rewrite the scheduler's "awaited inline" wording.
-_AWAITED_INLINE_PHRASE = re.compile(r"is awaited inline")
 
 # Bus, Scheduler, and Api docstrings each use a distinct "Must be awaited" phrasing.
 # Three distinct patterns are required; order in desync_docstring is load-bearing.
-
-# Api variant: entire standalone paragraph "Must be awaited — a forgotten ``await`` is
-# reported per ``forgotten_await_behavior`` (default: warn)." Consume the surrounding blank
-# lines so no extra blank line is left behind; the trailing group handles the last-paragraph case.
-_MUST_BE_AWAITED_FORGOTTEN_AWAIT = re.compile(
-    r"\n\n\s*Must be awaited — a forgotten\s+``await``\s+is reported per\s+"
-    r"``forgotten_await_behavior``\s+\(default: warn\)\."
-    r"(?:\s*\n\n|\s*$)"
-)
-# Bus/Scheduler variant: "Must be awaited. Registration/Scheduling completes …" — strip only
-# the leading "Must be awaited. " so the informative completion sentence is kept (it remains
-# true for sync callers).  The positive lookahead ensures we only strip this prefix when
-# followed immediately by an uppercase continuation word.
-_MUST_BE_AWAITED_PREFIX = re.compile(r"Must be awaited\.\s+(?=[A-Z])")
-# Bus 'on' variant: "...raw topic subscriptions. Must be awaited.\n" — "Must be awaited."
-# is appended to the end of an existing sentence rather than starting a new one.  Replace
-# ". Must be awaited." with "." to leave the host sentence intact.
-_MUST_BE_AWAITED_SENTENCE_SUFFIX = re.compile(r"\. Must be awaited\.")
 
 
 def desync_docstring(doc: str) -> str:

--- a/codegen/src/hassette_codegen/sync_facade/recording.py
+++ b/codegen/src/hassette_codegen/sync_facade/recording.py
@@ -62,14 +62,6 @@ FIXED_HEADER_SYMBOLS: set[str] = {"Any", "typing", "TYPE_CHECKING", "RecordingAp
 """Symbols always provided by the fixed module header — excluded from dynamic import derivation."""
 
 
-def _find_class(module: ast.Module, name: str, source_label: str) -> ast.ClassDef:
-    """Find a class by name in a parsed module, raising SystemExit if not found."""
-    for node in module.body:
-        if isinstance(node, ast.ClassDef) and node.name == name:
-            return node
-    raise SystemExit(f"Could not find class `{name}` in {source_label}")
-
-
 # Template for the module header of the generated recording facade file.
 # {imports} is replaced with the dynamically-derived import block.
 # {type_checking_imports} is replaced with the TYPE_CHECKING import block.
@@ -102,6 +94,14 @@ STUB_MSG_GENERIC = (
 )
 
 '''
+
+
+def _find_class(module: ast.Module, name: str, source_label: str) -> ast.ClassDef:
+    """Find a class by name in a parsed module, raising SystemExit if not found."""
+    for node in module.body:
+        if isinstance(node, ast.ClassDef) and node.name == name:
+            return node
+    raise SystemExit(f"Could not find class `{name}` in {source_label}")
 
 
 def generate_sync_recording(api_path: Path, recording_api_path: Path) -> str:

--- a/docs/pages/core-concepts/api/snippets/api_overview_usage.py
+++ b/docs/pages/core-concepts/api/snippets/api_overview_usage.py
@@ -7,5 +7,5 @@ class SunApp(App):
         try:
             state = await self.api.get_state("sun.sun")
             self.logger.info("Sun is %s", state.value)
-        except HassetteError as e:
-            self.logger.error("HA API error: %s", e)
+        except HassetteError as exc:
+            self.logger.error("HA API error: %s", exc)

--- a/docs/pages/core-concepts/states/snippets/state-registry/error_invalid_data.py
+++ b/docs/pages/core-concepts/states/snippets/state-registry/error_invalid_data.py
@@ -3,5 +3,5 @@ from hassette.exceptions import InvalidDataForStateConversionError
 
 try:
     state = STATE_REGISTRY.try_convert_state(None)
-except InvalidDataForStateConversionError as e:
-    print(f"Invalid state data: {e}")
+except InvalidDataForStateConversionError as exc:
+    print(f"Invalid state data: {exc}")

--- a/docs/pages/core-concepts/states/snippets/state-registry/error_invalid_entity_id.py
+++ b/docs/pages/core-concepts/states/snippets/state-registry/error_invalid_entity_id.py
@@ -4,5 +4,5 @@ from hassette.exceptions import InvalidEntityIdError
 try:
     # Entity ID must have format "domain.entity"
     state = STATE_REGISTRY.try_convert_state({"entity_id": "invalid"})
-except InvalidEntityIdError as e:
-    print(f"Invalid entity ID: {e}")
+except InvalidEntityIdError as exc:
+    print(f"Invalid entity ID: {exc}")

--- a/docs/pages/core-concepts/states/snippets/state-registry/error_unable_to_convert.py
+++ b/docs/pages/core-concepts/states/snippets/state-registry/error_unable_to_convert.py
@@ -4,6 +4,6 @@ from hassette.exceptions import UnableToConvertStateError
 data = {"entity_id": "light.bedroom", "state": "on"}  # Simplified data
 try:
     state = STATE_REGISTRY.try_convert_state(data)
-except UnableToConvertStateError as e:
-    print(f"Conversion failed: {e}")
+except UnableToConvertStateError as exc:
+    print(f"Conversion failed: {exc}")
     # This exception means both the resolved class and the BaseState fallback failed

--- a/docs/pages/core-concepts/states/snippets/type-registry/conversion_error.py
+++ b/docs/pages/core-concepts/states/snippets/type-registry/conversion_error.py
@@ -3,5 +3,5 @@ from hassette.exceptions import UnableToConvertValueError
 
 try:
     result = TYPE_REGISTRY.convert("not_a_number", int)
-except UnableToConvertValueError as e:
-    print(e)  # Error details about the conversion failure
+except UnableToConvertValueError as exc:
+    print(exc)  # Error details about the conversion failure

--- a/docs/pages/core-concepts/states/snippets/type-registry/missing_converter.py
+++ b/docs/pages/core-concepts/states/snippets/type-registry/missing_converter.py
@@ -10,5 +10,5 @@ class CustomType:
 
 try:
     result = TYPE_REGISTRY.convert("value", CustomType)
-except UnableToConvertValueError as e:
-    print(e)  # "Unable to convert 'value' to <class 'CustomType'>"
+except UnableToConvertValueError as exc:
+    print(exc)  # "Unable to convert 'value' to <class 'CustomType'>"

--- a/docs/pages/testing/snippets/testing_drain_exceptions.py
+++ b/docs/pages/testing/snippets/testing_drain_exceptions.py
@@ -17,8 +17,8 @@ async def test_drain_specific_handling():
     async with AppTestHarness(MotionLights, config={}) as harness:
         try:
             await harness.simulate_state_change("binary_sensor.motion", old_value="off", new_value="on")
-        except DrainError as e:
-            # e.task_exceptions is a list of (task_name, exception) pairs
+        except DrainError as exc:
+            # exc.task_exceptions is a list of (task_name, exception) pairs
             raise
         except DrainTimeout:
             # diagnostic message includes pending task names and a debounce hint

--- a/frontend/src/tokens.css
+++ b/frontend/src/tokens.css
@@ -50,7 +50,6 @@
 
   /* Code */
   --code-bg: var(--bg-sunken);
-  --code-comment: var(--ink-3);
 
   /* Typography */
   --font-display: "Newsreader", "Source Serif Pro", Georgia, serif;
@@ -123,7 +122,6 @@
 
   /* Additional font sizes */
   --fs-stat: 26px;
-  --fs-badge: 11.5px;
 
   /* Border radius */
   --r-sm: 6px;
@@ -139,7 +137,6 @@
 
   /* Overlay */
   --overlay-bg: rgba(0, 0, 0, 0.45);
-  --err-dark: #9a2020;
 
   /* Opacity */
   --op-ghost: 0.35;
@@ -233,7 +230,6 @@
 
   /* Overlay */
   --overlay-bg: rgba(0, 0, 0, 0.5);
-  --err-dark: #7a1a1a;
 
   /* Shadows */
   --shadow-1: 0 1px 2px rgba(0, 0, 0, 0.3);

--- a/ruff.toml
+++ b/ruff.toml
@@ -56,7 +56,7 @@ select = [
     "W",      # pycodestyle (warning)
     "F",      # pyflakes
     "UP",     # pyupgrade
-    "C419",   # pylint - convention - unnecessary-comprehension-in-call
+    "C4",     # flake8-comprehensions
     "RET",    # flake8-return
     "SIM",    # flake8-simplify
     "ARG",    # flake8-unused-arguments

--- a/src/hassette/cli/commands/app.py
+++ b/src/hassette/cli/commands/app.py
@@ -28,13 +28,6 @@ APP_LIST_COLUMNS: list[Column] = [
 ]
 
 
-def cmd_app(*, ctx: CLIContextParam = DEFAULT_CLI_CONTEXT) -> None:
-    """List all apps (GET /api/apps/manifests)."""
-    client = make_client(ctx)
-    result = client.get("/api/apps/manifests", AppManifestListResponse)
-    render_table(result.manifests, APP_LIST_COLUMNS, json_mode=ctx.json_mode)  # pyright: ignore[reportArgumentType]
-
-
 APP_HEALTH_COLUMNS: list[Column] = [
     Column("health_status", "Health", max_width=10),
     Column("error_rate", "Error Rate", max_width=10),
@@ -43,6 +36,23 @@ APP_HEALTH_COLUMNS: list[Column] = [
     Column("job_avg_duration", "Job Avg", max_width=9, formatter=fmt_duration_ms),
     Column("last_activity_ts", "Last Active", max_width=11, formatter=fmt_relative_time),
 ]
+APP_ACTIVITY_COLUMNS: list[Column] = [
+    Column("row_id", "ID", max_width=10),
+    Column("kind", "Kind", max_width=8),
+    Column("status", "Status", max_width=10),
+    Column("app_key", "App", max_width=16),
+    Column("handler_name", "Handler", max_width=22),
+    Column("duration_ms", "Duration", max_width=9, formatter=fmt_duration_ms),
+    Column("timestamp", "When", max_width=11, formatter=fmt_relative_time),
+    Column("error_type", "Error", max_width=16),
+]
+
+
+def cmd_app(*, ctx: CLIContextParam = DEFAULT_CLI_CONTEXT) -> None:
+    """List all apps (GET /api/apps/manifests)."""
+    client = make_client(ctx)
+    result = client.get("/api/apps/manifests", AppManifestListResponse)
+    render_table(result.manifests, APP_LIST_COLUMNS, json_mode=ctx.json_mode)  # pyright: ignore[reportArgumentType]
 
 
 def cmd_app_health(
@@ -66,18 +76,6 @@ def cmd_app_health(
 
     result = client.get(f"/api/telemetry/app/{key}/health", AppHealthResponse, params=params)
     render_detail(result, json_mode=ctx.json_mode)
-
-
-APP_ACTIVITY_COLUMNS: list[Column] = [
-    Column("row_id", "ID", max_width=10),
-    Column("kind", "Kind", max_width=8),
-    Column("status", "Status", max_width=10),
-    Column("app_key", "App", max_width=16),
-    Column("handler_name", "Handler", max_width=22),
-    Column("duration_ms", "Duration", max_width=9, formatter=fmt_duration_ms),
-    Column("timestamp", "When", max_width=11, formatter=fmt_relative_time),
-    Column("error_type", "Error", max_width=16),
-]
 
 
 def cmd_app_activity(

--- a/src/hassette/cli/commands/status.py
+++ b/src/hassette/cli/commands/status.py
@@ -5,6 +5,16 @@ from hassette.cli.context import DEFAULT_CLI_CONTEXT, CLIContextParam
 from hassette.cli.output import Column, fmt_duration_ms, fmt_relative_time, render_detail, render_table
 from hassette.web.models import DashboardAppGridResponse, SystemStatusResponse, TelemetryStatusResponse
 
+DASHBOARD_COLUMNS: list[Column] = [
+    Column("app_key", "App", max_width=20),
+    Column("status", "Status", max_width=8),
+    Column("total_invocations", "Invoc", max_width=6),
+    Column("total_errors", "Errs", max_width=5),
+    Column("avg_duration_ms", "Avg Dur", max_width=8, formatter=fmt_duration_ms),
+    Column("last_activity_ts", "Last Active", max_width=11, formatter=fmt_relative_time),
+    Column("health_status", "Health", max_width=9),
+]
+
 
 def cmd_status(*, ctx: CLIContextParam = DEFAULT_CLI_CONTEXT) -> None:
     """Show system status (GET /api/health)."""
@@ -18,17 +28,6 @@ def cmd_telemetry(*, ctx: CLIContextParam = DEFAULT_CLI_CONTEXT) -> None:
     client = make_client(ctx)
     result = client.get("/api/telemetry/status", TelemetryStatusResponse, tolerate_503=True)
     render_detail(result, json_mode=ctx.json_mode)
-
-
-DASHBOARD_COLUMNS: list[Column] = [
-    Column("app_key", "App", max_width=20),
-    Column("status", "Status", max_width=8),
-    Column("total_invocations", "Invoc", max_width=6),
-    Column("total_errors", "Errs", max_width=5),
-    Column("avg_duration_ms", "Avg Dur", max_width=8, formatter=fmt_duration_ms),
-    Column("last_activity_ts", "Last Active", max_width=11, formatter=fmt_relative_time),
-    Column("health_status", "Health", max_width=9),
-]
 
 
 def cmd_dashboard(*, ctx: CLIContextParam = DEFAULT_CLI_CONTEXT) -> None:

--- a/src/hassette/config/classes.py
+++ b/src/hassette/config/classes.py
@@ -80,7 +80,7 @@ class ExcludeExtrasMixin:
         if exclude is None:
             return set(extra_keys)
         if isinstance(exclude, dict):
-            return {**exclude, **{k: True for k in extra_keys}}
+            return {**exclude, **dict.fromkeys(extra_keys, True)}
         return set(exclude) | extra_keys
 
     def model_dump(self, *, exclude: Any | None = None, **kwargs: Any) -> dict[str, Any]:

--- a/src/hassette/config/helpers.py
+++ b/src/hassette/config/helpers.py
@@ -103,8 +103,8 @@ def filter_paths_to_unique_existing(value: Sequence[str | Path | None] | str | P
     """
     value = [value] if isinstance(value, str | Path | None) else value
 
-    paths = set(Path(v).resolve() for v in value if v)
-    paths = set(p for p in paths if p.exists())
+    paths = {Path(v).resolve() for v in value if v}
+    paths = {p for p in paths if p.exists()}
 
     return paths
 

--- a/src/hassette/config/models.py
+++ b/src/hassette/config/models.py
@@ -23,6 +23,11 @@ LOGGER = getLogger(__name__)
 APP_SHUTDOWN_TIMEOUT_SECONDS = 10
 
 
+LOG_ANNOTATION = Annotated[LOG_LEVEL_TYPE, BeforeValidator(partial(coerce_log_level, fallback="INFO"))]
+APP_REQUIRED_KEYS = frozenset({"filename", "class_name"})
+DEFAULT_WEB_API_PORT = 8126
+
+
 def validate_positive_or_none(value: Any) -> float | None:
     """Validate that a timeout value is None or a positive number."""
     if value is None:
@@ -33,13 +38,6 @@ def validate_positive_or_none(value: Any) -> float | None:
     if val <= 0:
         raise ValueError("timeout must be None or a positive number")
     return val
-
-
-LOG_ANNOTATION = Annotated[LOG_LEVEL_TYPE, BeforeValidator(partial(coerce_log_level, fallback="INFO"))]
-
-APP_REQUIRED_KEYS = frozenset({"filename", "class_name"})
-
-DEFAULT_WEB_API_PORT = 8126
 
 
 class DatabaseConfig(ExcludeExtrasMixin, BaseModel):

--- a/src/hassette/const/colors.py
+++ b/src/hassette/const/colors.py
@@ -153,5 +153,5 @@ Color = Literal[
 ]
 """Literal type for supported color names."""
 
-COLORS = list(sorted(set(get_args(Color))))
+COLORS = sorted(set(get_args(Color)))
 """List of supported color names."""

--- a/src/hassette/const/misc.py
+++ b/src/hassette/const/misc.py
@@ -1,5 +1,9 @@
 from typing_extensions import Sentinel
 
+SECONDS_PER_DAY = 86400
+SECONDS_PER_HOUR = 3600
+SECONDS_PER_MINUTE = 60
+
 
 class FalseySentinel(Sentinel):
     """A Sentinel subclass that is Falsey in boolean contexts."""
@@ -16,7 +20,3 @@ NOT_PROVIDED = FalseySentinel("NOT_PROVIDED")
 
 ANY_VALUE = FalseySentinel("ANY_VALUE")
 """Sentinel value to indicate any value is acceptable (used in predicates for presence checks)."""
-
-SECONDS_PER_DAY = 86400
-SECONDS_PER_HOUR = 3600
-SECONDS_PER_MINUTE = 60

--- a/src/hassette/conversion/annotation_converter.py
+++ b/src/hassette/conversion/annotation_converter.py
@@ -153,7 +153,7 @@ def convert_tuple(converter: "AnnotationConverter", value: Any, tp: Any) -> Any:
         return tuple(converter.convert(v, elem_tp) for v in value)
 
     if len(args) != len(value):
-        if len(args) == 1 and len(set(type(v) for v in value)) == 1:
+        if len(args) == 1 and len({type(v) for v in value}) == 1:
             # Special case: single-type tuple passed as tuple[T] instead of tuple[T, ...]
             elem_tp = args[0]
             return tuple(converter.convert(v, elem_tp) for v in value)

--- a/src/hassette/core/block_io_guard.py
+++ b/src/hassette/core/block_io_guard.py
@@ -53,6 +53,23 @@ _owner_id: int | None = None
 _in_wrapper = threading.local()
 
 
+_PRIMITIVE_TABLE: list[tuple[str, Any, str]] = [
+    # (primitive_label, target_object, attr_name)
+    ("builtins.open", builtins, "open"),
+    ("time.sleep", time, "sleep"),
+    ("os.listdir", os, "listdir"),
+    ("os.scandir", os, "scandir"),
+    ("os.walk", os, "walk"),
+    ("glob.glob", glob_module, "glob"),
+]
+_SOCKET_METHOD_TABLE: list[tuple[str, str]] = [
+    # (primitive_label, method_name_on_socket.socket)
+    ("socket.socket.connect", "connect"),
+    ("socket.socket.recv", "recv"),
+    ("socket.socket.send", "send"),
+]
+
+
 def resolve_blocking_io_behavior(owner: object) -> BlockingIOBehavior:
     """Resolve the effective ``BlockingIOBehavior`` for the given app owner.
 
@@ -347,23 +364,6 @@ def _emit(event: MonkeypatchEvent) -> None:
 #   - method: (class_obj, attr_name, original_callable)  — wrapper needs self
 #
 # Seeded from HA's block_async_io.py.
-
-_PRIMITIVE_TABLE: list[tuple[str, Any, str]] = [
-    # (primitive_label, target_object, attr_name)
-    ("builtins.open", builtins, "open"),
-    ("time.sleep", time, "sleep"),
-    ("os.listdir", os, "listdir"),
-    ("os.scandir", os, "scandir"),
-    ("os.walk", os, "walk"),
-    ("glob.glob", glob_module, "glob"),
-]
-
-_SOCKET_METHOD_TABLE: list[tuple[str, str]] = [
-    # (primitive_label, method_name_on_socket.socket)
-    ("socket.socket.connect", "connect"),
-    ("socket.socket.recv", "recv"),
-    ("socket.socket.send", "send"),
-]
 
 
 # Install / uninstall (idempotent, reversible, leak-proof)

--- a/src/hassette/core/state_proxy.py
+++ b/src/hassette/core/state_proxy.py
@@ -177,7 +177,7 @@ class StateProxy(Resource):
             ResourceNotReadyError: If not ready and cache is empty (cold start).
                 When disconnected but cache is populated, stale data is returned.
         """
-        return {eid: state for eid, state in self.yield_domain_states(domain)}
+        return dict(self.yield_domain_states(domain))
 
     @_retry_on_not_ready
     def yield_domain_states(self, domain: str) -> Generator[tuple[str, "HassStateDict"], Any, None]:

--- a/src/hassette/core/telemetry/repository.py
+++ b/src/hassette/core/telemetry/repository.py
@@ -18,6 +18,13 @@ if TYPE_CHECKING:
     from hassette.core.database_service import DatabaseService
 
 
+# The reconciliation query builders interpolate ``table`` and ``history_fk`` directly into
+# f-string SQL. Today every caller passes string literals, but an allowlist keeps that
+# interpolation injection-safe if a non-literal value is ever passed in.
+_RECONCILE_TABLES = frozenset({"listeners", "scheduled_jobs"})
+_RECONCILE_FK_COLUMNS = frozenset({"listener_id", "job_id"})
+
+
 def _execution_insert_params(record: ExecutionRecord) -> dict[str, Any]:
     """Build the named-parameter dict for an executions INSERT.
 
@@ -64,6 +71,7 @@ _EXECUTION_INSERT_COLUMNS = tuple(
         ExecutionRecord(kind="handler", session_id=None, execution_start_ts=0.0, duration_ms=0.0, status="success")
     )
 )
+
 _EXECUTION_INSERT_SQL = (
     f"INSERT INTO executions ({', '.join(_EXECUTION_INSERT_COLUMNS)}) "
     f"VALUES ({', '.join(f':{c}' for c in _EXECUTION_INSERT_COLUMNS)})"
@@ -155,13 +163,6 @@ async def _insert_row_with_fk_fallback(
                 retry_exc,
             )
             return True
-
-
-# The reconciliation query builders interpolate ``table`` and ``history_fk`` directly into
-# f-string SQL. Today every caller passes string literals, but an allowlist keeps that
-# interpolation injection-safe if a non-literal value is ever passed in.
-_RECONCILE_TABLES = frozenset({"listeners", "scheduled_jobs"})
-_RECONCILE_FK_COLUMNS = frozenset({"listener_id", "job_id"})
 
 
 def _assert_reconcile_identifiers(table: str, history_fk: str) -> None:

--- a/src/hassette/logging_.py
+++ b/src/hassette/logging_.py
@@ -26,6 +26,9 @@ if TYPE_CHECKING:
     from hassette.core.database_service import DatabaseService
 
 
+_RECORD_FIELDS = ("source_tier", "app_key", "execution_id", "instance_name", "instance_index")
+
+
 @dataclass
 class LogEntry:
     """A single captured log record."""
@@ -300,9 +303,6 @@ def add_execution_id(
     """
     event_dict["execution_id"] = CURRENT_EXECUTION_ID.get(None)
     return event_dict
-
-
-_RECORD_FIELDS = ("source_tier", "app_key", "execution_id", "instance_name", "instance_index")
 
 
 def _extract_record_fields(

--- a/src/hassette/scheduler/scheduler.py
+++ b/src/hassette/scheduler/scheduler.py
@@ -94,6 +94,9 @@ if typing.TYPE_CHECKING:
     from hassette.types.types import SchedulerErrorHandlerType, SchedulerPredicate
 
 
+_SCHEDULER_MATCHERS = (TypeMatcher(ScheduledJob),)
+
+
 class Scheduler(Resource):
     """Scheduler resource for managing scheduled jobs."""
 
@@ -982,9 +985,6 @@ class Scheduler(Resource):
             kwargs=kwargs,
             where=where,
         )
-
-
-_SCHEDULER_MATCHERS = (TypeMatcher(ScheduledJob),)
 
 
 def _build_predicate_invoker(predicate: "SchedulerPredicate") -> CallableInvoker:

--- a/src/hassette/state_manager/state_manager.py
+++ b/src/hassette/state_manager/state_manager.py
@@ -150,7 +150,7 @@ class DomainStates(Generic[StateT]):
             which may be expensive for large domains. Consider using the iterator
             returned by `__iter__` for lazy evaluation if performance is a concern.
         """
-        return {entity_id: value for entity_id, value in self}
+        return dict(self)
 
     def __iter__(self) -> typing.Generator[tuple[str, StateT], None, None]:
         """Iterate over all states in this domain."""

--- a/src/hassette/test_utils/app_harness.py
+++ b/src/hassette/test_utils/app_harness.py
@@ -25,10 +25,6 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, cast
 from unittest.mock import AsyncMock
 
-if TYPE_CHECKING:
-    from hassette import Hassette
-    from hassette.events import HassStateDict
-
 import pydantic
 from pydantic import BaseModel
 from pydantic_settings.sources import InitSettingsSource
@@ -49,8 +45,19 @@ from hassette.test_utils.simulation import SimulationMixin
 from hassette.test_utils.time_control import TimeControlMixin
 from hassette.types.enums import ResourceStatus
 
+if TYPE_CHECKING:
+    from hassette import Hassette
+    from hassette.events import HassStateDict
+
 LOGGER = getLogger(__name__)
 EPOCH_TIMESTAMP = "1970-01-01T00:00:00+00:00"
+
+
+# Cache of (hermetic_subclass, init_kwargs_ref) pairs keyed by app_config_cls — avoids
+# creating a new subclass per make_hermetic_config call, which would accumulate
+# permanently in __subclasses__() and Pydantic's internal model cache.
+# Same closure-ref pattern as _get_hermetic_hassette_config_cls in config.py (singleton variant).
+HERMETIC_CONFIG_CACHE: dict[type[AppConfig], tuple[type[AppConfig], list[dict[str, Any]]]] = {}
 
 
 class AppConfigurationError(Exception):
@@ -75,13 +82,6 @@ class AppConfigurationError(Exception):
         msg_detail = first.get("msg", "")
         summary = f"{count} validation error{'s' if count != 1 else ''} — field '{field}': {msg_detail}"
         super().__init__(f"AppConfigurationError for {app_cls.__name__}: {summary}")
-
-
-# Cache of (hermetic_subclass, init_kwargs_ref) pairs keyed by app_config_cls — avoids
-# creating a new subclass per make_hermetic_config call, which would accumulate
-# permanently in __subclasses__() and Pydantic's internal model cache.
-# Same closure-ref pattern as _get_hermetic_hassette_config_cls in config.py (singleton variant).
-HERMETIC_CONFIG_CACHE: dict[type[AppConfig], tuple[type[AppConfig], list[dict[str, Any]]]] = {}
 
 
 def get_hermetic_subclass(app_config_cls: type[AppConfig]) -> tuple[type[AppConfig], list[dict[str, Any]]]:

--- a/src/hassette/test_utils/harness.py
+++ b/src/hassette/test_utils/harness.py
@@ -51,6 +51,42 @@ if typing.TYPE_CHECKING:
 # any future re-tuning is a single-site edit.
 
 
+DEPENDENCIES: dict[str, set[str]] = {
+    "sync_executor": set(),
+    "bus": {"sync_executor"},
+    "scheduler": {"sync_executor"},
+    "file_watcher": set(),
+    "api_mock": set(),
+    "app_handler": {"bus", "scheduler", "state_proxy", "sync_executor"},
+    "state_proxy": {"bus", "scheduler"},
+    "state_registry": set(),
+    # service_watcher removed: ServiceWatcher is a real framework service but has no
+    # harness starter — the harness does not instantiate it.  Removing it eliminates
+    # the ghost entry that caused STARTUP_ORDER to include a component with no starter.
+}
+# Maps harness component names to the corresponding real framework service class.
+# Used by the harness consistency test to verify DEPENDENCIES stays in sync with
+# real service depends_on declarations.
+#
+# Omitted entries:
+#   "api_mock"       — harness-specific: wraps ApiResource with URL/header patches and
+#                      a local HTTP mock server; there is no single real class equivalent.
+#   "file_watcher"   — FileWatcherService has no depends_on (empty list), so consistency
+#                      checks would be vacuous.  Omitting avoids false-positive drift.
+#   "state_registry" — StateRegistry is not a Resource subclass; it is a plain dataclass
+#                      registry with no depends_on concept.
+#   "service_watcher"— Removed: ServiceWatcher has no harness starter; including it in
+#                      this map without a matching _starters entry created a ghost entry
+#                      that made the structural test impossible to satisfy.
+COMPONENT_CLASS_MAP: dict[str, type[Resource]] = {
+    "sync_executor": SyncExecutorService,
+    "bus": BusService,
+    "scheduler": SchedulerService,
+    "app_handler": AppHandler,
+    "state_proxy": StateProxy,
+}
+
+
 class Timeouts:
     """Centralised timeout constants for the test harness.
 
@@ -236,7 +272,7 @@ def sort_harness_graph(graph: dict[str, set[str]]) -> list[str]:
         return []
 
     white, gray, black = 0, 1, 2
-    color: dict[str, int] = {node: white for node in graph}
+    color: dict[str, int] = dict.fromkeys(graph, white)
     result: list[str] = []
 
     for start in graph:
@@ -274,44 +310,8 @@ def sort_harness_graph(graph: dict[str, set[str]]) -> list[str]:
     return result
 
 
-DEPENDENCIES: dict[str, set[str]] = {
-    "sync_executor": set(),
-    "bus": {"sync_executor"},
-    "scheduler": {"sync_executor"},
-    "file_watcher": set(),
-    "api_mock": set(),
-    "app_handler": {"bus", "scheduler", "state_proxy", "sync_executor"},
-    "state_proxy": {"bus", "scheduler"},
-    "state_registry": set(),
-    # service_watcher removed: ServiceWatcher is a real framework service but has no
-    # harness starter — the harness does not instantiate it.  Removing it eliminates
-    # the ghost entry that caused STARTUP_ORDER to include a component with no starter.
-}
-
 # Startup order derived from the dependency graph — no manual maintenance required.
 STARTUP_ORDER: list[str] = sort_harness_graph(DEPENDENCIES)
-
-# Maps harness component names to the corresponding real framework service class.
-# Used by the harness consistency test to verify DEPENDENCIES stays in sync with
-# real service depends_on declarations.
-#
-# Omitted entries:
-#   "api_mock"       — harness-specific: wraps ApiResource with URL/header patches and
-#                      a local HTTP mock server; there is no single real class equivalent.
-#   "file_watcher"   — FileWatcherService has no depends_on (empty list), so consistency
-#                      checks would be vacuous.  Omitting avoids false-positive drift.
-#   "state_registry" — StateRegistry is not a Resource subclass; it is a plain dataclass
-#                      registry with no depends_on concept.
-#   "service_watcher"— Removed: ServiceWatcher has no harness starter; including it in
-#                      this map without a matching _starters entry created a ghost entry
-#                      that made the structural test impossible to satisfy.
-COMPONENT_CLASS_MAP: dict[str, type[Resource]] = {
-    "sync_executor": SyncExecutorService,
-    "bus": BusService,
-    "scheduler": SchedulerService,
-    "app_handler": AppHandler,
-    "state_proxy": StateProxy,
-}
 
 
 class HassetteHarness:

--- a/src/hassette/test_utils/simulation.py
+++ b/src/hassette/test_utils/simulation.py
@@ -9,13 +9,6 @@ from logging import getLogger
 from typing import TYPE_CHECKING, Any
 
 from hassette.events.hassette import HassetteAppStateEvent, HassetteServiceEvent, HassetteSimpleEvent
-from hassette.types import ResourceRole, ResourceStatus, Topic
-
-if TYPE_CHECKING:
-    from hassette.app.app import App
-    from hassette.core.bus_service import BusService
-    from hassette.test_utils.harness import HassetteHarness
-
 from hassette.test_utils.exceptions import DrainError, DrainTimeout
 from hassette.test_utils.helpers import (
     create_call_service_event,
@@ -23,6 +16,12 @@ from hassette.test_utils.helpers import (
     create_service_registered_event,
     create_state_change_event,
 )
+from hassette.types import ResourceRole, ResourceStatus, Topic
+
+if TYPE_CHECKING:
+    from hassette.app.app import App
+    from hassette.core.bus_service import BusService
+    from hassette.test_utils.harness import HassetteHarness
 
 LOGGER = getLogger(__name__)
 DEFAULT_SIMULATE_TIMEOUT = 2.0

--- a/src/hassette/test_utils/web_helpers.py
+++ b/src/hassette/test_utils/web_helpers.py
@@ -52,7 +52,7 @@ _STATUS_KEYS = ("running", "failed", "stopped", "disabled", "blocked")
 
 def _tally_statuses(manifests: Sequence[AppManifestInfo | AppManifestResponse]) -> dict[str, int]:
     """Count manifests by status."""
-    counts: dict[str, int] = {k: 0 for k in _STATUS_KEYS}
+    counts: dict[str, int] = dict.fromkeys(_STATUS_KEYS, 0)
     for m in manifests:
         if m.status in counts:
             counts[m.status] += 1

--- a/src/hassette/types/types.py
+++ b/src/hassette/types/types.py
@@ -26,6 +26,23 @@ if TYPE_CHECKING:
 CliFormatStyle = Literal["duration_ms", "duration_s", "uptime", "relative_time", "services"]
 
 
+LOG_LEVEL_TYPE = Literal["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"]
+"""Log levels for configuring logging."""
+
+FRAMEWORK_APP_KEY = "__hassette__"
+"""Reserved app_key for framework-internal listeners and jobs.
+
+Referenced in SQL constraints and in Python guards throughout the codebase.
+All non-SQL usages should reference this constant or use ``is_framework_key()``."""
+
+FRAMEWORK_APP_KEY_PREFIX = "__hassette__."
+"""Prefix for component-specific framework keys (e.g. ``'__hassette__.service_watcher'``).
+
+The trailing dot distinguishes the prefix from the bare sentinel so that
+``'__hassette__other'`` is never mistakenly treated as a framework key.
+Use ``is_framework_key()`` rather than comparing against this constant directly."""
+
+
 @dataclass(frozen=True)
 class CliFormat:
     """Annotated metadata marker declaring how a field renders in CLI human mode.
@@ -37,9 +54,6 @@ class CliFormat:
 
     style: CliFormatStyle
 
-
-LOG_LEVEL_TYPE = Literal["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"]
-"""Log levels for configuring logging."""
 
 SourceTier = Literal["app", "framework"]
 """Identifies whether a telemetry record originates from a user app or the framework itself."""
@@ -73,19 +87,6 @@ class ExecutionStatus(StrEnum):
 
 QuerySourceTier = Literal["app", "framework", "all"]
 """Valid source_tier values for query-side filtering. 'all' disables the filter."""
-
-FRAMEWORK_APP_KEY = "__hassette__"
-"""Reserved app_key for framework-internal listeners and jobs.
-
-Referenced in SQL constraints and in Python guards throughout the codebase.
-All non-SQL usages should reference this constant or use ``is_framework_key()``."""
-
-FRAMEWORK_APP_KEY_PREFIX = "__hassette__."
-"""Prefix for component-specific framework keys (e.g. ``'__hassette__.service_watcher'``).
-
-The trailing dot distinguishes the prefix from the bare sentinel so that
-``'__hassette__other'`` is never mistakenly treated as a framework key.
-Use ``is_framework_key()`` rather than comparing against this constant directly."""
 
 
 def is_framework_key(app_key: str | None) -> bool:

--- a/src/hassette/utils/service_utils.py
+++ b/src/hassette/utils/service_utils.py
@@ -49,7 +49,7 @@ def topological_sort(types: "list[type[Resource]]") -> "list[type[Resource]]":
                 resolved.extend(t for t in types if issubclass(t, d))
         return resolved
 
-    color: dict[type, Color] = {t: Color.WHITE for t in types}
+    color: dict[type, Color] = dict.fromkeys(types, Color.WHITE)
     result: list[type] = []
 
     # Iterative DFS.  Each work item is (node, iterator_over_its_deps).

--- a/src/hassette/web/dependencies.py
+++ b/src/hassette/web/dependencies.py
@@ -18,6 +18,31 @@ if TYPE_CHECKING:
     from hassette.core.telemetry.query_service import TelemetryQueryService
 
 
+LOGGER = getLogger(__name__)
+LOG_LEVELS: dict[str, int] = {
+    "DEBUG": DEBUG,
+    "INFO": INFO,
+    "WARNING": WARNING,
+    "ERROR": ERROR,
+    "CRITICAL": CRITICAL,
+}
+VALID_LOG_LEVEL_NAMES: frozenset[str] = frozenset(LOG_LEVELS)
+DEFAULT_LOG_LEVEL = "INFO"
+VALID_SOURCE_TIERS: frozenset[str] = frozenset({"app", "framework"})
+SOURCE_TIER_PARAM = Query(
+    default="app",
+    description="Filter by source tier. 'app' excludes framework internals. "
+    "'framework' returns only internal actors. 'all' returns everything.",
+)
+INSTANCE_INDEX_PARAM = Query(  # pyright: ignore[reportCallInDefaultInitializer]
+    default=0,
+    description="App instance index. Defaults to 0. Multi-instance apps have indices 0..N-1.",
+)
+APP_KEY_PARAM = Path(  # pyright: ignore[reportCallInDefaultInitializer]
+    description="Use `__hassette__` to query framework-internal actor telemetry.",
+)
+
+
 def get_hassette(request: Request) -> "Hassette":
     return request.app.state.hassette
 
@@ -45,8 +70,6 @@ TelemetryDep = Annotated["TelemetryQueryService", Depends(get_telemetry)]
 SchedulerDep = Annotated["SchedulerService", Depends(get_scheduler)]
 ApiDep = Annotated["Api", Depends(get_api)]
 
-LOGGER = getLogger(__name__)
-
 
 @contextmanager
 def db_degrades_to(response: Response) -> Iterator[None]:
@@ -62,33 +85,3 @@ def db_degrades_to(response: Response) -> Iterator[None]:
     except TelemetryUnavailableError:
         LOGGER.warning("DB query failed; degrading to 503", exc_info=True)
         response.status_code = 503
-
-
-LOG_LEVELS: dict[str, int] = {
-    "DEBUG": DEBUG,
-    "INFO": INFO,
-    "WARNING": WARNING,
-    "ERROR": ERROR,
-    "CRITICAL": CRITICAL,
-}
-
-VALID_LOG_LEVEL_NAMES: frozenset[str] = frozenset(LOG_LEVELS)
-
-DEFAULT_LOG_LEVEL = "INFO"
-
-VALID_SOURCE_TIERS: frozenset[str] = frozenset({"app", "framework"})
-
-SOURCE_TIER_PARAM = Query(
-    default="app",
-    description="Filter by source tier. 'app' excludes framework internals. "
-    "'framework' returns only internal actors. 'all' returns everything.",
-)
-
-INSTANCE_INDEX_PARAM = Query(  # pyright: ignore[reportCallInDefaultInitializer]
-    default=0,
-    description="App instance index. Defaults to 0. Multi-instance apps have indices 0..N-1.",
-)
-
-APP_KEY_PARAM = Path(  # pyright: ignore[reportCallInDefaultInitializer]
-    description="Use `__hassette__` to query framework-internal actor telemetry.",
-)

--- a/src/hassette/web/mappers.py
+++ b/src/hassette/web/mappers.py
@@ -36,6 +36,11 @@ from hassette.web.models import (
 )
 from hassette.web.telemetry_helpers import format_handler_summary
 
+TOPIC_KIND_MAP: dict[str, ListenerKind] = {
+    Topic.HASS_EVENT_STATE_CHANGED: "state change",
+    Topic.HASS_EVENT_CALL_SERVICE: "service call",
+}
+
 
 def instance_response_from(info: AppInstanceInfo) -> AppInstanceResponse:
     """Convert a single ``AppInstanceInfo`` to ``AppInstanceResponse``.
@@ -146,12 +151,6 @@ def connected_payload_from(status: SystemStatus) -> ConnectedPayload:
         app_count=status.app_count,
         version=status.version,
     )
-
-
-TOPIC_KIND_MAP: dict[str, ListenerKind] = {
-    Topic.HASS_EVENT_STATE_CHANGED: "state change",
-    Topic.HASS_EVENT_CALL_SERVICE: "service call",
-}
 
 
 def listener_kind_from_topic(topic: str) -> ListenerKind:

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -55,6 +55,10 @@ DATA_LOAD_TIMEOUT_MS = 5000
 MOCK_LAST_CHANGED = "2024-01-01T00:00:00"
 
 
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SPA_INDEX = REPO_ROOT / "src" / "hassette" / "web" / "static" / "spa" / "index.html"
+
+
 @pytest.fixture(scope="session")
 def mock_hassette():
     """Create a session-scoped mock Hassette with rich seed data."""
@@ -170,10 +174,6 @@ def log_handler():
             record.source_tier = "framework"
         handler.emit(record)
     return handler
-
-
-REPO_ROOT = Path(__file__).resolve().parents[2]
-SPA_INDEX = REPO_ROOT / "src" / "hassette" / "web" / "static" / "spa" / "index.html"
 
 
 @pytest.fixture(scope="session")

--- a/tests/e2e/mock_fixtures.py
+++ b/tests/e2e/mock_fixtures.py
@@ -835,11 +835,10 @@ def wire_config(hassette) -> None:
 
 _listeners = build_listener_telemetry()
 
-LISTENER_MY_APP_1_TOTAL_INVOCATIONS: int = _listeners["my_app"][0].total_invocations
-LISTENER_MY_APP_2_TOTAL_INVOCATIONS: int = _listeners["my_app"][1].total_invocations
-
 
 _jobs = build_job_telemetry()
 
+LISTENER_MY_APP_1_TOTAL_INVOCATIONS: int = _listeners["my_app"][0].total_invocations
+LISTENER_MY_APP_2_TOTAL_INVOCATIONS: int = _listeners["my_app"][1].total_invocations
 JOB_MY_APP_1_TOTAL_EXECUTIONS: int = _jobs["my_app"][0].total_executions
 JOB_MY_APP_2_TOTAL_EXECUTIONS: int = _jobs["my_app"][1].total_executions

--- a/tests/e2e/test_navigation.py
+++ b/tests/e2e/test_navigation.py
@@ -10,6 +10,26 @@ from tests.e2e.conftest import ANIMATION_SETTLE_MS, DESKTOP_VIEWPORT, MOBILE_VIE
 pytestmark = pytest.mark.e2e
 
 
+SIDEBAR_LINKS = [
+    ("nav-apps", "/apps", "apps"),
+    ("nav-logs", "/logs", "logs"),
+    ("nav-config", "/config", "config"),
+    ("nav-diagnostics", "/diagnostics", "diagnostics"),
+]
+# Map pages to the active nav item testid
+SIDEBAR_ACTIVE = [
+    ("/apps", "nav-apps"),
+    ("/logs", "nav-logs"),
+    ("/config", "nav-config"),
+    ("/diagnostics", "nav-diagnostics"),
+]
+TITLE_MAP = [
+    ("/apps", "Apps - Hassette"),
+    ("/logs", "Logs - Hassette"),
+    ("/config", "Config - Hassette"),
+]
+
+
 def test_root_redirects_to_apps(page: Page, base_url: str) -> None:
     """/ redirects to /apps."""
     page.goto(base_url + "/")
@@ -25,14 +45,6 @@ def test_logs_page_loads(page: Page, base_url: str) -> None:
 def test_config_page_loads(page: Page, base_url: str) -> None:
     page.goto(base_url + "/config")
     expect(page.locator("body")).to_contain_text("config")
-
-
-SIDEBAR_LINKS = [
-    ("nav-apps", "/apps", "apps"),
-    ("nav-logs", "/logs", "logs"),
-    ("nav-config", "/config", "config"),
-    ("nav-diagnostics", "/diagnostics", "diagnostics"),
-]
 
 
 def test_sidebar_renders_nav_items(page: Page, base_url: str) -> None:
@@ -55,15 +67,6 @@ def test_sidebar_navigation(page: Page, base_url: str, testid: str, expected_pat
     page.locator(f'[data-testid="{testid}"]').click()
     expect(page).to_have_url(re.compile(re.escape(expected_path)))
     expect(page.locator("body")).to_contain_text(expected_content)
-
-
-# Map pages to the active nav item testid
-SIDEBAR_ACTIVE = [
-    ("/apps", "nav-apps"),
-    ("/logs", "nav-logs"),
-    ("/config", "nav-config"),
-    ("/diagnostics", "nav-diagnostics"),
-]
 
 
 @pytest.mark.parametrize(("path", "testid"), SIDEBAR_ACTIVE, ids=[p for p, _ in SIDEBAR_ACTIVE])
@@ -139,13 +142,6 @@ def test_skip_nav_link_exists(page: Page, base_url: str) -> None:
     expect(skip_link).to_have_attribute("href", "#main-content")
     main = page.locator("main#main-content")
     expect(main).to_be_attached()
-
-
-TITLE_MAP = [
-    ("/apps", "Apps - Hassette"),
-    ("/logs", "Logs - Hassette"),
-    ("/config", "Config - Hassette"),
-]
 
 
 @pytest.mark.parametrize(

--- a/tests/integration/bus/test_bus.py
+++ b/tests/integration/bus/test_bus.py
@@ -30,6 +30,18 @@ if TYPE_CHECKING:
     from hassette.test_utils.harness import HassetteHarness
 
 
+GLOB_CASES = [
+    ("sensor.kitchen", "sensor.kitchen"),
+    ("sensor.*", {"sensor.kitchen", "sensor.living_room"}),
+    ("*.kitchen", {"sensor.kitchen", "light.kitchen"}),
+    ("*kitchen*", {"sensor.kitchen", "light.kitchen"}),
+    ("sensor.kitch?n", "sensor.kitchen"),
+    ("senso?.kit*en", "sensor.kitchen"),
+    ("*", {"sensor.kitchen", "light.living_room", "switch.garage", "light.kitchen", "sensor.living_room"}),
+]
+GLOB_ENTITIES = ["sensor.kitchen", "light.kitchen", "light.living_room", "sensor.living_room", "switch.garage"]
+
+
 @pytest.fixture
 def bus(hassette_with_bus: "HassetteHarness") -> "Bus":
     """Return the Bus resource for the running Hassette harness."""
@@ -296,19 +308,6 @@ async def test_bus_uses_kwargs(hassette_with_bus: "HassetteHarness") -> None:
     assert formatted_messages == ["Value: Test!"], (
         f"Expected handler to receive formatted value, got {formatted_messages}"
     )
-
-
-GLOB_CASES = [
-    ("sensor.kitchen", "sensor.kitchen"),
-    ("sensor.*", {"sensor.kitchen", "sensor.living_room"}),
-    ("*.kitchen", {"sensor.kitchen", "light.kitchen"}),
-    ("*kitchen*", {"sensor.kitchen", "light.kitchen"}),
-    ("sensor.kitch?n", "sensor.kitchen"),
-    ("senso?.kit*en", "sensor.kitchen"),
-    ("*", {"sensor.kitchen", "light.living_room", "switch.garage", "light.kitchen", "sensor.living_room"}),
-]
-
-GLOB_ENTITIES = ["sensor.kitchen", "light.kitchen", "light.living_room", "sensor.living_room", "switch.garage"]
 
 
 async def assert_glob_matching(

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -20,18 +20,6 @@ if TYPE_CHECKING:
     from hassette.test_utils.harness import HassetteHarness
 
 
-@pytest.fixture
-async def hassette_instance(test_config: HassetteConfig):
-    """Provide a fresh Hassette instance and restore context afterwards."""
-    test_config.reload()
-    instance = Hassette(test_config)
-    instance.wire_services()
-    try:
-        yield instance
-    finally:
-        await cleanup_hassette_streams(instance)
-
-
 _HARNESS_FIXTURES = frozenset(
     {
         "hassette_with_sync_executor",
@@ -45,6 +33,18 @@ _HARNESS_FIXTURES = frozenset(
         # hassette_with_app_handler_custom_config excluded: function-scoped, recreated fresh per test.
     }
 )
+
+
+@pytest.fixture
+async def hassette_instance(test_config: HassetteConfig):
+    """Provide a fresh Hassette instance and restore context afterwards."""
+    test_config.reload()
+    instance = Hassette(test_config)
+    instance.wire_services()
+    try:
+        yield instance
+    finally:
+        await cleanup_hassette_streams(instance)
 
 
 @pytest.fixture(autouse=True)

--- a/tests/integration/test_api_helpers.py
+++ b/tests/integration/test_api_helpers.py
@@ -45,6 +45,16 @@ from hassette.models.helpers import (
 from hassette.models.services import ServiceResponse
 from hassette.models.states.base import Context
 
+IB_RECORD = {"id": "vacation_mode", "name": "Vacation Mode", "initial": False}
+IN_RECORD = {"id": "brightness", "name": "Brightness", "min": 0.0, "max": 100.0}
+IT_RECORD = {"id": "wifi_password", "name": "WiFi Password"}
+IS_RECORD = {"id": "theme", "name": "Theme", "options": ["light", "dark"]}
+IDT_RECORD = {"id": "alarm_time", "name": "Alarm Time", "has_date": False, "has_time": True}
+IBT_RECORD = {"id": "restart_btn", "name": "Restart"}
+CTR_RECORD = {"id": "motion_count", "name": "Motion Count", "initial": 0, "step": 1}
+TMR_RECORD = {"id": "cooldown", "name": "Cooldown Timer", "duration": "00:05:00"}
+SERVICE_RESPONSE = ServiceResponse(context=Context(id="ctx-1"))
+
 
 @pytest.fixture
 async def api(hassette_with_mock_api):
@@ -122,9 +132,6 @@ async def test_ws_helper_call_chains_error_with_context():
     assert e.__cause__ is original
 
 
-IB_RECORD = {"id": "vacation_mode", "name": "Vacation Mode", "initial": False}
-
-
 async def test_list_input_booleans(api: Api):
     """list_input_booleans sends correct command and parses response."""
     api.ws_send_and_wait = AsyncMock(return_value=[IB_RECORD])
@@ -183,9 +190,6 @@ async def test_delete_input_boolean(api: Api):
     assert result is None
 
 
-IN_RECORD = {"id": "brightness", "name": "Brightness", "min": 0.0, "max": 100.0}
-
-
 async def test_list_input_numbers(api: Api):
     api.ws_send_and_wait = AsyncMock(return_value=[IN_RECORD])
 
@@ -232,9 +236,6 @@ async def test_delete_input_number(api: Api):
     assert result is None
 
 
-IT_RECORD = {"id": "wifi_password", "name": "WiFi Password"}
-
-
 async def test_list_input_texts(api: Api):
     api.ws_send_and_wait = AsyncMock(return_value=[IT_RECORD])
 
@@ -278,9 +279,6 @@ async def test_delete_input_text(api: Api):
     assert call_kwargs["type"] == "input_text/delete"
     assert call_kwargs["input_text_id"] == "wifi_password"
     assert result is None
-
-
-IS_RECORD = {"id": "theme", "name": "Theme", "options": ["light", "dark"]}
 
 
 async def test_list_input_selects(api: Api):
@@ -330,9 +328,6 @@ async def test_delete_input_select(api: Api):
     assert result is None
 
 
-IDT_RECORD = {"id": "alarm_time", "name": "Alarm Time", "has_date": False, "has_time": True}
-
-
 async def test_list_input_datetimes(api: Api):
     api.ws_send_and_wait = AsyncMock(return_value=[IDT_RECORD])
 
@@ -379,9 +374,6 @@ async def test_delete_input_datetime(api: Api):
     assert result is None
 
 
-IBT_RECORD = {"id": "restart_btn", "name": "Restart"}
-
-
 async def test_list_input_buttons(api: Api):
     api.ws_send_and_wait = AsyncMock(return_value=[IBT_RECORD])
 
@@ -426,9 +418,6 @@ async def test_delete_input_button(api: Api):
     assert call_kwargs["type"] == "input_button/delete"
     assert call_kwargs["input_button_id"] == "restart_btn"
     assert result is None
-
-
-CTR_RECORD = {"id": "motion_count", "name": "Motion Count", "initial": 0, "step": 1}
 
 
 async def test_list_counters(api: Api):
@@ -480,9 +469,6 @@ async def test_delete_counter(api: Api):
     assert result is None
 
 
-TMR_RECORD = {"id": "cooldown", "name": "Cooldown Timer", "duration": "00:05:00"}
-
-
 async def test_list_timers(api: Api):
     api.ws_send_and_wait = AsyncMock(return_value=[TMR_RECORD])
 
@@ -529,9 +515,6 @@ async def test_delete_timer(api: Api):
     assert call_kwargs["type"] == "timer/delete"
     assert call_kwargs["timer_id"] == "cooldown"
     assert result is None
-
-
-SERVICE_RESPONSE = ServiceResponse(context=Context(id="ctx-1"))
 
 
 async def test_increment_counter_calls_service(api: Api):

--- a/tests/integration/test_app_factory_lifecycle.py
+++ b/tests/integration/test_app_factory_lifecycle.py
@@ -18,6 +18,9 @@ if TYPE_CHECKING:
     from hassette.test_utils.harness import HassetteHarness
 
 
+TEST_APPS_PATH = Path(__file__).parent.parent / "data" / "apps"
+
+
 def get_app(registry: AppRegistry, key: str, index: int = 0) -> "App[AppConfig]":
     app = registry.get(key, index)
     assert app is not None, f"expected app {key!r}[{index}] to be registered"
@@ -28,9 +31,6 @@ def get_failed_by_key(registry: AppRegistry, app_key: str) -> list[AppInstanceIn
     """Get failed app instances for a specific app_key."""
     snapshot = registry.get_snapshot()
     return [info for info in snapshot.failed if info.app_key == app_key]
-
-
-TEST_APPS_PATH = Path(__file__).parent.parent / "data" / "apps"
 
 
 def clear_class_cache():

--- a/tests/integration/test_models.py
+++ b/tests/integration/test_models.py
@@ -85,7 +85,7 @@ def test_all_domains_registered(
 
 def test_all_classes_in_registry(all_models: dict[str, type[states.BaseState]]):
     """Test that all state models are included in the state registry."""
-    registered_classes = [v for v in STATE_REGISTRY.registry.values()]
+    registered_classes = list(STATE_REGISTRY.registry.values())
     missing_classes = []
 
     for model_cls in all_models.values():

--- a/tests/unit/bus/test_bus_coroutine_conversion.py
+++ b/tests/unit/bus/test_bus_coroutine_conversion.py
@@ -25,6 +25,9 @@ from tests.unit.test_forgotten_await_completeness import CANONICAL_PROTECTED
 
 from .conftest import mock_add_listener
 
+# Derived from the canonical single source of truth — see test_forgotten_await_completeness.py.
+_PUBLIC_REGISTRATION_METHODS = sorted(CANONICAL_PROTECTED[Bus])
+
 
 @pytest.fixture(autouse=True)
 def _drain(drain_forgotten_await_handles: None) -> None:
@@ -36,9 +39,6 @@ async def handler(event: object) -> None:
 
 
 # public registration methods are plain def, not async def
-
-# Derived from the canonical single source of truth — see test_forgotten_await_completeness.py.
-_PUBLIC_REGISTRATION_METHODS = sorted(CANONICAL_PROTECTED[Bus])
 
 
 @pytest.mark.parametrize("method_name", _PUBLIC_REGISTRATION_METHODS)

--- a/tests/unit/resources/lifecycle/test_force_terminal.py
+++ b/tests/unit/resources/lifecycle/test_force_terminal.py
@@ -64,8 +64,8 @@ async def test_app_shutdown_propagates_to_bus_and_scheduler():
     await app.initialize()
 
     # Verify bus and scheduler are children that will receive propagated shutdown
-    assert app.bus in [child for child in app.children]
-    assert app.scheduler in [child for child in app.children]
+    assert app.bus in list(app.children)
+    assert app.scheduler in list(app.children)
 
     # Both should be ready after init
     assert app.bus.is_ready()

--- a/tests/unit/resources/lifecycle/test_init.py
+++ b/tests/unit/resources/lifecycle/test_init.py
@@ -37,6 +37,9 @@ from .conftest import SimpleParent
 _init_order: list[str] = []
 
 
+LEAF_TYPES = ["Bus", "Scheduler", "Api", "ApiSyncFacade", "_ScheduledJobQueue"]
+
+
 class InitTrackingChild(Resource):
     """Resource that records its unique_name on initialization."""
 
@@ -242,9 +245,6 @@ def make_leaf(hassette, leaf_type: str) -> Resource:
     if leaf_type == "_ScheduledJobQueue":
         return _ScheduledJobQueue(hassette)
     raise ValueError(f"Unknown leaf type: {leaf_type}")
-
-
-LEAF_TYPES = ["Bus", "Scheduler", "Api", "ApiSyncFacade", "_ScheduledJobQueue"]
 
 
 @pytest.mark.parametrize("leaf_type", LEAF_TYPES)

--- a/tests/unit/resources/test_emit_readiness_event.py
+++ b/tests/unit/resources/test_emit_readiness_event.py
@@ -3,13 +3,13 @@
 from typing import TYPE_CHECKING
 from unittest.mock import AsyncMock
 
+from hassette.test_utils import make_mock_hassette
 from hassette.types.enums import ResourceStatus
+
+from .conftest import ConcreteResource
 
 if TYPE_CHECKING:
     from hassette.events.hassette import ServiceStatusPayload
-from hassette.test_utils import make_mock_hassette
-
-from .conftest import ConcreteResource
 
 
 async def make_resource() -> tuple[ConcreteResource, AsyncMock]:

--- a/tests/unit/scheduler/test_scheduler_coroutine_conversion.py
+++ b/tests/unit/scheduler/test_scheduler_coroutine_conversion.py
@@ -27,6 +27,9 @@ from tests.unit.test_forgotten_await_completeness import CANONICAL_PROTECTED
 
 from .conftest import make_scheduler
 
+# Derived from the canonical single source of truth — see test_forgotten_await_completeness.py.
+_PUBLIC_SCHEDULING_METHODS = sorted(CANONICAL_PROTECTED[Scheduler])
+
 
 @pytest.fixture(autouse=True)
 def _drain(drain_forgotten_await_handles: None) -> None:
@@ -34,9 +37,6 @@ def _drain(drain_forgotten_await_handles: None) -> None:
 
 
 # Public scheduling methods must be plain def, not async def
-
-# Derived from the canonical single source of truth — see test_forgotten_await_completeness.py.
-_PUBLIC_SCHEDULING_METHODS = sorted(CANONICAL_PROTECTED[Scheduler])
 
 
 @pytest.mark.parametrize("method_name", _PUBLIC_SCHEDULING_METHODS)

--- a/tests/unit/test_api_coroutine_conversion.py
+++ b/tests/unit/test_api_coroutine_conversion.py
@@ -22,6 +22,17 @@ from hassette.utils.await_guard import RegistrationHandle
 from tests.unit.conftest import make_api
 from tests.unit.test_forgotten_await_completeness import CANONICAL_PROTECTED
 
+# Derived from the canonical single source of truth — see test_forgotten_await_completeness.py.
+_CONVERTED_METHODS = sorted(CANONICAL_PROTECTED[Api])
+_API_METHODS = [
+    pytest.param(lambda a: a.call_service("light", "turn_on"), id="call_service"),
+    pytest.param(lambda a: a.fire_event("custom_event"), id="fire_event"),
+    pytest.param(lambda a: a.set_state("light.test", "on"), id="set_state"),
+    pytest.param(lambda a: a.turn_on("light.kitchen"), id="turn_on"),
+    pytest.param(lambda a: a.turn_off("light.kitchen"), id="turn_off"),
+    pytest.param(lambda a: a.toggle_service("switch.fan"), id="toggle_service"),
+]
+
 
 @pytest.fixture(autouse=True)
 def drain(drain_forgotten_await_handles: None) -> None:
@@ -29,9 +40,6 @@ def drain(drain_forgotten_await_handles: None) -> None:
 
 
 # Converted public methods are plain def, not async def
-
-# Derived from the canonical single source of truth — see test_forgotten_await_completeness.py.
-_CONVERTED_METHODS = sorted(CANONICAL_PROTECTED[Api])
 
 
 @pytest.mark.parametrize("method_name", _CONVERTED_METHODS)
@@ -101,16 +109,6 @@ async def test_await_set_state_returns_dict() -> None:
 
 
 # Returned handle is a RegistrationHandle before awaiting
-
-
-_API_METHODS = [
-    pytest.param(lambda a: a.call_service("light", "turn_on"), id="call_service"),
-    pytest.param(lambda a: a.fire_event("custom_event"), id="fire_event"),
-    pytest.param(lambda a: a.set_state("light.test", "on"), id="set_state"),
-    pytest.param(lambda a: a.turn_on("light.kitchen"), id="turn_on"),
-    pytest.param(lambda a: a.turn_off("light.kitchen"), id="turn_off"),
-    pytest.param(lambda a: a.toggle_service("switch.fan"), id="toggle_service"),
-]
 
 
 @pytest.mark.parametrize("call", _API_METHODS)

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -16,6 +16,23 @@ from hassette.test_utils import run_hassette_startup_tasks
 from hassette.test_utils.config import TEST_TOKEN
 from hassette.utils import app_utils
 
+# Per-service log level nested attribute names under config.logging.*
+SERVICE_LOG_LEVEL_ATTRS = (
+    "database_service",
+    "bus_service",
+    "scheduler_service",
+    "app_handler",
+    "web_api",
+    "websocket",
+    "service_watcher",
+    "file_watcher",
+    "task_bucket",
+    "command_executor",
+    "apps",
+    "state_proxy",
+    "api",
+)
+
 
 def cleanup_env(*keys: str) -> None:
     for key in keys:
@@ -401,24 +418,6 @@ def clean_log_level_env(monkeypatch):
         if k.startswith("hassette__") and ("log_level" in k or k.startswith("hassette__logging__")):
             monkeypatch.delenv(key, raising=False)
     return
-
-
-# Per-service log level nested attribute names under config.logging.*
-SERVICE_LOG_LEVEL_ATTRS = (
-    "database_service",
-    "bus_service",
-    "scheduler_service",
-    "app_handler",
-    "web_api",
-    "websocket",
-    "service_watcher",
-    "file_watcher",
-    "task_bucket",
-    "command_executor",
-    "apps",
-    "state_proxy",
-    "api",
-)
 
 
 class LogLevelTestConfig(HassetteConfig):

--- a/tests/unit/test_config_log_level.py
+++ b/tests/unit/test_config_log_level.py
@@ -60,18 +60,6 @@ LOG_LEVEL_OVERRIDES = {
 }
 
 
-def stub_resource(cls: type[Resource]) -> Resource:
-    """Create a Resource instance by calling Resource.__init__ only (skips subclass constructors)."""
-    hassette = make_mock_hassette(
-        sealed=False,
-        logging=LOG_LEVEL_OVERRIDES,
-        lifecycle={"resource_shutdown_timeout_seconds": 5, "task_cancellation_timeout_seconds": 5},
-    )
-    obj = cls.__new__(cls)
-    Resource.__init__(obj, hassette, parent=hassette)
-    return obj
-
-
 OVERRIDE_CASES = [
     # Dedicated field overrides (Hassette-registered services)
     # Each tuple: (ResourceClass, nested_attr_on_config_logging)
@@ -102,6 +90,19 @@ OVERRIDE_CASES = [
     (Scheduler, "scheduler_service"),
     (ApiSyncFacade, "api"),
 ]
+ALL_OVERRIDE_CLASSES: list[type[Resource]] = [cls for cls, _ in OVERRIDE_CASES] + [App]
+
+
+def stub_resource(cls: type[Resource]) -> Resource:
+    """Create a Resource instance by calling Resource.__init__ only (skips subclass constructors)."""
+    hassette = make_mock_hassette(
+        sealed=False,
+        logging=LOG_LEVEL_OVERRIDES,
+        lifecycle={"resource_shutdown_timeout_seconds": 5, "task_cancellation_timeout_seconds": 5},
+    )
+    obj = cls.__new__(cls)
+    Resource.__init__(obj, hassette, parent=hassette)
+    return obj
 
 
 @pytest.mark.parametrize(
@@ -132,9 +133,6 @@ def test_api_resource_does_not_return_global_log_level() -> None:
     resource.hassette.config.logging.api = "DEBUG"
     assert resource.config_log_level == "DEBUG"
     assert resource.config_log_level != resource.hassette.config.logging.log_level
-
-
-ALL_OVERRIDE_CLASSES: list[type[Resource]] = [cls for cls, _ in OVERRIDE_CASES] + [App]
 
 
 @pytest.mark.parametrize("cls", ALL_OVERRIDE_CLASSES, ids=[c.__name__ for c in ALL_OVERRIDE_CLASSES])

--- a/tests/unit/test_entity_coroutine_conversion.py
+++ b/tests/unit/test_entity_coroutine_conversion.py
@@ -29,6 +29,10 @@ from hassette.models.entities.light import LightEntity
 from hassette.models.states import HumidifierState
 from tests.unit.conftest import make_api, make_light_entity
 
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_ENTITIES_DIR = _REPO_ROOT / "src" / "hassette" / "models" / "entities"
+_MANIFEST = _REPO_ROOT / ".generated-manifest"
+
 
 @pytest.fixture(autouse=True)
 def _drain(drain_forgotten_await_handles: None) -> None:
@@ -56,10 +60,6 @@ def make_humidifier_entity(api: "Api") -> tuple[HumidifierEntity, "Token[Hassett
 
 
 # Regen check — generated files use def -> Coroutine[...], not async def
-
-_REPO_ROOT = Path(__file__).resolve().parents[2]
-_ENTITIES_DIR = _REPO_ROOT / "src" / "hassette" / "models" / "entities"
-_MANIFEST = _REPO_ROOT / ".generated-manifest"
 
 
 def _manifest_entity_files() -> list[str]:

--- a/tests/unit/test_forgotten_await_completeness.py
+++ b/tests/unit/test_forgotten_await_completeness.py
@@ -208,6 +208,25 @@ DOCUMENTED_EXCLUSIONS: dict[type, set[str]] = {
 # Detection helper (same OR-semantics as the parity tests)
 
 
+# add_listener is handled separately (requires a Listener object).
+# sorted() pins the parametrize order: CANONICAL_PROTECTED[Bus] is a set, and unsorted set
+# iteration order varies with PYTHONHASHSEED across processes. Without the sort, xdist workers
+# collect these cases in different orders and abort with "Different tests were collected between
+# gw0 and gwN" under `-n` (the suite only survived because pytest-randomly syncs the seed).
+_BUS_METHODS_PARAMETRIZED = sorted(m for m in CANONICAL_PROTECTED[Bus] if m != "add_listener")
+# add_job is handled separately (requires a ScheduledJob object).
+# sorted() for the same cross-process determinism reason as _BUS_METHODS_PARAMETRIZED above.
+_SCHED_METHODS_PARAMETRIZED = sorted(m for m in CANONICAL_PROTECTED[Scheduler] if m != "add_job")
+_API_METHOD_CALLS: dict[str, object] = {
+    "call_service": lambda api: api.call_service("light", "turn_on"),
+    "fire_event": lambda api: api.fire_event("custom_event"),
+    "set_state": lambda api: api.set_state("light.test", "on"),
+    "turn_on": lambda api: api.turn_on("light.kitchen"),
+    "turn_off": lambda api: api.turn_off("light.kitchen"),
+    "toggle_service": lambda api: api.toggle_service("switch.fan"),
+}
+
+
 def _is_detected(cls: type, name: str) -> bool:
     """Return True if ``name`` on ``cls`` satisfies the completeness detection criterion.
 
@@ -425,13 +444,6 @@ def _bus_call(method_name: str):
     return _calls[method_name]
 
 
-# add_listener is handled separately (requires a Listener object).
-# sorted() pins the parametrize order: CANONICAL_PROTECTED[Bus] is a set, and unsorted set
-# iteration order varies with PYTHONHASHSEED across processes. Without the sort, xdist workers
-# collect these cases in different orders and abort with "Different tests were collected between
-# gw0 and gwN" under `-n` (the suite only survived because pytest-randomly syncs the seed).
-_BUS_METHODS_PARAMETRIZED = sorted(m for m in CANONICAL_PROTECTED[Bus] if m != "add_listener")
-
 # Scheduler fixtures
 
 
@@ -472,20 +484,7 @@ def _sched_call(method_name: str):
     return _calls[method_name]
 
 
-# add_job is handled separately (requires a ScheduledJob object).
-# sorted() for the same cross-process determinism reason as _BUS_METHODS_PARAMETRIZED above.
-_SCHED_METHODS_PARAMETRIZED = sorted(m for m in CANONICAL_PROTECTED[Scheduler] if m != "add_job")
-
 # Api fixtures
-
-_API_METHOD_CALLS: dict[str, object] = {
-    "call_service": lambda api: api.call_service("light", "turn_on"),
-    "fire_event": lambda api: api.fire_event("custom_event"),
-    "set_state": lambda api: api.set_state("light.test", "on"),
-    "turn_on": lambda api: api.turn_on("light.kitchen"),
-    "turn_off": lambda api: api.turn_off("light.kitchen"),
-    "toggle_service": lambda api: api.toggle_service("switch.fan"),
-}
 
 
 # Build parametrized cases

--- a/tests/unit/test_state_manager.py
+++ b/tests/unit/test_state_manager.py
@@ -11,6 +11,9 @@ from hassette.models.states import BaseState, DeviceTrackerState, LightState, Pe
 from hassette.state_manager.state_manager import DomainStates, StateManager
 from hassette.test_utils import make_light_state_dict, make_mock_hassette, make_state_dict
 
+BAD_TIMESTAMP = "INVALID-TIMESTAMP"
+BAD_CONTEXT = {"id": None, "parent_id": None, "user_id": None}
+
 
 @pytest.fixture
 def mock_hassette() -> AsyncMock:
@@ -162,10 +165,6 @@ class TestDomainStatesCacheValidation:
         assert first is not second
         assert spy.call_count == 2
         assert ds._cache["light.bedroom"].model is second
-
-
-BAD_TIMESTAMP = "INVALID-TIMESTAMP"
-BAD_CONTEXT = {"id": None, "parent_id": None, "user_id": None}
 
 
 def make_bad_state_dict(entity_id: str = "light.bad") -> dict:

--- a/tests/unit/tools/test_check_constants_position.py
+++ b/tests/unit/tools/test_check_constants_position.py
@@ -1,0 +1,175 @@
+"""Characterization tests for tools/check_constants_position.py.
+
+These pin the guard's observable behavior — which UPPER_CASE module constants are
+flagged as misplaced after the first class/function, which are auto-exempted because
+they reference an earlier-defined name, and which are exempted via the
+``# constant-after-def:`` annotation — so the detection internals can be reworked
+without changing what the guard reports.
+"""
+
+from collections.abc import Callable
+from pathlib import Path
+
+import pytest
+from check_constants_position import check_file
+
+# Each case: (id, source, expected violations as [(lineno, statement text), ...]).
+CASES: list[tuple[str, str, list[tuple[int, str]]]] = [
+    (
+        "no_defs_not_flagged",
+        """\
+        FOO = 1
+        BAR = 2
+        """,
+        [],
+    ),
+    (
+        "constant_before_def_not_flagged",
+        """\
+        FOO = 1
+
+
+        class C:
+            pass
+        """,
+        [],
+    ),
+    (
+        "constant_after_def_flagged",
+        """\
+        class C:
+            pass
+
+
+        FOO = 1
+        """,
+        [(5, "FOO = 1")],
+    ),
+    (
+        "constant_referencing_earlier_class_exempt",
+        """\
+        class MyEnum:
+            VALUE = "value"
+
+
+        DEFAULT = MyEnum.VALUE
+        """,
+        [],
+    ),
+    (
+        "constant_referencing_earlier_function_exempt",
+        """\
+        def compute():
+            return 1
+
+
+        RESULT = compute()
+        """,
+        [],
+    ),
+    (
+        "constant_with_annotation_exempt",
+        """\
+        class C:
+            pass
+
+
+        FOO = 1  # constant-after-def: legacy placement
+        """,
+        [],
+    ),
+    (
+        "empty_annotation_not_exempt",
+        """\
+        class C:
+            pass
+
+
+        FOO = 1  # constant-after-def:
+        """,
+        [(5, "FOO = 1  # constant-after-def:")],
+    ),
+    (
+        "dunder_not_flagged",
+        """\
+        class C:
+            pass
+
+
+        __all__ = ["C"]
+        """,
+        [],
+    ),
+    (
+        "lowercase_not_flagged",
+        """\
+        class C:
+            pass
+
+
+        my_var = 1
+        """,
+        [],
+    ),
+    (
+        "single_char_not_flagged",
+        """\
+        class C:
+            pass
+
+
+        X = 1
+        """,
+        [],
+    ),
+    (
+        "annotated_assign_flagged",
+        """\
+        class C:
+            pass
+
+
+        FOO: int = 1
+        """,
+        [(5, "FOO: int = 1")],
+    ),
+    (
+        "frozenset_wrapping_earlier_enum_exempt",
+        """\
+        class Status:
+            DONE = 1
+
+
+        TERMINAL = frozenset({Status.DONE})
+        """,
+        [],
+    ),
+    (
+        "annotation_referencing_earlier_class_exempt",
+        """\
+        class Handle:
+            pass
+
+
+        HANDLE_VAR: dict[str, Handle] = {}
+        """,
+        [],
+    ),
+    (
+        "constant_referencing_earlier_constant_exempt",
+        """\
+        def build():
+            return (1, 2)
+
+
+        _COLUMNS = build()
+        _INSERT_SQL = f"INSERT ({_COLUMNS})"
+        """,
+        [],
+    ),
+]
+
+
+@pytest.mark.parametrize(("source", "expected"), [(c[1], c[2]) for c in CASES], ids=[c[0] for c in CASES])
+def test_guard_behavior(write_sample: Callable[[str], Path], source: str, expected: list[tuple[int, str]]) -> None:
+    assert check_file(write_sample(source)) == expected

--- a/tests/unit/tools/test_check_exception_names.py
+++ b/tests/unit/tools/test_check_exception_names.py
@@ -1,0 +1,135 @@
+"""Characterization tests for tools/check_exception_names.py.
+
+These pin the guard's observable behavior — which bound exception names are
+flagged and at which line numbers — so the detection internals can be reworked
+without changing what the guard reports.
+"""
+
+from collections.abc import Callable
+from pathlib import Path
+
+import pytest
+from check_exception_names import check_file
+
+# Each case: (id, source, expected violations as [(lineno, handler_text), ...]).
+CASES: list[tuple[str, str, list[tuple[int, str]]]] = [
+    (
+        "except_no_binding_not_flagged",
+        """\
+        try:
+            pass
+        except ValueError:
+            pass
+        """,
+        [],
+    ),
+    (
+        "except_as_exc_not_flagged",
+        """\
+        try:
+            pass
+        except ValueError as exc:
+            pass
+        """,
+        [],
+    ),
+    (
+        "except_as_retry_exc_not_flagged",
+        """\
+        try:
+            pass
+        except ValueError as retry_exc:
+            pass
+        """,
+        [],
+    ),
+    (
+        "except_as_e_flagged",
+        """\
+        try:
+            pass
+        except ValueError as e:
+            pass
+        """,
+        [(3, "except ValueError as e:")],
+    ),
+    (
+        "except_as_ex_flagged",
+        """\
+        try:
+            pass
+        except ValueError as ex:
+            pass
+        """,
+        [(3, "except ValueError as ex:")],
+    ),
+    (
+        "except_as_err_flagged",
+        """\
+        try:
+            pass
+        except ValueError as err:
+            pass
+        """,
+        [(3, "except ValueError as err:")],
+    ),
+    (
+        "except_as_error_flagged",
+        """\
+        try:
+            pass
+        except ValueError as error:
+            pass
+        """,
+        [(3, "except ValueError as error:")],
+    ),
+    (
+        "bare_except_as_e_flagged",
+        """\
+        try:
+            pass
+        except Exception as e:
+            pass
+        """,
+        [(3, "except Exception as e:")],
+    ),
+    (
+        "multiple_handlers",
+        """\
+        try:
+            pass
+        except ValueError as exc:
+            pass
+        except TypeError as e:
+            pass
+        """,
+        [(5, "except TypeError as e:")],
+    ),
+    (
+        "nested_try_flagged",
+        """\
+        def f():
+            try:
+                pass
+            except ValueError as e:
+                pass
+        """,
+        [(4, "except ValueError as e:")],
+    ),
+    (
+        "docstring_example_not_flagged",
+        '''\
+        def f():
+            """Do a thing.
+
+            Example: except X as e: is what NOT to do.
+            """
+        ''',
+        [],
+    ),
+]
+
+
+@pytest.mark.parametrize(("source", "expected"), [(c[1], c[2]) for c in CASES], ids=[c[0] for c in CASES])
+def test_guard_behavior(write_sample: Callable[[str], Path], source: str, expected: list[tuple[int, str]]) -> None:
+    assert check_file(write_sample(source)) == expected

--- a/tests/unit/tools/test_check_file_size.py
+++ b/tests/unit/tools/test_check_file_size.py
@@ -1,0 +1,47 @@
+"""Characterization tests for tools/check_file_size.py.
+
+These pin the guard's observable behavior — which files are flagged, at which
+line count, and which annotations exempt them — so the detection internals can
+be reworked without changing what the guard reports.
+"""
+
+from collections.abc import Callable
+from pathlib import Path
+
+import pytest
+from check_file_size import check_file
+
+# Each case: (id, source, expected violations as [(lineno, message), ...]).
+CASES: list[tuple[str, str, list[tuple[int, str]]]] = [
+    (
+        "short_file_not_flagged",
+        "x = 1\n" * 10,
+        [],
+    ),
+    (
+        "exactly_800_not_flagged",
+        "x = 1\n" * 800,
+        [],
+    ),
+    (
+        "over_800_flagged",
+        "x = 1\n" * 801,
+        [(1, "801 lines (threshold: 800)")],
+    ),
+    (
+        "exempt_file_not_flagged",
+        "# file-size-exempt: tracking in #123\n" + "x = 1\n" * 900,
+        [],
+    ),
+    (
+        "empty_annotation_not_exempt",
+        "# file-size-exempt:\n" + "x = 1\n" * 900,
+        [(1, "901 lines (threshold: 800)")],
+    ),
+]
+
+
+@pytest.mark.parametrize(("source", "expected"), [(c[1], c[2]) for c in CASES], ids=[c[0] for c in CASES])
+def test_guard_behavior(write_sample: Callable[[str], Path], source: str, expected: list[tuple[int, str]]) -> None:
+    target = write_sample(source)
+    assert check_file(target) == expected

--- a/tests/unit/tools/test_check_internal_patches.py
+++ b/tests/unit/tools/test_check_internal_patches.py
@@ -11,14 +11,6 @@ from pathlib import Path
 import pytest
 from check_internal_patches import IN_SCOPE_FILES, check_file
 
-
-def run(tmp_path: Path, content: str) -> list[tuple[int, str]]:
-    """Write content to a temp file and return the guard's violations."""
-    target = tmp_path / "sample_test.py"
-    target.write_text(textwrap.dedent(content))
-    return check_file(target)
-
-
 # Each case: (id, source, expected violations as [(lineno, symbol), ...]).
 CASES: list[tuple[str, str, list[tuple[int, str]]]] = [
     (
@@ -122,6 +114,13 @@ CASES: list[tuple[str, str, list[tuple[int, str]]]] = [
         [(1, "load_cache")],
     ),
 ]
+
+
+def run(tmp_path: Path, content: str) -> list[tuple[int, str]]:
+    """Write content to a temp file and return the guard's violations."""
+    target = tmp_path / "sample_test.py"
+    target.write_text(textwrap.dedent(content))
+    return check_file(target)
 
 
 @pytest.mark.parametrize(("source", "expected"), [(c[1], c[2]) for c in CASES], ids=[c[0] for c in CASES])

--- a/tests/unit/tools/test_check_type_checking_position.py
+++ b/tests/unit/tools/test_check_type_checking_position.py
@@ -1,0 +1,105 @@
+"""Characterization tests for tools/check_type_checking_position.py.
+
+These pin the guard's observable behavior — which ``if TYPE_CHECKING:`` blocks
+are flagged, at which line numbers, and which positions are considered
+correct — so the detection internals can be reworked without changing what
+the guard reports.
+"""
+
+from collections.abc import Callable
+from pathlib import Path
+
+import pytest
+from check_type_checking_position import check_file
+
+# Each case: (id, source, expected violations as [(lineno, message), ...]).
+CASES: list[tuple[str, str, list[tuple[int, str]]]] = [
+    (
+        "no_type_checking_block",
+        """\
+        import os
+        from pathlib import Path
+        """,
+        [],
+    ),
+    (
+        "type_checking_at_end",
+        """\
+        import os
+        from typing import TYPE_CHECKING
+
+        if TYPE_CHECKING:
+            from pathlib import Path
+
+
+        class C:
+            pass
+        """,
+        [],
+    ),
+    (
+        "type_checking_between_imports",
+        """\
+        import os
+        from typing import TYPE_CHECKING
+
+        if TYPE_CHECKING:
+            from pathlib import Path
+
+        import sys
+        """,
+        [(4, "if TYPE_CHECKING: block at line 4 followed by imports at line 7")],
+    ),
+    (
+        "typing_dot_type_checking",
+        """\
+        import os
+        import typing
+
+        if typing.TYPE_CHECKING:
+            from pathlib import Path
+
+        import sys
+        """,
+        [(4, "if TYPE_CHECKING: block at line 4 followed by imports at line 7")],
+    ),
+    (
+        "type_checking_followed_by_class_not_flagged",
+        """\
+        from typing import TYPE_CHECKING
+
+        if TYPE_CHECKING:
+            from pathlib import Path
+
+
+        class C:
+            pass
+        """,
+        [],
+    ),
+    (
+        "multiple_type_checking_blocks",
+        """\
+        import os
+        from typing import TYPE_CHECKING
+
+        if TYPE_CHECKING:
+            from pathlib import Path
+
+        import sys
+
+        if TYPE_CHECKING:
+            from collections.abc import Iterator
+
+
+        class C:
+            pass
+        """,
+        [(4, "if TYPE_CHECKING: block at line 4 followed by imports at line 7")],
+    ),
+]
+
+
+@pytest.mark.parametrize(("source", "expected"), [(c[1], c[2]) for c in CASES], ids=[c[0] for c in CASES])
+def test_guard_behavior(write_sample: Callable[[str], Path], source: str, expected: list[tuple[int, str]]) -> None:
+    assert check_file(write_sample(source)) == expected

--- a/tests/unit/tools/test_generate_constraints.py
+++ b/tests/unit/tools/test_generate_constraints.py
@@ -34,6 +34,26 @@ PYPROJECT_WITH_EXTRAS = textwrap.dedent(
 )
 
 
+PYPROJECT_MULTI_EXTRAS = textwrap.dedent(
+    """\
+    [project]
+    name = "hassette"
+    version = "0.24.0"
+    dependencies = [
+        "httpx[http2,brotli]>=0.25",
+        "tzdata>=2024.1; sys_platform == 'win32'",
+    ]
+    """
+)
+PYPROJECT_NO_DEPS = textwrap.dedent(
+    """\
+    [project]
+    name = "hassette"
+    version = "0.24.0"
+    """
+)
+
+
 def run_generate(tmp_path: Path, pyproject_content: str, hassette_version: str = "0.24.0") -> list[str]:
     """Call generate_lines() with a fake pyproject.toml and mocked importlib.metadata."""
     toml_file = tmp_path / "pyproject.toml"
@@ -113,19 +133,6 @@ def test_no_duplicate_hassette(tmp_path: Path) -> None:
     assert len(hassette_lines) == 1, f"Expected exactly one hassette line, got: {hassette_lines}"
 
 
-PYPROJECT_MULTI_EXTRAS = textwrap.dedent(
-    """\
-    [project]
-    name = "hassette"
-    version = "0.24.0"
-    dependencies = [
-        "httpx[http2,brotli]>=0.25",
-        "tzdata>=2024.1; sys_platform == 'win32'",
-    ]
-    """
-)
-
-
 def test_multiple_comma_separated_extras_stripped(tmp_path: Path) -> None:
     """httpx[http2,brotli]>=0.25 → httpx>=0.25."""
     lines = run_generate(tmp_path, PYPROJECT_MULTI_EXTRAS)
@@ -157,15 +164,6 @@ def test_generate_lines_returns_list_of_strings(tmp_path: Path) -> None:
     lines = run_generate(tmp_path, SIMPLE_PYPROJECT)
     assert isinstance(lines, list)
     assert all(isinstance(line, str) for line in lines)
-
-
-PYPROJECT_NO_DEPS = textwrap.dedent(
-    """\
-    [project]
-    name = "hassette"
-    version = "0.24.0"
-    """
-)
 
 
 def test_missing_dependencies_key_produces_hassette_pin_only(tmp_path: Path) -> None:

--- a/tools/check_constants_position.py
+++ b/tools/check_constants_position.py
@@ -1,0 +1,234 @@
+#!/usr/bin/env python3
+"""CI guard: flag UPPER_CASE module constants defined after the first class/function.
+
+The house convention is that module-level constants sit at the top of the file,
+right after imports, so a reader can see the file's configuration surface before
+diving into behavior. But that convention has a legitimate exception: a constant
+that *derives* from an earlier class or function necessarily has to come after it —
+``DEFAULT_OVERLAP_MODE = ExecutionMode.SINGLE`` cannot appear before ``ExecutionMode``
+is defined.
+
+Detection is AST-based and only looks at top-level module statements (``tree.body``).
+A constant is a module-level ``ast.Assign``/``ast.AnnAssign`` whose target(s) are all
+UPPER_CASE names (2+ characters, not a dunder like ``__all__``). It is flagged when it
+appears after the first top-level ``ast.ClassDef``/``ast.FunctionDef``/``ast.AsyncFunctionDef``
+in the module, UNLESS it references a name bound by an earlier top-level statement —
+a class, a function, or another module-level assignment target — collected by walking
+its value (and, for ``ast.AnnAssign``, its annotation too, since annotations are
+evaluated at runtime in this codebase) for ``ast.Name`` nodes and matching against
+every name bound earlier in the same module body. Checking the annotation as well as
+the value matters: a ``ContextVar[SomeClass | None]`` annotation evaluates ``SomeClass``
+at import time exactly like a value expression would. Checking earlier assignment
+targets (not just classes/functions) matters too, so a constant-derived-from-a-constant
+chain is exempted as a whole rather than only its first link. That heuristic auto-exempts
+the common "derived constant" shapes:
+
+    class ExecutionMode(Enum):
+        SINGLE = "single"
+
+    DEFAULT_OVERLAP_MODE = ExecutionMode.SINGLE  # references ExecutionMode -> exempt
+
+    def sort_harness_graph(deps): ...
+
+    STARTUP_ORDER = sort_harness_graph(DEPENDENCIES)  # references sort_harness_graph -> exempt
+
+    def build_columns(): ...
+
+    _COLUMNS = build_columns()  # references build_columns -> exempt
+    _INSERT_SQL = f"INSERT INTO t ({', '.join(_COLUMNS)})"  # references _COLUMNS -> exempt too
+
+    @dataclass
+    class Handle:
+        thread: threading.Thread | None = None
+
+    HANDLE_VAR: ContextVar[Handle | None] = ContextVar("handle")  # annotation references Handle -> exempt
+
+The ``# constant-after-def:`` annotation is the escape hatch for the rare constant
+that legitimately needs to sit after a def but doesn't reference it in a way the AST
+can see. It requires a non-empty reason after the colon, matched the same way as
+``# lazy-import:`` in check_lazy_imports.py: anywhere on the assignment's own physical
+line span, or on the comment-only line immediately preceding it.
+
+Canonical annotation form: ``# constant-after-def: <reason>``
+
+Usage:
+    python tools/check_constants_position.py [FILE ...]
+
+With no arguments, scans every file under src/, tests/, scripts/, tools/, codegen/,
+docs/, and examples/. Given file paths (as pre-commit passes the staged files), scans
+only those — out-of-scope or non-Python paths are ignored.
+"""
+
+import ast
+import re
+import sys
+from pathlib import Path
+
+from lint_helpers import DEFAULT_SCAN_DIRS, REPO_ROOT, iter_python_files, run_check
+
+# Matches the annotation followed by a non-empty reason (at least one
+# non-whitespace character after the colon).
+ANNOTATION_RE = re.compile(r"#\s*constant-after-def:\s*\S")
+
+DUNDER_RE = re.compile(r"^__.+__$")
+CONSTANT_NAME_RE = re.compile(r"^[A-Z_][A-Z0-9_]*$")
+
+
+def _is_constant_name(name: str) -> bool:
+    """Return True if ``name`` reads as an UPPER_CASE constant by house convention."""
+    if len(name) < 2:
+        return False
+    if DUNDER_RE.match(name):
+        return False
+    return bool(CONSTANT_NAME_RE.match(name))
+
+
+def _collect_name_targets(target: ast.expr) -> list[str] | None:
+    """Return the flat list of names bound by an assignment target, or None if unsupported.
+
+    Handles plain names (``FOO = 1``) and tuple/list unpacking (``FOO, BAR = 1, 2``).
+    Any other target shape (attribute, subscript, starred) returns None so the caller
+    skips the statement rather than misjudging it.
+    """
+    if isinstance(target, ast.Name):
+        return [target.id]
+    if isinstance(target, (ast.Tuple, ast.List)):
+        names: list[str] = []
+        for elt in target.elts:
+            collected = _collect_name_targets(elt)
+            if collected is None:
+                return None
+            names.extend(collected)
+        return names
+    return None
+
+
+def _extract_target_names(node: ast.Assign | ast.AnnAssign) -> list[str]:
+    """Return the names bound by a module-level Assign/AnnAssign, or [] if not applicable."""
+    if isinstance(node, ast.AnnAssign):
+        if node.value is None or not isinstance(node.target, ast.Name):
+            return []
+        return [node.target.id]
+
+    names: list[str] = []
+    for target in node.targets:
+        collected = _collect_name_targets(target)
+        if collected is None:
+            return []
+        names.extend(collected)
+    return names
+
+
+def _references_earlier_binding(
+    node: ast.Assign | ast.AnnAssign, bound_names: dict[str, int], current_index: int
+) -> bool:
+    """Return True if the statement references a name bound by an earlier top-level statement.
+
+    Walks ``node.value`` and, for ``ast.AnnAssign``, ``node.annotation`` too — both are
+    evaluated at import time in this codebase (no ``from __future__ import annotations``),
+    so a subscripted annotation like ``ContextVar[Handle | None]`` needs ``Handle`` to
+    already be bound exactly like a value expression would.
+    """
+    exprs: list[ast.expr] = [node.value] if node.value is not None else []
+    if isinstance(node, ast.AnnAssign):
+        exprs.append(node.annotation)
+
+    for expr in exprs:
+        for sub in ast.walk(expr):
+            if isinstance(sub, ast.Name) and bound_names.get(sub.id, current_index) < current_index:
+                return True
+    return False
+
+
+def is_exempt(lines: list[str], lineno: int, end_lineno: int) -> bool:
+    """Return True if the assignment spanning [lineno, end_lineno] carries a defend comment.
+
+    Accepts the annotation anywhere on the statement's own physical lines, or on the
+    comment-only line immediately preceding it (1-based line numbers).
+    """
+    for i in range(lineno - 1, end_lineno):
+        if ANNOTATION_RE.search(lines[i]):
+            return True
+
+    if lineno >= 2:
+        prev = lines[lineno - 2].strip()
+        if prev.startswith("#") and ANNOTATION_RE.search(prev):
+            return True
+
+    return False
+
+
+def check_file(path: Path) -> list[tuple[int, str]]:
+    """Return (1-based line number, statement text) for constants misplaced after a def."""
+    source = path.read_text()
+    lines = source.splitlines()
+    tree = ast.parse(source)
+
+    # Every name bound by a top-level class, function, or assignment, mapped to its body
+    # index. Assignment targets are included (not just classes/functions) so a constant
+    # that derives from another earlier constant — which itself derives from a function —
+    # is recognized as part of the same legitimate dependency chain.
+    bound_names: dict[str, int] = {}
+    first_def_index: int | None = None
+    for i, node in enumerate(tree.body):
+        if isinstance(node, (ast.ClassDef, ast.FunctionDef, ast.AsyncFunctionDef)):
+            bound_names[node.name] = i
+            if first_def_index is None:
+                first_def_index = i
+        elif isinstance(node, (ast.Assign, ast.AnnAssign)):
+            for name in _extract_target_names(node):
+                bound_names.setdefault(name, i)
+
+    if first_def_index is None:
+        return []
+
+    violations: list[tuple[int, str]] = []
+    for i, node in enumerate(tree.body):
+        if i <= first_def_index:
+            continue
+        if not isinstance(node, (ast.Assign, ast.AnnAssign)):
+            continue
+
+        names = _extract_target_names(node)
+        if not names or not all(_is_constant_name(name) for name in names):
+            continue
+
+        if _references_earlier_binding(node, bound_names, i):
+            continue
+
+        end_lineno = node.end_lineno or node.lineno
+        if is_exempt(lines, node.lineno, end_lineno):
+            continue
+
+        violations.append((node.lineno, lines[node.lineno - 1].strip()))
+
+    return sorted(violations)
+
+
+def iter_paths() -> list[Path]:
+    """Return every .py file under the scanned directories, sorted for stable output.
+
+    The full-scan entry point the characterization tests parametrize over; ``main`` calls
+    ``iter_python_files`` directly so a pre-commit run can scan just the staged files. Both go
+    through ``iter_python_files``, so the full-scan path can't drift from the per-file path.
+    """
+    return iter_python_files([])
+
+
+def main() -> int:
+    return run_check(
+        iter_python_files(sys.argv[1:]),
+        REPO_ROOT,
+        check_file,
+        summary="UPPER_CASE constant(s) defined after the first class/function",
+        ok=f"no misplaced constants found under {', '.join(DEFAULT_SCAN_DIRS)}/.",
+        footer=(
+            "Move each flagged constant above the first class/function definition. If it\n"
+            "genuinely needs to stay (and doesn't reference an earlier def), annotate the line:\n"
+            "'# constant-after-def: <reason>' (the reason is required)."
+        ),
+    )
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/check_exception_names.py
+++ b/tools/check_exception_names.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+"""CI guard: enforce 'exc' naming for bound exception variables in scanned source files.
+
+The house rule is that a caught exception is bound to ``exc`` (or a descriptive
+name ending in ``_exc``, like ``retry_exc``) — never ``e``, ``ex``, ``err``, or
+``error``. A consistent name makes the bound exception grep-able across the
+codebase and removes a class of one-letter-variable review nits.
+
+Detection is AST-based. Every ``ast.ExceptHandler`` with a bound name
+(``except X as name:``) is checked; ``except X:`` with no binding is never
+flagged since there's nothing to name. A bound name is flagged unless it is
+exactly ``exc`` or ends with ``_exc``.
+
+There is no exemption annotation mechanism — there's no legitimate reason to
+bind an exception to anything else, so unlike ``check_lazy_imports.py`` this
+checker has no escape hatch to defend.
+
+Usage:
+    python tools/check_exception_names.py [FILE ...]
+
+With no arguments, scans every file under src/, tests/, scripts/, tools/, codegen/,
+docs/, and examples/. Given file paths (as pre-commit passes the staged files), scans
+only those — out-of-scope or non-Python paths are ignored.
+"""
+
+import ast
+import sys
+from pathlib import Path
+
+from lint_helpers import DEFAULT_SCAN_DIRS, REPO_ROOT, iter_python_files, run_check
+
+
+def check_file(path: Path) -> list[tuple[int, str]]:
+    """Return a sorted list of (1-based line number, handler text) for badly-named exception bindings."""
+    source = path.read_text()
+    lines = source.splitlines()
+
+    violations = [
+        (node.lineno, lines[node.lineno - 1].strip())
+        for node in ast.walk(ast.parse(source))
+        if isinstance(node, ast.ExceptHandler)
+        and node.name is not None
+        and node.name != "exc"
+        and not node.name.endswith("_exc")
+    ]
+    return sorted(violations)
+
+
+def iter_paths() -> list[Path]:
+    """Return every .py file under the scanned directories, sorted for stable output.
+
+    The full-scan entry point the characterization tests parametrize over; ``main`` calls
+    ``iter_python_files`` directly so a pre-commit run can scan just the staged files. Both go
+    through ``iter_python_files``, so the full-scan path can't drift from the per-file path.
+    """
+    return iter_python_files([])
+
+
+def main() -> int:
+    return run_check(
+        iter_python_files(sys.argv[1:]),
+        REPO_ROOT,
+        check_file,
+        summary="exception handler(s) bound to a non-'exc' name",
+        ok=f"all bound exception handlers use 'exc' or '*_exc' under {', '.join(DEFAULT_SCAN_DIRS)}/.",
+        footer="Rename the bound exception to 'exc' (or a descriptive '*_exc' name, e.g. 'retry_exc').",
+    )
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/check_file_size.py
+++ b/tools/check_file_size.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+"""CI guard: flag .py files that have grown past the house size convention.
+
+CLAUDE.md's coding-style guidance caps files at 800 lines (200-400 typical). This
+guard exits non-zero when any file exceeds the threshold. It runs in CI as a
+``continue-on-error`` step so violations surface as a visible yellow warning on
+the PR without blocking the merge.
+
+The ``# file-size-exempt:`` annotation opts a file out entirely. It requires a
+non-empty reason after the colon so an empty annotation does not exempt. One
+annotation anywhere in the file exempts the whole file.
+
+Usage:
+    python tools/check_file_size.py [FILE ...]
+
+With no arguments, scans every file under src/, tests/, scripts/, tools/, codegen/,
+docs/, and examples/. Given file paths, scans only those.
+"""
+
+import re
+import sys
+from pathlib import Path
+
+from lint_helpers import DEFAULT_SCAN_DIRS, REPO_ROOT, iter_python_files
+
+THRESHOLD = 800
+
+ANNOTATION_RE = re.compile(r"#\s*file-size-exempt:\s*\S")
+
+
+def check_file(path: Path) -> list[tuple[int, str]]:
+    """Return [(1, message)] if the file exceeds THRESHOLD lines and isn't exempt, else []."""
+    source = path.read_text()
+    lines = source.splitlines()
+    line_count = len(lines)
+
+    if line_count <= THRESHOLD:
+        return []
+
+    if any(ANNOTATION_RE.search(line) for line in lines):
+        return []
+
+    return [(1, f"{line_count} lines (threshold: {THRESHOLD})")]
+
+
+def iter_paths() -> list[Path]:
+    """Return every .py file under the scanned directories, sorted for stable output."""
+    return iter_python_files([])
+
+
+def main() -> int:
+    paths = iter_python_files(sys.argv[1:])
+    violations: list[tuple[Path, int, str]] = []
+    for path in paths:
+        rel = path.relative_to(REPO_ROOT)
+        for lineno, message in check_file(path):
+            violations.append((rel, lineno, message))
+
+    if violations:
+        print(f"WARNING: {len(violations)} file(s) exceed {THRESHOLD} lines:")
+        print()
+        for rel, _lineno, message in violations:
+            print(f"  {rel} — {message}")
+        print()
+        print("Consider decomposing. Exempt with '# file-size-exempt: <reason>'.")
+    else:
+        print(f"OK: no un-exempt files exceed {THRESHOLD} lines under {', '.join(DEFAULT_SCAN_DIRS)}/.")
+
+    return 1 if violations else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/check_module_boundaries.py
+++ b/tools/check_module_boundaries.py
@@ -65,6 +65,32 @@ SRC = REPO_ROOT / "src" / "hassette"
 SCAN_DIRS: list[str] = [SRC.relative_to(REPO_ROOT).as_posix()]
 
 
+#: Layers that own or legitimately wire Hassette internals, so reading ``hassette._foo``
+#: there is not a reach-through. ``core`` is where ``Hassette`` lives; ``test_utils`` is the
+#: test harness, whose whole job is assembling real components from their private slots.
+PRIVATE_ATTR_EXEMPT_LAYERS = frozenset({"core", "test_utils"})
+#: Reason shown for a private-attr reach-through violation.
+PRIVATE_ATTR_REASON = (
+    "subsystem code must not read private attributes of the Hassette core object; "
+    "use a public property (or add a reasoned PRIVATE_ATTR_ALLOWLIST entry for genuine internals)"
+)
+#: Violation message for a private-attr reach-through; ``{attr}`` is the private name accessed.
+#: The single source of truth shared by ``check_source`` and the test suite, so the two cannot drift.
+PRIVATE_ATTR_MSG_TEMPLATE = f"private-attr-reach-through: accesses hassette.{{attr}} — {PRIVATE_ATTR_REASON}"
+#: (src-relative POSIX path, private attr name) pairs allowed to reach into ``hassette._foo``.
+#: Each is a conscious exception for a genuine framework internal with no guarded public
+#: property to route through. The former service-slot entries (``_loop_thread_id``,
+#: ``_scheduler_service``, ``_bus_service``) were retired in #1092 once Hassette exposed
+#: public accessors for them.
+PRIVATE_ATTR_ALLOWLIST: frozenset[tuple[str, str]] = frozenset(
+    {
+        # Dependency-check bypass — internal coordination hook between Resource and Hassette,
+        # not a service slot, so it has no guarded public property to route through.
+        ("resources/base.py", "_should_skip_dependency_check"),
+    }
+)
+
+
 @dataclass(frozen=True)
 class Rule:
     """A forbidden-import boundary.
@@ -150,35 +176,6 @@ RULES: list[Rule] = [
         reason="models/states is a leaf below the codec; conversion ↔ models cycle resolved (#892)",
     ),
 ]
-
-
-#: Layers that own or legitimately wire Hassette internals, so reading ``hassette._foo``
-#: there is not a reach-through. ``core`` is where ``Hassette`` lives; ``test_utils`` is the
-#: test harness, whose whole job is assembling real components from their private slots.
-PRIVATE_ATTR_EXEMPT_LAYERS = frozenset({"core", "test_utils"})
-
-#: Reason shown for a private-attr reach-through violation.
-PRIVATE_ATTR_REASON = (
-    "subsystem code must not read private attributes of the Hassette core object; "
-    "use a public property (or add a reasoned PRIVATE_ATTR_ALLOWLIST entry for genuine internals)"
-)
-
-#: Violation message for a private-attr reach-through; ``{attr}`` is the private name accessed.
-#: The single source of truth shared by ``check_source`` and the test suite, so the two cannot drift.
-PRIVATE_ATTR_MSG_TEMPLATE = f"private-attr-reach-through: accesses hassette.{{attr}} — {PRIVATE_ATTR_REASON}"
-
-#: (src-relative POSIX path, private attr name) pairs allowed to reach into ``hassette._foo``.
-#: Each is a conscious exception for a genuine framework internal with no guarded public
-#: property to route through. The former service-slot entries (``_loop_thread_id``,
-#: ``_scheduler_service``, ``_bus_service``) were retired in #1092 once Hassette exposed
-#: public accessors for them.
-PRIVATE_ATTR_ALLOWLIST: frozenset[tuple[str, str]] = frozenset(
-    {
-        # Dependency-check bypass — internal coordination hook between Resource and Hassette,
-        # not a service slot, so it has no guarded public property to route through.
-        ("resources/base.py", "_should_skip_dependency_check"),
-    }
-)
 
 
 def layer_of(path: Path) -> str:

--- a/tools/check_type_checking_position.py
+++ b/tools/check_type_checking_position.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+"""CI guard: flag ``if TYPE_CHECKING:`` blocks sandwiched between import groups.
+
+The house rule is that an ``if TYPE_CHECKING:`` block sits at the end of the
+import section — after every regular ``import``/``from ... import`` statement,
+not in the middle of them. A block sandwiched between two groups of regular
+imports makes the import order confusing to scan, and it risks runtime vs.
+type-time confusion: a reader skimming top-to-bottom may assume everything
+above the block is unconditionally imported, then miss that a later import
+was actually meant to sit alongside the ``TYPE_CHECKING`` names.
+
+Detection is AST-based and only looks at top-level module statements
+(``tree.body``) — nested ``TYPE_CHECKING`` blocks (inside a class or function)
+are out of scope, since this rule is about the module's import section. A
+top-level ``ast.If`` node is treated as a ``TYPE_CHECKING`` guard when its test
+is either the bare name ``TYPE_CHECKING`` or the attribute
+``typing.TYPE_CHECKING``. The guard is flagged when any ``ast.Import`` or
+``ast.ImportFrom`` statement appears later in the module body.
+
+Usage:
+    python tools/check_type_checking_position.py [FILE ...]
+
+With no arguments, scans every file under src/, tests/, scripts/, tools/, codegen/,
+docs/, and examples/. Given file paths (as pre-commit passes the staged files), scans
+only those — out-of-scope or non-Python paths are ignored.
+"""
+
+import ast
+import sys
+from pathlib import Path
+
+from lint_helpers import DEFAULT_SCAN_DIRS, REPO_ROOT, iter_python_files, run_check
+
+
+def is_type_checking_guard(test: ast.expr) -> bool:
+    """Return True if ``test`` is ``TYPE_CHECKING`` or ``typing.TYPE_CHECKING``."""
+    if isinstance(test, ast.Name) and test.id == "TYPE_CHECKING":
+        return True
+    if not (isinstance(test, ast.Attribute) and test.attr == "TYPE_CHECKING"):
+        return False
+    return isinstance(test.value, ast.Name) and test.value.id == "typing"
+
+
+def check_file(path: Path) -> list[tuple[int, str]]:
+    """Return (1-based line number, message) for each mispositioned TYPE_CHECKING block."""
+    source = path.read_text()
+    tree = ast.parse(source)
+
+    violations: list[tuple[int, str]] = []
+    for i, node in enumerate(tree.body):
+        if not (isinstance(node, ast.If) and is_type_checking_guard(node.test)):
+            continue
+
+        later_import = next(
+            (later for later in tree.body[i + 1 :] if isinstance(later, (ast.Import, ast.ImportFrom))),
+            None,
+        )
+        if later_import is not None:
+            message = f"if TYPE_CHECKING: block at line {node.lineno} followed by imports at line {later_import.lineno}"
+            violations.append((node.lineno, message))
+
+    return violations
+
+
+def iter_paths() -> list[Path]:
+    """Return every .py file under the scanned directories, sorted for stable output.
+
+    The full-scan entry point the characterization tests parametrize over; ``main`` calls
+    ``iter_python_files`` directly so a pre-commit run can scan just the staged files. Both go
+    through ``iter_python_files``, so the full-scan path can't drift from the per-file path.
+    """
+    return iter_python_files([])
+
+
+def main() -> int:
+    return run_check(
+        iter_python_files(sys.argv[1:]),
+        REPO_ROOT,
+        check_file,
+        summary="if TYPE_CHECKING: block(s) sandwiched between import groups",
+        ok=f"no mispositioned TYPE_CHECKING blocks found under {', '.join(DEFAULT_SCAN_DIRS)}/.",
+        footer="Move each flagged 'if TYPE_CHECKING:' block to after the last regular import statement.",
+    )
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/docs/check_doc_voice.py
+++ b/tools/docs/check_doc_voice.py
@@ -32,6 +32,52 @@ MIN_INLINE_CODE_LINES = 2
 # Page classification
 
 
+COPULA_AVOIDANCE = re.compile(r"\b(serves?\s+as|acts?\s+as|functions?\s+as)\b", re.IGNORECASE)
+SIGNIFICANCE_INFLATION = re.compile(
+    r"\b(pivotal|crucial|fundamental|robust|essential|paramount|indispensable)\b", re.IGNORECASE
+)
+DANGLING_ING = re.compile(
+    r"(?:^|\.\s+)(Highlighting|Ensuring|Showcasing|Demonstrating|Providing|Fostering|Reflecting)\s",
+)
+FILLER_HEDGING = re.compile(
+    r"\b(it\s+is\s+important\s+to\s+note\s+that|in\s+order\s+to|due\s+to\s+the\s+fact\s+that"
+    r"|it\s+should\s+be\s+noted\s+that|it\s+is\s+worth\s+noting\s+that)\b",
+    re.IGNORECASE,
+)
+ABSTRACT_VERBS = re.compile(r"\b(utilize[sd]?|leverag(?:e[sd]?|ing)|facilitate[sd]?)\b", re.IGNORECASE)
+SURPRISE_SIGNALS = re.compile(
+    r"\b(you\s+might\s+be\s+surprised|surprisingly|contrary\s+to\s+what\s+you\s+might"
+    r"|you\s+might\s+expect|unexpectedly)\b",
+    re.IGNORECASE,
+)
+TRANSITION_OPENERS = re.compile(
+    r"^(Now\s+that\s+we|Let'?s\s+(?:look|move|turn|explore|dive)"
+    r"|Once\s+you(?:'ve|\s+have)|After\s+(?:you(?:'ve|\s+have)|we(?:'ve|\s+have)))",
+    re.IGNORECASE,
+)
+REASSURANCE = re.compile(
+    r"\b(don'?t\s+worry|no\s+need\s+to\s+worry|it'?s\s+(?:that\s+)?(?:simple|easy)"
+    r"|you'?ll\s+be\s+(?:happy|glad)\s+to\s+know)\b",
+    re.IGNORECASE,
+)
+CHATBOT_PHRASES = re.compile(
+    r"\b(I\s+hope\s+this\s+helps|Let\s+me\s+know\s+if|Of\s+course!|Certainly!|Great\s+question"
+    r"|You'?re\s+absolutely\s+right|Excellent\s+point)\b",
+    re.IGNORECASE,
+)
+WILL_FUTURE = re.compile(r"\bwill\s+(?:be\s+)?(?:run|fire|execute|call|create|return|send|deliver)\b", re.IGNORECASE)
+CAN_BE_USED = re.compile(r"\bcan\s+be\s+used\s+to\b", re.IGNORECASE)
+IS_ABLE_TO = re.compile(r"\bis\s+able\s+to\b", re.IGNORECASE)
+CATEGORY_DEFINITION = re.compile(
+    r"\bis\s+a\s+(?:service|system|mechanism|module|function|class|object|component|utility|tool"
+    r"|framework|library|wrapper|helper|interface|abstraction)\b",
+    re.IGNORECASE,
+)
+YOU_YOUR = re.compile(r"\b(you|your|you'?re|you'?ve|you'?ll|you'?d|yourself)\b", re.IGNORECASE)
+NEGATIVE_PARALLELISM = re.compile(r"\bit'?s\s+not\s+just\b", re.IGNORECASE)
+EM_DASH = re.compile(r"—")
+
+
 def classify_page(rel_path: str) -> str:
     """Classify a doc page by its path relative to docs/pages/.
 
@@ -117,51 +163,6 @@ class AuditResult:
 
 
 # Pattern checks
-
-COPULA_AVOIDANCE = re.compile(r"\b(serves?\s+as|acts?\s+as|functions?\s+as)\b", re.IGNORECASE)
-SIGNIFICANCE_INFLATION = re.compile(
-    r"\b(pivotal|crucial|fundamental|robust|essential|paramount|indispensable)\b", re.IGNORECASE
-)
-DANGLING_ING = re.compile(
-    r"(?:^|\.\s+)(Highlighting|Ensuring|Showcasing|Demonstrating|Providing|Fostering|Reflecting)\s",
-)
-FILLER_HEDGING = re.compile(
-    r"\b(it\s+is\s+important\s+to\s+note\s+that|in\s+order\s+to|due\s+to\s+the\s+fact\s+that"
-    r"|it\s+should\s+be\s+noted\s+that|it\s+is\s+worth\s+noting\s+that)\b",
-    re.IGNORECASE,
-)
-ABSTRACT_VERBS = re.compile(r"\b(utilize[sd]?|leverag(?:e[sd]?|ing)|facilitate[sd]?)\b", re.IGNORECASE)
-SURPRISE_SIGNALS = re.compile(
-    r"\b(you\s+might\s+be\s+surprised|surprisingly|contrary\s+to\s+what\s+you\s+might"
-    r"|you\s+might\s+expect|unexpectedly)\b",
-    re.IGNORECASE,
-)
-TRANSITION_OPENERS = re.compile(
-    r"^(Now\s+that\s+we|Let'?s\s+(?:look|move|turn|explore|dive)"
-    r"|Once\s+you(?:'ve|\s+have)|After\s+(?:you(?:'ve|\s+have)|we(?:'ve|\s+have)))",
-    re.IGNORECASE,
-)
-REASSURANCE = re.compile(
-    r"\b(don'?t\s+worry|no\s+need\s+to\s+worry|it'?s\s+(?:that\s+)?(?:simple|easy)"
-    r"|you'?ll\s+be\s+(?:happy|glad)\s+to\s+know)\b",
-    re.IGNORECASE,
-)
-CHATBOT_PHRASES = re.compile(
-    r"\b(I\s+hope\s+this\s+helps|Let\s+me\s+know\s+if|Of\s+course!|Certainly!|Great\s+question"
-    r"|You'?re\s+absolutely\s+right|Excellent\s+point)\b",
-    re.IGNORECASE,
-)
-WILL_FUTURE = re.compile(r"\bwill\s+(?:be\s+)?(?:run|fire|execute|call|create|return|send|deliver)\b", re.IGNORECASE)
-CAN_BE_USED = re.compile(r"\bcan\s+be\s+used\s+to\b", re.IGNORECASE)
-IS_ABLE_TO = re.compile(r"\bis\s+able\s+to\b", re.IGNORECASE)
-CATEGORY_DEFINITION = re.compile(
-    r"\bis\s+a\s+(?:service|system|mechanism|module|function|class|object|component|utility|tool"
-    r"|framework|library|wrapper|helper|interface|abstraction)\b",
-    re.IGNORECASE,
-)
-YOU_YOUR = re.compile(r"\b(you|your|you'?re|you'?ve|you'?ll|you'?d|yourself)\b", re.IGNORECASE)
-NEGATIVE_PARALLELISM = re.compile(r"\bit'?s\s+not\s+just\b", re.IGNORECASE)
-EM_DASH = re.compile(r"—")
 
 
 def is_prose_line(line: str) -> bool:

--- a/tools/frontend/check_dead_tokens.py
+++ b/tools/frontend/check_dead_tokens.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+"""CI guard: detect unused CSS custom properties in frontend/src/tokens.css.
+
+Extracts all custom property definitions (--name: value) from tokens.css and
+checks each against all .css, .ts, and .tsx files under frontend/src/. Reports
+properties that are never referenced via var(--name). Exits non-zero if any
+unreferenced tokens are found.
+
+Usage:
+    python tools/frontend/check_dead_tokens.py
+"""
+
+import re
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+TOKENS_CSS = REPO_ROOT / "frontend" / "src" / "tokens.css"
+FRONTEND_SRC = REPO_ROOT / "frontend" / "src"
+
+
+def extract_token_definitions(css_text: str) -> list[str]:
+    """Extract all unique custom property names defined in tokens.css."""
+    pattern = re.compile(r"^\s*(--[\w-]+)\s*:", re.MULTILINE)
+    return list(dict.fromkeys(pattern.findall(css_text)))
+
+
+def find_frontend_files() -> list[Path]:
+    """Return all .css/.ts/.tsx files under frontend/src/ (excluding .d.ts)."""
+    files: list[Path] = []
+    for pattern in ("*.css", "*.ts*"):
+        files.extend(FRONTEND_SRC.rglob(pattern))
+    return [f for f in files if not f.name.endswith(".d.ts")]
+
+
+def build_corpus(files: list[Path]) -> str:
+    """Concatenate all file contents for substring search."""
+    parts = []
+    for f in files:
+        try:
+            parts.append(f.read_text())
+        except OSError:
+            continue
+    return "\n".join(parts)
+
+
+def is_referenced(token: str, corpus: str) -> bool:
+    """Return True if `token` appears outside its own definition line(s) as a complete token.
+
+    Uses a word-boundary match to avoid prefix collisions: ``--accent`` must not
+    be counted as referenced just because ``--accent-hover`` appears in the corpus.
+    A token name is delimited by any non-identifier character (whitespace, comma,
+    closing paren, colon, semicolon) or end-of-string.
+    """
+    definition_line = re.compile(rf"^\s*{re.escape(token)}\s*:.*$", re.MULTILINE)
+    remainder = definition_line.sub("", corpus)
+    reference_re = re.compile(rf"{re.escape(token)}(?![\w-])")
+    return bool(reference_re.search(remainder))
+
+
+def main() -> int:
+    if not TOKENS_CSS.exists():
+        print(f"ERROR: tokens file not found: {TOKENS_CSS}", file=sys.stderr)
+        return 1
+
+    css_text = TOKENS_CSS.read_text()
+    all_tokens = extract_token_definitions(css_text)
+
+    source_files = find_frontend_files()
+    if not source_files:
+        print("WARNING: No .css/.ts/.tsx files found under frontend/src/", file=sys.stderr)
+        return 0
+
+    corpus = build_corpus(source_files)
+
+    unreferenced = [token for token in all_tokens if not is_referenced(token, corpus)]
+
+    if unreferenced:
+        print(f"ERROR: {len(unreferenced)} unreferenced token(s) found in tokens.css:")
+        for token in sorted(unreferenced):
+            print(f"  {token}")
+        print()
+        print("These tokens are not referenced in any .css/.ts/.tsx file under frontend/src/.")
+        print("Remove them from tokens.css if they are truly unused.")
+    else:
+        print(f"OK: all {len(all_tokens)} tokens in tokens.css appear to be referenced.")
+
+    return 1 if unreferenced else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
### New linters

- `check_exception_names.py` — enforces `except X as exc:` over `as e:` so exception variables read consistently across the codebase; fixed 9 existing violations in codegen output and doc snippets.
- `check_type_checking_position.py` — flags `TYPE_CHECKING` blocks that sit between regular imports instead of after all of them, keeping the import section scannable; fixed 3 violations.
- `check_constants_position.py` — flags `UPPER_CASE` module constants defined after the first class/function. Uses an AST-based heuristic that auto-exempts constants genuinely derived from an earlier definition (e.g. `DEFAULT_OVERLAP_MODE = ExecutionMode.SINGLE`), so only real convention violations get flagged instead of every legitimate "derived constant" pattern. Reordered constants in `status.py`, `models.py`, and `types.py`.
- `check_file_size.py` — CI warning (non-blocking, `continue-on-error`) for files over 800 lines. Added as a signal rather than a gate since flagging existing large files as hard failures would block unrelated PRs.
- `check_dead_tokens.py` — flags CSS custom properties defined in `tokens.css` but never referenced; removed 3 dead tokens.

All new Python linters have characterization tests (`tests/unit/tools/`). The frontend linter follows the existing convention of no pytest coverage for `tools/frontend/` checks — tracked as a gap in #1309.

### Ruff C4 family

Replaced the narrow `C419` (unnecessary-comprehension-in-call) select with the full `C4` (flake8-comprehensions) family, catching a broader set of comprehension anti-patterns instead of just one rule. Applied 13 auto-fixes across the codebase.

Closes #1273
Closes #1287
Closes #1302
Closes #1304
Closes #1305
