### PR TITLE
feat!: add configurable timezone for wall-clock scheduling

### DIFF
--- a/codegen/src/hassette_codegen/generators/states.py
+++ b/codegen/src/hassette_codegen/generators/states.py
@@ -42,7 +42,7 @@ def generate_state_model(domain: ExtractedDomain) -> str:
 
     datetime_fields = [p.name for p in properties if _is_pure_datetime_field(p.python_type)]
     if datetime_fields:
-        extra_imports.append("from hassette.utils.date_utils import convert_datetime_str_to_system_tz")
+        extra_imports.append("from hassette.utils.date_utils import convert_datetime_str_to_tz")
 
     return template.render(
         domain=domain.name,

--- a/codegen/src/hassette_codegen/output.py
+++ b/codegen/src/hassette_codegen/output.py
@@ -1,6 +1,7 @@
 """Shared output utilities: ruff formatting, per-file validation, atomic write, drift checking."""
 
 import contextlib
+import difflib
 import py_compile
 import subprocess
 import sys
@@ -8,18 +9,16 @@ import tempfile
 from pathlib import Path
 
 
-def run_ruff_step(cmd: list[str], step_name: str) -> None:
-    """Run a single ruff subprocess step, raising SystemExit on failure."""
+def _run_ruff_quiet(cmd: list[str], step_name: str) -> None:
+    """Run a ruff subprocess step with stdout suppressed."""
     try:
-        subprocess.run(cmd, check=True, timeout=30)
+        subprocess.run(cmd, check=True, timeout=30, stdout=subprocess.DEVNULL)
     except FileNotFoundError as exc:
         raise SystemExit("ruff not found on PATH. Install with: uv tool install ruff") from exc
     except subprocess.TimeoutExpired as exc:
         raise SystemExit(f"ruff {step_name} timed out after 30s — check for filesystem stall") from exc
     except subprocess.CalledProcessError as exc:
-        raise SystemExit(
-            f"ruff {step_name} failed with exit code {exc.returncode}. See the ruff output above for details."
-        ) from exc
+        raise SystemExit(f"ruff {step_name} failed with exit code {exc.returncode}.") from exc
 
 
 def format_via_ruff(content: str) -> str:
@@ -40,8 +39,8 @@ def format_via_ruff(content: str) -> str:
             tmp.write(content)
             tmp_path = tmp.name
 
-        run_ruff_step(["ruff", "format", tmp_path], "format")
-        run_ruff_step(["ruff", "check", "--fix", "--ignore", "S105", tmp_path], "fix")
+        _run_ruff_quiet(["ruff", "format", tmp_path], "format")
+        _run_ruff_quiet(["ruff", "check", "--fix", "--ignore", "S105", tmp_path], "fix")
 
         return Path(tmp_path).read_text(encoding="utf-8")
     finally:
@@ -62,7 +61,7 @@ def run_ruff(path: Path, *, logical_path: Path | None = None) -> None:
     operates on the file directly — ruff format output is independent of the
     filename, so per-file-ignores routing via --stdin-filename isn't needed there.
     """
-    run_ruff_step(["ruff", "format", str(path)], "format")
+    _run_ruff_quiet(["ruff", "format", str(path)], "format")
     if logical_path is not None:
         # Pipe through stdin so --stdin-filename controls per-file-ignores lookup.
         # S105 stays ignored for generated code (test-token-like string literals).
@@ -90,7 +89,7 @@ def run_ruff(path: Path, *, logical_path: Path | None = None) -> None:
             sys.stderr.buffer.write(result.stderr)
             raise SystemExit("ruff fix failed with exit code 1 (unfixable violations).")
     else:
-        run_ruff_step(["ruff", "check", "--fix", "--ignore", "S105", str(path)], "fix")
+        _run_ruff_quiet(["ruff", "check", "--fix", "--ignore", "S105", str(path)], "fix")
 
 
 def atomic_write(out_path: Path, content: str) -> bool:
@@ -153,4 +152,12 @@ def check_drift(target_path: Path, generated_content: str, label: str = "") -> b
 
     display = label or target_path.name
     print(f"{display} is out of date.", file=sys.stderr)
+    diff = difflib.unified_diff(
+        normalized_committed.splitlines(keepends=True),
+        normalized_generated.splitlines(keepends=True),
+        fromfile=f"committed/{target_path.name}",
+        tofile=f"generated/{target_path.name}",
+        n=3,
+    )
+    sys.stderr.writelines(diff)
     return False

--- a/codegen/src/hassette_codegen/output.py
+++ b/codegen/src/hassette_codegen/output.py
@@ -10,14 +10,16 @@ from pathlib import Path
 
 
 def _run_ruff_quiet(cmd: list[str], step_name: str) -> None:
-    """Run a ruff subprocess step with stdout suppressed."""
+    """Run a ruff subprocess step, surfacing stdout only on failure."""
     try:
-        subprocess.run(cmd, check=True, timeout=30, stdout=subprocess.DEVNULL)
+        subprocess.run(cmd, check=True, timeout=30, stdout=subprocess.PIPE)
     except FileNotFoundError as exc:
         raise SystemExit("ruff not found on PATH. Install with: uv tool install ruff") from exc
     except subprocess.TimeoutExpired as exc:
         raise SystemExit(f"ruff {step_name} timed out after 30s — check for filesystem stall") from exc
     except subprocess.CalledProcessError as exc:
+        if exc.stdout:
+            sys.stderr.buffer.write(exc.stdout)
         raise SystemExit(f"ruff {step_name} failed with exit code {exc.returncode}.") from exc
 
 

--- a/codegen/src/hassette_codegen/templates/state_model.py.j2
+++ b/codegen/src/hassette_codegen/templates/state_model.py.j2
@@ -47,7 +47,7 @@ class {{ domain_title }}Attributes(AttributesBase):
     @field_validator({{ datetime_fields | map("tojson") | join(", ") }}, mode="before")
     @classmethod
     def _parse_datetime_fields(cls, value: str | ZonedDateTime | None) -> ZonedDateTime | None:
-        return convert_datetime_str_to_system_tz(value)
+        return convert_datetime_str_to_tz(value)
 {% endif %}
 {% for enum in features %}
 {% for member_name, _member_value in enum.members %}

--- a/codegen/tests/test_state_generator.py
+++ b/codegen/tests/test_state_generator.py
@@ -115,7 +115,7 @@ class TestStateModelGenerator:
         output = generate_state_model(domain)
         assert "field_validator" in output
         assert '"last_triggered"' in output
-        assert "convert_datetime_str_to_system_tz" in output
+        assert "convert_datetime_str_to_tz" in output
         assert "_parse_datetime_fields" in output
 
     def test_mixed_union_datetime_fields_excluded_from_validator(self) -> None:
@@ -145,7 +145,7 @@ class TestStateModelGenerator:
         )
         output = generate_state_model(domain)
         assert "field_validator" not in output
-        assert "convert_datetime_str_to_system_tz" not in output
+        assert "convert_datetime_str_to_tz" not in output
 
 
 class TestNormalizeEnumPrefixes:

--- a/docs/pages/core-concepts/configuration/index.md
+++ b/docs/pages/core-concepts/configuration/index.md
@@ -54,7 +54,7 @@ HASSETTE__TOKEN=your_long_lived_access_token
 
 | TOML section | Controls |
 |---|---|
-| `[hassette]` | Connection (`base_url`, `verify_ssl`, `token`), runtime flags, data directory |
+| `[hassette]` | Connection (`base_url`, `verify_ssl`, `token`), timezone, runtime flags, data directory |
 | `[hassette.apps]` | App discovery, auto-detection, individual app definitions |
 | `[hassette.web_api]` | Web UI and API server host, port, and feature flags |
 | `[hassette.database]` | Storage path, retention, and write-queue settings |
@@ -69,6 +69,17 @@ App definitions live inside `[hassette.apps]` as named subsections, as shown in 
 ## Design Notes
 
 The `HassetteConfig` reference covers every field, its type, and its default. The notes below explain the "why" for fields where the field name alone does not make the intent obvious.
+
+### Timezone {#timezone}
+
+`timezone` sets the IANA timezone name (e.g. `"America/Chicago"`) for wall-clock operations. Scheduler triggers (`Daily`, `Once`, `Cron`), event timestamp conversion, and state model datetime fields all use it. When unset, the process timezone applies.
+
+Docker containers commonly default to UTC. Home Assistant uses a local zone configured by the user. Without an explicit `timezone`, scheduled jobs fire at UTC wall-clock times. `timezone` in `hassette.toml` (or `HASSETTE__TIMEZONE`) resolves this without modifying the container's `TZ` variable.
+
+```toml
+[hassette]
+timezone = "America/Chicago"
+```
 
 ### Data Directory and Upgrades
 

--- a/docs/pages/core-concepts/configuration/index.md
+++ b/docs/pages/core-concepts/configuration/index.md
@@ -77,8 +77,7 @@ The `HassetteConfig` reference covers every field, its type, and its default. Th
 Docker containers commonly default to UTC. Home Assistant uses a local zone configured by the user. Without an explicit `timezone`, scheduled jobs fire at UTC wall-clock times. `timezone` in `hassette.toml` (or `HASSETTE__TIMEZONE`) resolves this without modifying the container's `TZ` variable.
 
 ```toml
-[hassette]
-timezone = "America/Chicago"
+--8<-- "pages/core-concepts/configuration/snippets/timezone_config.toml"
 ```
 
 ### Data Directory and Upgrades

--- a/docs/pages/core-concepts/configuration/snippets/timezone_config.toml
+++ b/docs/pages/core-concepts/configuration/snippets/timezone_config.toml
@@ -1,0 +1,2 @@
+[hassette]
+timezone = "America/Chicago"

--- a/docs/pages/core-concepts/scheduler/index.md
+++ b/docs/pages/core-concepts/scheduler/index.md
@@ -41,7 +41,7 @@ The `delay` parameter accepts seconds as a `float`. The job fires once and does 
 --8<-- "pages/core-concepts/scheduler/snippets/scheduler_run_daily.py"
 ```
 
-The `at` parameter accepts `"HH:MM"` strings. Without `at=`, the job fires at midnight local time. `run_daily` is DST-safe — it fires at the local wall-clock time regardless of clock changes.
+The `at` parameter accepts `"HH:MM"` strings. Without `at=`, the job fires at midnight. `run_daily` is DST-safe — it fires at the configured wall-clock time regardless of clock changes. The [`timezone`](../configuration/index.md#timezone) setting in `hassette.toml` controls which timezone "wall-clock" means; when unset, the process timezone applies.
 
 ??? note "Synchronous usage (AppSync only)"
     [`AppSync`][hassette.app.app.AppSync] is an alternative base class for automations that must call blocking libraries. Its lifecycle hooks run in a worker thread outside the async event loop. `self.scheduler.sync` exposes a [`SchedulerSyncFacade`][hassette.scheduler.sync.SchedulerSyncFacade] that mirrors all scheduling methods as blocking calls. The [Apps](../apps/index.md) page covers the `AppSync` pattern.

--- a/docs/pages/core-concepts/scheduler/methods.md
+++ b/docs/pages/core-concepts/scheduler/methods.md
@@ -116,7 +116,7 @@ The handler runs once at a specific wall-clock time. The [`Once`][hassette.sched
 | Parameter | Type | Default | Description |
 |---|---|---|---|
 | `func` | callable | *(required)* | The handler to run. |
-| `at` | `str \| ZonedDateTime` | *(required)* | Target time. A `"HH:MM"` string is interpreted as today in the system timezone. A [`ZonedDateTime`](https://whenever.readthedocs.io/) (from the `whenever` library, which ships with Hassette — `from whenever import ZonedDateTime`) fires at the exact instant specified. |
+| `at` | `str \| ZonedDateTime` | *(required)* | Target time. A `"HH:MM"` string is interpreted as today in the configured timezone (see [`timezone`](../configuration/index.md#timezone)). A [`ZonedDateTime`](https://whenever.readthedocs.io/) (from the `whenever` library, which ships with Hassette — `from whenever import ZonedDateTime`) fires at the exact instant specified. |
 | `if_past` | `"tomorrow"` \| `"error"` | `"tomorrow"` | Behavior when the target is already in the past. `"tomorrow"` defers by one day and logs a WARNING. `"error"` raises `ValueError` for both input types. |
 
 Shared parameters apply.

--- a/docs/pages/core-concepts/scheduler/triggers.md
+++ b/docs/pages/core-concepts/scheduler/triggers.md
@@ -20,8 +20,8 @@ from hassette.scheduler import After, Once, Every, Daily, Cron, TriggerProtocol
 
 `After` also accepts `minutes=` or a `whenever.TimeDelta` via `timedelta=` — `After(minutes=5)` reads better than `After(seconds=300)`. `Every` accepts an optional `start=` anchor (a `ZonedDateTime` from the [`whenever`](https://whenever.readthedocs.io/) library, which ships with Hassette): with `Every(minutes=15, start=anchor)`, runs align to the anchor's minute marks (`:00`, `:15`, `:30`, `:45`) instead of starting from registration time.
 
-!!! warning "Wall-clock times use the process timezone"
-    `Once(at="07:00")` and `Daily(at="07:00")` interpret the time in the *process* timezone. Docker containers commonly run with `TZ=UTC` while Home Assistant uses a local zone — the job then fires at 07:00 UTC with no warning. Set the `TZ` environment variable where Hassette runs — on the container (the [Docker guide](../../getting-started/docker/index.md) compose file does this), or in the host environment for non-Docker installs — so wall-clock times mean local time.
+!!! warning "Wall-clock times use the configured timezone"
+    `Once(at="07:00")` and `Daily(at="07:00")` interpret the time in the configured timezone. The [`timezone`](../configuration/index.md#timezone) field in `hassette.toml` controls which timezone the scheduler uses; when unset, the process timezone applies. Docker containers commonly default to UTC while Home Assistant uses a local zone, so the job fires at 07:00 UTC with no warning. `timezone = "America/Chicago"` in `hassette.toml` (or `HASSETTE__TIMEZONE`) resolves this. The `TZ` environment variable works as a fallback.
 
 Each convenience method on the scheduler maps to one trigger:
 

--- a/docs/pages/getting-started/docker/index.md
+++ b/docs/pages/getting-started/docker/index.md
@@ -28,7 +28,7 @@ The `image:` line pulls Hassette from GitHub Container Registry (`ghcr.io`) — 
 - `./config` and `./apps` mount your local directories into the container.
 - `data` and `uv_cache` are named volumes for persistent data and the package cache. Docker Compose creates them automatically — no action needed.
 
-Port `8126` exposes the web UI. It is unauthenticated, so keep it off public networks. Set `TZ` to your local timezone so scheduled automations fire at the right times.
+Port `8126` exposes the web UI. It is unauthenticated, so keep it off public networks. Add `HASSETTE__TIMEZONE=America/Chicago` (with your own timezone) to `config/.env` so scheduled automations fire at the right times. The `TZ` environment variable on the container works as a fallback.
 
 ### Step 3: Create config/.env
 

--- a/docs/pages/getting-started/docker/snippets/docker-compose.yml
+++ b/docs/pages/getting-started/docker/snippets/docker-compose.yml
@@ -13,7 +13,7 @@ services:
       - "8126:8126"
     environment:
       - HASSETTE__LOG_LEVEL=info
-      - TZ=America/New_York # Set your timezone
+      - TZ=America/New_York # Fallback timezone; HASSETTE__TIMEZONE in .env is preferred
     healthcheck:
       # Keep this pointed at /api/health/live — it stays healthy during HA outages.
       # Using /api/health/ready here causes a restart loop whenever HA restarts.

--- a/docs/pages/getting-started/docker/snippets/env-file.sh
+++ b/docs/pages/getting-started/docker/snippets/env-file.sh
@@ -1,3 +1,4 @@
 # config/.env
 HASSETTE__TOKEN=your_long_lived_access_token_here
 HASSETTE__BASE_URL=http://homeassistant:8123
+HASSETTE__TIMEZONE=America/New_York

--- a/hassette.schema.json
+++ b/hassette.schema.json
@@ -41,6 +41,19 @@
           "$ref": "#/$defs/BlockingIODetectionConfig",
           "description": "Blocking-I/O detection settings for the shared event loop."
         },
+        "timezone": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "IANA timezone name (e.g. ``\"America/Chicago\"``) used for all wall-clock\noperations: scheduler trigger resolution, event timestamp conversion, and\nstate model datetime fields.\n\nWhen ``None`` (default), the system process timezone is used. Set this when\nthe hassette process runs in a different timezone than Home Assistant (e.g.\nDocker containers running UTC while HA is configured for a local zone).",
+          "title": "Timezone"
+        },
         "config_file": {
           "anyOf": [
             {

--- a/src/hassette/cli/output.py
+++ b/src/hassette/cli/output.py
@@ -56,6 +56,7 @@ def fmt_relative_time(value: Any) -> str:
                 try:
                     epoch = OffsetDateTime.parse_iso(s).timestamp()
                 except ValueError:
+                    # CLI display: user's terminal timezone, not the configured Hassette timezone
                     epoch = PlainDateTime.parse_iso(s).assume_system_tz().timestamp()
         delta = now_epoch() - epoch
         if delta < 0:

--- a/src/hassette/cli/types.py
+++ b/src/hassette/cli/types.py
@@ -65,12 +65,14 @@ def convert_since(value: str) -> float:
 
     if _ISO_NAIVE_PATTERN.match(value):
         try:
+            # CLI input: user's terminal timezone, not the configured Hassette timezone
             return PlainDateTime.parse_iso(value).assume_system_tz().timestamp()
         except ValueError:
             pass
 
     if _DATE_ONLY_PATTERN.match(value):
         try:
+            # CLI input: user's terminal timezone, not the configured Hassette timezone
             return PlainDateTime.parse_iso(value + "T00:00:00").assume_system_tz().timestamp()
         except ValueError:
             pass

--- a/src/hassette/config/config.py
+++ b/src/hassette/config/config.py
@@ -2,6 +2,7 @@ from contextlib import suppress
 from logging import getLogger
 from pathlib import Path
 from typing import Any
+from zoneinfo import ZoneInfo
 
 from pydantic import AliasChoices, Field, SecretStr, field_validator, model_validator
 from pydantic_settings import BaseSettings, PydanticBaseSettingsSource, SettingsConfigDict
@@ -106,6 +107,15 @@ class HassetteConfig(ExcludeExtrasMixin, BaseSettings):
 
     blocking_io: BlockingIODetectionConfig = Field(default_factory=BlockingIODetectionConfig)
     """Blocking-I/O detection settings for the shared event loop."""
+
+    timezone: str | None = Field(default=None)
+    """IANA timezone name (e.g. ``"America/Chicago"``) used for all wall-clock
+    operations: scheduler trigger resolution, event timestamp conversion, and
+    state model datetime fields.
+
+    When ``None`` (default), the system process timezone is used. Set this when
+    the hassette process runs in a different timezone than Home Assistant (e.g.
+    Docker containers running UTC while HA is configured for a local zone)."""
 
     # note - not actually used here, reflects the --config-file / --env-file flags on the cyclopts default command
     config_file: Path | str | None = Field(default=Path("hassette.toml"))
@@ -275,6 +285,19 @@ class HassetteConfig(ExcludeExtrasMixin, BaseSettings):
                 f"database.retention_days ({self.database.retention_days})"
             )
         return self
+
+    @field_validator("timezone", mode="before")
+    @classmethod
+    def validate_timezone(cls, value: str | None) -> str | None:
+        if value is None:
+            return None
+        try:
+            ZoneInfo(value)
+        except (KeyError, ValueError):
+            raise ValueError(
+                f"Invalid timezone: {value!r}. Use an IANA timezone name (e.g. 'America/Chicago', 'Europe/London')."
+            ) from None
+        return value
 
     @field_validator("config_dir", "data_dir", mode="after")
     @classmethod

--- a/src/hassette/conversion/type_registry.py
+++ b/src/hassette/conversion/type_registry.py
@@ -10,7 +10,7 @@ from typing import Any, ClassVar, Generic, TypeVar, overload
 from whenever import Date, Instant, OffsetDateTime, PlainDateTime, Time, ZonedDateTime
 
 from hassette.exceptions import UnableToConvertValueError
-from hassette.utils.date_utils import convert_datetime_str_to_system_tz
+from hassette.utils.date_utils import convert_datetime_str_to_tz
 
 R = TypeVar("R")
 T = TypeVar("T")
@@ -291,7 +291,7 @@ register_simple_type_converter(ZonedDateTime, str, fn=ZonedDateTime.format_iso)
 @register_type_converter_fn(error_message="String must be a datetime-like value, got {from_type}")
 def from_string_to_zoned_date_time(value: str) -> ZonedDateTime:
     with suppress(ValueError):
-        return convert_datetime_str_to_system_tz(value)
+        return convert_datetime_str_to_tz(value)
     with suppress(ValueError):
         return PlainDateTime.parse_iso(value).assume_system_tz()
     with suppress(ValueError):

--- a/src/hassette/conversion/type_registry.py
+++ b/src/hassette/conversion/type_registry.py
@@ -10,7 +10,7 @@ from typing import Any, ClassVar, Generic, TypeVar, overload
 from whenever import Date, Instant, OffsetDateTime, PlainDateTime, Time, ZonedDateTime
 
 from hassette.exceptions import UnableToConvertValueError
-from hassette.utils.date_utils import convert_datetime_str_to_tz
+from hassette.utils.date_utils import assume_tz, convert_datetime_str_to_tz
 
 R = TypeVar("R")
 T = TypeVar("T")
@@ -293,9 +293,9 @@ def from_string_to_zoned_date_time(value: str) -> ZonedDateTime:
     with suppress(ValueError):
         return convert_datetime_str_to_tz(value)
     with suppress(ValueError):
-        return PlainDateTime.parse_iso(value).assume_system_tz()
+        return assume_tz(PlainDateTime.parse_iso(value))
     with suppress(ValueError):
-        return Date.parse_iso(value).at(Time(0, 0, 0, nanosecond=0)).assume_system_tz()
+        return assume_tz(Date.parse_iso(value).at(Time(0, 0, 0, nanosecond=0)))
     raise ValueError
 
 

--- a/src/hassette/core/bus_service.py
+++ b/src/hassette/core/bus_service.py
@@ -731,7 +731,7 @@ def compute_elapsed(current_state: "HassStateDict", duration_config: DurationCon
     if not isinstance(last_changed_raw, str):
         return 0.0
 
-    last_changed = _date_utils.convert_datetime_str_to_system_tz(last_changed_raw)
+    last_changed = _date_utils.convert_datetime_str_to_tz(last_changed_raw)
     now_dt = _date_utils.now()
     raw_elapsed = (now_dt - last_changed).total("seconds")
     return max(0.0, min(raw_elapsed, duration))

--- a/src/hassette/core/core.py
+++ b/src/hassette/core/core.py
@@ -6,6 +6,7 @@ from typing import Any, final
 
 from dotenv import load_dotenv
 
+import hassette.utils.date_utils as date_utils
 from hassette import context
 from hassette.api import Api
 from hassette.app.app import App
@@ -171,6 +172,10 @@ class Hassette(Resource):
         Must be called after construction and before run_forever().
         """
         self.logger.info("Starting Hassette...")
+
+        date_utils.configure(self.config.timezone)
+        if self.config.timezone:
+            self.logger.info("Using configured timezone: %s", self.config.timezone)
 
         # set context variables
         context.set_global_hassette(self)

--- a/src/hassette/events/hass/hass.py
+++ b/src/hassette/events/hass/hass.py
@@ -5,7 +5,7 @@ from typing import Any, Generic, Literal, TypeAlias
 from hassette.const import MISSING_VALUE
 from hassette.events.base import Event, HassContext, HassPayload
 from hassette.types import StateT, Topic
-from hassette.utils.date_utils import convert_datetime_str_to_system_tz
+from hassette.utils.date_utils import convert_datetime_str_to_tz
 
 from .raw import HassEventEnvelopeDict, HassStateDict
 
@@ -219,7 +219,7 @@ def create_event_from_hass(data: HassEventEnvelopeDict) -> Event:
         "event_type": event_type,
         "origin": event["origin"],
         "context": HassContext(**event["context"]),
-        "time_fired": convert_datetime_str_to_system_tz(event["time_fired"]),
+        "time_fired": convert_datetime_str_to_tz(event["time_fired"]),
     }
 
     match event_type:

--- a/src/hassette/models/states/automation.py
+++ b/src/hassette/models/states/automation.py
@@ -3,7 +3,7 @@ from typing import Literal
 from pydantic import Field, field_validator
 from whenever import ZonedDateTime
 
-from hassette.utils.date_utils import convert_datetime_str_to_system_tz
+from hassette.utils.date_utils import convert_datetime_str_to_tz
 
 from .base import AttributesBase, BoolBaseState
 
@@ -18,7 +18,7 @@ class AutomationAttributes(AttributesBase):
     @field_validator("last_triggered", mode="before")
     @classmethod
     def _parse_datetime_fields(cls, value: str | ZonedDateTime | None) -> ZonedDateTime | None:
-        return convert_datetime_str_to_system_tz(value)
+        return convert_datetime_str_to_tz(value)
 
 
 class AutomationState(BoolBaseState):

--- a/src/hassette/models/states/base.py
+++ b/src/hassette/models/states/base.py
@@ -163,10 +163,10 @@ class BaseState(BaseModel, Generic[StateValueT]):
         if value is None:
             return None
         if isinstance(value, int | float):
-            return date_utils.convert_utc_timestamp_to_system_tz(value)
+            return date_utils.convert_utc_timestamp_to_tz(value)
         if isinstance(value, str):
             # need to use OffsetDateTime since the value is +00:00, not Z or a timezone
-            return date_utils.convert_datetime_str_to_system_tz(value)
+            return date_utils.convert_datetime_str_to_tz(value)
 
         return value
 

--- a/src/hassette/models/states/datetime.py
+++ b/src/hassette/models/states/datetime.py
@@ -3,7 +3,7 @@ from typing import Literal
 from pydantic import Field, field_validator
 from whenever import ZonedDateTime
 
-from hassette.utils.date_utils import convert_datetime_str_to_system_tz
+from hassette.utils.date_utils import convert_datetime_str_to_tz
 
 from .base import AttributesBase, StringBaseState
 
@@ -14,7 +14,7 @@ class DateTimeAttributes(AttributesBase):
     @field_validator("native_value", mode="before")
     @classmethod
     def _parse_datetime_fields(cls, value: str | ZonedDateTime | None) -> ZonedDateTime | None:
-        return convert_datetime_str_to_system_tz(value)
+        return convert_datetime_str_to_tz(value)
 
 
 class DateTimeState(StringBaseState):

--- a/src/hassette/models/states/image.py
+++ b/src/hassette/models/states/image.py
@@ -4,7 +4,7 @@ from typing import Literal
 from pydantic import Field, field_validator
 from whenever import ZonedDateTime
 
-from hassette.utils.date_utils import convert_datetime_str_to_system_tz
+from hassette.utils.date_utils import convert_datetime_str_to_tz
 
 from .base import AttributesBase, StringBaseState
 
@@ -22,7 +22,7 @@ class ImageAttributes(AttributesBase):
     @field_validator("image_last_updated", mode="before")
     @classmethod
     def _parse_datetime_fields(cls, value: str | ZonedDateTime | None) -> ZonedDateTime | None:
-        return convert_datetime_str_to_system_tz(value)
+        return convert_datetime_str_to_tz(value)
 
 
 class ImageState(StringBaseState):

--- a/src/hassette/models/states/input.py
+++ b/src/hassette/models/states/input.py
@@ -54,7 +54,7 @@ class InputDatetimeAttributes(InputAttributesBase):
         return Instant.from_timestamp(self.timestamp)
 
     @property
-    def timestamp_as_system_datetime(self) -> ZonedDateTime | None:
+    def timestamp_as_datetime(self) -> ZonedDateTime | None:
         if self.timestamp is None:
             return None
         return convert_utc_timestamp_to_tz(self.timestamp)

--- a/src/hassette/models/states/input.py
+++ b/src/hassette/models/states/input.py
@@ -3,7 +3,7 @@ from typing import Any, Literal
 from pydantic import Field
 from whenever import Instant, ZonedDateTime
 
-from hassette.utils.date_utils import convert_utc_timestamp_to_system_tz
+from hassette.utils.date_utils import convert_utc_timestamp_to_tz
 
 from .base import AttributesBase, BoolBaseState, DateTimeBaseState, NumericBaseState, StringBaseState
 
@@ -57,7 +57,7 @@ class InputDatetimeAttributes(InputAttributesBase):
     def timestamp_as_system_datetime(self) -> ZonedDateTime | None:
         if self.timestamp is None:
             return None
-        return convert_utc_timestamp_to_system_tz(self.timestamp)
+        return convert_utc_timestamp_to_tz(self.timestamp)
 
 
 class InputDatetimeState(DateTimeBaseState):

--- a/src/hassette/models/states/media_player.py
+++ b/src/hassette/models/states/media_player.py
@@ -4,7 +4,7 @@ from typing import Literal
 from pydantic import Field, field_validator
 from whenever import ZonedDateTime
 
-from hassette.utils.date_utils import convert_datetime_str_to_system_tz
+from hassette.utils.date_utils import convert_datetime_str_to_tz
 
 from .base import AttributesBase, StringBaseState
 
@@ -181,7 +181,7 @@ class MediaPlayerAttributes(AttributesBase):
     @field_validator("media_position_updated_at", mode="before")
     @classmethod
     def _parse_datetime_fields(cls, value: str | ZonedDateTime | None) -> ZonedDateTime | None:
-        return convert_datetime_str_to_system_tz(value)
+        return convert_datetime_str_to_tz(value)
 
     @property
     def supports_pause(self) -> bool:

--- a/src/hassette/models/states/script.py
+++ b/src/hassette/models/states/script.py
@@ -3,7 +3,7 @@ from typing import Literal
 from pydantic import Field, field_validator
 from whenever import ZonedDateTime
 
-from hassette.utils.date_utils import convert_datetime_str_to_system_tz
+from hassette.utils.date_utils import convert_datetime_str_to_tz
 
 from .base import AttributesBase, BoolBaseState
 
@@ -18,7 +18,7 @@ class ScriptAttributes(AttributesBase):
     @field_validator("last_triggered", mode="before")
     @classmethod
     def _parse_datetime_fields(cls, value: str | ZonedDateTime | None) -> ZonedDateTime | None:
-        return convert_datetime_str_to_system_tz(value)
+        return convert_datetime_str_to_tz(value)
 
 
 class ScriptState(BoolBaseState):

--- a/src/hassette/models/states/sensor.py
+++ b/src/hassette/models/states/sensor.py
@@ -5,7 +5,7 @@ from typing import Literal
 from pydantic import Field, field_validator
 from whenever import Date, ZonedDateTime
 
-from hassette.utils.date_utils import convert_datetime_str_to_system_tz
+from hassette.utils.date_utils import convert_datetime_str_to_tz
 
 from .base import AttributesBase, StringBaseState
 
@@ -105,7 +105,7 @@ class SensorAttributes(AttributesBase):
     @field_validator("last_reset", mode="before")
     @classmethod
     def _parse_datetime_fields(cls, value: str | ZonedDateTime | None) -> ZonedDateTime | None:
-        return convert_datetime_str_to_system_tz(value)
+        return convert_datetime_str_to_tz(value)
 
 
 class SensorState(StringBaseState):

--- a/src/hassette/models/states/sun.py
+++ b/src/hassette/models/states/sun.py
@@ -3,7 +3,7 @@ from typing import Literal
 from pydantic import Field, field_validator
 from whenever import ZonedDateTime
 
-from hassette.utils.date_utils import convert_datetime_str_to_system_tz
+from hassette.utils.date_utils import convert_datetime_str_to_tz
 
 from .base import AttributesBase, StringBaseState
 
@@ -24,7 +24,7 @@ class SunAttributes(AttributesBase):
     )
     @classmethod
     def _parse_datetime_fields(cls, value: str | ZonedDateTime | None) -> ZonedDateTime | None:
-        return convert_datetime_str_to_system_tz(value)
+        return convert_datetime_str_to_tz(value)
 
 
 class SunState(StringBaseState):

--- a/src/hassette/models/states/timer.py
+++ b/src/hassette/models/states/timer.py
@@ -3,7 +3,7 @@ from typing import Literal
 from pydantic import Field, field_validator
 from whenever import ZonedDateTime
 
-from hassette.utils.date_utils import convert_datetime_str_to_system_tz
+from hassette.utils.date_utils import convert_datetime_str_to_tz
 
 from .base import AttributesBase, StringBaseState
 
@@ -19,7 +19,7 @@ class TimerAttributes(AttributesBase):
     @field_validator("last_transition", "finishes_at", mode="before")
     @classmethod
     def _parse_datetime_fields(cls, value: str | ZonedDateTime | None) -> ZonedDateTime | None:
-        return convert_datetime_str_to_system_tz(value)
+        return convert_datetime_str_to_tz(value)
 
 
 class TimerState(StringBaseState):

--- a/src/hassette/scheduler/scheduler.py
+++ b/src/hassette/scheduler/scheduler.py
@@ -604,8 +604,8 @@ class Scheduler(Resource):
 
         Args:
             func: The function to run.
-            at: Target time. A ``"HH:MM"`` string (today in system timezone, or
-                tomorrow if already past) or a ``ZonedDateTime``.
+            at: Target time. A ``"HH:MM"`` string (today in the configured
+                timezone, or tomorrow if already past) or a ``ZonedDateTime``.
             name: Required stable name for the job.
             group: Optional group name.
             jitter: Optional seconds of random offset to apply at enqueue time.

--- a/src/hassette/scheduler/scheduler.py
+++ b/src/hassette/scheduler/scheduler.py
@@ -605,7 +605,8 @@ class Scheduler(Resource):
         Args:
             func: The function to run.
             at: Target time. A ``"HH:MM"`` string (today in the configured
-                timezone, or tomorrow if already past) or a ``ZonedDateTime``.
+                timezone — falls back to the process timezone when unset —
+                or tomorrow if already past) or a ``ZonedDateTime``.
             name: Required stable name for the job.
             group: Optional group name.
             jitter: Optional seconds of random offset to apply at enqueue time.

--- a/src/hassette/scheduler/sync.py
+++ b/src/hassette/scheduler/sync.py
@@ -265,8 +265,8 @@ class SchedulerSyncFacade(Resource):
 
         Args:
             func: The function to run.
-            at: Target time. A ``"HH:MM"`` string (today in system timezone, or
-                tomorrow if already past) or a ``ZonedDateTime``.
+            at: Target time. A ``"HH:MM"`` string (today in the configured
+                timezone, or tomorrow if already past) or a ``ZonedDateTime``.
             name: Required stable name for the job.
             group: Optional group name.
             jitter: Optional seconds of random offset to apply at enqueue time.

--- a/src/hassette/scheduler/sync.py
+++ b/src/hassette/scheduler/sync.py
@@ -266,7 +266,8 @@ class SchedulerSyncFacade(Resource):
         Args:
             func: The function to run.
             at: Target time. A ``"HH:MM"`` string (today in the configured
-                timezone, or tomorrow if already past) or a ``ZonedDateTime``.
+                timezone — falls back to the process timezone when unset —
+                or tomorrow if already past) or a ``ZonedDateTime``.
             name: Required stable name for the job.
             group: Optional group name.
             jitter: Optional seconds of random offset to apply at enqueue time.

--- a/src/hassette/scheduler/triggers.py
+++ b/src/hassette/scheduler/triggers.py
@@ -81,20 +81,11 @@ class After:
 class Once:
     """One-shot trigger that fires at a specific wall-clock time.
 
-    .. warning::
-        ``"HH:MM"`` string inputs are resolved against the **system process
-        timezone** (``date_utils.now().tz``). Docker containers commonly run
-        with ``TZ=UTC`` while the user's Home Assistant is configured for a
-        local zone — a ``Once(at="07:00")`` written for local time will fire
-        at 07:00 UTC in that environment with no warning. To avoid this: set
-        ``TZ`` on the container to match the HA zone, or pass a
-        ``ZonedDateTime`` directly with the intended timezone.
-
     Args:
         at: Target time. Accepts a ``"HH:MM"`` string (interpreted as today's
-            wall-clock time in the **system process timezone** — see warning
-            above) or a ``ZonedDateTime`` (absolute instant; timezone is
-            explicit).
+            wall-clock time in the configured timezone — see
+            ``HassetteConfig.timezone``) or a ``ZonedDateTime`` (absolute
+            instant; timezone is explicit).
         if_past: Behavior when the computed fire time is in the past.
             - ``"tomorrow"`` (default): For ``"HH:MM"`` string inputs, defers to the next day.
               No effect for ``ZonedDateTime`` inputs (the absolute instant is used as-is;
@@ -251,18 +242,10 @@ class Daily:
     Internally delegates to a 5-field cron expression to ensure DST-correct,
     wall-clock-aligned scheduling.
 
-    .. warning::
-        ``"HH:MM"`` is resolved against the **system process timezone** (from
-        ``date_utils.now().tz``). Docker containers commonly run ``TZ=UTC``
-        while the user's Home Assistant is configured for a local zone — a
-        ``Daily(at="07:00")`` written for local time will fire at 07:00 UTC
-        in that environment with no warning. To avoid this: set ``TZ`` on the
-        container to match the HA zone. A future ``tz=`` parameter is tracked
-        in the design doc follow-up work.
-
     Args:
         at: Target time in ``"HH:MM"`` format (e.g. ``"07:00"``),
-            interpreted in the **system process timezone** — see warning above.
+            interpreted in the configured timezone (see
+            ``HassetteConfig.timezone``).
 
     Example:
         Daily(at="07:00")   # fires every day at 07:00 wall-clock time

--- a/src/hassette/scheduler/triggers.py
+++ b/src/hassette/scheduler/triggers.py
@@ -84,8 +84,9 @@ class Once:
     Args:
         at: Target time. Accepts a ``"HH:MM"`` string (interpreted as today's
             wall-clock time in the configured timezone — see
-            ``HassetteConfig.timezone``) or a ``ZonedDateTime`` (absolute
-            instant; timezone is explicit).
+            ``HassetteConfig.timezone``; falls back to the process timezone
+            when unset) or a ``ZonedDateTime`` (absolute instant; timezone
+            is explicit).
         if_past: Behavior when the computed fire time is in the past.
             - ``"tomorrow"`` (default): For ``"HH:MM"`` string inputs, defers to the next day.
               No effect for ``ZonedDateTime`` inputs (the absolute instant is used as-is;
@@ -245,7 +246,8 @@ class Daily:
     Args:
         at: Target time in ``"HH:MM"`` format (e.g. ``"07:00"``),
             interpreted in the configured timezone (see
-            ``HassetteConfig.timezone``).
+            ``HassetteConfig.timezone``; falls back to the process timezone
+            when unset).
 
     Example:
         Daily(at="07:00")   # fires every day at 07:00 wall-clock time

--- a/src/hassette/test_utils/harness.py
+++ b/src/hassette/test_utils/harness.py
@@ -13,6 +13,7 @@ from unittest.mock import AsyncMock, Mock
 from aiohttp import web
 from yarl import URL
 
+import hassette.utils.date_utils as date_utils
 from hassette import HassetteConfig, context
 from hassette.api import Api
 from hassette.bus import Bus
@@ -347,6 +348,7 @@ class HassetteHarness:
 
         if not skip_global_set:
             self._hassette_ctx_token = context.set_global_hassette(self.hassette)
+        date_utils.configure(self.config.timezone)
         self.config.set_validated_app_manifests()
 
     @property

--- a/src/hassette/test_utils/harness.py
+++ b/src/hassette/test_utils/harness.py
@@ -345,6 +345,7 @@ class HassetteHarness:
         self._previous_task_factory: typing.Any = None
         self._hassette_ctx_token: typing.Any = None  # Token[Hassette] | None
         self._original_app_manifests: dict[str, AppManifest] | None = None
+        self._original_tz = date_utils._configured_tz
 
         if not skip_global_set:
             self._hassette_ctx_token = context.set_global_hassette(self.hassette)
@@ -687,6 +688,7 @@ class HassetteHarness:
             # every subsequent test on the worker with "already set" errors.
             if self._hassette_ctx_token is not None:
                 context.HASSETTE_INSTANCE.reset(self._hassette_ctx_token)
+            date_utils.configure(self._original_tz)
 
             if self.hassette._loop is not None:
                 self.hassette._loop.set_task_factory(self._previous_task_factory)

--- a/src/hassette/utils/__init__.py
+++ b/src/hassette/utils/__init__.py
@@ -1,8 +1,9 @@
-from .date_utils import convert_datetime_str_to_tz, convert_utc_timestamp_to_tz
+from .date_utils import assume_tz, convert_datetime_str_to_tz, convert_utc_timestamp_to_tz
 from .exception_utils import get_traceback_string
 from .service_utils import topological_levels, topological_sort, validate_dependency_graph, wait_for_ready
 
 __all__ = [
+    "assume_tz",
     "convert_datetime_str_to_tz",
     "convert_utc_timestamp_to_tz",
     "get_traceback_string",

--- a/src/hassette/utils/__init__.py
+++ b/src/hassette/utils/__init__.py
@@ -1,10 +1,10 @@
-from .date_utils import convert_datetime_str_to_system_tz, convert_utc_timestamp_to_system_tz
+from .date_utils import convert_datetime_str_to_tz, convert_utc_timestamp_to_tz
 from .exception_utils import get_traceback_string
 from .service_utils import topological_levels, topological_sort, validate_dependency_graph, wait_for_ready
 
 __all__ = [
-    "convert_datetime_str_to_system_tz",
-    "convert_utc_timestamp_to_system_tz",
+    "convert_datetime_str_to_tz",
+    "convert_utc_timestamp_to_tz",
     "get_traceback_string",
     "topological_levels",
     "topological_sort",

--- a/src/hassette/utils/date_utils.py
+++ b/src/hassette/utils/date_utils.py
@@ -15,7 +15,7 @@ def configure(tz: str | None) -> None:
     _configured_tz = tz
 
 
-def convert_utc_timestamp_to_system_tz(timestamp: int | float) -> ZonedDateTime:
+def convert_utc_timestamp_to_tz(timestamp: int | float) -> ZonedDateTime:
     """Convert a UTC timestamp to a ZonedDateTime in the configured timezone.
 
     Uses the configured timezone if set, otherwise the system process timezone.
@@ -26,14 +26,14 @@ def convert_utc_timestamp_to_system_tz(timestamp: int | float) -> ZonedDateTime:
 
 
 @overload
-def convert_datetime_str_to_system_tz(value: str | ZonedDateTime) -> ZonedDateTime: ...
+def convert_datetime_str_to_tz(value: str | ZonedDateTime) -> ZonedDateTime: ...
 
 
 @overload
-def convert_datetime_str_to_system_tz(value: None) -> None: ...
+def convert_datetime_str_to_tz(value: None) -> None: ...
 
 
-def convert_datetime_str_to_system_tz(value: str | ZonedDateTime | None) -> ZonedDateTime | None:
+def convert_datetime_str_to_tz(value: str | ZonedDateTime | None) -> ZonedDateTime | None:
     """Convert an ISO 8601 datetime string to a ZonedDateTime in the configured timezone.
 
     Uses the configured timezone if set, otherwise the system process timezone.

--- a/src/hassette/utils/date_utils.py
+++ b/src/hassette/utils/date_utils.py
@@ -2,16 +2,26 @@ from typing import overload
 
 from whenever import OffsetDateTime, ZonedDateTime
 
+_configured_tz: str | None = None
+
+
+def configure(tz: str | None) -> None:
+    """Set the timezone used by all date utility functions.
+
+    Called once during Hassette startup with the value from ``HassetteConfig.timezone``.
+    When ``tz`` is ``None``, functions fall back to the system process timezone.
+    """
+    global _configured_tz
+    _configured_tz = tz
+
 
 def convert_utc_timestamp_to_system_tz(timestamp: int | float) -> ZonedDateTime:
-    """Convert a UTC timestamp to ZonedDateTime in system timezone.
+    """Convert a UTC timestamp to a ZonedDateTime in the configured timezone.
 
-    Args:
-        timestamp: The UTC timestamp.
-
-    Returns:
-        The converted ZonedDateTime.
+    Uses the configured timezone if set, otherwise the system process timezone.
     """
+    if _configured_tz is not None:
+        return ZonedDateTime.from_timestamp(timestamp, tz=_configured_tz)
     return ZonedDateTime.from_timestamp(timestamp, tz="UTC").to_system_tz()
 
 
@@ -24,23 +34,22 @@ def convert_datetime_str_to_system_tz(value: None) -> None: ...
 
 
 def convert_datetime_str_to_system_tz(value: str | ZonedDateTime | None) -> ZonedDateTime | None:
-    """Convert an ISO 8601 datetime string to ZonedDateTime in system timezone.
+    """Convert an ISO 8601 datetime string to a ZonedDateTime in the configured timezone.
 
-    Args:
-        value: The ISO 8601 datetime string.
-
-    Returns:
-        ZonedDateTime | None: The converted ZonedDateTime or None if input is None.
+    Uses the configured timezone if set, otherwise the system process timezone.
     """
     if value is None or isinstance(value, ZonedDateTime):
         return value
+    if _configured_tz is not None:
+        return OffsetDateTime.parse_iso(value).to_tz(_configured_tz)
     return OffsetDateTime.parse_iso(value).to_system_tz()
 
 
 def now() -> ZonedDateTime:
-    """Get the current time.
+    """Get the current time in the configured timezone.
 
-    This exists to avoid direct calls to ZonedDateTime.now_in_system_tz() in the codebase, in case we need to change
-    the implementation later.
+    Uses the configured timezone if set, otherwise the system process timezone.
     """
+    if _configured_tz is not None:
+        return ZonedDateTime.now(_configured_tz)
     return ZonedDateTime.now_in_system_tz()

--- a/src/hassette/utils/date_utils.py
+++ b/src/hassette/utils/date_utils.py
@@ -1,6 +1,6 @@
 from typing import overload
 
-from whenever import OffsetDateTime, ZonedDateTime
+from whenever import OffsetDateTime, PlainDateTime, ZonedDateTime
 
 _configured_tz: str | None = None
 
@@ -43,6 +43,16 @@ def convert_datetime_str_to_tz(value: str | ZonedDateTime | None) -> ZonedDateTi
     if _configured_tz is not None:
         return OffsetDateTime.parse_iso(value).to_tz(_configured_tz)
     return OffsetDateTime.parse_iso(value).to_system_tz()
+
+
+def assume_tz(dt: PlainDateTime) -> ZonedDateTime:
+    """Interpret a naive datetime in the configured timezone.
+
+    Uses the configured timezone if set, otherwise the system process timezone.
+    """
+    if _configured_tz is not None:
+        return dt.assume_tz(_configured_tz)
+    return dt.assume_system_tz()
 
 
 def now() -> ZonedDateTime:

--- a/tests/unit/config/test_timezone_config.py
+++ b/tests/unit/config/test_timezone_config.py
@@ -1,0 +1,32 @@
+"""Tests for HassetteConfig.timezone field validation."""
+
+import pytest
+
+from hassette.config import HassetteConfig
+from hassette.test_utils.config import TEST_TOKEN
+
+
+def make_config(**kwargs) -> HassetteConfig:
+    return HassetteConfig(token=TEST_TOKEN, **kwargs)
+
+
+class TestTimezoneValidation:
+    def test_none_is_default(self) -> None:
+        config = make_config()
+        assert config.timezone is None
+
+    def test_valid_timezone_accepted(self) -> None:
+        config = make_config(timezone="America/Chicago")
+        assert config.timezone == "America/Chicago"
+
+    def test_utc_accepted(self) -> None:
+        config = make_config(timezone="UTC")
+        assert config.timezone == "UTC"
+
+    def test_invalid_timezone_rejected(self) -> None:
+        with pytest.raises(Exception, match="Invalid timezone"):
+            make_config(timezone="Not/A/Timezone")
+
+    def test_empty_string_rejected(self) -> None:
+        with pytest.raises(Exception, match="Invalid timezone"):
+            make_config(timezone="")

--- a/tests/unit/config/test_timezone_config.py
+++ b/tests/unit/config/test_timezone_config.py
@@ -1,6 +1,7 @@
 """Tests for HassetteConfig.timezone field validation."""
 
 import pytest
+from pydantic import ValidationError
 
 from hassette.config import HassetteConfig
 from hassette.test_utils.config import TEST_TOKEN
@@ -24,9 +25,9 @@ class TestTimezoneValidation:
         assert config.timezone == "UTC"
 
     def test_invalid_timezone_rejected(self) -> None:
-        with pytest.raises(Exception, match="Invalid timezone"):
+        with pytest.raises(ValidationError, match="Invalid timezone"):
             make_config(timezone="Not/A/Timezone")
 
     def test_empty_string_rejected(self) -> None:
-        with pytest.raises(Exception, match="Invalid timezone"):
+        with pytest.raises(ValidationError, match="Invalid timezone"):
             make_config(timezone="")

--- a/tests/unit/scheduler/test_trigger_timezone.py
+++ b/tests/unit/scheduler/test_trigger_timezone.py
@@ -1,0 +1,64 @@
+"""Tests that scheduler triggers resolve HH:MM against the configured timezone."""
+
+import pytest
+from whenever import ZonedDateTime
+
+import hassette.utils.date_utils as date_utils
+from hassette.scheduler.triggers import Daily, Once
+
+
+@pytest.fixture(autouse=True)
+def _reset_configured_tz():
+    yield
+    date_utils.configure(None)
+
+
+class TestOnceWithConfiguredTz:
+    def test_once_resolves_against_configured_tz(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Once(at='07:00') uses the configured timezone, not system tz."""
+        date_utils.configure("America/Chicago")
+        fake_now = ZonedDateTime(2025, 8, 18, 6, 0, 0, tz="America/Chicago")
+        monkeypatch.setattr("hassette.utils.date_utils.now", lambda: fake_now)
+
+        trigger = Once(at="07:00")
+        fire_time = trigger.first_run_time(fake_now)
+
+        assert fire_time.tz == "America/Chicago"
+        assert fire_time.hour == 7
+        assert fire_time.minute == 0
+
+    def test_once_uses_system_tz_when_unconfigured(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Once(at='07:00') uses system tz when no timezone is configured."""
+        system_tz = ZonedDateTime.now_in_system_tz().tz
+        fake_now = ZonedDateTime(2025, 8, 18, 6, 0, 0, tz=system_tz)
+        monkeypatch.setattr("hassette.utils.date_utils.now", lambda: fake_now)
+
+        trigger = Once(at="07:00")
+        fire_time = trigger.first_run_time(fake_now)
+
+        assert fire_time.tz == system_tz
+
+
+class TestDailyWithConfiguredTz:
+    def test_daily_resolves_against_configured_tz(self) -> None:
+        """Daily(at='07:00') uses the configured timezone for cron scheduling."""
+        date_utils.configure("America/Chicago")
+        current = ZonedDateTime(2025, 8, 18, 6, 0, 0, tz="America/Chicago")
+
+        trigger = Daily(at="07:00")
+        fire_time = trigger.first_run_time(current)
+
+        assert fire_time.tz == "America/Chicago"
+        assert fire_time.hour == 7
+        assert fire_time.minute == 0
+
+    def test_daily_next_day_when_past(self) -> None:
+        """Daily(at='07:00') schedules for tomorrow when current time is past 07:00."""
+        date_utils.configure("America/Chicago")
+        current = ZonedDateTime(2025, 8, 18, 8, 0, 0, tz="America/Chicago")
+
+        trigger = Daily(at="07:00")
+        fire_time = trigger.first_run_time(current)
+
+        assert fire_time.day == 19
+        assert fire_time.hour == 7

--- a/tests/unit/utils/test_date_utils_timezone.py
+++ b/tests/unit/utils/test_date_utils_timezone.py
@@ -1,0 +1,105 @@
+"""Tests for configurable timezone in date_utils."""
+
+import pytest
+from whenever import ZonedDateTime
+
+import hassette.utils.date_utils as date_utils
+
+
+@pytest.fixture(autouse=True)
+def _reset_configured_tz():
+    """Reset the configured timezone after each test."""
+    yield
+    date_utils.configure(None)
+
+
+class TestConfigure:
+    def test_configure_sets_timezone(self) -> None:
+        date_utils.configure("America/Chicago")
+        assert date_utils._configured_tz == "America/Chicago"
+
+    def test_configure_none_clears_timezone(self) -> None:
+        date_utils.configure("America/Chicago")
+        date_utils.configure(None)
+        assert date_utils._configured_tz is None
+
+
+class TestNow:
+    def test_now_uses_configured_tz(self) -> None:
+        date_utils.configure("America/Chicago")
+        result = date_utils.now()
+        assert result.tz == "America/Chicago"
+
+    def test_now_uses_system_tz_when_unconfigured(self) -> None:
+        result = date_utils.now()
+        system_tz = ZonedDateTime.now_in_system_tz().tz
+        assert result.tz == system_tz
+
+    def test_now_different_timezones_same_instant(self) -> None:
+        """now() in different configured timezones represents the same instant."""
+        date_utils.configure("America/Chicago")
+        chicago = date_utils.now()
+        date_utils.configure("Europe/London")
+        london = date_utils.now()
+        diff = abs((london - chicago).total("seconds"))
+        assert diff < 1
+
+
+class TestConvertUtcTimestamp:
+    def test_uses_configured_tz(self) -> None:
+        date_utils.configure("America/Chicago")
+        result = date_utils.convert_utc_timestamp_to_system_tz(0)
+        assert result.tz == "America/Chicago"
+        assert result.hour == 18
+        assert result.day == 31
+        assert result.month == 12
+        assert result.year == 1969
+
+    def test_uses_system_tz_when_unconfigured(self) -> None:
+        result = date_utils.convert_utc_timestamp_to_system_tz(0)
+        system_tz = ZonedDateTime.now_in_system_tz().tz
+        assert result.tz == system_tz
+
+    def test_same_instant_regardless_of_tz(self) -> None:
+        """The same timestamp maps to the same instant in different timezones."""
+        ts = 1_700_000_000
+        date_utils.configure("America/Chicago")
+        chicago = date_utils.convert_utc_timestamp_to_system_tz(ts)
+        date_utils.configure("Asia/Tokyo")
+        tokyo = date_utils.convert_utc_timestamp_to_system_tz(ts)
+        assert chicago.to_instant() == tokyo.to_instant()
+
+
+class TestConvertDatetimeStr:
+    def test_uses_configured_tz(self) -> None:
+        date_utils.configure("America/Chicago")
+        result = date_utils.convert_datetime_str_to_system_tz("2025-06-15T12:00:00+00:00")
+        assert result is not None
+        assert result.tz == "America/Chicago"
+        assert result.hour == 7
+
+    def test_uses_system_tz_when_unconfigured(self) -> None:
+        result = date_utils.convert_datetime_str_to_system_tz("2025-06-15T12:00:00+00:00")
+        assert result is not None
+        system_tz = ZonedDateTime.now_in_system_tz().tz
+        assert result.tz == system_tz
+
+    def test_none_passthrough(self) -> None:
+        date_utils.configure("America/Chicago")
+        assert date_utils.convert_datetime_str_to_system_tz(None) is None
+
+    def test_zoned_datetime_passthrough(self) -> None:
+        zdt = ZonedDateTime(2025, 6, 15, 12, 0, tz="Europe/London")
+        date_utils.configure("America/Chicago")
+        result = date_utils.convert_datetime_str_to_system_tz(zdt)
+        assert result is zdt
+
+    def test_same_instant_regardless_of_tz(self) -> None:
+        iso = "2025-06-15T12:00:00+00:00"
+        date_utils.configure("America/Chicago")
+        chicago = date_utils.convert_datetime_str_to_system_tz(iso)
+        date_utils.configure("Asia/Tokyo")
+        tokyo = date_utils.convert_datetime_str_to_system_tz(iso)
+        assert chicago is not None
+        assert tokyo is not None
+        assert chicago.to_instant() == tokyo.to_instant()

--- a/tests/unit/utils/test_date_utils_timezone.py
+++ b/tests/unit/utils/test_date_utils_timezone.py
@@ -48,7 +48,7 @@ class TestNow:
 class TestConvertUtcTimestamp:
     def test_uses_configured_tz(self) -> None:
         date_utils.configure("America/Chicago")
-        result = date_utils.convert_utc_timestamp_to_system_tz(0)
+        result = date_utils.convert_utc_timestamp_to_tz(0)
         assert result.tz == "America/Chicago"
         assert result.hour == 18
         assert result.day == 31
@@ -56,7 +56,7 @@ class TestConvertUtcTimestamp:
         assert result.year == 1969
 
     def test_uses_system_tz_when_unconfigured(self) -> None:
-        result = date_utils.convert_utc_timestamp_to_system_tz(0)
+        result = date_utils.convert_utc_timestamp_to_tz(0)
         system_tz = ZonedDateTime.now_in_system_tz().tz
         assert result.tz == system_tz
 
@@ -64,42 +64,42 @@ class TestConvertUtcTimestamp:
         """The same timestamp maps to the same instant in different timezones."""
         ts = 1_700_000_000
         date_utils.configure("America/Chicago")
-        chicago = date_utils.convert_utc_timestamp_to_system_tz(ts)
+        chicago = date_utils.convert_utc_timestamp_to_tz(ts)
         date_utils.configure("Asia/Tokyo")
-        tokyo = date_utils.convert_utc_timestamp_to_system_tz(ts)
+        tokyo = date_utils.convert_utc_timestamp_to_tz(ts)
         assert chicago.to_instant() == tokyo.to_instant()
 
 
 class TestConvertDatetimeStr:
     def test_uses_configured_tz(self) -> None:
         date_utils.configure("America/Chicago")
-        result = date_utils.convert_datetime_str_to_system_tz("2025-06-15T12:00:00+00:00")
+        result = date_utils.convert_datetime_str_to_tz("2025-06-15T12:00:00+00:00")
         assert result is not None
         assert result.tz == "America/Chicago"
         assert result.hour == 7
 
     def test_uses_system_tz_when_unconfigured(self) -> None:
-        result = date_utils.convert_datetime_str_to_system_tz("2025-06-15T12:00:00+00:00")
+        result = date_utils.convert_datetime_str_to_tz("2025-06-15T12:00:00+00:00")
         assert result is not None
         system_tz = ZonedDateTime.now_in_system_tz().tz
         assert result.tz == system_tz
 
     def test_none_passthrough(self) -> None:
         date_utils.configure("America/Chicago")
-        assert date_utils.convert_datetime_str_to_system_tz(None) is None
+        assert date_utils.convert_datetime_str_to_tz(None) is None
 
     def test_zoned_datetime_passthrough(self) -> None:
         zdt = ZonedDateTime(2025, 6, 15, 12, 0, tz="Europe/London")
         date_utils.configure("America/Chicago")
-        result = date_utils.convert_datetime_str_to_system_tz(zdt)
+        result = date_utils.convert_datetime_str_to_tz(zdt)
         assert result is zdt
 
     def test_same_instant_regardless_of_tz(self) -> None:
         iso = "2025-06-15T12:00:00+00:00"
         date_utils.configure("America/Chicago")
-        chicago = date_utils.convert_datetime_str_to_system_tz(iso)
+        chicago = date_utils.convert_datetime_str_to_tz(iso)
         date_utils.configure("Asia/Tokyo")
-        tokyo = date_utils.convert_datetime_str_to_system_tz(iso)
+        tokyo = date_utils.convert_datetime_str_to_tz(iso)
         assert chicago is not None
         assert tokyo is not None
         assert chicago.to_instant() == tokyo.to_instant()


### PR DESCRIPTION
## Summary

Adds `HassetteConfig.timezone`, a single explicit setting that fixes the
Docker-container-vs-Home-Assistant timezone mismatch: containers commonly
run `TZ=UTC` while HA is configured for a local zone, so `Daily(at="07:00")`
silently fired at 07:00 UTC instead of local time.

## Timezone Configuration

- Add `timezone: str | None` to `HassetteConfig`, validated via `ZoneInfo`
  at parse time so a typo'd zone name fails fast at startup instead of at
  the first scheduled fire.
- `date_utils.configure()` is called once during `Hassette.start()` (and by
  `HassetteHarness` for test parity) so every wall-clock helper —
  `now()`, timestamp conversion, ISO-string parsing — consults the same
  configured zone, falling back to the system process timezone when unset.
- `Once`/`Daily` `"HH:MM"` string resolution and event timestamp conversion
  now go through the configured zone instead of hardcoding
  `ZonedDateTime.now_in_system_tz()`, so setting `timezone` fixes scheduling
  and timestamp interpretation in one place rather than requiring the
  container's `TZ` env var to match HA.
- Docs updated: new "Timezone" section in the configuration reference, the
  Docker guide now recommends `HASSETTE__TIMEZONE` over relying on the
  container's `TZ` (kept as a documented fallback), and the `Once`/`Daily`
  docstring warnings about system-tz footguns are replaced with a pointer
  to the config field.

## Breaking Change: date_utils rename

- `convert_datetime_str_to_system_tz` → `convert_datetime_str_to_tz` and
  `convert_utc_timestamp_to_system_tz` → `convert_utc_timestamp_to_tz`
  (both exported from `hassette.utils`). The old names implied a
  system-tz-only behavior that's no longer accurate now that these
  functions consult the configured timezone first.

BREAKING CHANGE: `hassette.utils.convert_datetime_str_to_system_tz` and
`hassette.utils.convert_utc_timestamp_to_system_tz` are renamed to
`convert_datetime_str_to_tz` and `convert_utc_timestamp_to_tz`. Update any
direct imports to the new names; behavior is unchanged when
`HassetteConfig.timezone` is unset.
