### PR TITLE
fix(testing): Harden app testing helpers

### DIFF
--- a/codegen/src/hassette_codegen/sync_facade/recording.py
+++ b/codegen/src/hassette_codegen/sync_facade/recording.py
@@ -81,6 +81,12 @@ from typing import Any
 if typing.TYPE_CHECKING:
     from hassette.test_utils.recording_api import RecordingApi
 {type_checking_imports}\
+RECORDED_API_METHODS = frozenset(
+    {{
+{recorded_api_methods}
+    }}
+)
+
 # Stub message templates — imported by tests to avoid brittle substring matches.
 # Must stay byte-identical with the constants in codegen/src/hassette_codegen/sync_facade/.
 STUB_MSG_STATE_CONVERSION = (
@@ -94,6 +100,16 @@ STUB_MSG_GENERIC = (
 )
 
 '''
+
+_RECORDING_HELPERS = frozenset({"_record_call", "_create_helper", "_update_helper", "_delete_helper"})
+
+
+def _records_api_call(func: ast.AsyncFunctionDef | ast.FunctionDef) -> bool:
+    """Return whether a method records through the canonical helper path."""
+    return any(
+        isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute) and node.func.attr in _RECORDING_HELPERS
+        for node in ast.walk(func)
+    )
 
 
 def _find_class(module: ast.Module, name: str, source_label: str) -> ast.ClassDef:
@@ -169,6 +185,7 @@ def generate_sync_recording(api_path: Path, recording_api_path: Path) -> str:
 
     # Generate each method; track body nodes for import derivation.
     generated_methods: list[str] = []
+    recorded_api_methods: set[str] = set()
     all_body_nodes: list[ast.stmt] = []
     all_runtime_annotation_symbols: set[str] = set()
     all_string_ref_symbols: set[str] = set()
@@ -183,6 +200,8 @@ def generate_sync_recording(api_path: Path, recording_api_path: Path) -> str:
 
         if use_body_copy:
             assert rec_func is not None
+            if _records_api_call(rec_func):
+                recorded_api_methods.add(method_name)
             # Collect annotation symbols from the recording_api signature
             runtime_syms, string_syms = collect_annotation_symbols(rec_func)
             all_runtime_annotation_symbols |= runtime_syms
@@ -250,6 +269,7 @@ def generate_sync_recording(api_path: Path, recording_api_path: Path) -> str:
         _RECORDING_MODULE_HEADER_TEMPLATE.format(
             imports=import_block,
             type_checking_imports=type_checking_imports,
+            recorded_api_methods="\n".join(f'        "{name}",' for name in sorted(recorded_api_methods)),
         )
         + _RECORDING_CLASS_HEADER
         + "\n"

--- a/src/hassette/test_utils/app_harness.py
+++ b/src/hassette/test_utils/app_harness.py
@@ -19,10 +19,11 @@ import inspect
 import re
 import shutil
 import tempfile
+from collections.abc import Mapping
 from contextlib import AsyncExitStack
 from logging import getLogger
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, Any, Generic, TypeVar, cast
 from unittest.mock import AsyncMock
 
 import pydantic
@@ -52,6 +53,7 @@ if TYPE_CHECKING:
 
 LOGGER = getLogger(__name__)
 EPOCH_TIMESTAMP = "1970-01-01T00:00:00+00:00"
+AppType = TypeVar("AppType", bound=App)
 
 
 # Cache of (hermetic_subclass, init_kwargs_ref) pairs keyed by app_config_cls — avoids
@@ -187,7 +189,7 @@ def synthesize_manifest(app_cls: type[App]) -> AppManifest:
     )
 
 
-class AppTestHarness(SimulationMixin, TimeControlMixin):
+class AppTestHarness(SimulationMixin, TimeControlMixin, Generic[AppType]):
     """Async context manager that wires an App class into Hassette test infrastructure.
 
     Provides a fully initialized app instance with access to its bus, scheduler,
@@ -212,8 +214,8 @@ class AppTestHarness(SimulationMixin, TimeControlMixin):
 
     def __init__(
         self,
-        app_cls: type[App],
-        config: dict[str, Any],
+        app_cls: type[AppType],
+        config: Mapping[str, Any] | None = None,
         *,
         tmp_path: Path | None = None,
     ) -> None:
@@ -221,25 +223,27 @@ class AppTestHarness(SimulationMixin, TimeControlMixin):
 
         Args:
             app_cls: The App subclass to instantiate and test.
-            config: Dict of config values to validate against app_cls.app_config_cls.
+            config: Config values to validate against app_cls.app_config_cls. Defaults
+                to an empty mapping for apps without required settings.
             tmp_path: Optional directory for Hassette data. Auto-created and cleaned
                 up if not provided.
         """
         self._app_cls = app_cls
-        self._config_dict = config
+        self._config_dict = dict(config or {})
         self._tmp_path = tmp_path
 
         # Set during __aenter__
         self._exit_stack: AsyncExitStack | None = None
         self._harness: HassetteHarness | None = None
-        self._app: App | None = None
+        self._app: AppType | None = None
 
         # Time control (set by freeze_time)
         self._test_clock = None
         self._time_patcher: list[object] | None = None
         self._time_patcher_registered: bool = False
+        self._freeze_time_lock_held: bool = False
 
-    async def __aenter__(self) -> "AppTestHarness":
+    async def __aenter__(self) -> "AppTestHarness[AppType]":
         """Set up the full harness in 11 steps with LIFO teardown via AsyncExitStack."""
         exit_stack = AsyncExitStack()
         self._exit_stack = exit_stack
@@ -372,7 +376,7 @@ class AppTestHarness(SimulationMixin, TimeControlMixin):
             self._exit_stack = None
 
     @property
-    def app(self) -> App:
+    def app(self) -> AppType:
         """The fully initialized App instance."""
         if self._app is None:
             raise RuntimeError("AppTestHarness is not active — use 'async with AppTestHarness(...) as harness'")

--- a/src/hassette/test_utils/recording_api.py
+++ b/src/hassette/test_utils/recording_api.py
@@ -8,10 +8,13 @@ fidelity should use a full integration test with a live HA connection.
 """
 
 import copy
+import inspect
+from difflib import get_close_matches
 from enum import StrEnum
 from typing import TYPE_CHECKING, Any, ClassVar, Never, Protocol, cast, runtime_checkable
 
 import aiohttp
+from pydantic import BaseModel
 from slugify import slugify as _py_slugify
 from whenever import Date, PlainDateTime, ZonedDateTime
 
@@ -50,7 +53,7 @@ from hassette.models.states.base import BaseState, Context
 from hassette.resources.base import Resource
 from hassette.resources.lifecycle import mark_ready
 from hassette.test_utils.api_call import ApiCall
-from hassette.test_utils.sync_facade import RecordingSyncFacade
+from hassette.test_utils.sync_facade import RECORDED_API_METHODS, RecordingSyncFacade
 
 if TYPE_CHECKING:
     from hassette import Hassette
@@ -417,7 +420,7 @@ class RecordingApi(Resource):
         entity_id = str(entity_id)
         if domain is None:
             domain = entity_id.split(".", 1)[0]
-        self.calls.append(
+        self._record_call(
             ApiCall(
                 method="turn_on",
                 args=(entity_id,),
@@ -430,7 +433,7 @@ class RecordingApi(Resource):
         entity_id = str(entity_id)
         if domain is None:
             domain = entity_id.split(".", 1)[0]
-        self.calls.append(
+        self._record_call(
             ApiCall(
                 method="turn_off",
                 args=(entity_id,),
@@ -443,7 +446,7 @@ class RecordingApi(Resource):
         entity_id = str(entity_id)
         if domain is None:
             domain = entity_id.split(".", 1)[0]
-        self.calls.append(
+        self._record_call(
             ApiCall(
                 method="toggle",
                 args=(entity_id,),
@@ -460,7 +463,7 @@ class RecordingApi(Resource):
         **data: Any,
     ) -> ServiceResponse | None:
         """Record a call_service call. Returns stub ServiceResponse when return_response=True."""
-        self.calls.append(
+        self._record_call(
             ApiCall(
                 method="call_service",
                 args=(domain, service),
@@ -489,7 +492,7 @@ class RecordingApi(Resource):
     ) -> dict:
         """Record a set_state call. Returns an empty dict stub."""
         entity_id = str(entity_id)
-        self.calls.append(
+        self._record_call(
             ApiCall(
                 method="set_state",
                 args=(entity_id, state),
@@ -511,7 +514,7 @@ class RecordingApi(Resource):
         event_data: dict[str, Any] | None = None,
     ) -> dict[str, Any]:
         """Record a fire_event call. Returns an empty dict stub."""
-        self.calls.append(
+        self._record_call(
             ApiCall(
                 method="fire_event",
                 args=(event_type,),
@@ -673,7 +676,7 @@ class RecordingApi(Resource):
             A copy of the newly created record.
         """
         domain, deep_copy = RECORD_TYPE_TO_DOMAIN[record_type]
-        self.calls.append(
+        self._record_call(
             ApiCall(
                 method=method_name,
                 args=(),
@@ -704,7 +707,7 @@ class RecordingApi(Resource):
             FailedMessageError: With code='not_found' if helper_id is not seeded.
         """
         domain, deep_copy = RECORD_TYPE_TO_DOMAIN[record_type]
-        self.calls.append(
+        self._record_call(
             ApiCall(
                 method=method_name,
                 args=(helper_id,),
@@ -735,7 +738,7 @@ class RecordingApi(Resource):
             FailedMessageError: With code='not_found' if helper_id is not seeded.
         """
         domain, _deep_copy = RECORD_TYPE_TO_DOMAIN[record_type]
-        self.calls.append(
+        self._record_call(
             ApiCall(
                 method=method_name,
                 args=(helper_id,),
@@ -894,7 +897,7 @@ class RecordingApi(Resource):
 
     async def increment_counter(self, entity_id: str) -> None:
         """Record an increment_counter call directly (not via call_service)."""
-        self.calls.append(
+        self._record_call(
             ApiCall(
                 method="increment_counter",
                 args=(entity_id,),
@@ -904,7 +907,7 @@ class RecordingApi(Resource):
 
     async def decrement_counter(self, entity_id: str) -> None:
         """Record a decrement_counter call directly (not via call_service)."""
-        self.calls.append(
+        self._record_call(
             ApiCall(
                 method="decrement_counter",
                 args=(entity_id,),
@@ -914,13 +917,77 @@ class RecordingApi(Resource):
 
     async def reset_counter(self, entity_id: str) -> None:
         """Record a reset_counter call directly (not via call_service)."""
-        self.calls.append(
+        self._record_call(
             ApiCall(
                 method="reset_counter",
                 args=(entity_id,),
                 kwargs={"entity_id": entity_id},
             )
         )
+
+    @classmethod
+    def _validate_recorded_method(cls, method: str) -> None:
+        """Reject method names that this test double can never record."""
+        if method in RECORDED_API_METHODS:
+            return
+
+        suggestions = get_close_matches(method, RECORDED_API_METHODS, n=3, cutoff=0.5)
+        hint = f" Did you mean {', '.join(repr(name) for name in suggestions)}?" if suggestions else ""
+        raise ValueError(f"Unknown recorded API method {method!r}.{hint}")
+
+    @classmethod
+    def _validate_expected_kwargs(cls, method: str, expected: dict[str, Any]) -> None:
+        """Reject unknown assertion keys when the recording signature is closed."""
+        parameters = inspect.signature(getattr(cls, method)).parameters.values()
+        if any(parameter.kind is inspect.Parameter.VAR_KEYWORD for parameter in parameters):
+            return
+
+        valid_names: set[str] = set()
+        for parameter in parameters:
+            if parameter.name == "self":
+                continue
+            annotation = parameter.annotation
+            if isinstance(annotation, type) and issubclass(annotation, BaseModel):
+                valid_names.update(annotation.model_fields)
+            else:
+                valid_names.add(parameter.name)
+
+        unknown_names = expected.keys() - valid_names
+        if not unknown_names:
+            return
+
+        hints = []
+        for name in sorted(unknown_names):
+            suggestions = get_close_matches(name, valid_names, n=1, cutoff=0.5)
+            hint = f" (did you mean {suggestions[0]!r}?)" if suggestions else ""
+            hints.append(f"{name!r}{hint}")
+        raise ValueError(f"Unknown assertion keyword(s) for {method!r}: {', '.join(hints)}")
+
+    def _record_call(self, call: ApiCall) -> None:
+        """Record a call after checking it against the assertion contract."""
+        self._validate_recorded_method(call.method)
+        self.calls.append(call)
+
+    @staticmethod
+    def _describe_closest_call(calls: list[ApiCall], expected: dict[str, Any], *, exact: bool = False) -> str:
+        """Describe how the closest recorded call differs from expected kwargs."""
+        candidates: list[tuple[int, int, dict[str, Any], dict[str, Any], dict[str, Any]]] = []
+        for index, call in enumerate(calls, start=1):
+            missing = {key: value for key, value in expected.items() if key not in call.kwargs}
+            mismatched = {
+                key: {"expected": value, "actual": call.kwargs[key]}
+                for key, value in expected.items()
+                if key in call.kwargs and call.kwargs[key] != value
+            }
+            extra = {key: value for key, value in call.kwargs.items() if exact and key not in expected}
+            distance = len(missing) + len(mismatched) + len(extra)
+            candidates.append((distance, index, missing, mismatched, extra))
+
+        _, index, missing, mismatched, extra = min(candidates, key=lambda candidate: candidate[0])
+        differences = [f"missing={missing!r}", f"mismatched={mismatched!r}"]
+        if exact:
+            differences.append(f"extra={extra!r}")
+        return f"Closest call #{index}: {'; '.join(differences)}"
 
     def __getattr__(self, name: str) -> Any:
         """Raise NotImplementedError for public attributes not defined on RecordingApi.
@@ -980,6 +1047,8 @@ class RecordingApi(Resource):
         Raises:
             AssertionError: If no call matches.
         """
+        self._validate_recorded_method(method)
+        self._validate_expected_kwargs(method, kwargs)
         matching = self.get_calls(method)
         if not matching:
             raise AssertionError(f"Expected '{method}' to have been called, but it was never called.")
@@ -991,9 +1060,10 @@ class RecordingApi(Resource):
                 # so kwargs-based assertions work uniformly for all methods.
                 if all(k in call.kwargs and call.kwargs[k] == v for k, v in kwargs.items()):
                     return
+            closest = self._describe_closest_call(matching, kwargs)
             raise AssertionError(
                 f"'{method}' was called {len(matching)} time(s), but none matched kwargs {kwargs!r}. "
-                f"Calls recorded: {[{'args': c.args, 'kwargs': c.kwargs} for c in matching]}"
+                f"{closest}. Calls recorded: {[{'args': c.args, 'kwargs': c.kwargs} for c in matching]}"
             )
 
     def assert_called_partial(self, method: str, **kwargs: Any) -> None:
@@ -1051,6 +1121,8 @@ class RecordingApi(Resource):
             # Passes — matches exactly
             api.assert_called_exact("turn_off", entity_id="light.x", domain="light")
         """
+        self._validate_recorded_method(method)
+        self._validate_expected_kwargs(method, kwargs)
         matching = self.get_calls(method)
         if not matching:
             raise AssertionError(f"Expected '{method}' to have been called, but it was never called.")
@@ -1058,9 +1130,10 @@ class RecordingApi(Resource):
         for call in matching:
             if call.kwargs == kwargs:
                 return
+        closest = self._describe_closest_call(matching, kwargs, exact=True)
         raise AssertionError(
             f"'{method}' was called {len(matching)} time(s), but none matched kwargs exactly {kwargs!r}. "
-            f"Calls recorded: {[{'args': c.args, 'kwargs': c.kwargs} for c in matching]}"
+            f"{closest}. Calls recorded: {[{'args': c.args, 'kwargs': c.kwargs} for c in matching]}"
         )
 
     def assert_not_called(self, method: str, **kwargs: Any) -> None:
@@ -1076,6 +1149,8 @@ class RecordingApi(Resource):
         Raises:
             AssertionError: If a matching call was recorded.
         """
+        self._validate_recorded_method(method)
+        self._validate_expected_kwargs(method, kwargs)
         matching = self.get_calls(method)
         if kwargs:
             matching = [c for c in matching if all(k in c.kwargs and c.kwargs[k] == v for k, v in kwargs.items())]
@@ -1105,6 +1180,11 @@ class RecordingApi(Resource):
         Raises:
             AssertionError: If the call count does not match.
         """
+        self._validate_recorded_method(method)
+        self._validate_expected_kwargs(method, kwargs)
+        if count < 0:
+            raise ValueError(f"assert_call_count() count must be non-negative, got {count}.")
+
         matching = self.get_calls(method)
         if kwargs:
             matching = [c for c in matching if all(k in c.kwargs and c.kwargs[k] == v for k, v in kwargs.items())]

--- a/src/hassette/test_utils/simulation.py
+++ b/src/hassette/test_utils/simulation.py
@@ -5,6 +5,7 @@ machinery extracted from ``app_harness.py``.
 """
 
 import asyncio
+import math
 from logging import getLogger
 from typing import TYPE_CHECKING, Any
 
@@ -56,6 +57,12 @@ class SimulationMixin:
             raise RuntimeError("AppTestHarness is not active")
         return harness
 
+    @staticmethod
+    def _validate_timeout(timeout: float) -> None:
+        """Reject deadlines that cannot bound a simulation."""
+        if not math.isfinite(timeout) or timeout < 0:
+            raise ValueError(f"timeout must be finite and non-negative, got {timeout!r}.")
+
     async def simulate_state_change(
         self,
         entity_id: str,
@@ -90,6 +97,7 @@ class SimulationMixin:
             DrainError: If any handler raised an exception.
             DrainTimeout: If drain does not reach quiescence within ``timeout``.
         """
+        self._validate_timeout(timeout)
         harness = self.require_harness()
 
         # Merge seeded attributes from StateProxy when not explicitly provided.
@@ -146,6 +154,7 @@ class SimulationMixin:
             DrainError: If any handler raised an exception.
             DrainTimeout: If drain does not reach quiescence within ``timeout``.
         """
+        self._validate_timeout(timeout)
         harness = self.require_harness()
 
         # Read both state value and existing attributes from the proxy.
@@ -191,6 +200,7 @@ class SimulationMixin:
             DrainError: If any handler raised an exception.
             DrainTimeout: If drain does not reach quiescence within ``timeout``.
         """
+        self._validate_timeout(timeout)
         harness = self.require_harness()
 
         event = create_call_service_event(domain=domain, service=service, service_data=data)
@@ -209,9 +219,11 @@ class SimulationMixin:
             timeout: Maximum seconds to wait for handlers to complete.
 
         Raises:
+            ValueError: If timeout is non-finite or negative.
             DrainError: If any handler task raised a non-cancellation exception.
             DrainTimeout: If the drain does not reach quiescence within ``timeout``.
         """
+        self._validate_timeout(timeout)
         harness = self.require_harness()
 
         event = create_component_loaded_event(component)
@@ -235,6 +247,7 @@ class SimulationMixin:
             DrainError: If any handler task raised a non-cancellation exception.
             DrainTimeout: If the drain does not reach quiescence within ``timeout``.
         """
+        self._validate_timeout(timeout)
         harness = self.require_harness()
 
         event = create_service_registered_event(domain, service)
@@ -274,6 +287,7 @@ class SimulationMixin:
             ``throttle=``, pass a ``timeout=`` larger than the debounce window.
             See :meth:`drain_task_bucket` for details.
         """
+        self._validate_timeout(timeout)
         harness = self.require_harness()
 
         event = HassetteServiceEvent.from_service_status(
@@ -376,6 +390,7 @@ class SimulationMixin:
             ``throttle=``, pass a ``timeout=`` larger than the debounce window.
             See :meth:`drain_task_bucket` for details.
         """
+        self._validate_timeout(timeout)
         harness = self.require_harness()
 
         event = HassetteSimpleEvent.from_topic(topic=Topic.HASSETTE_EVENT_WEBSOCKET_CONNECTED)
@@ -400,6 +415,7 @@ class SimulationMixin:
             ``throttle=``, pass a ``timeout=`` larger than the debounce window.
             See :meth:`drain_task_bucket` for details.
         """
+        self._validate_timeout(timeout)
         harness = self.require_harness()
 
         event = HassetteSimpleEvent.from_topic(topic=Topic.HASSETTE_EVENT_WEBSOCKET_DISCONNECTED)
@@ -435,6 +451,7 @@ class SimulationMixin:
             ``throttle=``, pass a ``timeout=`` larger than the debounce window.
             See :meth:`drain_task_bucket` for details.
         """
+        self._validate_timeout(timeout)
         harness = self.require_harness()
         app = self._app
         if app is None:
@@ -537,6 +554,7 @@ class SimulationMixin:
             through App-level registration via ``self.bus.on_state_change`` inside
             an App.
         """
+        self._validate_timeout(timeout)
         harness = self.require_harness()
 
         bus_service = harness.bus_service

--- a/src/hassette/test_utils/sync_facade.py
+++ b/src/hassette/test_utils/sync_facade.py
@@ -50,6 +50,44 @@ from hassette.test_utils.api_call import ApiCall
 if typing.TYPE_CHECKING:
     from hassette.events import HassStateDict
     from hassette.test_utils.recording_api import RecordingApi
+RECORDED_API_METHODS = frozenset(
+    {
+        "call_service",
+        "create_counter",
+        "create_input_boolean",
+        "create_input_button",
+        "create_input_datetime",
+        "create_input_number",
+        "create_input_select",
+        "create_input_text",
+        "create_timer",
+        "decrement_counter",
+        "delete_counter",
+        "delete_input_boolean",
+        "delete_input_button",
+        "delete_input_datetime",
+        "delete_input_number",
+        "delete_input_select",
+        "delete_input_text",
+        "delete_timer",
+        "fire_event",
+        "increment_counter",
+        "reset_counter",
+        "set_state",
+        "toggle",
+        "turn_off",
+        "turn_on",
+        "update_counter",
+        "update_input_boolean",
+        "update_input_button",
+        "update_input_datetime",
+        "update_input_number",
+        "update_input_select",
+        "update_input_text",
+        "update_timer",
+    }
+)
+
 # Stub message templates — imported by tests to avoid brittle substring matches.
 # Must stay byte-identical with the constants in codegen/src/hassette_codegen/sync_facade/.
 STUB_MSG_STATE_CONVERSION = (
@@ -142,7 +180,7 @@ class RecordingSyncFacade:  # pyright: ignore[reportUnusedClass]
 
     def fire_event(self, event_type: str, event_data: dict[str, Any] | None = None) -> dict[str, Any]:
         """Record a fire_event call. Returns an empty dict stub."""
-        self._parent.calls.append(
+        self._parent._record_call(
             ApiCall(
                 method="fire_event",
                 args=(event_type,),
@@ -160,7 +198,7 @@ class RecordingSyncFacade:  # pyright: ignore[reportUnusedClass]
         **data: Any,
     ) -> ServiceResponse | None:
         """Record a call_service call. Returns stub ServiceResponse when return_response=True."""
-        self._parent.calls.append(
+        self._parent._record_call(
             ApiCall(
                 method="call_service",
                 args=(domain, service),
@@ -182,7 +220,7 @@ class RecordingSyncFacade:  # pyright: ignore[reportUnusedClass]
         entity_id = str(entity_id)
         if domain is None:
             domain = entity_id.split(".", 1)[0]
-        self._parent.calls.append(
+        self._parent._record_call(
             ApiCall(method="turn_on", args=(entity_id,), kwargs={"entity_id": entity_id, "domain": domain, **data})
         )
 
@@ -191,7 +229,7 @@ class RecordingSyncFacade:  # pyright: ignore[reportUnusedClass]
         entity_id = str(entity_id)
         if domain is None:
             domain = entity_id.split(".", 1)[0]
-        self._parent.calls.append(
+        self._parent._record_call(
             ApiCall(method="turn_off", args=(entity_id,), kwargs={"entity_id": entity_id, "domain": domain, **data})
         )
 
@@ -200,7 +238,7 @@ class RecordingSyncFacade:  # pyright: ignore[reportUnusedClass]
         entity_id = str(entity_id)
         if domain is None:
             domain = entity_id.split(".", 1)[0]
-        self._parent.calls.append(
+        self._parent._record_call(
             ApiCall(method="toggle", args=(entity_id,), kwargs={"entity_id": entity_id, "domain": domain, **data})
         )
 
@@ -301,7 +339,7 @@ class RecordingSyncFacade:  # pyright: ignore[reportUnusedClass]
     def set_state(self, entity_id: str | StrEnum, state: Any, attributes: dict[str, Any] | None = None) -> dict:
         """Record a set_state call. Returns an empty dict stub."""
         entity_id = str(entity_id)
-        self._parent.calls.append(
+        self._parent._record_call(
             ApiCall(
                 method="set_state",
                 args=(entity_id, state),
@@ -488,16 +526,16 @@ class RecordingSyncFacade:  # pyright: ignore[reportUnusedClass]
 
     def increment_counter(self, entity_id: str) -> None:
         """Record an increment_counter call directly (not via call_service)."""
-        self._parent.calls.append(
+        self._parent._record_call(
             ApiCall(method="increment_counter", args=(entity_id,), kwargs={"entity_id": entity_id})
         )
 
     def decrement_counter(self, entity_id: str) -> None:
         """Record a decrement_counter call directly (not via call_service)."""
-        self._parent.calls.append(
+        self._parent._record_call(
             ApiCall(method="decrement_counter", args=(entity_id,), kwargs={"entity_id": entity_id})
         )
 
     def reset_counter(self, entity_id: str) -> None:
         """Record a reset_counter call directly (not via call_service)."""
-        self._parent.calls.append(ApiCall(method="reset_counter", args=(entity_id,), kwargs={"entity_id": entity_id}))
+        self._parent._record_call(ApiCall(method="reset_counter", args=(entity_id,), kwargs={"entity_id": entity_id}))

--- a/src/hassette/test_utils/time_control.py
+++ b/src/hassette/test_utils/time_control.py
@@ -5,6 +5,7 @@ and supporting helpers extracted from ``app_harness.py``.
 """
 
 import contextlib
+import math
 import threading
 from contextlib import AsyncExitStack
 from logging import getLogger
@@ -105,6 +106,7 @@ class TimeControlMixin:
         self._test_clock: _TestClock | None = None
         self._time_patcher: list[object] | None = None
         self._time_patcher_registered: bool = False
+        self._freeze_time_lock_held: bool = False
 
     def _stop_time_patchers(self) -> None:
         """Stop all active time patchers. Called by exit stack on teardown."""
@@ -119,8 +121,9 @@ class TimeControlMixin:
     def _release_freeze_time(self) -> None:
         """Stop time patchers and release the process-global freeze_time lock."""
         self._stop_time_patchers()
-        with contextlib.suppress(RuntimeError):
+        if self._freeze_time_lock_held:
             FREEZE_TIME_LOCK.release()
+            self._freeze_time_lock_held = False
 
     def freeze_time(self, instant: Instant | ZonedDateTime) -> None:
         """Freeze time at the given instant.
@@ -142,17 +145,20 @@ class TimeControlMixin:
         Raises:
             RuntimeError: If called outside the async with block, or if another
                 harness already holds the freeze_time lock.
+            AttributeError: If a configured time patch target does not exist.
         """
         if self._exit_stack is None:
             raise RuntimeError("freeze_time() must be called inside 'async with AppTestHarness(...) as harness:'.")
 
         # Acquire the process-global lock (non-blocking). Idempotent re-freeze
         # from the same harness is allowed (we already hold the lock).
-        if self._time_patcher is None and not FREEZE_TIME_LOCK.acquire(blocking=False):
-            raise RuntimeError(
-                "freeze_time is already held by another harness — "
-                "time-controlling tests must be isolated (e.g., separate xdist workers)."
-            )
+        if not self._freeze_time_lock_held:
+            if not FREEZE_TIME_LOCK.acquire(blocking=False):
+                raise RuntimeError(
+                    "freeze_time is already held by another harness — "
+                    "time-controlling tests must be isolated (e.g., separate xdist workers)."
+                )
+            self._freeze_time_lock_held = True
 
         # Register teardown BEFORE starting patchers — if p.start() raises, the
         # lock is still released on exit. Only register once; subsequent freeze_time
@@ -168,14 +174,21 @@ class TimeControlMixin:
         self._test_clock = clock
 
         patchers: list[object] = []
-        for target in self._NOW_PATCH_TARGETS:
-            try:
+        try:
+            for target in self._NOW_PATCH_TARGETS:
                 p = patch(target, side_effect=clock.current)
                 p.start()
                 patchers.append(p)
-            except AttributeError:
-                # Module may not import `now` — skip gracefully
-                LOGGER.debug("freeze_time: could not patch %s (module does not import now)", target)
+        except Exception as exc:
+            for started_patcher in reversed(patchers):
+                with contextlib.suppress(Exception):
+                    started_patcher.stop()  # pyright: ignore[reportAttributeAccessIssue]
+            self._test_clock = None
+            self._time_patcher = None
+            self._release_freeze_time()
+            if isinstance(exc, AttributeError):
+                raise AttributeError(f"freeze_time() patch target {target!r} does not exist") from exc
+            raise
 
         self._time_patcher = patchers
 
@@ -192,12 +205,24 @@ class TimeControlMixin:
 
         Raises:
             RuntimeError: If :meth:`freeze_time` has not been called first.
+            ValueError: If any delta is non-finite or the combined delta is negative.
         """
         if self._test_clock is None:
             raise RuntimeError(
                 "advance_time() requires freeze_time() to be called first. "
                 "Call harness.freeze_time(instant) before advancing time."
             )
+
+        for field, value in (("seconds", seconds), ("minutes", minutes), ("hours", hours)):
+            if not math.isfinite(value):
+                raise ValueError(f"advance_time() {field} must be finite, got {value!r}.")
+
+        total_seconds = seconds + minutes * 60 + hours * 3600
+        if not math.isfinite(total_seconds):
+            raise ValueError(f"advance_time() total duration must be finite, got {total_seconds!r} seconds.")
+        if total_seconds < 0:
+            raise ValueError(f"advance_time() total duration must be non-negative, got {total_seconds} seconds.")
+
         self._test_clock.advance(seconds=seconds, minutes=minutes, hours=hours)
 
     async def trigger_due_jobs(self) -> int:

--- a/tests/integration/test_app_harness_simulation.py
+++ b/tests/integration/test_app_harness_simulation.py
@@ -3,6 +3,9 @@
 Tests freeze_time, advance_time, trigger_due_jobs, and the _TestClock internals.
 """
 
+import math
+from contextlib import AsyncExitStack
+
 import pytest
 from whenever import Instant, ZonedDateTime
 
@@ -11,6 +14,7 @@ from hassette.app.app import App
 from hassette.app.app_config import AppConfig
 from hassette.events import RawStateChangeEvent
 from hassette.test_utils.app_harness import AppTestHarness
+from hassette.test_utils.time_control import TimeControlMixin
 
 
 class SimConfig(AppConfig):
@@ -87,6 +91,80 @@ async def test_advance_time_hours_and_minutes():
         result = date_utils.now()
         expected = frozen.to_system_tz().add(hours=1, minutes=30)
         assert result == expected
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("seconds", math.nan),
+        ("seconds", math.inf),
+        ("minutes", -math.inf),
+    ],
+)
+async def test_advance_time_rejects_non_finite_values(field: str, value: float):
+    """advance_time rejects values that cannot produce a finite clock delta."""
+    frozen = Instant.from_utc(2026, 4, 7, 6, 0)
+    async with AppTestHarness(SimTestApp, config={}) as harness:
+        harness.freeze_time(frozen)
+        with pytest.raises(ValueError, match=rf"{field} must be finite"):
+            harness.advance_time(**{field: value})
+
+
+async def test_advance_time_rejects_negative_total_duration():
+    """advance_time is forward-only even when multiple units are combined."""
+    frozen = Instant.from_utc(2026, 4, 7, 6, 0)
+    async with AppTestHarness(SimTestApp, config={}) as harness:
+        harness.freeze_time(frozen)
+        with pytest.raises(ValueError, match="total duration must be non-negative"):
+            harness.advance_time(minutes=1, seconds=-61)
+
+
+async def test_advance_time_rejects_overflowed_total_duration():
+    """Individually finite units cannot overflow into an infinite total delta."""
+    frozen = Instant.from_utc(2026, 4, 7, 6, 0)
+    async with AppTestHarness(SimTestApp, config={}) as harness:
+        harness.freeze_time(frozen)
+        with pytest.raises(ValueError, match="total duration must be finite"):
+            harness.advance_time(hours=1e308)
+
+
+async def test_freeze_time_fails_closed_and_releases_lock(monkeypatch: pytest.MonkeyPatch):
+    """A missing patch target fails without poisoning later freeze attempts."""
+    frozen = Instant.from_utc(2026, 4, 7, 6, 0)
+    async with AppTestHarness(SimTestApp, config={}) as harness:
+        monkeypatch.setattr(harness, "_NOW_PATCH_TARGETS", ("hassette.utils.date_utils.missing_now",))
+        with pytest.raises(AttributeError, match=r"hassette\.utils\.date_utils\.missing_now"):
+            harness.freeze_time(frozen)
+
+        monkeypatch.setattr(harness, "_NOW_PATCH_TARGETS", ("hassette.utils.date_utils.now",))
+        harness.freeze_time(frozen)
+        assert date_utils.now() == frozen.to_system_tz()
+
+
+async def test_failed_freeze_cleanup_cannot_release_another_owner():
+    """A stale exit callback cannot unlock a later harness's active patch."""
+    frozen = Instant.from_utc(2026, 4, 7, 6, 0)
+    first = TimeControlMixin()
+    second = TimeControlMixin()
+    third = TimeControlMixin()
+    first._exit_stack = AsyncExitStack()
+    second._exit_stack = AsyncExitStack()
+    third._exit_stack = AsyncExitStack()
+    first._NOW_PATCH_TARGETS = ("hassette.utils.date_utils.missing_now",)
+
+    try:
+        with pytest.raises(AttributeError):
+            first.freeze_time(frozen)
+
+        second.freeze_time(frozen)
+        await first._exit_stack.aclose()
+
+        with pytest.raises(RuntimeError, match="freeze_time is already held"):
+            third.freeze_time(frozen)
+    finally:
+        await third._exit_stack.aclose()
+        await second._exit_stack.aclose()
+        await first._exit_stack.aclose()
 
 
 async def test_trigger_due_jobs_fires_scheduled():

--- a/tests/integration/test_app_harness_simulation.py
+++ b/tests/integration/test_app_harness_simulation.py
@@ -5,10 +5,12 @@ Tests freeze_time, advance_time, trigger_due_jobs, and the _TestClock internals.
 
 import math
 from contextlib import AsyncExitStack
+from unittest.mock import Mock
 
 import pytest
 from whenever import Instant, ZonedDateTime
 
+import hassette.test_utils.time_control as time_control
 import hassette.utils.date_utils as date_utils
 from hassette.app.app import App
 from hassette.app.app_config import AppConfig
@@ -139,6 +141,37 @@ async def test_freeze_time_fails_closed_and_releases_lock(monkeypatch: pytest.Mo
         monkeypatch.setattr(harness, "_NOW_PATCH_TARGETS", ("hassette.utils.date_utils.now",))
         harness.freeze_time(frozen)
         assert date_utils.now() == frozen.to_system_tz()
+
+
+async def test_freeze_time_cleans_up_started_patchers_when_start_raises(monkeypatch: pytest.MonkeyPatch):
+    """A non-AttributeError while starting patchers fully cleans up freeze state."""
+    frozen = Instant.from_utc(2026, 4, 7, 6, 0)
+    started_patcher = Mock()
+    failing_patcher = Mock()
+    start_error = RuntimeError("patcher start failed")
+    failing_patcher.start.side_effect = start_error
+    monkeypatch.setattr(time_control, "patch", Mock(side_effect=[started_patcher, failing_patcher]))
+
+    control = TimeControlMixin()
+    exit_stack = AsyncExitStack()
+    control._exit_stack = exit_stack
+    control._NOW_PATCH_TARGETS = ("first.target", "second.target")
+
+    try:
+        with pytest.raises(RuntimeError) as exc_info:
+            control.freeze_time(frozen)
+
+        assert exc_info.value is start_error
+        started_patcher.start.assert_called_once_with()
+        failing_patcher.start.assert_called_once_with()
+        started_patcher.stop.assert_called_once_with()
+        failing_patcher.stop.assert_not_called()
+        assert control._test_clock is None
+        assert control._time_patcher is None
+        assert not control._freeze_time_lock_held
+        assert not time_control.FREEZE_TIME_LOCK.locked()
+    finally:
+        await exit_stack.aclose()
 
 
 async def test_failed_freeze_cleanup_cannot_release_another_owner():

--- a/tests/integration/test_app_test_harness.py
+++ b/tests/integration/test_app_test_harness.py
@@ -70,6 +70,12 @@ async def test_basic_lifecycle():
         assert harness.app.status == ResourceStatus.RUNNING
 
 
+async def test_empty_config_defaults_when_omitted():
+    """Apps without required settings do not need config={} ceremony."""
+    async with AppTestHarness(SensorApp) as harness:
+        assert harness.app.app_config.test_entity == "sensor.test"
+
+
 async def test_api_recorder_is_recording_api():
     """harness.api_recorder is a RecordingApi instance."""
     async with AppTestHarness(SensorApp, config={}) as harness:

--- a/tests/integration/test_drain_iterative.py
+++ b/tests/integration/test_drain_iterative.py
@@ -13,6 +13,8 @@ Covers:
 
 import asyncio
 import inspect
+import math
+from unittest.mock import AsyncMock, patch
 
 import pytest
 
@@ -283,6 +285,29 @@ async def test_drain_timeout_message_has_debounce_hint_when_applicable() -> None
             await harness.simulate_state_change("sensor.test", old_value="off", new_value="on", timeout=0.15)
         msg = str(exc_info.value)
         assert "debounce" in msg
+
+
+@pytest.mark.parametrize("timeout", [math.nan, math.inf, -math.inf, -1.0])
+async def test_drain_rejects_invalid_timeout(timeout: float) -> None:
+    """Invalid drain timeouts fail immediately instead of disabling the deadline."""
+    async with AppTestHarness(Depth1App, config={}) as harness:
+        with pytest.raises(ValueError, match="timeout must be finite and non-negative"):
+            await asyncio.wait_for(harness.drain_task_bucket(timeout=timeout), timeout=0.2)
+
+
+async def test_simulation_rejects_invalid_timeout_before_dispatch() -> None:
+    """Timeout validation happens before the simulation can emit an event."""
+    async with AppTestHarness(Depth1App, config={}) as harness:
+        hassette = harness.require_harness().hassette
+        with patch.object(hassette, "send_event", new_callable=AsyncMock) as send_event:
+            with pytest.raises(ValueError, match="timeout must be finite and non-negative"):
+                await harness.simulate_state_change(
+                    "sensor.test",
+                    old_value="off",
+                    new_value="on",
+                    timeout=math.nan,
+                )
+            send_event.assert_not_awaited()
 
 
 def test_drain_error_message_single_exception() -> None:

--- a/tests/pyright_probes/harness_typing_probe.py
+++ b/tests/pyright_probes/harness_typing_probe.py
@@ -1,0 +1,28 @@
+"""Pyright probe proving AppTestHarness preserves the concrete app type."""
+
+# ruff: noqa
+# pyright: basic
+
+from typing import assert_type
+
+from hassette.app.app import App
+from hassette.app.app_config import AppConfig
+from hassette.test_utils.app_harness import AppTestHarness
+
+
+class ProbeConfig(AppConfig):
+    pass
+
+
+class ProbeApp(App[ProbeConfig]):
+    probe_value: int
+
+
+async def probe_harness_type() -> None:
+    harness = AppTestHarness(ProbeApp)
+    assert_type(harness, AppTestHarness[ProbeApp])
+
+    async with harness as active:
+        assert_type(active, AppTestHarness[ProbeApp])
+        assert_type(active.app, ProbeApp)
+        active.app.probe_value

--- a/tests/pyright_probes/pyrightconfig.json
+++ b/tests/pyright_probes/pyrightconfig.json
@@ -12,6 +12,7 @@
     "reportUnusedImport": "none",
     "reportUnusedFunction": "none",
     "reportGeneralTypeIssues": "none",
+    "reportAssertTypeFailure": "error",
     "reportAttributeAccessIssue": "none",
     "reportOperatorIssue": "none",
     "reportAssignmentType": "none",

--- a/tests/unit/test_harness_coverage.py
+++ b/tests/unit/test_harness_coverage.py
@@ -5,9 +5,30 @@ If this test fails, a new ``on_*`` method was added to ``Bus`` without a corresp
 ``simulate_*`` method to ``hassette.test_utils.simulation.SimulationMixin``.
 """
 
+import pytest
+
 from hassette.bus import Bus
 from hassette.resources.base import Resource
 from hassette.test_utils.app_harness import AppTestHarness
+from hassette.test_utils.simulation import SimulationMixin
+from hassette.types import ResourceStatus
+
+SIMULATION_TIMEOUT_CASES: list[tuple[str, tuple, dict]] = [
+    ("simulate_state_change", ("sensor.test",), {"old_value": "off", "new_value": "on"}),
+    (
+        "simulate_attribute_change",
+        ("sensor.test", "temperature"),
+        {"old_value": 20, "new_value": 21},
+    ),
+    ("simulate_call_service", ("light", "turn_on"), {}),
+    ("simulate_component_loaded", ("mqtt",), {}),
+    ("simulate_service_registered", ("light", "turn_on"), {}),
+    ("simulate_hassette_service_status", ("WebSocketService", ResourceStatus.RUNNING), {}),
+    ("simulate_websocket_connected", (), {}),
+    ("simulate_websocket_disconnected", (), {}),
+    ("simulate_app_state_changed", (ResourceStatus.RUNNING,), {}),
+    ("drain_task_bucket", (), {}),
+]
 
 
 def test_all_bus_subscriptions_have_simulate_counterparts():
@@ -35,3 +56,20 @@ def test_all_bus_subscriptions_have_simulate_counterparts():
         f"{sorted('on_' + m for m in missing)}. "
         f"Add simulate_* methods to SimulationMixin for each."
     )
+
+
+@pytest.mark.parametrize(
+    ("method_name", "args", "kwargs"),
+    SIMULATION_TIMEOUT_CASES,
+    ids=[case[0] for case in SIMULATION_TIMEOUT_CASES],
+)
+async def test_simulation_entry_points_validate_timeout_before_harness_access(
+    method_name: str,
+    args: tuple,
+    kwargs: dict,
+) -> None:
+    """Invalid deadlines fail before a simulation requires or dispatches through a harness."""
+    simulation = SimulationMixin()
+
+    with pytest.raises(ValueError, match="timeout must be finite and non-negative"):
+        await getattr(simulation, method_name)(*args, **kwargs, timeout=-1.0)

--- a/tests/unit/test_pyright_probe.py
+++ b/tests/unit/test_pyright_probe.py
@@ -27,6 +27,7 @@ import pytest
 WORKTREE_ROOT = Path(__file__).resolve().parents[2]
 PROBE_DIR = WORKTREE_ROOT / "tests" / "pyright_probes"
 PROBE_FILE = PROBE_DIR / "forgotten_await_probe.py"
+HARNESS_TYPE_PROBE_FILE = PROBE_DIR / "harness_typing_probe.py"
 
 EXPECTED_PROBE_COUNT = 5
 
@@ -75,6 +76,7 @@ def test_pyright_probe_fires_unused_coroutine() -> None:
                 "pyright",
                 "--project",
                 str(PROBE_DIR),
+                str(PROBE_FILE),
             ],
             capture_output=True,
             text=True,
@@ -117,3 +119,24 @@ def test_pyright_probe_fires_unused_coroutine() -> None:
         "Pyright exited with code 0 on the probe file — expected errors but got none. "
         "The probe file may not have been found, or all bare calls were silently removed."
     )
+
+
+def test_pyright_harness_probe_preserves_concrete_app_type() -> None:
+    """Pyright accepts concrete AppTestHarness and harness.app type assertions."""
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "pyright",
+            "--project",
+            str(PROBE_DIR),
+            str(HARNESS_TYPE_PROBE_FILE),
+        ],
+        capture_output=True,
+        text=True,
+        cwd=str(WORKTREE_ROOT),
+        timeout=120,
+    )
+
+    output = result.stdout + result.stderr
+    assert result.returncode == 0, f"AppTestHarness typing probe failed:\n{output}"

--- a/tests/unit/test_recording_api.py
+++ b/tests/unit/test_recording_api.py
@@ -260,6 +260,13 @@ async def test_assertions_reject_unknown_keyword_for_closed_method(assertion: st
         getattr(api, assertion)("set_state", entity="sensor.test")
 
 
+async def test_assertions_allow_known_keyword_for_closed_method():
+    """A valid keyword is accepted for a method without arbitrary kwargs."""
+    api = make_recording_api()
+
+    api.assert_not_called("set_state", entity_id="sensor.test")
+
+
 async def test_assertions_validate_flattened_helper_fields():
     """Helper assertions validate the fields recorded from their params model."""
     api = make_recording_api()

--- a/tests/unit/test_recording_api.py
+++ b/tests/unit/test_recording_api.py
@@ -212,10 +212,82 @@ async def test_assert_called_rejects_absent_key_matching_none():
     """
     api = make_recording_api()
     # Manually record a call with no 'brightness' key at all
-    api.calls.append(ApiCall(method="test_method", kwargs={"entity_id": "light.x"}))
+    api.calls.append(ApiCall(method="turn_on", kwargs={"entity_id": "light.x"}))
     # brightness is absent from kwargs — asserting brightness=None must fail
     with pytest.raises(AssertionError):
-        api.assert_called("test_method", brightness=None)
+        api.assert_called("turn_on", brightness=None)
+
+
+@pytest.mark.parametrize("assertion", ["assert_called", "assert_not_called", "assert_called_exact"])
+async def test_assertions_reject_unknown_method(assertion: str):
+    """A misspelled method cannot make a positive or negative assertion look valid."""
+    api = make_recording_api()
+
+    with pytest.raises(ValueError, match=r"Unknown recorded API method 'turn-on'.*turn_on"):
+        getattr(api, assertion)("turn-on")
+
+
+async def test_assert_call_count_rejects_unknown_method_at_zero():
+    """A zero count for a misspelled method is invalid rather than vacuously true."""
+    api = make_recording_api()
+
+    with pytest.raises(ValueError, match=r"Unknown recorded API method 'turn-on'.*turn_on"):
+        api.assert_call_count("turn-on", 0)
+
+
+async def test_assert_call_count_rejects_negative_count():
+    """Negative expected counts are assertion misuse."""
+    api = make_recording_api()
+
+    with pytest.raises(ValueError, match="count must be non-negative"):
+        api.assert_call_count("turn_on", -1)
+
+
+async def test_recording_rejects_method_outside_assertion_contract():
+    """Recording and assertion validation use the same method-name contract."""
+    api = make_recording_api()
+
+    with pytest.raises(ValueError, match="Unknown recorded API method 'not_recordable'"):
+        api._record_call(ApiCall(method="not_recordable"))
+
+
+@pytest.mark.parametrize("assertion", ["assert_called", "assert_not_called", "assert_called_exact"])
+async def test_assertions_reject_unknown_keyword_for_closed_method(assertion: str):
+    """A misspelled keyword cannot make an assertion look valid."""
+    api = make_recording_api()
+
+    with pytest.raises(ValueError, match=r"'entity'.*'entity_id'"):
+        getattr(api, assertion)("set_state", entity="sensor.test")
+
+
+async def test_assertions_validate_flattened_helper_fields():
+    """Helper assertions validate the fields recorded from their params model."""
+    api = make_recording_api()
+
+    with pytest.raises(ValueError, match=r"'helper_name'.*'name'"):
+        api.assert_not_called("create_input_boolean", helper_name="Vacation mode")
+
+
+async def test_assertions_allow_arbitrary_service_data_for_open_method():
+    """Methods accepting **data keep supporting domain-specific assertion keys."""
+    api = make_recording_api()
+
+    api.assert_not_called("turn_on", custom_service_field=True)
+
+
+async def test_assert_called_reports_closest_call_differences():
+    """Mismatch output identifies missing and differing values on the closest call."""
+    api = make_recording_api()
+    await api.turn_on("light.hallway", brightness=100)
+    await api.turn_on("light.kitchen", brightness=150)
+
+    with pytest.raises(AssertionError) as exc_info:
+        api.assert_called("turn_on", entity_id="light.kitchen", brightness=200, transition=1)
+
+    message = str(exc_info.value)
+    assert "Closest call #2" in message
+    assert "missing={'transition': 1}" in message
+    assert "mismatched={'brightness': {'expected': 200, 'actual': 150}}" in message
 
 
 async def test_assert_not_called_passes_when_not_called():
@@ -499,10 +571,10 @@ async def test_get_entity_or_none_returns_none_for_missing_entity_with_model():
 async def test_assert_called_exact_match():
     """assert_called_exact passes when the recorded kwargs match exactly."""
     api = make_recording_api()
-    api.calls.append(ApiCall(method="test_method", kwargs={"a": 1, "b": 2}))
+    api.calls.append(ApiCall(method="turn_on", kwargs={"a": 1, "b": 2}))
 
     # Exact match — passes.
-    api.assert_called_exact("test_method", a=1, b=2)
+    api.assert_called_exact("turn_on", a=1, b=2)
 
 
 async def test_assert_called_exact_mismatch_extra_key():

--- a/tests/unit/test_recording_sync_facade.py
+++ b/tests/unit/test_recording_sync_facade.py
@@ -34,7 +34,12 @@ from hassette.models.helpers import (
 from hassette.models.services import ServiceResponse
 from hassette.test_utils.factories import make_recording_api
 from hassette.test_utils.helpers import make_state_dict
-from hassette.test_utils.sync_facade import STUB_MSG_GENERIC, STUB_MSG_STATE_CONVERSION, RecordingSyncFacade
+from hassette.test_utils.sync_facade import (
+    RECORDED_API_METHODS,
+    STUB_MSG_GENERIC,
+    STUB_MSG_STATE_CONVERSION,
+    RecordingSyncFacade,
+)
 
 
 async def test_recording_api_sync_is_recording_sync_facade():
@@ -368,3 +373,5 @@ async def test_body_copied_methods_are_sync():
             raise AssertionError(
                 f"{method_name}() returned a {type(result).__name__} — body-copy produced hidden async call"
             )
+
+    assert {call.method for call in api.calls} == RECORDED_API_METHODS


### PR DESCRIPTION
### Harness ergonomics and typing
- Preserve the concrete app subtype through `AppTestHarness` so editors and Pyright expose app-specific members without casts while keeping runtime behavior unchanged.
- Accept an optional read-only config mapping and normalize it internally, removing repeated `config={}` ceremony for apps with no required settings without introducing a shared mutable default.

### Time and simulation boundaries
- Reject non-finite and negative simulation timeouts before event dispatch so invalid deadlines cannot silently disable drain bounds or hang tests.
- Keep clock advancement forward-only and fail closed when a time patch cannot be installed, including rolling back partial setup and releasing only the lock owned by that harness.

### Recording assertions
- Generate one canonical set of recordable API methods and use it for both async and sync recording paths, preventing assertion behavior from drifting between facades.
- Reject misspelled method names, invalid closed-signature keywords, and negative call counts so malformed negative assertions cannot produce false-green tests.
- Report the closest recorded call with missing, mismatched, and exact-match-only extra values, making failures actionable without changing partial-versus-exact matching semantics.

### Verification
- `prek -a`
- `uv run nox -s dev` (7,946 passed, 1 skipped, 2 xfailed)
- Focused generator and test-utils suite (196 passed)
- Code, integration, readability, and clean-code gates

### Follow-up
- Further structural decomposition of the test orchestration paths remains tracked in #1363 and is intentionally outside this quick-win PR.

Closes #1332

Closes #1337

Closes #1343

Closes #1354
