### PR TITLE
fix: remove --reruns from unit/integration nox sessions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -250,3 +250,6 @@ coverage.system.xml
 # codegen atomic-write temp files (leaked only if a run is interrupted)
 .*.py.*.tmp
 /ha-core/
+
+# Resource tracker per-worker results (transient, aggregated at session end)
+.resource-tracker/

--- a/docs/pages/testing/factories.md
+++ b/docs/pages/testing/factories.md
@@ -127,6 +127,7 @@ The mock is sealed by default. Accessing any attribute not wired by the factory 
 | `set_ready` | `True` | Pre-sets `ready_event` so `wait_for_ready()` resolves immediately. |
 | `set_loop` | `True` | Sets `loop` to `asyncio.get_running_loop()`. `False` suits session-scoped fixtures running outside an event loop. |
 | `sealed` | `True` | Calls `seal()` after wiring. Unlisted attribute access raises `AttributeError`. |
+| `live_executor` | `False` | Keeps the sync executor alive for `run_in_thread` submissions. When `False`, the executor is shut down at creation — tests that only need the attribute to exist use the default. When `True`, the fixture must call `hassette.sync_executor.shutdown(join_threads_or_timeout=False)` at teardown. |
 | `**config_overrides` | | Any `HassetteConfig` field, merged on top of test defaults. |
 
 ## `make_test_config`

--- a/docs/pages/testing/factories.md
+++ b/docs/pages/testing/factories.md
@@ -127,7 +127,6 @@ The mock is sealed by default. Accessing any attribute not wired by the factory 
 | `set_ready` | `True` | Pre-sets `ready_event` so `wait_for_ready()` resolves immediately. |
 | `set_loop` | `True` | Sets `loop` to `asyncio.get_running_loop()`. `False` suits session-scoped fixtures running outside an event loop. |
 | `sealed` | `True` | Calls `seal()` after wiring. Unlisted attribute access raises `AttributeError`. |
-| `live_executor` | `False` | Keeps the sync executor alive for `run_in_thread` submissions. When `False`, the executor is shut down at creation — tests that only need the attribute to exist use the default. When `True`, the fixture must call `hassette.sync_executor.shutdown(join_threads_or_timeout=False)` at teardown. |
 | `**config_overrides` | | Any `HassetteConfig` field, merged on top of test defaults. |
 
 ## `make_test_config`

--- a/noxfile.py
+++ b/noxfile.py
@@ -46,8 +46,6 @@ def dev(session: "Session"):
         "loadscope",
         "-v",
         "--tb=short",
-        "--reruns",
-        "2",
         external=True,
     )
 
@@ -75,8 +73,6 @@ def tests(session: "Session"):
         "60",
         "--timeout-method",
         "thread",
-        "--reruns",
-        "2",
         external=True,
     )
 
@@ -199,6 +195,8 @@ def _run_system_tests(session: "Session", *, marker: str, extra_args: list[str] 
         "120",
         "--timeout-method",
         "thread",
+        # System tests hit real Docker/HA — retry genuine infra flakiness.
+        # Unit/integration sessions intentionally have no reruns (see #1322).
         "--reruns",
         "2",
         "--reruns-delay",
@@ -239,8 +237,6 @@ def tests_with_coverage(session: "Session"):
         "60",
         "--timeout-method",
         "thread",
-        "--reruns",
-        "2",
         external=True,
     )
     session.run("uv", "run", "--active", "coverage", "combine", external=True)

--- a/src/hassette/core/app_lifecycle_service.py
+++ b/src/hassette/core/app_lifecycle_service.py
@@ -197,6 +197,14 @@ class AppLifecycleService(Resource):
                         inst.app_config.instance_name,
                         exc_info=True,
                     )
+                try:
+                    await inst.cache.close()
+                except Exception:
+                    self.logger.warning(
+                        "Cache cleanup failed for instance '%s'",
+                        inst.app_config.instance_name,
+                        exc_info=True,
+                    )
         except TimeoutError:
             self.logger.warning(
                 "Cleanup timed out for failed instance '%s' — some listeners or jobs may leak until restart",

--- a/src/hassette/test_utils/app_harness.py
+++ b/src/hassette/test_utils/app_harness.py
@@ -361,6 +361,10 @@ class AppTestHarness(SimulationMixin, TimeControlMixin, Generic[AppType]):
             await app.shutdown()
         except Exception:
             LOGGER.warning("AppTestHarness: app.shutdown() raised during teardown", exc_info=True)
+        try:
+            await app.cache.close()
+        except Exception:
+            LOGGER.warning("AppTestHarness: app.cache.close() raised during teardown", exc_info=True)
 
     def _cleanup_tmpdir(self, data_dir: Path) -> None:
         """Remove auto-created tmpdir on teardown."""

--- a/src/hassette/test_utils/mock_hassette.py
+++ b/src/hassette/test_utils/mock_hassette.py
@@ -25,6 +25,7 @@ def make_mock_hassette(
     set_ready: bool = True,
     set_loop: bool = True,
     sealed: bool = True,
+    live_executor: bool = False,
     **config_overrides: Any,
 ) -> AsyncMock:
     """Create a fully-wired :class:`unittest.mock.AsyncMock` that stands in for Hassette.
@@ -50,6 +51,10 @@ def make_mock_hassette(
             fixtures that run outside an async event loop.
         sealed: If ``True`` (default), calls :func:`unittest.mock.seal` after wiring all
             attributes. Pass ``False`` if the test needs to set additional attributes.
+        live_executor: If ``True``, keeps the executor alive via ``weakref.finalize`` for
+            the mock's lifetime so ``TaskBucket.run_in_thread`` can submit real work. If
+            ``False`` (default), the executor is shut down immediately after creation —
+            cheaper for tests that only need ``.sync_executor`` to exist as an attribute.
         **config_overrides: Any :class:`~hassette.config.config.HassetteConfig` field to
             override. Merged on top of ``make_test_config()`` defaults. Nested group fields
             may be passed as dicts::
@@ -78,8 +83,8 @@ def make_mock_hassette(
         - ``.wait_for_ready``: :class:`~unittest.mock.AsyncMock` returning ``True``
         - ``.children``: ``[]``
         - ``.sync_executor``: real :class:`~hassette.task_bucket.interruptible_executor.InterruptibleThreadPoolExecutor`
-            (``max_workers=2``, ``thread_name_prefix="hassette-sync"``) so that tests
-            reaching ``TaskBucket.run_in_thread`` submit work on the correct pool
+            (``max_workers=2``, ``thread_name_prefix="hassette-sync"``). Only usable for
+            ``run_in_thread`` when ``live_executor=True``; otherwise pre-shutdown
         - ``.sync_executor_service``: ``None`` (the service is not wired in unit tests)
 
     Example::
@@ -165,7 +170,10 @@ def make_mock_hassette(
         max_workers=2,
         thread_name_prefix=SYNC_EXECUTOR_THREAD_NAME_PREFIX,
     )
-    weakref.finalize(hassette, executor.shutdown, join_threads_or_timeout=False)
+    if live_executor:
+        weakref.finalize(hassette, executor.shutdown, join_threads_or_timeout=False)
+    else:
+        executor.shutdown(join_threads_or_timeout=False)
     hassette.sync_executor = executor
 
     # SyncExecutorService is not wired in unit tests. Set to None explicitly so the

--- a/src/hassette/test_utils/resource_tracker.py
+++ b/src/hassette/test_utils/resource_tracker.py
@@ -1,0 +1,338 @@
+"""Pytest plugin: track closeable resource lifecycle.
+
+Monkeypatches resource constructors and close/shutdown methods to record which
+test created each resource and whether it was properly cleaned up. Reports
+unclosed resources at session end with creation context (test name + stack).
+
+Tracked resource types:
+- EventStreamService (anyio memory streams)
+- MemoryObjectReceiveStream.clone() (cloned streams passed to BusService)
+- aiosqlite.Connection (database connections)
+- aiohttp.ClientSession (HTTP sessions for REST API and WebSocket)
+- ThreadPoolExecutor (sync executor thread pools)
+
+Quiet on clean runs — only prints when leaks are detected.
+
+xdist-aware: each worker writes its results to a JSON file; the controller
+aggregates all workers in pytest_sessionfinish.
+
+Disable by setting HASSETTE_DISABLE_RESOURCE_TRACKER=1.
+"""
+
+import contextlib
+import json
+import os
+import traceback
+import typing
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+
+import aiohttp
+import aiosqlite
+import pytest
+from anyio.streams.memory import MemoryObjectReceiveStream
+
+from hassette.core.event_stream_service import EventStreamService
+
+if typing.TYPE_CHECKING:
+    from collections.abc import Iterator
+
+# Frames of caller context to capture in creation stacks.
+_STACK_CONTEXT_FRAMES = 6
+
+
+class _TrackedResource:
+    __slots__ = ("closed", "creation_stack", "kind", "obj", "obj_id", "test_name")
+
+    def __init__(self, kind: str, obj_id: int, test_name: str, creation_stack: str, obj: object) -> None:
+        self.kind = kind
+        self.obj_id = obj_id
+        self.test_name = test_name
+        self.creation_stack = creation_stack
+        self.closed = False
+        # Strong ref prevents id() reuse while the resource is tracked as open.
+        self.obj: object | None = obj
+
+    def to_dict(self) -> dict[str, typing.Any]:
+        return {
+            "kind": self.kind,
+            "test_name": self.test_name,
+            "creation_stack": self.creation_stack,
+            "closed": self.closed,
+        }
+
+
+class ResourceTracker:
+    def __init__(self) -> None:
+        self.resources: dict[int, _TrackedResource] = {}
+        self._original_ess_init: typing.Any = None
+        self._original_ess_close: typing.Any = None
+        self._original_recv_clone: typing.Any = None
+        self._original_recv_aclose: typing.Any = None
+        self._original_aiosqlite_connect: typing.Any = None
+        self._original_aiosqlite_close: typing.Any = None
+        self._original_aiohttp_init: typing.Any = None
+        self._original_aiohttp_close: typing.Any = None
+        self._original_executor_init: typing.Any = None
+        self._original_executor_shutdown: typing.Any = None
+
+    def _current_test(self) -> str:
+        return os.environ.get("PYTEST_CURRENT_TEST", "<unknown>")
+
+    def _stack(self) -> str:
+        frames = traceback.extract_stack()
+        # Drop the 3 innermost frames (this method, record_creation, and the monkeypatch wrapper).
+        relevant = frames[:-3][-_STACK_CONTEXT_FRAMES:]
+        return "".join(traceback.format_list(relevant))
+
+    def record_creation(self, kind: str, obj: object) -> None:
+        obj_id = id(obj)
+        self.resources[obj_id] = _TrackedResource(
+            kind=kind,
+            obj_id=obj_id,
+            test_name=self._current_test(),
+            creation_stack=self._stack(),
+            obj=obj,
+        )
+
+    def record_close(self, kind: str, obj: object) -> None:
+        obj_id = id(obj)
+        if obj_id in self.resources:
+            self.resources[obj_id].closed = True
+            self.resources[obj_id].obj = None
+
+    def install_patches(self) -> None:
+        self._patch_event_stream_service()
+        self._patch_recv_stream_clone()
+        self._patch_aiosqlite()
+        self._patch_aiohttp()
+        self._patch_thread_pool_executor()
+
+    def remove_patches(self) -> None:
+        self._unpatch_event_stream_service()
+        self._unpatch_recv_stream_clone()
+        self._unpatch_aiosqlite()
+        self._unpatch_aiohttp()
+        self._unpatch_thread_pool_executor()
+
+    def _patch_event_stream_service(self) -> None:
+        self._original_ess_init = EventStreamService.__init__
+        self._original_ess_close = EventStreamService.close_streams
+
+        original_init = self._original_ess_init
+        original_close = self._original_ess_close
+
+        def patched_init(self_ess: typing.Any, *args: typing.Any, **kwargs: typing.Any) -> None:
+            original_init(self_ess, *args, **kwargs)
+            self.record_creation("EventStreamService", self_ess)
+
+        async def patched_close(self_ess: typing.Any) -> None:
+            self.record_close("EventStreamService", self_ess)
+            await original_close(self_ess)
+
+        EventStreamService.__init__ = patched_init  # pyright: ignore[reportAttributeAccessIssue]
+        EventStreamService.close_streams = patched_close  # pyright: ignore[reportAttributeAccessIssue]
+
+    def _unpatch_event_stream_service(self) -> None:
+        if self._original_ess_init is not None:
+            EventStreamService.__init__ = self._original_ess_init  # pyright: ignore[reportAttributeAccessIssue]
+        if self._original_ess_close is not None:
+            EventStreamService.close_streams = self._original_ess_close  # pyright: ignore[reportAttributeAccessIssue]
+
+    def _patch_recv_stream_clone(self) -> None:
+        self._original_recv_clone = MemoryObjectReceiveStream.clone
+        self._original_recv_aclose = MemoryObjectReceiveStream.aclose
+
+        original_clone = self._original_recv_clone
+        original_aclose = self._original_recv_aclose
+
+        def patched_clone(self_stream: typing.Any) -> MemoryObjectReceiveStream:  # pyright: ignore[reportReturnType]
+            cloned = original_clone(self_stream)
+            self.record_creation("MemoryObjectReceiveStream.clone", cloned)
+            return cloned
+
+        async def patched_aclose(self_stream: typing.Any) -> None:
+            self.record_close("MemoryObjectReceiveStream.clone", self_stream)
+            await original_aclose(self_stream)
+
+        MemoryObjectReceiveStream.clone = patched_clone  # pyright: ignore[reportAttributeAccessIssue]
+        MemoryObjectReceiveStream.aclose = patched_aclose  # pyright: ignore[reportAttributeAccessIssue]
+
+    def _unpatch_recv_stream_clone(self) -> None:
+        if self._original_recv_clone is not None:
+            MemoryObjectReceiveStream.clone = self._original_recv_clone  # pyright: ignore[reportAttributeAccessIssue]
+        if self._original_recv_aclose is not None:
+            MemoryObjectReceiveStream.aclose = self._original_recv_aclose  # pyright: ignore[reportAttributeAccessIssue]
+
+    def _patch_aiosqlite(self) -> None:
+        self._original_aiosqlite_connect = aiosqlite.connect
+        self._original_aiosqlite_close = aiosqlite.Connection.close
+
+        original_connect = self._original_aiosqlite_connect
+        original_close = self._original_aiosqlite_close
+
+        def patched_connect(database: typing.Any, **kwargs: typing.Any) -> aiosqlite.Connection:
+            conn = original_connect(database, **kwargs)
+            self.record_creation("aiosqlite.Connection", conn)
+            return conn
+
+        async def patched_close(self_conn: typing.Any) -> None:
+            self.record_close("aiosqlite.Connection", self_conn)
+            await original_close(self_conn)
+
+        aiosqlite.connect = patched_connect  # pyright: ignore[reportAttributeAccessIssue]
+        aiosqlite.Connection.close = patched_close  # pyright: ignore[reportAttributeAccessIssue]
+
+    def _unpatch_aiosqlite(self) -> None:
+        if self._original_aiosqlite_connect is not None:
+            aiosqlite.connect = self._original_aiosqlite_connect  # pyright: ignore[reportAttributeAccessIssue]
+        if self._original_aiosqlite_close is not None:
+            aiosqlite.Connection.close = self._original_aiosqlite_close  # pyright: ignore[reportAttributeAccessIssue]
+
+    def _patch_aiohttp(self) -> None:
+        self._original_aiohttp_init = aiohttp.ClientSession.__init__
+        self._original_aiohttp_close = aiohttp.ClientSession.close
+
+        original_init = self._original_aiohttp_init
+        original_close = self._original_aiohttp_close
+
+        def patched_init(self_session: typing.Any, *args: typing.Any, **kwargs: typing.Any) -> None:
+            original_init(self_session, *args, **kwargs)
+            self.record_creation("aiohttp.ClientSession", self_session)
+
+        async def patched_close(self_session: typing.Any) -> None:
+            self.record_close("aiohttp.ClientSession", self_session)
+            await original_close(self_session)
+
+        aiohttp.ClientSession.__init__ = patched_init  # pyright: ignore[reportAttributeAccessIssue]
+        aiohttp.ClientSession.close = patched_close  # pyright: ignore[reportAttributeAccessIssue]
+
+    def _unpatch_aiohttp(self) -> None:
+        if self._original_aiohttp_init is not None:
+            aiohttp.ClientSession.__init__ = self._original_aiohttp_init  # pyright: ignore[reportAttributeAccessIssue]
+        if self._original_aiohttp_close is not None:
+            aiohttp.ClientSession.close = self._original_aiohttp_close  # pyright: ignore[reportAttributeAccessIssue]
+
+    def _patch_thread_pool_executor(self) -> None:
+        self._original_executor_init = ThreadPoolExecutor.__init__
+        self._original_executor_shutdown = ThreadPoolExecutor.shutdown
+
+        original_init = self._original_executor_init
+        original_shutdown = self._original_executor_shutdown
+
+        def patched_init(self_executor: typing.Any, *args: typing.Any, **kwargs: typing.Any) -> None:
+            original_init(self_executor, *args, **kwargs)
+            self.record_creation("ThreadPoolExecutor", self_executor)
+
+        def patched_shutdown(self_executor: typing.Any, *args: typing.Any, **kwargs: typing.Any) -> None:
+            self.record_close("ThreadPoolExecutor", self_executor)
+            original_shutdown(self_executor, *args, **kwargs)
+
+        ThreadPoolExecutor.__init__ = patched_init  # pyright: ignore[reportAttributeAccessIssue]
+        ThreadPoolExecutor.shutdown = patched_shutdown  # pyright: ignore[reportAttributeAccessIssue]
+
+    def _unpatch_thread_pool_executor(self) -> None:
+        if self._original_executor_init is not None:
+            ThreadPoolExecutor.__init__ = self._original_executor_init  # pyright: ignore[reportAttributeAccessIssue]
+        if self._original_executor_shutdown is not None:
+            ThreadPoolExecutor.shutdown = self._original_executor_shutdown  # pyright: ignore[reportAttributeAccessIssue]
+
+    def unclosed(self) -> list[_TrackedResource]:
+        return [r for r in self.resources.values() if not r.closed]
+
+    def save_results(self, path: str) -> None:
+        unclosed = self.unclosed()
+        data = {
+            "total": len(self.resources),
+            "closed": len(self.resources) - len(unclosed),
+            "unclosed": [r.to_dict() for r in unclosed],
+        }
+        with open(path, "w") as f:
+            json.dump(data, f, indent=2)
+
+
+def _results_dir(config: pytest.Config) -> Path:
+    base = config.rootpath / ".resource-tracker"
+    base.mkdir(exist_ok=True)
+    return base
+
+
+def _worker_id() -> str:
+    return os.environ.get("PYTEST_XDIST_WORKER", "main")
+
+
+def format_report(results: list[dict[str, typing.Any]]) -> str:
+    total = sum(r["total"] for r in results)
+    closed = sum(r["closed"] for r in results)
+    all_unclosed: list[dict[str, typing.Any]] = []
+    for r in results:
+        all_unclosed.extend(r["unclosed"])
+
+    if not all_unclosed:
+        return ""
+
+    by_test: dict[str, list[dict[str, typing.Any]]] = {}
+    for u in all_unclosed:
+        by_test.setdefault(u["test_name"], []).append(u)
+
+    lines = [
+        "",
+        "=" * 80,
+        "RESOURCE LEAK REPORT",
+        "=" * 80,
+        f"Total tracked: {total}  |  Closed: {closed}  |  UNCLOSED: {len(all_unclosed)}",
+        "",
+        "-" * 80,
+    ]
+
+    for test_name, resources in sorted(by_test.items()):
+        lines.append(f"\n  {test_name}")
+        for r in resources:
+            lines.append(f"    [{r['kind']}]")
+            lines.extend(f"      {stack_line}" for stack_line in r["creation_stack"].strip().splitlines())
+
+    lines.extend(["", "=" * 80, ""])
+    return "\n".join(lines)
+
+
+@pytest.fixture(autouse=True, scope="session")
+def _resource_tracker(request: pytest.FixtureRequest) -> "Iterator[None]":  # pyright: ignore[reportUnusedFunction]
+    if os.environ.get("HASSETTE_DISABLE_RESOURCE_TRACKER"):
+        yield
+        return
+
+    tracker = ResourceTracker()
+    tracker.install_patches()
+    yield
+    tracker.remove_patches()
+
+    results_dir = _results_dir(request.config)
+    worker = _worker_id()
+    tracker.save_results(str(results_dir / f"{worker}.json"))
+
+
+def pytest_sessionfinish(session: pytest.Session, exitstatus: int) -> None:  # noqa: ARG001
+    if os.environ.get("HASSETTE_DISABLE_RESOURCE_TRACKER"):
+        return
+    if _worker_id() != "main":
+        return
+
+    results_dir = _results_dir(session.config)
+    results: list[dict[str, typing.Any]] = []
+
+    for child in sorted(results_dir.iterdir()):
+        if child.suffix != ".json":
+            continue
+        with child.open() as fh:
+            results.append(json.load(fh))
+        child.unlink()
+
+    with contextlib.suppress(OSError):
+        results_dir.rmdir()
+
+    if not results:
+        return
+
+    report = format_report(results)
+    if report:
+        print(report)

--- a/src/hassette/test_utils/resource_tracker.py
+++ b/src/hassette/test_utils/resource_tracker.py
@@ -127,8 +127,8 @@ class ResourceTracker:
             self.record_creation("EventStreamService", self_ess)
 
         async def patched_close(self_ess: typing.Any) -> None:
-            self.record_close("EventStreamService", self_ess)
             await original_close(self_ess)
+            self.record_close("EventStreamService", self_ess)
 
         EventStreamService.__init__ = patched_init  # pyright: ignore[reportAttributeAccessIssue]
         EventStreamService.close_streams = patched_close  # pyright: ignore[reportAttributeAccessIssue]
@@ -152,8 +152,8 @@ class ResourceTracker:
             return cloned
 
         async def patched_aclose(self_stream: typing.Any) -> None:
-            self.record_close("MemoryObjectReceiveStream.clone", self_stream)
             await original_aclose(self_stream)
+            self.record_close("MemoryObjectReceiveStream.clone", self_stream)
 
         MemoryObjectReceiveStream.clone = patched_clone  # pyright: ignore[reportAttributeAccessIssue]
         MemoryObjectReceiveStream.aclose = patched_aclose  # pyright: ignore[reportAttributeAccessIssue]
@@ -177,8 +177,8 @@ class ResourceTracker:
             return conn
 
         async def patched_close(self_conn: typing.Any) -> None:
-            self.record_close("aiosqlite.Connection", self_conn)
             await original_close(self_conn)
+            self.record_close("aiosqlite.Connection", self_conn)
 
         aiosqlite.connect = patched_connect  # pyright: ignore[reportAttributeAccessIssue]
         aiosqlite.Connection.close = patched_close  # pyright: ignore[reportAttributeAccessIssue]
@@ -201,8 +201,8 @@ class ResourceTracker:
             self.record_creation("aiohttp.ClientSession", self_session)
 
         async def patched_close(self_session: typing.Any) -> None:
-            self.record_close("aiohttp.ClientSession", self_session)
             await original_close(self_session)
+            self.record_close("aiohttp.ClientSession", self_session)
 
         aiohttp.ClientSession.__init__ = patched_init  # pyright: ignore[reportAttributeAccessIssue]
         aiohttp.ClientSession.close = patched_close  # pyright: ignore[reportAttributeAccessIssue]
@@ -225,8 +225,8 @@ class ResourceTracker:
             self.record_creation("ThreadPoolExecutor", self_executor)
 
         def patched_shutdown(self_executor: typing.Any, *args: typing.Any, **kwargs: typing.Any) -> None:
-            self.record_close("ThreadPoolExecutor", self_executor)
             original_shutdown(self_executor, *args, **kwargs)
+            self.record_close("ThreadPoolExecutor", self_executor)
 
         ThreadPoolExecutor.__init__ = patched_init  # pyright: ignore[reportAttributeAccessIssue]
         ThreadPoolExecutor.shutdown = patched_shutdown  # pyright: ignore[reportAttributeAccessIssue]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -44,7 +44,7 @@ assert APPS_TOML_TEMPLATE.exists(), f"Apps TOML template {APPS_TOML_TEMPLATE} do
 
 # this wants package.nested_directories.final_file_name
 # do not include the name of the fixture
-pytest_plugins = ["hassette.test_utils.fixtures"]
+pytest_plugins = ["hassette.test_utils.fixtures", "hassette.test_utils.resource_tracker"]
 
 
 @pytest.fixture(autouse=True)

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -73,14 +73,17 @@ def db_hassette(premigrated_db_path: Path) -> AsyncMock:
 
     Note: telemetry/conftest.py defines a variant with web_api={"run": True} for telemetry tests.
     """
-    return make_mock_hassette(
+    hassette = make_mock_hassette(
         data_dir=premigrated_db_path.parent,
         set_ready=False,
         sealed=False,
+        live_executor=True,
         database={"telemetry_write_queue_max": 500, "max_size_mb": 0},
         lifecycle={"resource_shutdown_timeout_seconds": 5},
         scheduler={"min_delay_seconds": 0.1, "max_delay_seconds": 60.0, "default_delay_seconds": 1.0},
     )
+    yield hassette
+    hassette.sync_executor.shutdown(join_threads_or_timeout=False)
 
 
 @pytest.fixture

--- a/tests/integration/database/test_database_service.py
+++ b/tests/integration/database/test_database_service.py
@@ -20,13 +20,15 @@ from hassette.test_utils.mock_hassette import make_mock_hassette
 @pytest.fixture
 def mock_hassette_fresh(tmp_path: Path) -> AsyncMock:
     """Create a mock Hassette with a fresh (empty) data_dir for migration-from-scratch tests."""
-    return make_mock_hassette(
+    hassette = make_mock_hassette(
         sealed=False,
         data_dir=tmp_path,
         set_ready=False,
         database={"telemetry_write_queue_max": 500},
         lifecycle={"resource_shutdown_timeout_seconds": 5},
     )
+    yield hassette
+    hassette.sync_executor.shutdown(join_threads_or_timeout=False)
 
 
 @pytest.fixture

--- a/tests/integration/telemetry/conftest.py
+++ b/tests/integration/telemetry/conftest.py
@@ -16,13 +16,16 @@ from hassette.test_utils.mock_hassette import make_mock_hassette
 @pytest.fixture
 def db_hassette(premigrated_db_path: Path) -> MagicMock:
     """Variant of integration/conftest.db_hassette with web_api enabled for telemetry query tests."""
-    return make_mock_hassette(
+    hassette = make_mock_hassette(
         data_dir=premigrated_db_path.parent,
         set_ready=False,
+        live_executor=True,
         database={"telemetry_write_queue_max": 500, "max_size_mb": 0},
         lifecycle={"resource_shutdown_timeout_seconds": 5},
         web_api={"run": True},
     )
+    yield hassette
+    hassette.sync_executor.shutdown(join_threads_or_timeout=False)
 
 
 @pytest.fixture

--- a/tests/integration/telemetry/test_telemetry_query_service_misc.py
+++ b/tests/integration/telemetry/test_telemetry_query_service_misc.py
@@ -178,13 +178,15 @@ class TestCheckHealth:
 class TestReadTimeout:
     @pytest.fixture
     def short_timeout_hassette(self, premigrated_db_path: Path) -> MagicMock:
-        return make_mock_hassette(
+        hassette = make_mock_hassette(
             data_dir=premigrated_db_path.parent,
             set_ready=False,
             database={"telemetry_write_queue_max": 500, "max_size_mb": 0, "read_timeout_seconds": 0.1},
             lifecycle={"resource_shutdown_timeout_seconds": 5},
             web_api={"run": True},
         )
+        yield hassette
+        hassette.sync_executor.shutdown(join_threads_or_timeout=False)
 
     @pytest.fixture
     async def short_timeout_db(self, short_timeout_hassette: MagicMock) -> AsyncIterator[tuple[DatabaseService, int]]:

--- a/tests/integration/test_app_factory_lifecycle.py
+++ b/tests/integration/test_app_factory_lifecycle.py
@@ -52,9 +52,11 @@ def app_factory(hassette_with_app_handler: "HassetteHarness", app_registry: AppR
 
 
 @pytest.fixture
-def app_lifecycle(hassette_with_app_handler: "HassetteHarness", app_registry: AppRegistry) -> AppLifecycleService:
+async def app_lifecycle(hassette_with_app_handler: "HassetteHarness", app_registry: AppRegistry) -> AppLifecycleService:
     """Create an AppLifecycleService with real Hassette instance."""
-    return AppLifecycleService(hassette_with_app_handler.hassette, parent=None, registry=app_registry)
+    lifecycle = AppLifecycleService(hassette_with_app_handler.hassette, parent=None, registry=app_registry)
+    yield lifecycle
+    await lifecycle.shutdown_all()
 
 
 def make_manifest(  # factory-local: returns AppManifest, not AppManifestInfo
@@ -399,6 +401,8 @@ class TestAppLifecycleServiceIntegration:
         success_instance = get_app(app_registry, "multi_instance", 0)
         assert success_instance.status == ResourceStatus.RUNNING
 
+        await lifecycle.shutdown_all()
+
     async def test_lifecycle_shuts_down_real_app(
         self, app_factory: AppFactory, app_lifecycle: AppLifecycleService, app_registry: AppRegistry
     ):
@@ -458,6 +462,8 @@ class TestFullIntegrationFlow:
         # Verify running
         app = get_app(app_registry, "multi_instance", 0)
         assert app.status == ResourceStatus.RUNNING
+
+        await lifecycle.shutdown_all()
 
     async def test_full_flow_with_registry_state(
         self, hassette_with_app_handler: "HassetteHarness", app_registry: AppRegistry
@@ -524,6 +530,8 @@ class TestFullIntegrationFlow:
         assert multi1_instance.status == ResourceStatus.RUNNING
         assert my_app_instance.status == ResourceStatus.RUNNING
 
+        await lifecycle.shutdown_all()
+
     async def test_snapshot_shows_running_apps(
         self, hassette_with_app_handler: "HassetteHarness", app_registry: AppRegistry
     ):
@@ -542,6 +550,8 @@ class TestFullIntegrationFlow:
         assert snapshot.running_count == 1
         assert "multi_instance" in snapshot.running_apps
 
+        await lifecycle.shutdown_all()
+
     async def test_snapshot_shows_failed_apps(
         self, hassette_with_app_handler: "HassetteHarness", app_registry: AppRegistry
     ):
@@ -559,6 +569,8 @@ class TestFullIntegrationFlow:
         snapshot = app_registry.get_snapshot()
         assert snapshot.failed_count == 1
         assert "failing" in snapshot.failed_apps
+
+        await lifecycle.shutdown_all()
 
 
 class TestAppRestartPreservesChildren:

--- a/tests/integration/test_event_stream_service.py
+++ b/tests/integration/test_event_stream_service.py
@@ -13,7 +13,9 @@ from hassette.test_utils import make_mock_hassette
 @pytest.fixture
 def mock_hassette():
     """Create a mock Hassette with the event buffer size config."""
-    return make_mock_hassette(sealed=False)
+    hassette = make_mock_hassette(sealed=False)
+    yield hassette
+    hassette.sync_executor.shutdown(join_threads_or_timeout=False)
 
 
 @pytest.fixture
@@ -75,6 +77,7 @@ async def test_custom_buffer_size() -> None:
             await task
     finally:
         await service.close_streams()
+        hassette.sync_executor.shutdown(join_threads_or_timeout=False)
 
 
 async def test_default_buffer_size() -> None:
@@ -88,6 +91,7 @@ async def test_default_buffer_size() -> None:
             await service.send_event(SimpleNamespace(topic=f"topic.{i}", n=i))  # pyright: ignore[reportArgumentType]
     finally:
         await service.close_streams()
+        hassette.sync_executor.shutdown(join_threads_or_timeout=False)
 
 
 async def test_receive_stream_returns_correct_end(event_stream_service: EventStreamService) -> None:

--- a/tests/integration/test_thread_leaked_observability.py
+++ b/tests/integration/test_thread_leaked_observability.py
@@ -62,7 +62,7 @@ async def test_not_started_sync_timeout_no_false_positive(
     # The barrier releases only once both fillers have provably started on the pool,
     # replacing a racy fixed sleep.
     started = threading.Barrier(3)
-    hassette_mock = make_mock_hassette()
+    hassette_mock = make_mock_hassette(live_executor=True)
     bucket = TaskBucket(hassette_mock)
 
     def pool_filler() -> None:
@@ -131,7 +131,7 @@ async def test_sync_handler_timeout_sets_thread_leaked(
     # make_mock_hassette provisions a real InterruptibleThreadPoolExecutor so
     # run_in_thread can submit via loop.run_in_executor(hassette.sync_executor, ...)
     # without creating an unawaited AsyncMock coroutine.
-    bucket = TaskBucket(make_mock_hassette())
+    bucket = TaskBucket(make_mock_hassette(live_executor=True))
 
     released = threading.Event()
 

--- a/tests/unit/app/test_app_cache.py
+++ b/tests/unit/app/test_app_cache.py
@@ -151,7 +151,7 @@ class TestCleanupClosesCache:
 class TestAppSyncBeforeInitializeCallsSuper:
     async def test_before_initialize_calls_super_and_initializes_cache(self, tmp_path: Path) -> None:
         """AppSync.before_initialize must call super() first so cache init fires for sync apps."""
-        hassette = make_mock_hassette(data_dir=tmp_path, sealed=False)
+        hassette = make_mock_hassette(data_dir=tmp_path, sealed=False, live_executor=True)
         app = AppSync(hassette, app_config=_make_app_config(), index=0, app_key="kitchen_lights")
         assert isinstance(app.cache, AsyncCache)
         app.cache.initialize = AsyncMock(wraps=app.cache.initialize)  # pyright: ignore[reportAttributeAccessIssue]

--- a/tests/unit/core/conftest.py
+++ b/tests/unit/core/conftest.py
@@ -121,6 +121,7 @@ def mock_hassette() -> AsyncMock:
     """Create a mock Hassette instance with config for AppLifecycleService tests."""
     hassette = make_mock_hassette(
         sealed=False,
+        live_executor=True,
         dev_mode=True,
         logging={"app_handler": "DEBUG"},
         lifecycle={"app_startup_timeout_seconds": 30},
@@ -135,7 +136,8 @@ def mock_hassette() -> AsyncMock:
     hassette.scheduler_service.remove_jobs_by_owner = MagicMock(side_effect=lambda _owner: asyncio.sleep(0))
     hassette.session_id = 1
     hassette.try_session_id.return_value = 1
-    return hassette
+    yield hassette
+    hassette.sync_executor.shutdown(join_threads_or_timeout=False)
 
 
 def set_registry_apps(registry: MagicMock, apps: dict[str, dict[int, Any]]) -> None:

--- a/tests/unit/core/test_core_coverage.py
+++ b/tests/unit/core/test_core_coverage.py
@@ -331,17 +331,21 @@ class TestOnChildrenStopped:
     async def test_emits_stopped_event_and_closes_streams(self, wired_hassette: Hassette) -> None:
         """_on_children_stopped() calls handle_stop() then closes event streams."""
         h = wired_hassette
+        original_close = h._event_stream_service.close_streams
         close_streams_mock = AsyncMock()
         h._event_stream_service.close_streams = close_streams_mock
 
-        # handle_stop() is a module-level function (hassette.resources.lifecycle), not a
-        # method — patch it at the call site (core.py) rather than reassigning an instance
-        # attribute, since _on_children_stopped() calls the free function directly.
-        with patch("hassette.core.core.handle_stop") as mock_handle_stop:
-            await h._on_children_stopped()
+        try:
+            # handle_stop() is a module-level function (hassette.resources.lifecycle), not a
+            # method — patch it at the call site (core.py) rather than reassigning an instance
+            # attribute, since _on_children_stopped() calls the free function directly.
+            with patch("hassette.core.core.handle_stop") as mock_handle_stop:
+                await h._on_children_stopped()
 
-            mock_handle_stop.assert_awaited_once_with(h)
-        close_streams_mock.assert_awaited_once()
+                mock_handle_stop.assert_awaited_once_with(h)
+            close_streams_mock.assert_awaited_once()
+        finally:
+            h._event_stream_service.close_streams = original_close
 
 
 class TestRecordFatalReason:

--- a/tests/unit/core/test_database_service.py
+++ b/tests/unit/core/test_database_service.py
@@ -16,12 +16,14 @@ from hassette.test_utils.mock_hassette import make_mock_hassette
 @pytest.fixture
 def mock_hassette(tmp_path: Path) -> MagicMock:
     """Create a mock Hassette with database config defaults."""
-    return make_mock_hassette(
+    hassette = make_mock_hassette(
         data_dir=tmp_path,
         set_ready=False,
         database={"telemetry_write_queue_max": 500},
         lifecycle={"resource_shutdown_timeout_seconds": 5},
     )
+    yield hassette
+    hassette.sync_executor.shutdown(join_threads_or_timeout=False)
 
 
 @pytest.fixture

--- a/tests/unit/core/test_log_records_retention.py
+++ b/tests/unit/core/test_log_records_retention.py
@@ -20,12 +20,14 @@ from .conftest import TELEMETRY_TEST_DDL as DDL
 @pytest.fixture
 def mock_hassette_for_db(tmp_path: Path) -> MagicMock:
     """Mock Hassette for DatabaseService tests."""
-    return make_mock_hassette(
+    hassette = make_mock_hassette(
         data_dir=tmp_path,
         set_ready=False,
         database={"telemetry_write_queue_max": 500},
         lifecycle={"resource_shutdown_timeout_seconds": 5},
     )
+    yield hassette
+    hassette.sync_executor.shutdown(join_threads_or_timeout=False)
 
 
 @pytest.fixture

--- a/tests/unit/task_bucket/test_run_in_thread_context_propagation.py
+++ b/tests/unit/task_bucket/test_run_in_thread_context_propagation.py
@@ -21,7 +21,7 @@ from hassette.test_utils import make_mock_hassette
 
 @pytest.fixture
 def hassette_mock() -> Iterator[AsyncMock]:
-    hassette = make_mock_hassette()
+    hassette = make_mock_hassette(live_executor=True)
     token = ctx.HASSETTE_INSTANCE.set(hassette)
     config_token = ctx.HASSETTE_CONFIG.set(hassette.config)
     try:

--- a/tests/unit/task_bucket/test_run_in_thread_executor_routing.py
+++ b/tests/unit/task_bucket/test_run_in_thread_executor_routing.py
@@ -30,11 +30,10 @@ def hassette_mock() -> Iterator[AsyncMock]:
 
     The executor is joined at teardown so its worker threads don't outlive the test.
     """
-    hassette = make_mock_hassette()
+    hassette = make_mock_hassette(live_executor=True)
     try:
         yield hassette
     finally:
-        # Deterministically join the worker threads so they don't outlive the test.
         hassette.sync_executor.shutdown(join_threads_or_timeout=True)
 
 

--- a/tests/unit/test_make_async_adapter_timeout.py
+++ b/tests/unit/test_make_async_adapter_timeout.py
@@ -10,7 +10,7 @@ async def test_sync_fn_timeout_error_propagates_cleanly() -> None:
     """TimeoutError in sync handler propagates without being caught by the except Exception block."""
     # make_mock_hassette provisions a real hassette-sync executor, so run_in_thread
     # can submit via loop.run_in_executor(hassette.sync_executor, ...) without raising.
-    hassette = make_mock_hassette()
+    hassette = make_mock_hassette(live_executor=True)
     bucket = TaskBucket(hassette)
 
     def sync_fn() -> None:

--- a/tests/unit/test_sync_executor_service_wiring.py
+++ b/tests/unit/test_sync_executor_service_wiring.py
@@ -184,13 +184,17 @@ def isolated_hassette_context(monkeypatch: pytest.MonkeyPatch):
 
 
 @pytest.fixture
-def wired_hassette(isolated_hassette_context: object) -> Hassette:  # noqa: ARG001
+async def wired_hassette(isolated_hassette_context: object) -> Hassette:  # noqa: ARG001
     config = make_sync_executor_config()
     h = Hassette(config)
     h.wire_services()
     yield h  # pyright: ignore[reportReturnType]
     if h._sync_executor_service is not None and hasattr(h._sync_executor_service, "executor"):
         h._sync_executor_service.executor.shutdown(join_threads_or_timeout=False)
+    if h._bus_service is not None and not h._bus_service.stream._closed:
+        await h._bus_service.stream.aclose()
+    if not h._event_stream_service.event_streams_closed:
+        await h._event_stream_service.close_streams()
 
 
 class TestWireServicesRegistration:

--- a/tests/unit/test_task_bucket.py
+++ b/tests/unit/test_task_bucket.py
@@ -29,7 +29,9 @@ from hassette.test_utils.helpers import async_noop
 @pytest.fixture
 def hassette_mock():
     """Minimal Hassette mock sufficient to construct a TaskBucket."""
-    return make_mock_hassette()
+    hassette = make_mock_hassette()
+    yield hassette
+    hassette.sync_executor.shutdown(join_threads_or_timeout=False)
 
 
 @pytest.fixture


### PR DESCRIPTION
Remove `pytest-rerunfailures` from the unit/integration/coverage nox sessions. It was masking a consistently-failing test across all CI matrix runs, and caused a coverage worker crash on Python 3.14 that dropped reported coverage from ~86% to 78%.

- Drop `--reruns 2` from `dev`, `tests`, and `tests_with_coverage` sessions in `noxfile.py`
- System tests keep `--reruns 2` — they hit real Docker/HA infrastructure where transient failures are expected; a comment now documents why the two session groups diverge

Closes #1322
