### PR TITLE
chore: inject SyncExecutorService into TaskBucket via dependency injection

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -13,6 +13,7 @@ reviews:
   # Keep the summary out of the PR description: PR_BODY becomes the squash commit
   # body, and a summary appended below the BREAKING CHANGE: footers pollutes the
   # release-please changelog (the last footer absorbs trailing text).
+  review_status: false
   high_level_summary: false
   poem: false
 

--- a/src/hassette/core/command_executor.py
+++ b/src/hassette/core/command_executor.py
@@ -23,6 +23,7 @@ from hassette.core.database_service import DatabaseService
 from hassette.core.execution_record import SYNTHETIC_ORIGIN, ExecutionRecord
 from hassette.core.loop_watchdog import WatchdogEvent
 from hassette.core.registration import ListenerRegistration, ScheduledJobRegistration
+from hassette.core.sync_executor_service import SYNC_WORKER_HANDLE
 from hassette.core.telemetry.repository import TelemetryRepository
 from hassette.error_context import ErrorContext
 from hassette.events.hassette import HassetteExecutionCompletedEvent
@@ -33,7 +34,6 @@ from hassette.resources.restart import RestartSpec
 from hassette.resources.service import Service
 from hassette.scheduler.error_context import SchedulerErrorContext
 from hassette.schemas.telemetry_models import BlockingEvent
-from hassette.task_bucket.task_bucket import SYNC_WORKER_HANDLE
 from hassette.types.enums import RestartType
 from hassette.types.types import LOG_LEVEL_TYPE
 from hassette.utils.execution import ExecutionResult, track_execution

--- a/src/hassette/core/command_executor.py
+++ b/src/hassette/core/command_executor.py
@@ -324,14 +324,15 @@ class CommandExecutor(Service):
             pass
         # result is available for both success and error paths
         if result.is_timed_out:
-            # Check whether the sync worker thread is still alive after the timeout.
+            # Check whether the sync worker thread is still running the submitted fn.
             # The handle was set by run_in_thread on this same asyncio task (same context),
             # so SYNC_WORKER_HANDLE.get() returns the same SyncWorkerHandle the worker mutates.
-            # handle.thread is None when: (a) the handler is async (no worker), or (b) the
-            # timeout fired before the worker dequeued _call (not-started timeout).
-            # Neither case is a leak; only a live thread after the await is cancelled is.
+            # Three non-leak cases: (a) handle.thread is None — async handler or not-started
+            # timeout; (b) handle.active is False — fn finished just before the timeout check,
+            # but the pool thread is still alive (pool threads persist between jobs); (c) the
+            # thread is no longer alive. Only an active, live thread is a genuine leak.
             handle = SYNC_WORKER_HANDLE.get()
-            if handle is not None and handle.thread is not None and handle.thread.is_alive():
+            if handle is not None and handle.active and handle.thread is not None and handle.thread.is_alive():
                 result.thread_leaked = True
                 self.logger.warning(
                     "Sync worker thread still alive after timeout (%.1fms elapsed, thread=%s) — "

--- a/src/hassette/core/core.py
+++ b/src/hassette/core/core.py
@@ -21,7 +21,6 @@ from hassette.resources.lifecycle import handle_stop, mark_not_ready, start
 from hassette.scheduler import Scheduler
 from hassette.state_manager import StateManager
 from hassette.task_bucket import TaskBucket, make_task_factory
-from hassette.task_bucket.interruptible_executor import InterruptibleThreadPoolExecutor
 from hassette.types.enums import ResourceStatus
 from hassette.utils.app_utils import run_apps_pre_check
 from hassette.utils.service_utils import topological_levels, topological_sort, validate_dependency_graph, wait_for_ready
@@ -183,10 +182,15 @@ class Hassette(Resource):
 
         self.startup_tasks()
 
-        # SyncExecutorService: placed early for readability only — depends_on=[] so it has no
-        # ordering constraint here.  Start/stop sequencing is driven by the depends_on graph,
-        # not by registration order.
+        # SyncExecutorService MUST be the first add_child — the _create_task_bucket factory
+        # reads hassette.sync_executor_service to wire it into every subsequently created
+        # TaskBucket. Moving this later would leave intervening services' buckets unwired.
         self._sync_executor_service = self.add_child(SyncExecutorService)
+
+        # Patch the two TaskBuckets created before _sync_executor_service existed
+        # (Hassette's own and SyncExecutorService's own — both created during add_child).
+        self.task_bucket._sync_service = self._sync_executor_service
+        self._sync_executor_service.task_bucket._sync_service = self._sync_executor_service
 
         # private background services — EventStreamService FIRST (BusService needs receive_stream at construction)
         self._event_stream_service = self.add_child(EventStreamService)
@@ -317,26 +321,10 @@ class Hassette(Resource):
 
     @property
     def sync_executor_service(self) -> SyncExecutorService:
-        """The SyncExecutorService instance that owns the dedicated sync thread pool.
-
-        Used by TaskBucket.run_in_thread to track active submissions and emit
-        rate-limited pool-saturation warnings.
-        """
+        """The SyncExecutorService instance that owns the dedicated sync thread pool."""
         if self._sync_executor_service is None:
             raise _service_not_wired_error("SyncExecutorService")
         return self._sync_executor_service
-
-    @property
-    def sync_executor(self) -> InterruptibleThreadPoolExecutor:
-        """Dedicated thread-pool executor for sync user code.
-
-        TaskBucket.run_in_thread routes all sync handler/job/App-lifecycle submissions
-        here.  Framework-internal asyncio.to_thread calls (logging, database) continue
-        using the loop-default executor and are NOT routed through this property.
-        """
-        if self._sync_executor_service is None:
-            raise _service_not_wired_error("SyncExecutorService")
-        return self._sync_executor_service.executor
 
     @property
     def command_executor(self) -> CommandExecutor:

--- a/src/hassette/core/sync_executor_service.py
+++ b/src/hassette/core/sync_executor_service.py
@@ -13,8 +13,11 @@ AppSync hook submits to a closed pool and raises RuntimeError.
 """
 
 import asyncio
+import threading
 import time
-from typing import TYPE_CHECKING, Any, ClassVar
+from contextvars import ContextVar, copy_context
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, ClassVar, ParamSpec, TypeVar, cast
 
 from hassette.resources.base import Resource
 from hassette.resources.lifecycle import mark_ready
@@ -23,7 +26,12 @@ from hassette.resources.service import Service
 from hassette.task_bucket.interruptible_executor import InterruptibleThreadPoolExecutor
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+
     from hassette import Hassette
+
+P = ParamSpec("P")
+R = TypeVar("R")
 
 # Pool saturation constants — mirror command_executor._CAPACITY_WARN_THRESHOLD /
 # _CAPACITY_WARN_RATE_LIMIT_SECS but scoped to global pool saturation.
@@ -49,6 +57,31 @@ _SATURATION_PROBE_INTERVAL_SECS = 30.0
 # Worker thread name prefix for the dedicated sync-user-code pool. Shared with the test
 # mock executor so pool-identity assertions match production threads.
 SYNC_EXECUTOR_THREAD_NAME_PREFIX = "hassette-sync"
+
+
+@dataclass
+class SyncWorkerHandle:
+    """Shared handle between the loop thread and a sync worker for thread-identity tracking.
+
+    Created by ``submit()`` on the loop thread and stored in ``SYNC_WORKER_HANDLE``.
+    The worker thread sets ``handle.thread`` via closure; ``_execute`` in
+    ``command_executor`` reads it at the timeout site to check liveness.
+    """
+
+    thread: threading.Thread | None = None
+
+
+SYNC_WORKER_HANDLE: ContextVar[SyncWorkerHandle | None] = ContextVar("sync_worker_handle", default=None)
+"""Carries the worker handle for the current sync submission from the loop thread to _execute.
+
+Set on the loop thread in ``submit()`` immediately after creating the handle.
+``_execute`` (same asyncio task, same context snapshot) reads this ContextVar to check
+``handle.thread.is_alive()`` at the timeout site.
+
+The worker accesses the handle via closure, not via this ContextVar.  The ContextVar exists so
+that ``_execute`` (running on the loop thread, in the same asyncio task) can read back the
+handle reference.
+"""
 
 
 class SyncExecutorService(Service):
@@ -88,6 +121,33 @@ class SyncExecutorService(Service):
         )
         self._active_workers = 0
         self._last_saturation_warn_ts = 0.0
+
+    def submit(self, fn: "Callable[P, R]", *args: "P.args", **kwargs: "P.kwargs") -> "asyncio.Future[R]":
+        """Submit a sync function to the dedicated executor with context propagation.
+
+        Captures the calling thread's contextvars, wraps them into the worker call,
+        and tracks the submission for pool-saturation monitoring.
+
+        Args:
+            fn: The synchronous function to run.
+            *args: Positional arguments to pass to the function.
+            **kwargs: Keyword arguments to pass to the function.
+
+        Returns:
+            An :class:`asyncio.Future` that resolves to the return value of *fn*.
+        """
+        parent_ctx = copy_context()
+        handle = SyncWorkerHandle()
+        SYNC_WORKER_HANDLE.set(handle)
+
+        def _call() -> R:
+            handle.thread = threading.current_thread()
+            return parent_ctx.run(fn, *args, **kwargs)
+
+        loop = asyncio.get_running_loop()
+        future: asyncio.Future[R] = loop.run_in_executor(self.executor, _call)
+        self.track_submission(cast("asyncio.Future[Any]", future))
+        return future
 
     def track_submission(self, future: "asyncio.Future[Any]") -> None:
         """Track an active submission: increment counter and decrement via done-callback.

--- a/src/hassette/core/sync_executor_service.py
+++ b/src/hassette/core/sync_executor_service.py
@@ -64,11 +64,15 @@ class SyncWorkerHandle:
     """Shared handle between the loop thread and a sync worker for thread-identity tracking.
 
     Created by ``submit()`` on the loop thread and stored in ``SYNC_WORKER_HANDLE``.
-    The worker thread sets ``handle.thread`` via closure; ``_execute`` in
-    ``command_executor`` reads it at the timeout site to check liveness.
+    The worker thread sets ``handle.thread`` and ``handle.active`` via closure;
+    ``_execute`` in ``command_executor`` reads both at the timeout site — ``active``
+    distinguishes a genuinely leaked thread from a pool thread that finished the
+    submitted fn but remains alive between jobs.
     """
 
     thread: threading.Thread | None = None
+    active: bool = False
+    """True while ``fn`` is executing on the worker thread; False before and after."""
 
 
 SYNC_WORKER_HANDLE: ContextVar[SyncWorkerHandle | None] = ContextVar("sync_worker_handle", default=None)
@@ -142,7 +146,11 @@ class SyncExecutorService(Service):
 
         def _call() -> R:
             handle.thread = threading.current_thread()
-            return parent_ctx.run(fn, *args, **kwargs)
+            handle.active = True
+            try:
+                return parent_ctx.run(fn, *args, **kwargs)
+            finally:
+                handle.active = False
 
         loop = asyncio.get_running_loop()
         future: asyncio.Future[R] = loop.run_in_executor(self.executor, _call)

--- a/src/hassette/task_bucket/task_bucket.py
+++ b/src/hassette/task_bucket/task_bucket.py
@@ -6,8 +6,6 @@ import typing
 from collections.abc import Awaitable, Callable, Coroutine
 from concurrent.futures import Future
 from concurrent.futures import TimeoutError as CfTimeoutError  # aliased to distinguish from builtin TimeoutError
-from contextvars import ContextVar, copy_context
-from dataclasses import dataclass
 from typing import Any, ParamSpec, TypeVar, cast, overload
 
 from hassette import context as ctx
@@ -19,33 +17,9 @@ from hassette.utils.func_utils import is_async_callable
 
 _CROSS_THREAD_SPAWN_TIMEOUT_SECS = 10.0
 
-
-@dataclass
-class SyncWorkerHandle:
-    """Shared handle between the loop thread and a sync worker for thread-identity tracking.
-
-    Created by ``run_in_thread`` on the loop thread and stored in ``SYNC_WORKER_HANDLE``.
-    The worker thread sets ``handle.thread`` via closure; ``_execute`` reads it at the
-    timeout site to check liveness.
-    """
-
-    thread: threading.Thread | None = None
-
-
-SYNC_WORKER_HANDLE: ContextVar[SyncWorkerHandle | None] = ContextVar("sync_worker_handle", default=None)
-"""Carries the worker handle for the current sync submission from the loop thread to _execute.
-
-Set on the loop thread in ``run_in_thread`` immediately after creating the handle.
-``_execute`` (same asyncio task, same context snapshot) reads this ContextVar to check
-``handle.thread.is_alive()`` at the timeout site.
-
-The worker accesses the handle via closure, not via this ContextVar.  The ContextVar exists so
-that ``_execute`` (running on the loop thread, in the same asyncio task) can read back the
-handle reference.
-"""
-
 if typing.TYPE_CHECKING:
     from hassette import Hassette
+    from hassette.core.sync_executor_service import SyncExecutorService
 
 T = TypeVar("T")
 P = ParamSpec("P")
@@ -73,6 +47,7 @@ class TaskBucket(Resource):
         super().__init__(hassette, parent=parent)
         self._tasks: set[asyncio.Task[Any]] = set()
         self._exception_recorders = []
+        self._sync_service: SyncExecutorService | None = None
         mark_ready(self, reason="TaskBucket initialized")
 
     @property
@@ -195,21 +170,8 @@ class TaskBucket(Resource):
     def run_in_thread(self, fn: Callable[P, R], *args: P.args, **kwargs: P.kwargs) -> "asyncio.Future[R]":
         """Run a synchronous function on the dedicated sync-handler executor.
 
-        Routes sync user code (handlers, jobs, App lifecycle hooks) through
-        ``hassette.sync_executor`` (an
-        :class:`~hassette.task_bucket.interruptible_executor.InterruptibleThreadPoolExecutor`)
-        so that slow sync handlers are isolated from framework-internal
-        ``asyncio.to_thread`` calls (logging, database), which continue using the
-        loop-default executor.
-
-        **Context propagation:** ``loop.run_in_executor`` does NOT copy the calling
-        thread's contextvars into the worker (unlike ``asyncio.to_thread``).  This
-        method captures a full snapshot via ``contextvars.copy_context()`` and runs
-        *fn* inside it so that all contextvars set on the loop thread are visible to
-        sync user code.
-
-        **Thread handle:** see :class:`SyncWorkerHandle` and :data:`SYNC_WORKER_HANDLE`
-        for the shared-handle mechanism used by the timeout site.
+        Delegates to :meth:`SyncExecutorService.submit`, which handles context
+        propagation, thread-handle tracking, and pool-saturation monitoring.
 
         Args:
             fn: The synchronous function to run.
@@ -218,37 +180,19 @@ class TaskBucket(Resource):
 
         Returns:
             An :class:`asyncio.Future` that resolves to the return value of *fn*.
+
+        Raises:
+            RuntimeError: If ``SyncExecutorService`` has not been wired into this
+                TaskBucket (indicates a startup ordering bug or a test that needs
+                to inject the service).
         """
-        parent_ctx = copy_context()
-        handle = SyncWorkerHandle()
-        SYNC_WORKER_HANDLE.set(handle)
-
-        def _call() -> R:
-            handle.thread = threading.current_thread()
-            return parent_ctx.run(fn, *args, **kwargs)
-
-        # Submit to the dedicated executor so sync user code is isolated from
-        # framework-internal asyncio.to_thread calls (logging, database).
-        # loop.run_in_executor returns an asyncio.Future (awaitable) — callers
-        # that do ``await self.run_in_thread(...)`` work identically to before.
-        loop = asyncio.get_running_loop()
-        future: asyncio.Future[R] = loop.run_in_executor(self.hassette.sync_executor, _call)
-
-        # Submission-time saturation check: track the active worker count and emit a
-        # rate-limited WARNING if the pool is approaching its ceiling.
-        # The periodic probe in SyncExecutorService.serve() covers the case where
-        # submissions stop (fully-starved pool); this check catches the rising-load
-        # signal on each new submission.
-        try:
-            executor_service = self.hassette.sync_executor_service
-        except RuntimeError:
-            # The property raises RuntimeError until wire_services() wires the service
-            # (early startup, or unit tests that never construct it).
-            executor_service = None
-        if executor_service is not None:
-            executor_service.track_submission(cast("asyncio.Future[Any]", future))
-
-        return future
+        if self._sync_service is None:
+            raise RuntimeError(
+                f"TaskBucket({self.unique_name}).run_in_thread called but no SyncExecutorService "
+                "is wired. In production this means a startup ordering bug; in tests, inject "
+                "a SyncExecutorService or mock via task_bucket._sync_service."
+            )
+        return self._sync_service.submit(fn, *args, **kwargs)
 
     def post_to_loop(self, fn: Callable[..., Any], *args: Any, **kwargs: Any) -> None:
         """Schedule a callable on the event loop from any thread."""
@@ -433,4 +377,13 @@ def make_task_factory(
     return factory
 
 
-register_task_bucket_factory(lambda hassette, owner: TaskBucket(hassette, parent=owner))
+def _create_task_bucket(hassette: "Hassette", owner: "Resource") -> "TaskBucket":
+    bucket = TaskBucket(hassette, parent=owner)
+    # suppress RuntimeError: the property raises before wire_services() runs;
+    # Hassette.wire_services() patches the early-created buckets afterward.
+    with contextlib.suppress(RuntimeError):
+        bucket._sync_service = hassette.sync_executor_service
+    return bucket
+
+
+register_task_bucket_factory(_create_task_bucket)

--- a/src/hassette/test_utils/__init__.py
+++ b/src/hassette/test_utils/__init__.py
@@ -25,6 +25,7 @@ from .factories import make_mock_parent as make_mock_parent
 from .factories import make_recording_api as make_recording_api
 from .factories import make_scheduled_job as make_scheduled_job
 from .factories import make_scheduler as make_scheduler
+from .factories import make_sync_service as make_sync_service
 from .fixtures import build_harness as build_harness
 from .fixtures import dummy_cache as dummy_cache
 from .fixtures import hassette_harness as hassette_harness
@@ -35,6 +36,7 @@ from .fixtures import hassette_with_mock_api as hassette_with_mock_api
 from .fixtures import hassette_with_scheduler as hassette_with_scheduler
 from .fixtures import hassette_with_state_proxy as hassette_with_state_proxy
 from .fixtures import run_hassette_startup_tasks as run_hassette_startup_tasks
+from .fixtures import sync_service as sync_service
 from .harness import HassetteHarness as HassetteHarness
 from .harness import preserve_config as preserve_config
 from .harness import wait_for as wait_for

--- a/src/hassette/test_utils/factories.py
+++ b/src/hassette/test_utils/factories.py
@@ -4,6 +4,7 @@ Override-friendly factories that replace per-file duplicates. Every field has
 a sensible default; callers pass only the fields they care about.
 """
 
+import logging
 from typing import Any, Literal
 from unittest.mock import AsyncMock, MagicMock, Mock
 
@@ -14,9 +15,11 @@ from hassette.commands import InvokeHandler
 from hassette.conversion import STATE_REGISTRY
 from hassette.core.registration import ListenerRegistration, ScheduledJobRegistration
 from hassette.core.state_proxy import StateProxy
+from hassette.core.sync_executor_service import SYNC_EXECUTOR_THREAD_NAME_PREFIX, SyncExecutorService
 from hassette.events.base import Event, HassContext, HassettePayload, HassPayload
 from hassette.scheduler.classes import ScheduledJob
 from hassette.scheduler.scheduler import Scheduler
+from hassette.task_bucket.interruptible_executor import InterruptibleThreadPoolExecutor
 from hassette.test_utils.config import DEFAULT_TEST_APP_KEY, TEST_SOURCE_LOCATION
 from hassette.test_utils.mock_hassette import make_mock_hassette
 from hassette.test_utils.recording_api import RecordingApi
@@ -345,3 +348,27 @@ def make_mock_parent(
     parent.class_name = class_name
     parent.app_config = app_config
     return parent
+
+
+def make_sync_service(*, max_workers: int = 2) -> SyncExecutorService:
+    """Build a standalone SyncExecutorService for tests that need run_in_thread.
+
+    Bypasses ``__init__`` (which requires a real Hassette) and wires only the
+    attributes needed for ``submit()``: executor, saturation counters, logger.
+    Does NOT set ``hassette``, ``parent``, ``children``, or ``unique_name`` —
+    those require a real Resource chain.  Use ``tests/unit/conftest.py:make_service``
+    (which goes through real ``__init__``) for tests that exercise the full
+    Service lifecycle or config-driven max_workers.
+
+    Caller is responsible for calling
+    ``svc.executor.shutdown(join_threads_or_timeout=True)`` at teardown.
+    """
+    svc = SyncExecutorService.__new__(SyncExecutorService)
+    svc.executor = InterruptibleThreadPoolExecutor(
+        max_workers=max_workers,
+        thread_name_prefix=SYNC_EXECUTOR_THREAD_NAME_PREFIX,
+    )
+    svc._active_workers = 0
+    svc._last_saturation_warn_ts = 0.0
+    svc.logger = logging.getLogger("test.sync_executor_service")
+    return svc

--- a/src/hassette/test_utils/fixtures.py
+++ b/src/hassette/test_utils/fixtures.py
@@ -3,6 +3,7 @@ import json
 import os
 import random
 import typing
+from collections.abc import Iterator
 from logging import getLogger
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -11,8 +12,10 @@ import pytest
 
 from hassette.cache import DummyCache
 from hassette.core.core import Hassette
+from hassette.core.sync_executor_service import SyncExecutorService
 from hassette.events import Event, RawStateChangeEvent, create_event_from_hass
 
+from .factories import make_sync_service
 from .harness import HassetteHarness
 
 LOGGER = getLogger(__name__)
@@ -68,11 +71,21 @@ async def hassette_with_sync_executor(
 ) -> "AsyncIterator[HassetteHarness]":
     """Harness with the sync executor wired, but no bus/scheduler/app components.
 
-    TaskBucket.run_in_thread routes sync work to hassette.sync_executor, so any
+    TaskBucket.run_in_thread delegates to SyncExecutorService.submit(), so any
     test that dispatches a sync handler through the bare task bucket needs it.
     """
     async with hassette_harness(test_config).with_sync_executor() as harness:
         yield harness
+
+
+@pytest.fixture
+def sync_service() -> Iterator[SyncExecutorService]:
+    """Standalone SyncExecutorService with a real executor for tests that need run_in_thread."""
+    svc = make_sync_service()
+    try:
+        yield svc
+    finally:
+        svc.executor.shutdown(join_threads_or_timeout=True)
 
 
 @pytest.fixture(scope="module")

--- a/src/hassette/test_utils/harness.py
+++ b/src/hassette/test_utils/harness.py
@@ -700,6 +700,8 @@ class HassetteHarness:
 
     async def _start_sync_executor(self) -> None:
         self.hassette._sync_executor_service = self.hassette.add_child(SyncExecutorService)
+        self.hassette.task_bucket._sync_service = self.hassette._sync_executor_service
+        self.hassette._sync_executor_service.task_bucket._sync_service = self.hassette._sync_executor_service
 
     async def _start_bus(self) -> None:
         # Use _HarnessEventStreamService so that test-initiated hassette.shutdown() calls

--- a/src/hassette/test_utils/mock_hassette.py
+++ b/src/hassette/test_utils/mock_hassette.py
@@ -9,13 +9,10 @@ import atexit
 import shutil
 import tempfile
 import threading
-import weakref
 from pathlib import Path
 from typing import Any
 from unittest.mock import AsyncMock, Mock, seal
 
-from hassette.core.sync_executor_service import SYNC_EXECUTOR_THREAD_NAME_PREFIX
-from hassette.task_bucket.interruptible_executor import InterruptibleThreadPoolExecutor
 from hassette.test_utils.config import TEST_WS_URL, make_test_config
 
 
@@ -25,7 +22,6 @@ def make_mock_hassette(
     set_ready: bool = True,
     set_loop: bool = True,
     sealed: bool = True,
-    live_executor: bool = False,
     **config_overrides: Any,
 ) -> AsyncMock:
     """Create a fully-wired :class:`unittest.mock.AsyncMock` that stands in for Hassette.
@@ -51,10 +47,6 @@ def make_mock_hassette(
             fixtures that run outside an async event loop.
         sealed: If ``True`` (default), calls :func:`unittest.mock.seal` after wiring all
             attributes. Pass ``False`` if the test needs to set additional attributes.
-        live_executor: If ``True``, keeps the executor alive via ``weakref.finalize`` for
-            the mock's lifetime so ``TaskBucket.run_in_thread`` can submit real work. If
-            ``False`` (default), the executor is shut down immediately after creation —
-            cheaper for tests that only need ``.sync_executor`` to exist as an attribute.
         **config_overrides: Any :class:`~hassette.config.config.HassetteConfig` field to
             override. Merged on top of ``make_test_config()`` defaults. Nested group fields
             may be passed as dicts::
@@ -82,10 +74,8 @@ def make_mock_hassette(
         - ``.database_service``: ``None``
         - ``.wait_for_ready``: :class:`~unittest.mock.AsyncMock` returning ``True``
         - ``.children``: ``[]``
-        - ``.sync_executor``: real :class:`~hassette.task_bucket.interruptible_executor.InterruptibleThreadPoolExecutor`
-            (``max_workers=2``, ``thread_name_prefix="hassette-sync"``). Only usable for
-            ``run_in_thread`` when ``live_executor=True``; otherwise pre-shutdown
-        - ``.sync_executor_service``: ``None`` (the service is not wired in unit tests)
+        - ``._sync_executor_service``: ``None`` (not wired; tests needing ``run_in_thread``
+            must create their own executor and wire it into their TaskBucket)
 
     Example::
 
@@ -160,26 +150,10 @@ def make_mock_hassette(
     # Resource children
     hassette.children = []
 
-    # Dedicated sync-user-code executor — a real InterruptibleThreadPoolExecutor so
-    # TaskBucket.run_in_thread can submit work during tests.  Thread names carry the
-    # "hassette-sync" prefix, matching production and allowing pool-identity assertions.
-    # Shutdown is tied to the mock's lifetime via weakref.finalize: each executor is
-    # cleaned up when its mock is garbage-collected, rather than living until process
-    # exit, so repeated factory calls don't accumulate live executors.
-    executor = InterruptibleThreadPoolExecutor(
-        max_workers=2,
-        thread_name_prefix=SYNC_EXECUTOR_THREAD_NAME_PREFIX,
-    )
-    if live_executor:
-        weakref.finalize(hassette, executor.shutdown, join_threads_or_timeout=False)
-    else:
-        executor.shutdown(join_threads_or_timeout=False)
-    hassette.sync_executor = executor
-
-    # SyncExecutorService is not wired in unit tests. Set to None explicitly so the
-    # sealed mock exposes the attribute (run_in_thread reads it for saturation tracking
-    # and skips when None) instead of raising AttributeError on access.
-    hassette.sync_executor_service = None
+    # SyncExecutorService is not wired in mock hassette. Tests that need run_in_thread
+    # must create their own SyncExecutorService or executor and wire it into their
+    # TaskBucket via task_bucket._sync_service.
+    hassette._sync_executor_service = None
 
     if sealed:
         seal(hassette)

--- a/src/hassette/test_utils/mock_hassette.py
+++ b/src/hassette/test_utils/mock_hassette.py
@@ -74,8 +74,9 @@ def make_mock_hassette(
         - ``.database_service``: ``None``
         - ``.wait_for_ready``: :class:`~unittest.mock.AsyncMock` returning ``True``
         - ``.children``: ``[]``
-        - ``._sync_executor_service``: ``None`` (not wired; tests needing ``run_in_thread``
-            must create their own executor and wire it into their TaskBucket)
+        - ``._sync_executor_service`` / ``.sync_executor_service``: ``None`` (not wired;
+            tests needing ``run_in_thread`` must inject a real ``SyncExecutorService``
+            into both attributes)
 
     Example::
 
@@ -150,10 +151,11 @@ def make_mock_hassette(
     # Resource children
     hassette.children = []
 
-    # SyncExecutorService is not wired in mock hassette. Tests that need run_in_thread
-    # must create their own SyncExecutorService or executor and wire it into their
-    # TaskBucket via task_bucket._sync_service.
+    # SyncExecutorService — set both the backing field and the public accessor (same
+    # pattern as fatal_shutdown_reason above) so _create_task_bucket's
+    # `hassette.sync_executor_service` access works on sealed mocks.
     hassette._sync_executor_service = None
+    hassette.sync_executor_service = None
 
     if sealed:
         seal(hassette)

--- a/src/hassette/utils/execution.py
+++ b/src/hassette/utils/execution.py
@@ -39,7 +39,7 @@ class ExecutionResult:
     """True when the execution timed out and the sync worker thread was still alive after the timeout.
 
     Set by ``CommandExecutor._execute`` at the timeout site after reading the
-    ``SyncWorkerHandle`` exposed by ``TaskBucket.run_in_thread``.  False for async handlers,
+    ``SyncWorkerHandle`` exposed by ``SyncExecutorService.submit()``.  False for async handlers,
     not-started timeouts (``handle.thread`` is ``None``), and all non-timed-out executions.
 
     Subject to a small race window: if the worker finishes between the timeout cancellation and the

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -12,6 +12,7 @@ import pytest
 from hassette import Hassette
 from hassette.config.config import HassetteConfig
 from hassette.core.database_service import DatabaseService
+from hassette.core.sync_executor_service import SyncExecutorService
 from hassette.test_utils import make_mock_hassette
 from hassette.test_utils.helpers import cleanup_hassette_streams
 from hassette.types.enums import ExecutionMode
@@ -68,7 +69,7 @@ def premigrated_db_path(_migrated_db_template: Path, tmp_path: Path) -> Path:
 
 
 @pytest.fixture
-def db_hassette(premigrated_db_path: Path) -> AsyncMock:
+def db_hassette(premigrated_db_path: Path, sync_service: SyncExecutorService) -> AsyncMock:
     """Provide a mock Hassette with real validated config pointing to a pre-migrated DB.
 
     Note: telemetry/conftest.py defines a variant with web_api={"run": True} for telemetry tests.
@@ -77,13 +78,12 @@ def db_hassette(premigrated_db_path: Path) -> AsyncMock:
         data_dir=premigrated_db_path.parent,
         set_ready=False,
         sealed=False,
-        live_executor=True,
         database={"telemetry_write_queue_max": 500, "max_size_mb": 0},
         lifecycle={"resource_shutdown_timeout_seconds": 5},
         scheduler={"min_delay_seconds": 0.1, "max_delay_seconds": 60.0, "default_delay_seconds": 1.0},
     )
-    yield hassette
-    hassette.sync_executor.shutdown(join_threads_or_timeout=False)
+    hassette._sync_executor_service = sync_service
+    return hassette
 
 
 @pytest.fixture

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -83,6 +83,7 @@ def db_hassette(premigrated_db_path: Path, sync_service: SyncExecutorService) ->
         scheduler={"min_delay_seconds": 0.1, "max_delay_seconds": 60.0, "default_delay_seconds": 1.0},
     )
     hassette._sync_executor_service = sync_service
+    hassette.sync_executor_service = sync_service
     return hassette
 
 

--- a/tests/integration/database/test_database_service.py
+++ b/tests/integration/database/test_database_service.py
@@ -20,15 +20,13 @@ from hassette.test_utils.mock_hassette import make_mock_hassette
 @pytest.fixture
 def mock_hassette_fresh(tmp_path: Path) -> AsyncMock:
     """Create a mock Hassette with a fresh (empty) data_dir for migration-from-scratch tests."""
-    hassette = make_mock_hassette(
+    return make_mock_hassette(
         sealed=False,
         data_dir=tmp_path,
         set_ready=False,
         database={"telemetry_write_queue_max": 500},
         lifecycle={"resource_shutdown_timeout_seconds": 5},
     )
-    yield hassette
-    hassette.sync_executor.shutdown(join_threads_or_timeout=False)
 
 
 @pytest.fixture

--- a/tests/integration/telemetry/conftest.py
+++ b/tests/integration/telemetry/conftest.py
@@ -16,16 +16,13 @@ from hassette.test_utils.mock_hassette import make_mock_hassette
 @pytest.fixture
 def db_hassette(premigrated_db_path: Path) -> MagicMock:
     """Variant of integration/conftest.db_hassette with web_api enabled for telemetry query tests."""
-    hassette = make_mock_hassette(
+    return make_mock_hassette(
         data_dir=premigrated_db_path.parent,
         set_ready=False,
-        live_executor=True,
         database={"telemetry_write_queue_max": 500, "max_size_mb": 0},
         lifecycle={"resource_shutdown_timeout_seconds": 5},
         web_api={"run": True},
     )
-    yield hassette
-    hassette.sync_executor.shutdown(join_threads_or_timeout=False)
 
 
 @pytest.fixture

--- a/tests/integration/telemetry/test_telemetry_query_service_misc.py
+++ b/tests/integration/telemetry/test_telemetry_query_service_misc.py
@@ -178,15 +178,13 @@ class TestCheckHealth:
 class TestReadTimeout:
     @pytest.fixture
     def short_timeout_hassette(self, premigrated_db_path: Path) -> MagicMock:
-        hassette = make_mock_hassette(
+        return make_mock_hassette(
             data_dir=premigrated_db_path.parent,
             set_ready=False,
             database={"telemetry_write_queue_max": 500, "max_size_mb": 0, "read_timeout_seconds": 0.1},
             lifecycle={"resource_shutdown_timeout_seconds": 5},
             web_api={"run": True},
         )
-        yield hassette
-        hassette.sync_executor.shutdown(join_threads_or_timeout=False)
 
     @pytest.fixture
     async def short_timeout_db(self, short_timeout_hassette: MagicMock) -> AsyncIterator[tuple[DatabaseService, int]]:

--- a/tests/integration/test_event_stream_service.py
+++ b/tests/integration/test_event_stream_service.py
@@ -13,9 +13,7 @@ from hassette.test_utils import make_mock_hassette
 @pytest.fixture
 def mock_hassette():
     """Create a mock Hassette with the event buffer size config."""
-    hassette = make_mock_hassette(sealed=False)
-    yield hassette
-    hassette.sync_executor.shutdown(join_threads_or_timeout=False)
+    return make_mock_hassette(sealed=False)
 
 
 @pytest.fixture
@@ -77,7 +75,6 @@ async def test_custom_buffer_size() -> None:
             await task
     finally:
         await service.close_streams()
-        hassette.sync_executor.shutdown(join_threads_or_timeout=False)
 
 
 async def test_default_buffer_size() -> None:
@@ -91,7 +88,6 @@ async def test_default_buffer_size() -> None:
             await service.send_event(SimpleNamespace(topic=f"topic.{i}", n=i))  # pyright: ignore[reportArgumentType]
     finally:
         await service.close_streams()
-        hassette.sync_executor.shutdown(join_threads_or_timeout=False)
 
 
 async def test_receive_stream_returns_correct_end(event_stream_service: EventStreamService) -> None:

--- a/tests/integration/test_thread_leaked_observability.py
+++ b/tests/integration/test_thread_leaked_observability.py
@@ -242,6 +242,60 @@ async def test_pure_async_timeout_no_handle_no_thread_leaked(
     assert record.thread_leaked is False
 
 
+# Completed sync handler with user-code TimeoutError → thread_leaked=False
+# (regression test for handle.active guard)
+
+
+async def test_completed_sync_handler_no_false_thread_leaked(
+    executor: CommandExecutor,
+    sync_service: SyncExecutorService,
+) -> None:
+    """A sync handler that raises TimeoutError from user code must not set thread_leaked.
+
+    When a sync handler raises TimeoutError itself (not from the framework timeout),
+    result.is_timed_out is True and the pool thread is still alive (pool threads persist
+    between jobs).  Without the handle.active guard, handle.thread.is_alive() alone
+    would cause a false thread_leaked=True.  The active flag — cleared by _call's finally
+    block when the handler returns/raises — prevents this false positive.
+    """
+    bucket = TaskBucket(make_mock_hassette())
+    bucket._sync_service = sync_service
+
+    def sync_raises_timeout(_event: object) -> None:
+        raise TimeoutError("user-code timeout")
+
+    adapted = bucket.make_async_adapter(sync_raises_timeout)
+
+    async def invoke(event: object) -> None:
+        await adapted(event)
+
+    listener = make_mock_listener()
+    listener.invoker.invoke = invoke
+    listener.invoker.error_handler = None
+    listener.identity.app_key = "test_app"
+    listener.identity.instance_index = 0
+
+    cmd = InvokeHandler(
+        listener=listener,
+        event=MagicMock(),
+        topic="test",
+        listener_id=5,
+        source_tier="app",
+        effective_timeout=None,  # no framework timeout — the TimeoutError is from user code
+    )
+
+    await executor.execute(cmd)
+
+    assert not executor._write_queue.empty()
+    record = executor._write_queue.get_nowait()
+    assert isinstance(record, ExecutionRecord)
+    assert record.status == "timed_out"
+    assert record.thread_leaked is False, (
+        "thread_leaked must be False when the sync handler completed (active=False) "
+        "even though the pool thread is still alive"
+    )
+
+
 # Round-trip persistence — thread_leaked column survives write+read back
 
 

--- a/tests/integration/test_thread_leaked_observability.py
+++ b/tests/integration/test_thread_leaked_observability.py
@@ -20,6 +20,7 @@ from hassette.commands import InvokeHandler
 from hassette.core.command_executor import CommandExecutor
 from hassette.core.database_service import DatabaseService
 from hassette.core.execution_record import ExecutionRecord
+from hassette.core.sync_executor_service import SyncExecutorService
 from hassette.task_bucket.task_bucket import TaskBucket
 from hassette.test_utils.factories import make_listener_registration, make_mock_listener
 from hassette.test_utils.mock_hassette import make_mock_hassette
@@ -46,6 +47,7 @@ async def executor(
 
 async def test_not_started_sync_timeout_no_false_positive(
     executor: CommandExecutor,
+    sync_service: SyncExecutorService,
 ) -> None:
     """run_in_thread is called but worker hasn't dequeued before timeout → thread_leaked=False.
 
@@ -54,26 +56,21 @@ async def test_not_started_sync_timeout_no_false_positive(
     still None (the worker never called _call), so the liveness guard must not flag
     thread_leaked.  Exercises the ``handle.thread is not None`` branch in _execute.
     """
-    # Gate for the two pool-filling blockers.  We release it after the test assertion
-    # so they exit cleanly before the test tears down.
     pool_gate = threading.Event()
-    # Barrier with 3 parties: the two filler threads, plus this test (which waits via
-    # asyncio.to_thread below, so its wait runs on a real thread and counts as a party).
-    # The barrier releases only once both fillers have provably started on the pool,
-    # replacing a racy fixed sleep.
     started = threading.Barrier(3)
-    hassette_mock = make_mock_hassette(live_executor=True)
+    hassette_mock = make_mock_hassette()
     bucket = TaskBucket(hassette_mock)
+    bucket._sync_service = sync_service
 
     def pool_filler() -> None:
         started.wait(timeout=2.0)
         pool_gate.wait(timeout=10.0)
 
-    # Submit two jobs to saturate both workers (max_workers=2 in make_mock_hassette).
-    # Use the underlying sync_executor directly so these don't touch SYNC_WORKER_HANDLE.
+    # Submit two jobs to saturate both workers (max_workers=2 on the sync service's executor).
+    # Use the underlying executor directly so these don't touch SYNC_WORKER_HANDLE.
     loop = asyncio.get_running_loop()
-    filler_f1 = loop.run_in_executor(hassette_mock.sync_executor, pool_filler)
-    filler_f2 = loop.run_in_executor(hassette_mock.sync_executor, pool_filler)
+    filler_f1 = loop.run_in_executor(sync_service.executor, pool_filler)
+    filler_f2 = loop.run_in_executor(sync_service.executor, pool_filler)
 
     # Wait until both fillers have definitely dequeued and started.
     await asyncio.to_thread(started.wait, 2.0)
@@ -122,16 +119,15 @@ async def test_not_started_sync_timeout_no_false_positive(
 
 async def test_sync_handler_timeout_sets_thread_leaked(
     executor: CommandExecutor,
+    sync_service: SyncExecutorService,
 ) -> None:
     """A sync handler blocking past its timeout produces thread_leaked=True.
 
     The handler sleeps for much longer than the timeout; when asyncio cancels
     the await the worker thread is still alive, so the liveness check fires.
     """
-    # make_mock_hassette provisions a real InterruptibleThreadPoolExecutor so
-    # run_in_thread can submit via loop.run_in_executor(hassette.sync_executor, ...)
-    # without creating an unawaited AsyncMock coroutine.
-    bucket = TaskBucket(make_mock_hassette(live_executor=True))
+    bucket = TaskBucket(make_mock_hassette())
+    bucket._sync_service = sync_service
 
     released = threading.Event()
 

--- a/tests/unit/app/test_app_cache.py
+++ b/tests/unit/app/test_app_cache.py
@@ -155,6 +155,7 @@ class TestAppSyncBeforeInitializeCallsSuper:
         hassette = make_mock_hassette(data_dir=tmp_path, sealed=False)
         svc = make_sync_service()
         hassette._sync_executor_service = svc
+        hassette.sync_executor_service = svc
         app = AppSync(hassette, app_config=_make_app_config(), index=0, app_key="kitchen_lights")
         assert isinstance(app.cache, AsyncCache)
         app.cache.initialize = AsyncMock(wraps=app.cache.initialize)  # pyright: ignore[reportAttributeAccessIssue]

--- a/tests/unit/app/test_app_cache.py
+++ b/tests/unit/app/test_app_cache.py
@@ -18,6 +18,7 @@ from hassette.app.app_config import AppConfig
 from hassette.cache import AsyncCache, DummyCache
 from hassette.config.classes import AppManifest
 from hassette.test_utils import make_mock_hassette
+from hassette.test_utils.factories import make_sync_service
 
 
 def _make_app_config(name: str = "kitchen") -> AppConfig:
@@ -151,7 +152,9 @@ class TestCleanupClosesCache:
 class TestAppSyncBeforeInitializeCallsSuper:
     async def test_before_initialize_calls_super_and_initializes_cache(self, tmp_path: Path) -> None:
         """AppSync.before_initialize must call super() first so cache init fires for sync apps."""
-        hassette = make_mock_hassette(data_dir=tmp_path, sealed=False, live_executor=True)
+        hassette = make_mock_hassette(data_dir=tmp_path, sealed=False)
+        svc = make_sync_service()
+        hassette._sync_executor_service = svc
         app = AppSync(hassette, app_config=_make_app_config(), index=0, app_key="kitchen_lights")
         assert isinstance(app.cache, AsyncCache)
         app.cache.initialize = AsyncMock(wraps=app.cache.initialize)  # pyright: ignore[reportAttributeAccessIssue]
@@ -160,9 +163,8 @@ class TestAppSyncBeforeInitializeCallsSuper:
             await app.before_initialize()
             app.cache.initialize.assert_awaited_once()  # pyright: ignore[reportAttributeAccessIssue]
         finally:
-            # This test opens real aiosqlite connections via initialize() -- close them so no
-            # unclosed-connection ResourceWarning leaks into an unrelated later test's teardown.
             await app.cache.close()
+            svc.executor.shutdown(join_threads_or_timeout=True)
 
 
 class TestDefaultCacheTtlResolution:

--- a/tests/unit/core/conftest.py
+++ b/tests/unit/core/conftest.py
@@ -121,7 +121,6 @@ def mock_hassette() -> AsyncMock:
     """Create a mock Hassette instance with config for AppLifecycleService tests."""
     hassette = make_mock_hassette(
         sealed=False,
-        live_executor=True,
         dev_mode=True,
         logging={"app_handler": "DEBUG"},
         lifecycle={"app_startup_timeout_seconds": 30},
@@ -136,8 +135,7 @@ def mock_hassette() -> AsyncMock:
     hassette.scheduler_service.remove_jobs_by_owner = MagicMock(side_effect=lambda _owner: asyncio.sleep(0))
     hassette.session_id = 1
     hassette.try_session_id.return_value = 1
-    yield hassette
-    hassette.sync_executor.shutdown(join_threads_or_timeout=False)
+    return hassette
 
 
 def set_registry_apps(registry: MagicMock, apps: dict[str, dict[int, Any]]) -> None:

--- a/tests/unit/core/test_database_service.py
+++ b/tests/unit/core/test_database_service.py
@@ -16,14 +16,12 @@ from hassette.test_utils.mock_hassette import make_mock_hassette
 @pytest.fixture
 def mock_hassette(tmp_path: Path) -> MagicMock:
     """Create a mock Hassette with database config defaults."""
-    hassette = make_mock_hassette(
+    return make_mock_hassette(
         data_dir=tmp_path,
         set_ready=False,
         database={"telemetry_write_queue_max": 500},
         lifecycle={"resource_shutdown_timeout_seconds": 5},
     )
-    yield hassette
-    hassette.sync_executor.shutdown(join_threads_or_timeout=False)
 
 
 @pytest.fixture

--- a/tests/unit/core/test_hassette_lifecycle.py
+++ b/tests/unit/core/test_hassette_lifecycle.py
@@ -41,7 +41,6 @@ class TestServiceAccessorGuards:
             ("session_manager", "SessionManager"),
             ("event_stream_service", "EventStreamService"),
             ("sync_executor_service", "SyncExecutorService"),
-            ("sync_executor", "SyncExecutorService"),
             ("command_executor", "CommandExecutor"),
             ("logging_service", "LoggingService"),
             ("runtime_query_service", "RuntimeQueryService"),

--- a/tests/unit/core/test_log_records_retention.py
+++ b/tests/unit/core/test_log_records_retention.py
@@ -20,14 +20,12 @@ from .conftest import TELEMETRY_TEST_DDL as DDL
 @pytest.fixture
 def mock_hassette_for_db(tmp_path: Path) -> MagicMock:
     """Mock Hassette for DatabaseService tests."""
-    hassette = make_mock_hassette(
+    return make_mock_hassette(
         data_dir=tmp_path,
         set_ready=False,
         database={"telemetry_write_queue_max": 500},
         lifecycle={"resource_shutdown_timeout_seconds": 5},
     )
-    yield hassette
-    hassette.sync_executor.shutdown(join_threads_or_timeout=False)
 
 
 @pytest.fixture

--- a/tests/unit/task_bucket/test_run_in_thread_context_propagation.py
+++ b/tests/unit/task_bucket/test_run_in_thread_context_propagation.py
@@ -15,13 +15,14 @@ from unittest.mock import AsyncMock
 import pytest
 
 from hassette import context as ctx
-from hassette.task_bucket.task_bucket import SYNC_WORKER_HANDLE, TaskBucket
+from hassette.core.sync_executor_service import SYNC_WORKER_HANDLE, SyncExecutorService
+from hassette.task_bucket.task_bucket import TaskBucket
 from hassette.test_utils import make_mock_hassette
 
 
 @pytest.fixture
 def hassette_mock() -> Iterator[AsyncMock]:
-    hassette = make_mock_hassette(live_executor=True)
+    hassette = make_mock_hassette()
     token = ctx.HASSETTE_INSTANCE.set(hassette)
     config_token = ctx.HASSETTE_CONFIG.set(hassette.config)
     try:
@@ -29,12 +30,13 @@ def hassette_mock() -> Iterator[AsyncMock]:
     finally:
         ctx.HASSETTE_CONFIG.reset(config_token)
         ctx.HASSETTE_INSTANCE.reset(token)
-        hassette.sync_executor.shutdown(join_threads_or_timeout=True)
 
 
 @pytest.fixture
-def bucket(hassette_mock: AsyncMock) -> TaskBucket:
-    return TaskBucket(hassette_mock)
+def bucket(hassette_mock: AsyncMock, sync_service: SyncExecutorService) -> TaskBucket:
+    tb = TaskBucket(hassette_mock)
+    tb._sync_service = sync_service
+    return tb
 
 
 async def test_hassette_instance_visible_in_worker(hassette_mock: AsyncMock, bucket: TaskBucket) -> None:

--- a/tests/unit/task_bucket/test_run_in_thread_executor_routing.py
+++ b/tests/unit/task_bucket/test_run_in_thread_executor_routing.py
@@ -13,34 +13,25 @@ Covers:
 import asyncio
 import threading
 import time
-from collections.abc import Iterator
 from unittest.mock import AsyncMock
 
 import pytest
 
-from hassette.task_bucket.task_bucket import SYNC_WORKER_HANDLE, TaskBucket
+from hassette.core.sync_executor_service import SYNC_WORKER_HANDLE, SyncExecutorService
+from hassette.task_bucket.task_bucket import TaskBucket
 from hassette.test_utils import make_mock_hassette
 
-# Shared fixture
+
+@pytest.fixture
+def hassette_mock() -> AsyncMock:
+    return make_mock_hassette()
 
 
 @pytest.fixture
-def hassette_mock() -> Iterator[AsyncMock]:
-    """Hassette mock with a real sync executor (thread_name_prefix="hassette-sync").
-
-    The executor is joined at teardown so its worker threads don't outlive the test.
-    """
-    hassette = make_mock_hassette(live_executor=True)
-    try:
-        yield hassette
-    finally:
-        hassette.sync_executor.shutdown(join_threads_or_timeout=True)
-
-
-@pytest.fixture
-def bucket(hassette_mock) -> TaskBucket:
-    """TaskBucket wired to the mock hassette."""
-    return TaskBucket(hassette_mock)
+def bucket(hassette_mock: AsyncMock, sync_service: SyncExecutorService) -> TaskBucket:
+    tb = TaskBucket(hassette_mock)
+    tb._sync_service = sync_service
+    return tb
 
 
 # Sync user code runs on the dedicated pool

--- a/tests/unit/test_make_async_adapter_timeout.py
+++ b/tests/unit/test_make_async_adapter_timeout.py
@@ -2,16 +2,16 @@
 
 import pytest
 
+from hassette.core.sync_executor_service import SyncExecutorService
 from hassette.task_bucket.task_bucket import TaskBucket
 from hassette.test_utils.mock_hassette import make_mock_hassette
 
 
-async def test_sync_fn_timeout_error_propagates_cleanly() -> None:
+async def test_sync_fn_timeout_error_propagates_cleanly(sync_service: SyncExecutorService) -> None:
     """TimeoutError in sync handler propagates without being caught by the except Exception block."""
-    # make_mock_hassette provisions a real hassette-sync executor, so run_in_thread
-    # can submit via loop.run_in_executor(hassette.sync_executor, ...) without raising.
-    hassette = make_mock_hassette(live_executor=True)
+    hassette = make_mock_hassette()
     bucket = TaskBucket(hassette)
+    bucket._sync_service = sync_service
 
     def sync_fn() -> None:
         raise TimeoutError("timed out")

--- a/tests/unit/test_sync_executor_service_saturation.py
+++ b/tests/unit/test_sync_executor_service_saturation.py
@@ -659,8 +659,6 @@ class TestTrackSubmission:
         """After run_in_thread submits work, track_submission is called (which calls log check)."""
         svc = make_service(max_workers=1, shutdown_timeout=5.0)
         mock_hassette = svc.hassette
-        mock_hassette.sync_executor_service = svc
-        mock_hassette.sync_executor = svc.executor
 
         track_calls: list[None] = []
         original = svc.track_submission
@@ -671,8 +669,8 @@ class TestTrackSubmission:
 
         svc.track_submission = counting_track  # pyright: ignore[reportAttributeAccessIssue]
 
-        # Build a minimal TaskBucket using the mock hassette
         tb = TaskBucket(mock_hassette)
+        tb._sync_service = svc
 
         done = threading.Event()
 

--- a/tests/unit/test_sync_executor_service_wiring.py
+++ b/tests/unit/test_sync_executor_service_wiring.py
@@ -2,7 +2,7 @@
 
 Covers:
 - Executor is constructed in on_initialize (survives restart-in-place)
-- Service is registered in wire_services() and reachable via hassette.sync_executor
+- Service is registered in wire_services() and reachable via hassette.sync_executor_service
 - depends_on=[] (leaf dependency — no DB or other service required)
 - BusService, SchedulerService, AppHandler declare depends_on=[SyncExecutorService]
 - Dependency graph validation still passes after registration
@@ -164,7 +164,7 @@ class TestDependencyGraph:
         assert len(SyncExecutorService.depends_on) == 0
 
 
-# wire_services() registration and hassette.sync_executor property
+# wire_services() registration and hassette.sync_executor_service property
 
 
 @pytest.fixture(autouse=False)
@@ -208,20 +208,6 @@ class TestWireServicesRegistration:
         assert wired_hassette._sync_executor_service is not None
         assert isinstance(wired_hassette._sync_executor_service, SyncExecutorService)
 
-    @pytest.mark.anyio
-    async def test_sync_executor_property_returns_executor(self, wired_hassette: Hassette) -> None:
-        """hassette.sync_executor returns the InterruptibleThreadPoolExecutor after initialization."""
-        await wired_hassette._sync_executor_service.on_initialize()
-        executor = wired_hassette.sync_executor
-        assert isinstance(executor, InterruptibleThreadPoolExecutor)
-
-    def test_sync_executor_property_raises_before_wire_services(self) -> None:
-        """hassette.sync_executor raises RuntimeError when wire_services() hasn't been called."""
-        config = make_sync_executor_config()
-        h = Hassette(config)
-        with pytest.raises(RuntimeError, match="wire_services"):
-            _ = h.sync_executor
-
     def test_sync_executor_service_property_returns_service(self, wired_hassette: Hassette) -> None:
         """hassette.sync_executor_service returns the SyncExecutorService instance."""
         svc = wired_hassette.sync_executor_service
@@ -233,6 +219,15 @@ class TestWireServicesRegistration:
         h = Hassette(config)
         with pytest.raises(RuntimeError, match="wire_services"):
             _ = h.sync_executor_service
+
+    def test_task_bucket_sync_service_wired_after_wire_services(self, wired_hassette: Hassette) -> None:
+        """wire_services() sets _sync_service on Hassette's own TaskBucket."""
+        assert wired_hassette.task_bucket._sync_service is wired_hassette._sync_executor_service
+
+    def test_child_task_buckets_get_sync_service_from_factory(self, wired_hassette: Hassette) -> None:
+        """Children created after wire_services() get _sync_service via the TaskBucket factory."""
+        bus_svc = wired_hassette._bus_service
+        assert bus_svc.task_bucket._sync_service is wired_hassette._sync_executor_service
 
     def test_wire_services_graph_validates_without_error(self, wired_hassette: Hassette) -> None:
         """wire_services() completes without ValueError from the dependency graph validator."""

--- a/tests/unit/test_task_bucket.py
+++ b/tests/unit/test_task_bucket.py
@@ -29,9 +29,7 @@ from hassette.test_utils.helpers import async_noop
 @pytest.fixture
 def hassette_mock():
     """Minimal Hassette mock sufficient to construct a TaskBucket."""
-    hassette = make_mock_hassette()
-    yield hassette
-    hassette.sync_executor.shutdown(join_threads_or_timeout=False)
+    return make_mock_hassette()
 
 
 @pytest.fixture


### PR DESCRIPTION
### SyncExecutorService dependency injection

- `TaskBucket.run_in_thread` used to reach up through `self.hassette.sync_executor` (and separately `self.hassette.sync_executor_service`) to submit sync work — two properties, two lookups, and a `try/except RuntimeError` guard for the startup window before the service was wired. Replaced with a single `_sync_service: SyncExecutorService | None` reference injected directly on the bucket, and a new `SyncExecutorService.submit()` that owns context propagation, thread-handle tracking, and pool-saturation monitoring in one place (previously split between `TaskBucket.run_in_thread` and `SyncExecutorService.track_submission`).
- `SyncWorkerHandle` and `SYNC_WORKER_HANDLE` moved from `task_bucket.py` to `sync_executor_service.py`, co-located with the `submit()` that creates them.
- Removed the `Hassette.sync_executor` property entirely — it returned the raw `InterruptibleThreadPoolExecutor`, which is now an implementation detail fully owned by `SyncExecutorService`. `Hassette.sync_executor_service` remains as the one path callers need.
- Wiring: `SyncExecutorService` must still be the first `add_child` in `Hassette.wire_services()` so the `TaskBucket` factory can read it, but the two buckets created *before* that point (Hassette's own and the service's own) now get patched explicitly right after, instead of relying on the wiring order alone and a fallback property lookup at call time. If `run_in_thread` is ever called with no service wired, it now raises immediately with a message naming the bucket and the likely cause (startup ordering bug or a test that forgot to inject one), rather than silently skipping saturation tracking.

### Test infrastructure

- Added `make_sync_service()` and a matching `sync_service` fixture — a standalone `SyncExecutorService` with a real executor, built via `__new__` so tests don't need a full `Hassette`/`Resource` chain just to exercise `run_in_thread`. Tests now inject it via `bucket._sync_service = sync_service` instead of relying on `make_mock_hassette(live_executor=True)`.
- Removed the `live_executor` parameter and the `weakref.finalize`-tied executor from `make_mock_hassette` — the mock no longer constructs a real thread pool at all, so callers that needed live `run_in_thread` behavior get it from the new `sync_service` fixture instead. This also removes the ~9 fixtures' worth of manual `hassette.sync_executor.shutdown(...)` teardown, since the `sync_service` fixture owns its own executor's lifecycle.
- Related to #1368 (making test factories own resource cleanup) — this covers the `sync_executor`/`live_executor` half of that issue's affected-fixtures list. The `app_lifecycle`/`shutdown_all()` consolidation called out in the same issue is not part of this change.
