### PR TITLE
chore: Fix frontend audit findings

### DIFF
--- a/design/audits/2026-07-19-frontend-quality-audit/audit.md
+++ b/design/audits/2026-07-19-frontend-quality-audit/audit.md
@@ -1,0 +1,314 @@
+# Hassette Frontend Audit
+
+Date: 2026-07-19
+Scope: `frontend/`, `tests/e2e/`, frontend CI/tooling, and the live demo at 320/375/768/900/1280px in light and dark themes.
+
+Post-audit follow-up in this branch resolves H4, H5, M1, and #765; the remaining findings below preserve the original audit snapshot and roadmap context.
+
+## Anti-Patterns Verdict
+
+**Partial fail: the product does not look wholly AI-generated, but several surfaces still look like a polished generic admin UI.**
+
+The domain-specific density, evidence views, status language, graphite dark theme, and restrained motion give Hassette a real identity. The strongest view, App Detail, clearly serves an operational workflow rather than a template.
+
+The main AI/admin tells are:
+
+- Too many similarly weighted bordered, rounded containers.
+- Repetitive card stacks on mobile.
+- A pale, low-tension light theme with a generic blue-violet accent.
+- Newsreader + Geist, now a common AI-generated pairing, although the repository explicitly treats it as intentional product identity.
+- Flat page rhythm in which title, stats, search, and table often receive similar visual weight.
+
+Do not start by replacing the fonts. The higher-value facelift is to reduce boxed chrome, strengthen hierarchy, make exception-first scanning more obvious, and deliberately choose how much color the product should carry. The current “almost no color unless status/interactive” posture may be too timid; the next design pass should explore a richer but still operational palette instead of assuming restraint means grayscale.
+
+## Executive Summary
+
+- **Actionable themes:** 24
+- **Critical:** 0
+- **High:** 9
+- **Medium:** 11
+- **Low:** 4
+- **Overall:** Strong foundations, meaningful tests, and good design intent; the remaining risk is concentrated in boundary correctness, composite accessibility, live-data coherence, and mobile diagnostic presentation.
+
+### Objective Quality Baseline
+
+- 88 Vitest files, 1,372 tests, all passing.
+- 91.26% statements, 84.47% branches, 86.36% functions, 93.33% lines.
+- 159 E2E tests across 11 files; two targeted browser tests passed during this audit.
+- Strict TypeScript, ESLint, Prettier, generated REST/WS contracts, schema validation, CSS hygiene guards, breakpoint drift checks, dead-token checks, bundle limits, and E2E CI are already present.
+- Local lint, typecheck, formatting, and all seven CSS/token/breakpoint guard scripts passed.
+- No automated accessibility engine is installed.
+- 49 fixed waits/sleeps occur in E2E tests.
+- 39 of 88 unit-test files use `vi.mock` (84 mock declarations).
+- 89 open issues currently carry `area:ui`, so backlog consolidation is part of the solution.
+
+### Top Risks
+
+1. Logs ignore the selected time window and can drop distinct records at the REST/WS merge boundary.
+2. Multi-instance app status is keyed only by app key, so one instance overwrites another.
+3. The mobile drawer, command palette, and clickable log rows contain verified keyboard/ARIA defects.
+4. Key diagnostic tables crop identifiers, headers, and timestamps at supported viewports.
+5. The browser suite bypasses the production-default WS-gated path and lacks automatic accessibility, page-error, and reconnect enforcement.
+
+## High Findings
+
+### H1. Logs ignore the selected time window
+
+- **Location:** `frontend/src/components/shared/log-table/use-log-data.ts:59-63`, `frontend/src/lib/query-keys.ts:7-8`
+- **Category:** Correctness
+- **Impact:** Narrow windows show out-of-window records; wide windows omit older records. A core evidence surface silently disagrees with the global selector.
+- **Recommendation:** Thread effective `since` into the request and query key; add a test that changes the preset and verifies refetch/request parameters.
+
+### H2. Multi-instance live status loses instance identity
+
+- **Location:** `frontend/src/state/create-app-state.ts:21-28,94-103`, `frontend/src/hooks/use-websocket.ts:110-121`, `frontend/src/pages/app-detail.tsx:117-122`
+- **Category:** Correctness / state architecture
+- **Impact:** Status for one instance overwrites another, so table and detail views can display the wrong state.
+- **Recommendation:** Key live status by app key plus instance identity. Already tracked by #754.
+
+### H3. Log merge can silently drop records
+
+- **Location:** `frontend/src/components/shared/log-table/use-log-data.ts:73-87`
+- **Category:** Correctness
+- **Impact:** Distinct records sharing the newest REST timestamp are discarded, undermining trust in live logs.
+- **Recommendation:** Deduplicate by stable identity such as `seq`/row key, not timestamp. The broader dual-path problem is tracked by #1373.
+
+### H4. Negative instance indices reach the backend
+
+**Status:** resolved in this branch.
+
+- **Location:** `frontend/src/pages/app-detail.tsx:73-76,127-132`
+- **Category:** Correctness / routing
+- **Impact:** `?instance=-1` is accepted and produces invalid listener/job requests rather than canonicalizing the URL.
+- **Recommendation:** Require a non-negative integer before use and test the malformed URL path.
+
+### H5. Closed mobile drawer remains keyboard-focusable
+
+**Status:** resolved in this branch.
+
+- **Location:** `frontend/src/app.tsx:31-37,97-99`
+- **Category:** Accessibility
+- **Standard:** WCAG 2.1.1, 2.4.3, 4.1.2
+- **Impact:** Keyboard focus can enter an off-screen subtree marked `aria-hidden`.
+- **Recommendation:** Unmount after close animation or apply `inert` while closed.
+
+### H6. Command palette uses an invalid composite pattern
+
+- **Location:** `frontend/src/components/layout/command-palette.tsx:119-169,183-208`
+- **Category:** Accessibility
+- **Standard:** WCAG 4.1.2 / ARIA APG combobox-listbox pattern
+- **Impact:** `aria-activedescendant`, `listbox`, button-options, and focus sentinels conflict, producing unreliable screen-reader behavior.
+- **Recommendation:** Implement the APG combobox pattern fully or simplify to a dialog with a normal search field and button list.
+
+### H7. Clickable log rows conflict with table/link semantics
+
+- **Location:** `frontend/src/components/shared/log-table/log-table-row.tsx:32-42,56-77`
+- **Category:** Accessibility / interaction
+- **Standard:** WCAG 2.1.1, 4.1.2
+- **Impact:** A focusable `tr[role=button]` contains nested links and relies on event propagation workarounds.
+- **Recommendation:** Make the row non-interactive and add an explicit detail control, or use a list/card interaction model.
+
+### H8. Diagnostic tables are unreadable at supported viewports
+
+- **Location:** Live screenshots for global Handlers, Logs, Apps, and App Detail at 320-1280px.
+- **Category:** Responsive / information hierarchy
+- **Impact:** Headers collide, identifiers are ellipsized despite being primary keys, recent timestamps become `just ...`, and recent-activity columns crop.
+- **Recommendation:** Reapply column priority: preserve identifiers, merge or hide lower-value metrics, and use purpose-built mobile row layouts where necessary. Related issues: #900, #1009, #1249, #752.
+
+### H9. Browser gates miss important production behavior
+
+- **Location:** `tests/e2e/conftest.py:290-333`, `tests/e2e/test_websocket.py`, `frontend/src/app.test.tsx:8-60`
+- **Category:** Testing / accessibility
+- **Impact:** Most E2E tests force the `1h` preset and bypass default `since-restart` WS gating. There is no connected-reconnecting-connected browser proof, no global console/pageerror/network guard, and no axe/pa11y equivalent.
+- **Recommendation:** Add default-path, reconnect, and browser-error fixtures; add axe checks to representative pages and interactive composites. Related issues: #599 and #1118.
+
+## Medium Findings
+
+### M1. Resetting log columns can throw when storage is unavailable
+
+**Status:** resolved in this branch.
+
+- **Location:** `frontend/src/components/shared/log-table/use-column-visibility.ts:104-107`
+- **Impact:** The module tolerates storage errors elsewhere, but Reset can crash synchronously.
+- **Recommendation:** Guard `removeItem` and test restricted storage.
+
+### M2. Fetch-error states are dead ends
+
+- **Location:** `frontend/src/pages/apps.tsx:203-208`, `frontend/src/pages/handlers.tsx:81-86`, `frontend/src/pages/app-detail.tsx:142-147`
+- **Impact:** Raw messages provide no retry or diagnostic next step.
+- **Recommendation:** Standardize section-scoped retryable error states.
+
+### M3. Touch targets are inconsistently enforced
+
+- **Location:** `frontend/src/components/shared/info-popover.module.css:8-20`, log drawer controls, Apps search, traceback controls.
+- **Impact:** Several controls render at 18-30px despite `--sz-touch: 44px`.
+- **Recommendation:** Enforce responsive hit-area sizing on icon, copy, search, and disclosure controls.
+
+### M4. Every log row creates a media-query listener
+
+- **Location:** `frontend/src/components/shared/log-table/log-table-row.tsx:24-27`, `frontend/src/hooks/use-media-query.ts:19-35`
+- **Impact:** Large log tables create avoidable listener churn.
+- **Recommendation:** Resolve viewport state once in the parent and pass it down.
+
+### M5. App Detail eagerly couples every tab to telemetry
+
+- **Location:** `frontend/src/pages/app-detail.tsx:79-147`
+- **Impact:** Config/log/code tabs wait on listener/job queries and WS uptime; unrelated query failure can block the whole page.
+- **Recommendation:** Move tab-specific queries into tab boundaries and keep partial failures local.
+
+### M6. REST cache and live-signal coherence is distributed manually
+
+- **Location:** `frontend/src/state/create-app-state.ts`, `frontend/src/hooks/use-query-invalidator.ts`, `frontend/src/hooks/use-manifests.ts`, `frontend/src/components/shared/action-buttons.tsx`
+- **Impact:** Sidebar, alerts, rows, and mutation feedback can disagree until a normal refetch. #1153 is one visible symptom.
+- **Recommendation:** Define one status ownership/reconciliation policy rather than per-view overlays and eventual WS updates.
+
+### M7. Route and contract vocabularies are duplicated
+
+- **Location:** `frontend/src/app.tsx`, `frontend/src/components/layout/sidebar.tsx`, `frontend/src/components/layout/palette-items.ts`, `frontend/src/api/endpoints.ts`, `frontend/src/api/generated-types.ts`
+- **Impact:** `/design` already appears in routing but not nav/palette; hand-written route strings can drift from generated contracts.
+- **Recommendation:** Centralize route builders/page metadata and derive endpoint types/paths from generated contracts where practical.
+
+### M8. Several orchestration modules are too broad
+
+- **Location:** `frontend/src/state/create-app-state.ts:74-218`, `frontend/src/hooks/use-websocket.ts:30-196`, `frontend/src/components/shared/log-table/use-log-filters.ts:131-305`, `frontend/src/pages/app-detail.tsx:64-259`
+- **Impact:** Unrelated concerns and hidden mode switches raise change risk.
+- **Recommendation:** Split by state domain and explicit adapters, starting with WebSocket connection vs message handling (#769), not arbitrary component extraction.
+
+### M9. Aggregate coverage masks weak critical entrypoints
+
+- **Location:** `frontend/vitest.config.ts:10-21`
+- **Evidence:** `main.tsx` 0% lines, `app.tsx` 74.2% lines, `use-websocket.ts` 65.2% branches.
+- **Impact:** Global 80% thresholds stay green while startup and reconnection regressions remain possible.
+- **Recommendation:** Add targeted tests and per-file/diff expectations for critical entrypoints rather than simply raising the global percentage.
+
+### M10. E2E reliability and adversarial coverage are uneven
+
+- **Location:** `tests/e2e/`
+- **Evidence:** 49 fixed waits; session-scoped mutable backend fixtures; limited non-log API failures; no hostile payload/XSS cases.
+- **Recommendation:** Replace sleeps with state/event gates, add section-failure and hostile-payload cases, and reset mutable test state explicitly.
+
+### M11. The visual system needs a focused theme exploration and facelift
+
+- **Location:** Cross-page live matrix.
+- **Category:** Theming / hierarchy
+- **Impact:** Dark mode feels intentional; light mode and mobile read more like a generic boxed admin product. Repeated healthy green, error row tints, faint `--ink-4` operational text, and equal-weight containers flatten scan priority. The current “low color” stance may be overcorrecting; a richer palette could make the UI more memorable and easier to scan if color remains semantic and disciplined.
+- **Recommendation:** Explore color-forward operational themes alongside the muted baseline. Reduce table/list chrome, strengthen hierarchy, introduce a more distinctive accent/status/surface palette, tighten page identity groups, and make mobile exception-first.
+
+## Low Findings
+
+### L1. Tutorial-style comments and tiny wrappers add reading noise
+
+- **Location:** `frontend/src/state/create-app-state.ts`, `frontend/src/components/shared/config-schema-view.tsx`, `frontend/src/app.tsx`
+- **Recommendation:** Remove comments that restate code and single-use wrappers only when touching those areas; do not run a broad churn-only cleanup.
+
+### L2. Import, inline-style, and raw-value hygiene has residual drift
+
+- **Evidence:** Approximately 193 deep `../../` imports in component folders, eight production inline-style sites, and about 20 raw layout values outside tokens.
+- **Recommendation:** Enforce the existing `@/` alias (#1303) and clean shared primitives opportunistically.
+
+### L3. Tests are structurally brittle in places
+
+- **Evidence:** Roughly 305 `querySelector`/`closest` uses, about 180 production `data-testid` attributes, and at least seven test files over 400 lines.
+- **Recommendation:** Prefer role/name behavior assertions in new tests and address fixture/test duplication under #1282.
+
+### L4. Design references conflict
+
+- **Location:** `frontend/DESIGN_RULES.md:104-121` says tables are not cards and should have no border/shadow; `design/context.md:87,698-705` describes a contained `TableCard` pattern. `DESIGN_RULES.md:5` also points to the stale path `src/styles/tokens.css` rather than `src/tokens.css`.
+- **Impact:** Agents can follow either source and both appear authoritative, causing recurring visual drift.
+- **Recommendation:** Reconcile these documents before the facelift.
+
+## Live Visual QA
+
+| Page | Broken | Degraded | Polish |
+|---|---:|---:|---:|
+| Apps | 1 | 4 | 0 |
+| App Detail | 2 | 6 | 0 |
+| App Handlers | 0 | 2 | 1 |
+| Handlers | 2 | 3 | 0 |
+| Logs | 1 | 5 | 0 |
+| Config | 0 | 4 | 0 |
+| Diagnostics | 0 | 3 | 1 |
+
+| Persona | Verdict | Findings |
+|---|---|---:|
+| Morgan, 2am phone responder | Completed with friction | 4 |
+| Riley, first-day user | Completed with friction | 10 |
+| Devon, power-user debugger | Completed with friction | 7 |
+
+The workflows were completable. The recurring friction was not basic navigation failure; it was weak evidence connection: registration name vs callable name, hidden execution filters, no “surrounding logs” transition, no handler-level log link, ambiguous zero-activity states, and multi-instance context leakage. This aligns directly with the design context's intended “evidence trail.” Related issue: #1250.
+
+## Systemic Patterns
+
+1. **The frontend is not under-tested by volume.** Its weakness is that high aggregate coverage and broad E2E happy paths do not target the most failure-prone boundaries.
+2. **Live state has multiple owners.** Signals, query cache, URL state, local storage, and direct DOM updates are synchronized manually.
+3. **Accessibility defects cluster in custom composites.** Native controls and simple shared primitives are generally sound; drawer/palette/clickable-row patterns are not.
+4. **Visual drift comes from conflicting hierarchy rules, not missing tokens.** The token system is strong; application and source-of-truth consistency need work.
+5. **The issue backlog is already rich but fragmented.** Several audit findings map to existing issues, so another large batch of issues would increase rather than reduce uncertainty.
+
+## Positive Findings Worth Keeping
+
+- Strict TypeScript and type-aware ESLint.
+- Runtime WebSocket schema validation and generated API contracts.
+- Query defaults that avoid retrying 4xx responses.
+- Strict MSW handling of unexpected requests.
+- Co-located test organization and meaningful hook/component coverage.
+- Existing CSS/token/dead-class/breakpoint guard scripts.
+- Bundle-size enforcement in CI.
+- Token-driven light/dark theming.
+- Shared semantic variants for buttons, badges, chips, and status shapes.
+- Skip link, focus baseline, reduced-motion handling, lazy Shiki loading, and conditional command-palette fetching.
+- The App Detail concept and evidence-oriented design direction.
+
+## Priority Plan
+
+### Phase 0: Triage the backlog
+
+Create one short frontend quality milestone/epic and group existing issues into correctness, accessibility, test gates, architecture, and facelift. Close duplicates and mark superseded visual issues. Do not add 24 new issues.
+
+### Phase 1: Fix verified correctness and accessibility defects
+
+1. Log time-window propagation and identity-based merge.
+2. Multi-instance status ownership (#754).
+3. Negative instance validation and storage reset safety.
+4. Drawer inertness, command-palette semantics, and log-row interaction model.
+5. Supported-viewport identifier/timestamp/header clipping (#900, #1009, #1249).
+
+### Phase 2: Add guardrails before more AI-authored UI work
+
+1. `eslint-plugin-jsx-a11y` plus axe browser/component checks (#1118).
+2. `react-hooks/exhaustive-deps` and enforced `@/` imports (#1303).
+3. Stylelint only if configured around the existing token/module conventions (#1377); avoid duplicating custom guards.
+4. Add Testing Library/Vitest lint rules for new tests.
+5. Add global E2E `pageerror`, unexpected console error, and failed-request capture.
+6. Add default WS-gated, reconnect, deep execution route, and error-state browser tests (#599).
+
+### Phase 3: Simplify the riskiest seams
+
+1. Split WebSocket connection management from message projection (#769).
+2. Consolidate log assembly (#1373).
+3. Establish one route/page registry and typed builders.
+4. Decompose app state by domain only where it reduces cross-owner synchronization.
+5. Refactor tests toward behavior while touching each subsystem (#1282).
+
+### Phase 4: Explore and apply a more distinctive frontend theme
+
+Pilot Apps and App Detail first, capture before/after at all supported breakpoints, then propagate shared changes.
+
+1. Reconcile `DESIGN_RULES.md` and `design/context.md` first.
+2. Explore at least two color directions: a restrained graphite baseline and a richer operational palette. Do not assume “no color” is a virtue by itself.
+3. Reduce generic table/list chrome and reserve elevation for true summary/evidence blocks.
+4. Strengthen light-mode surface, border, and metadata contrast.
+5. Tighten title/metadata/tab identity groups and section hierarchy.
+6. Mute repeated healthy status only when it improves exception scanning; allow color elsewhere when it clarifies structure, ownership, or navigation.
+7. Make mobile a quick-check view rather than a stack of desktop cards.
+8. Reassess the blue-violet accent as part of the palette exploration, not as an isolated token tweak.
+
+## Recommended First Slice
+
+One bounded first PR should:
+
+1. Fix drawer focus, command-palette semantics, and log-row semantics.
+2. Add jsx-a11y plus one axe smoke test for the shell/palette.
+3. Add E2E page-error/console-error capture.
+
+This creates immediate user value and makes future AI-authored frontend changes safer. Follow it with the log correctness slice, then the visual pilot.

--- a/design/audits/2026-07-19-frontend-quality-audit/issues.md
+++ b/design/audits/2026-07-19-frontend-quality-audit/issues.md
@@ -1,0 +1,97 @@
+# Frontend Quality & Facelift Issue Map
+
+Milestone: [Frontend Quality & Facelift](https://github.com/NodeJSmith/hassette/milestone/9)
+
+This audit did not require a full new backlog. Most findings mapped to existing `area:ui` issues. The new issues below cover gaps that were either concrete bugs without a ticket or design-system coordination work that existing issues did not capture.
+
+Post-audit follow-up in this branch resolves #1378, #1379, #1385, and #765.
+
+## Newly Filed
+
+- [#1378 Reject invalid negative app instance query params](https://github.com/NodeJSmith/hassette/issues/1378) — resolved in this branch
+- [#1379 Make the closed mobile drawer inert](https://github.com/NodeJSmith/hassette/issues/1379) — resolved in this branch
+- [#1380 Correct command palette ARIA and keyboard semantics](https://github.com/NodeJSmith/hassette/issues/1380)
+- [#1382 Replace clickable log table rows with explicit detail controls](https://github.com/NodeJSmith/hassette/issues/1382)
+- [#1383 Reconcile frontend design rules before the facelift](https://github.com/NodeJSmith/hassette/issues/1383)
+- [#1384 Explore a more expressive frontend color direction](https://github.com/NodeJSmith/hassette/issues/1384)
+- [#1385 Handle storage failures when resetting log columns](https://github.com/NodeJSmith/hassette/issues/1385) — resolved in this branch
+- [#1386 Centralize frontend route metadata and path builders](https://github.com/NodeJSmith/hassette/issues/1386)
+- [#1387 Fix log time-window filtering and live-log merge](https://github.com/NodeJSmith/hassette/issues/1387)
+
+## Existing Issues Reused
+
+### Correctness And Live Data
+
+- [#754 Key appStatus WS state per instance, not just per app_key](https://github.com/NodeJSmith/hassette/issues/754)
+- [#958 Fix app page logs not updating after reload](https://github.com/NodeJSmith/hassette/issues/958)
+- [#1153 Stats strip on Apps page does not update in realtime when apps are started or stopped](https://github.com/NodeJSmith/hassette/issues/1153)
+- [#1253 Handle high-volume live logs without freezing the UI](https://github.com/NodeJSmith/hassette/issues/1253)
+- [#1373 Eliminate dual-path log assembly by switching WS log broadcast to notify-and-batch](https://github.com/NodeJSmith/hassette/issues/1373)
+
+### Accessibility And Browser Guardrails
+
+- [#599 Add E2E tests for user workflows, error states, and empty states](https://github.com/NodeJSmith/hassette/issues/599)
+- [#851 Add focus-visible styles to all interactive elements](https://github.com/NodeJSmith/hassette/issues/851)
+- [#1010 Make diagnostics ready_phase accessible on touch devices](https://github.com/NodeJSmith/hassette/issues/1010)
+- [#1118 Add automated accessibility enforcement (jsx-a11y lint + axe tests)](https://github.com/NodeJSmith/hassette/issues/1118)
+- [#1187 Add :focus-visible style to execution table rows](https://github.com/NodeJSmith/hassette/issues/1187)
+
+### Responsive And Diagnostic Evidence UX
+
+- [#384 Add resizable columns to log table](https://github.com/NodeJSmith/hassette/issues/384)
+- [#652 Add structured error summaries to error display](https://github.com/NodeJSmith/hassette/issues/652)
+- [#752 Fix over-stretched table columns on apps overview page](https://github.com/NodeJSmith/hassette/issues/752)
+- [#762 Fix mobile display of per-execution logs on app detail pages](https://github.com/NodeJSmith/hassette/issues/762)
+- [#764 Collapse app detail tabs on mobile to avoid horizontal scrollbar](https://github.com/NodeJSmith/hassette/issues/764)
+- [#765 Reorder log detail drawer to show message first](https://github.com/NodeJSmith/hassette/issues/765) — resolved in this branch
+- [#900 Hide low-priority table columns at narrow viewports](https://github.com/NodeJSmith/hassette/issues/900)
+- [#902 Collapsible metadata on detail pages](https://github.com/NodeJSmith/hassette/issues/902)
+- [#903 Mobile detail page density improvements](https://github.com/NodeJSmith/hassette/issues/903)
+- [#1009 Fix truncated relative timestamps in logs table on mobile](https://github.com/NodeJSmith/hassette/issues/1009)
+- [#1246 Restructure app detail around triage and investigation](https://github.com/NodeJSmith/hassette/issues/1246)
+- [#1249 Fix mobile overflow in diagnostic views](https://github.com/NodeJSmith/hassette/issues/1249)
+- [#1250 Connect logs to handler and execution evidence](https://github.com/NodeJSmith/hassette/issues/1250)
+
+### Tooling, Hygiene, And Architecture
+
+- [#457 Add CI guard for ws-types.ts against ws-schema.json drift](https://github.com/NodeJSmith/hassette/issues/457)
+- [#760 Add frontend state QA tooling for dev-mode scenario testing](https://github.com/NodeJSmith/hassette/issues/760)
+- [#769 Split use-websocket.ts into connection manager and message handler](https://github.com/NodeJSmith/hassette/issues/769)
+- [#821 Add list virtualization for log and handler tables](https://github.com/NodeJSmith/hassette/issues/821)
+- [#1086 Add frontend hygiene guards for section dividers and leaked spec tokens](https://github.com/NodeJSmith/hassette/issues/1086)
+- [#1282 Audit frontend test infrastructure for factory duplication and dead code](https://github.com/NodeJSmith/hassette/issues/1282)
+- [#1303 Enable exhaustive-deps and enforce @/ import alias in frontend ESLint config](https://github.com/NodeJSmith/hassette/issues/1303)
+- [#1371 Add lint rule catching native <a> tags for internal routes instead of wouter Link](https://github.com/NodeJSmith/hassette/issues/1371)
+- [#1376 Simplify HandlersTab render branching](https://github.com/NodeJSmith/hassette/issues/1376)
+- [#1377 Add stylelint to frontend lint pipeline](https://github.com/NodeJSmith/hassette/issues/1377)
+
+### Theme, Color, And Facelift
+
+- [#843 Expand status color scales to 4-5 stops each](https://github.com/NodeJSmith/hassette/issues/843)
+- [#844 Add inset shadow token for sunken regions](https://github.com/NodeJSmith/hassette/issues/844)
+- [#845 Add bottom shadow to sticky headers on scroll](https://github.com/NodeJSmith/hassette/issues/845)
+- [#846 Whitespace density tuning pass](https://github.com/NodeJSmith/hassette/issues/846)
+- [#847 Audit align-items: center for baseline alignment opportunities](https://github.com/NodeJSmith/hassette/issues/847)
+- [#848 Improve sidebar visual separation between sections](https://github.com/NodeJSmith/hassette/issues/848)
+- [#849 Ground page titles with visual weight](https://github.com/NodeJSmith/hassette/issues/849)
+- [#852 Derive dark mode surfaces from accent hue via oklch](https://github.com/NodeJSmith/hassette/issues/852)
+- [#901 Add skeleton loading states for pages](https://github.com/NodeJSmith/hassette/issues/901)
+- [#904 Evaluate removing stats strip from apps list page](https://github.com/NodeJSmith/hassette/issues/904)
+- [#1007 Fix instance count wrapping under status badge in apps table](https://github.com/NodeJSmith/hassette/issues/1007)
+- [#1148 Polish app detail overview tab and header layout](https://github.com/NodeJSmith/hassette/issues/1148)
+- [#1247 Redesign diagnostics as system health](https://github.com/NodeJSmith/hassette/issues/1247)
+- [#1251 Audit and tune badge and chip visual semantics](https://github.com/NodeJSmith/hassette/issues/1251)
+
+### Config UX
+
+- [#1149 Render or strip RST markup in config field description popovers](https://github.com/NodeJSmith/hassette/issues/1149)
+- [#1150 Add search/filter to the config pages](https://github.com/NodeJSmith/hassette/issues/1150)
+- [#1156 Add collapse/expand toggle to config section headers](https://github.com/NodeJSmith/hassette/issues/1156)
+- [#1374 Config page shows 'not set' for fields configured via env vars or .env files](https://github.com/NodeJSmith/hassette/issues/1374)
+
+## Not Filed Separately
+
+- Fetch-error dead ends are covered by #599, #901, and #652 unless a specific section failure is found during implementation.
+- Per-row media-query listener churn is covered by #1253 and #821 unless profiling proves a separate lightweight fix is warranted.
+- App Detail eager telemetry coupling is covered by #1246 unless it blocks an unrelated tab after that restructure.
+- Broader route-link hygiene is covered by #1371 plus new #1386.

--- a/frontend/src/app.test.tsx
+++ b/frontend/src/app.test.tsx
@@ -127,12 +127,20 @@ describe("App — hamburger button", () => {
     expect(drawer!.className).not.toContain("is-open");
   });
 
+  it("keeps the closed drawer inert", () => {
+    const { container } = render(<App />);
+    const drawer = container.querySelector(".ht-drawer");
+    expect(drawer).not.toBeNull();
+    expect(drawer!.hasAttribute("inert")).toBe(true);
+  });
+
   it("clicking the hamburger opens the drawer", () => {
     const { container } = render(<App />);
     const btn = container.querySelector("[data-testid='hamburger']")!;
     fireEvent.click(btn);
     const drawer = container.querySelector(".ht-drawer");
     expect(drawer!.className).toContain("is-open");
+    expect(drawer!.hasAttribute("inert")).toBe(false);
   });
 
   it("hamburger aria-expanded updates to true when drawer is open", () => {

--- a/frontend/src/app.tsx
+++ b/frontend/src/app.tsx
@@ -94,7 +94,12 @@ export function App() {
         </a>
 
         {/* Off-canvas drawer (mobile) */}
-        <div ref={drawerRef} class={`ht-drawer${drawerOpen ? " is-open" : ""}`} aria-hidden={!drawerOpen}>
+        <div
+          ref={drawerRef}
+          class={`ht-drawer${drawerOpen ? " is-open" : ""}`}
+          aria-hidden={!drawerOpen}
+          {...(!drawerOpen ? { inert: true } : {})}
+        >
           {drawerMounted && <Sidebar onOpenPalette={() => setPaletteOpen(true)} />}
         </div>
         {drawerOpen && <div class="ht-drawer-backdrop" role="presentation" onClick={() => setDrawerOpen(false)} />}

--- a/frontend/src/components/app-detail/handlers-tab.test.tsx
+++ b/frontend/src/components/app-detail/handlers-tab.test.tsx
@@ -46,7 +46,6 @@ function renderHandlersTab(
       selectedHandler={selectedHandler}
       selectedExecId={null}
       appKey="test_app"
-      instanceQs=""
     />,
     { stateOverrides: { uptimeSeconds: signal<number | null>(120) } },
   );
@@ -64,14 +63,7 @@ describe("HandlersTab", () => {
 
   it("renders empty state when no listeners or jobs", () => {
     const { getByTestId } = renderWithAppState(
-      <HandlersTab
-        listeners={[]}
-        jobs={[]}
-        selectedHandler={null}
-        selectedExecId={null}
-        appKey="test_app"
-        instanceQs=""
-      />,
+      <HandlersTab listeners={[]} jobs={[]} selectedHandler={null} selectedExecId={null} appKey="test_app" />,
       { stateOverrides: { uptimeSeconds: signal<number | null>(120) } },
     );
     expect(getByTestId("handlers-empty")).toBeDefined();
@@ -444,7 +436,7 @@ describe("HandlersTab", () => {
         selectedHandler={null}
         selectedExecId={null}
         appKey="test_app"
-        instanceQs="?instance=1"
+        instanceIndex={1}
       />,
       { stateOverrides: { uptimeSeconds: signal<number | null>(120) } },
     );
@@ -614,7 +606,6 @@ describe("HandlersTab", () => {
         selectedHandler="listener/45"
         selectedExecId={null}
         appKey="test_app"
-        instanceQs=""
         onSwitchToCode={onSwitch}
       />,
       { stateOverrides: { uptimeSeconds: signal<number | null>(120) } },
@@ -710,14 +701,7 @@ describe("HandlersTab", () => {
 
   it("renders execution detail even when no handlers are registered", () => {
     const { getByTestId, queryByTestId } = renderWithAppState(
-      <HandlersTab
-        listeners={[]}
-        jobs={[]}
-        selectedHandler="listener/5"
-        selectedExecId="abc-123"
-        appKey="test_app"
-        instanceQs=""
-      />,
+      <HandlersTab listeners={[]} jobs={[]} selectedHandler="listener/5" selectedExecId="abc-123" appKey="test_app" />,
       { stateOverrides: { uptimeSeconds: signal<number | null>(120) } },
     );
     expect(getByTestId("execution-detail-fetcher")).toBeTruthy();

--- a/frontend/src/components/app-detail/handlers-tab.tsx
+++ b/frontend/src/components/app-detail/handlers-tab.tsx
@@ -6,6 +6,7 @@ import type { JobData, ListenerData } from "../../api/endpoints";
 import { useCorrectUrl } from "../../hooks/use-correct-url";
 import { BREAKPOINT_MOBILE } from "../../hooks/use-media-query";
 import { useSignal } from "../../hooks/use-signal";
+import { appHandlerDetailPath, appHandlersPath } from "../../utils/app-routes";
 import { lastDotSegment } from "../../utils/format";
 import { Button } from "../shared/button";
 import { EmptyState } from "../shared/empty-state";
@@ -31,7 +32,7 @@ interface Props {
   selectedHandler: string | null;
   selectedExecId: string | null;
   appKey: string;
-  instanceQs: string;
+  instanceIndex?: number;
   onSwitchToCode?: (line?: number) => void;
 }
 
@@ -62,7 +63,7 @@ export function HandlersTab({
   selectedHandler,
   selectedExecId,
   appKey,
-  instanceQs,
+  instanceIndex,
   onSwitchToCode,
 }: Props) {
   const [, navigate] = useLocation();
@@ -86,6 +87,7 @@ export function HandlersTab({
   }, [isMobile]);
 
   const hasItems = listeners.length > 0 || jobs.length > 0;
+  const instanceQs = instanceIndex !== undefined ? `?instance=${instanceIndex}` : "";
 
   const parsed = parseSelectedHandler(selectedHandler);
 
@@ -102,13 +104,13 @@ export function HandlersTab({
         ? listeners.some((l) => l.listener_id === parsed.id)
         : jobs.some((j) => j.job_id === parsed.id);
     if (!found) {
-      correctUrl(`/apps/${appKey}/handlers${instanceQs}`);
+      correctUrl(appHandlersPath(appKey, { instance: instanceIndex }));
     }
-  }, [selectedHandler, parsed, selectedExecId, hasItems, listeners, jobs, appKey, instanceQs, correctUrl]);
+  }, [selectedHandler, parsed, selectedExecId, hasItems, listeners, jobs, appKey, instanceIndex, correctUrl]);
 
   const handleSelect = (id: SelectedHandlerId) => {
     const segment = id.kind === "listener" ? `listener/${id.id}` : `job/${id.id}`;
-    navigate(`/apps/${appKey}/handlers/${segment}${instanceQs}`);
+    navigate(appHandlerDetailPath(appKey, segment, { instance: instanceIndex }));
   };
 
   if (selectedExecId && parsed) {
@@ -152,7 +154,7 @@ export function HandlersTab({
           size="sm"
           class="ht-mb-3"
           data-testid="back-to-list"
-          onClick={() => navigate(`/apps/${appKey}/handlers${instanceQs}`)}
+          onClick={() => navigate(appHandlersPath(appKey, { instance: instanceIndex }))}
           aria-label="Back to handler list"
         >
           ← back

--- a/frontend/src/components/shared/log-table/log-detail-drawer.test.tsx
+++ b/frontend/src/components/shared/log-table/log-detail-drawer.test.tsx
@@ -130,6 +130,16 @@ describe("LogDetailDrawer", () => {
       expect(drawer.textContent).toContain("Traceback");
     });
 
+    it("shows message and exception before metadata", () => {
+      const entry = makeEntry({ exc_info: "Traceback (most recent call last):\nValueError: bad" });
+      const { queryByRole } = renderDrawer({ entries: [entry] });
+      const text = queryByRole("complementary")!.textContent ?? "";
+
+      expect(text.indexOf("message")).toBeLessThan(text.indexOf("exception"));
+      expect(text.indexOf("exception")).toBeLessThan(text.indexOf("App"));
+      expect(text.indexOf("test message")).toBeLessThan(text.indexOf("on_ready()"));
+    });
+
     it("does not show exception section when exc_info is null", () => {
       const { queryByRole } = renderDrawer();
       const drawer = queryByRole("complementary")!;

--- a/frontend/src/components/shared/log-table/log-detail-drawer.tsx
+++ b/frontend/src/components/shared/log-table/log-detail-drawer.tsx
@@ -164,6 +164,28 @@ export function LogDetailDrawer({ selectedKey, entries, onClose, onNavigate }: P
               <span class={styles.timestamp}>{formatTimestamp(entry.timestamp)}</span>
             </div>
 
+            <div class={styles.section}>
+              <div class={styles.sectionHeader}>
+                <span class={styles.sectionLabel}>message</span>
+                <CopyButton text={entry.message} label="Copy message" />
+              </div>
+              <pre class={styles.codeBlock} data-log-scrollable>
+                {entry.message}
+              </pre>
+            </div>
+
+            {entry.exc_info && (
+              <div class={styles.section}>
+                <div class={styles.sectionHeader}>
+                  <span class={styles.sectionLabel}>exception</span>
+                  <CopyButton text={entry.exc_info} label="Copy exception" />
+                </div>
+                <pre class={clsx(styles.codeBlock, styles.exceptionBlock)} data-log-scrollable>
+                  {entry.exc_info}
+                </pre>
+              </div>
+            )}
+
             <dl class={styles.metaGrid}>
               {entry.app_key && (
                 <>
@@ -208,28 +230,6 @@ export function LogDetailDrawer({ selectedKey, entries, onClose, onNavigate }: P
               <dt>Logger</dt>
               <dd class={styles.monoValue}>{entry.logger_name}</dd>
             </dl>
-
-            <div class={styles.section}>
-              <div class={styles.sectionHeader}>
-                <span class={styles.sectionLabel}>message</span>
-                <CopyButton text={entry.message} label="Copy message" />
-              </div>
-              <pre class={styles.codeBlock} data-log-scrollable>
-                {entry.message}
-              </pre>
-            </div>
-
-            {entry.exc_info && (
-              <div class={styles.section}>
-                <div class={styles.sectionHeader}>
-                  <span class={styles.sectionLabel}>exception</span>
-                  <CopyButton text={entry.exc_info} label="Copy exception" />
-                </div>
-                <pre class={clsx(styles.codeBlock, styles.exceptionBlock)} data-log-scrollable>
-                  {entry.exc_info}
-                </pre>
-              </div>
-            )}
           </div>
         ) : null}
       </aside>

--- a/frontend/src/components/shared/log-table/use-column-visibility.test.ts
+++ b/frontend/src/components/shared/log-table/use-column-visibility.test.ts
@@ -116,6 +116,21 @@ describe("useColumnVisibility", () => {
       expect(result.current.visibleColumns).toEqual(DEFAULT_COLUMNS_GLOBAL);
       expect(localStorage.getItem("hassette-log-columns-global")).toBeNull();
     });
+
+    it("restores defaults when localStorage removal throws", () => {
+      const removeSpy = vi.spyOn(Storage.prototype, "removeItem").mockImplementation(() => {
+        throw new Error("storage unavailable");
+      });
+      const { result } = renderHook(() => useColumnVisibility("global"));
+
+      act(() => result.current.toggle("module"));
+      expect(result.current.visibleColumns).not.toContain("module");
+
+      expect(() => act(() => result.current.reset())).not.toThrow();
+      expect(result.current.visibleColumns).toEqual(DEFAULT_COLUMNS_GLOBAL);
+
+      removeSpy.mockRestore();
+    });
   });
 
   describe("viewport-responsive hiding", () => {

--- a/frontend/src/components/shared/log-table/use-column-visibility.ts
+++ b/frontend/src/components/shared/log-table/use-column-visibility.ts
@@ -104,7 +104,11 @@ export function useColumnVisibility(context: ViewContext): UseColumnVisibilityRe
   const reset = useCallback(() => {
     const defaults = defaultColumns(context);
     userColumns.value = defaults;
-    localStorage.removeItem(storageKey(context));
+    try {
+      localStorage.removeItem(storageKey(context));
+    } catch {
+      // localStorage unavailable — degrade silently
+    }
   }, [context]);
 
   return { visibleColumns, selectedColumns: userColumns.value, viewportHidden, toggle, reset };

--- a/frontend/src/pages/app-detail.test.tsx
+++ b/frontend/src/pages/app-detail.test.tsx
@@ -491,6 +491,88 @@ describe("AppDetailPage", () => {
     });
   });
 
+  it("corrects negative instance query params before preserving them in links", async () => {
+    const manifest = createManifest({
+      instance_count: 2,
+      instances: [
+        createInstance({ index: 0, instance_name: "inst_0", status: "running" }),
+        createInstance({ index: 1, instance_name: "inst_1", status: "running" }),
+      ],
+    });
+    setupApi(manifest);
+    mockSearchString = "instance=-1";
+
+    const { findByRole } = render(<AppDetailPage params={{ key: "test_app", tab: "logs" }} />, {
+      wrapper: createWrapper(state),
+    });
+
+    await vi.waitFor(() => {
+      expect(mockCorrectUrl).toHaveBeenCalledWith("/apps/test_app/logs?instance=0");
+    });
+    expect((await findByRole("tab", { name: /overview/i })).getAttribute("href")).toBe("/apps/test_app/overview");
+  });
+
+  it.each(["0x1", "1e2"])("corrects malformed instance query param %s", async (instanceParam) => {
+    const manifest = createManifest({
+      instance_count: 2,
+      instances: [
+        createInstance({ index: 0, instance_name: "inst_0", status: "running" }),
+        createInstance({ index: 1, instance_name: "inst_1", status: "running" }),
+      ],
+    });
+    setupApi(manifest);
+    mockSearchString = `instance=${instanceParam}`;
+
+    render(<AppDetailPage params={{ key: "test_app", tab: "logs" }} />, {
+      wrapper: createWrapper(state),
+    });
+
+    await vi.waitFor(() => {
+      expect(mockCorrectUrl).toHaveBeenCalledWith("/apps/test_app/logs?instance=0");
+    });
+  });
+
+  it("preserves code line deep links when correcting invalid instance params", async () => {
+    const manifest = createManifest({
+      instance_count: 2,
+      instances: [
+        createInstance({ index: 0, instance_name: "inst_0", status: "running" }),
+        createInstance({ index: 1, instance_name: "inst_1", status: "running" }),
+      ],
+    });
+    setupApi(manifest);
+    mockSearchString = "line=42&instance=-1";
+
+    render(<AppDetailPage params={{ key: "test_app", tab: "code" }} />, {
+      wrapper: createWrapper(state),
+    });
+
+    await vi.waitFor(() => {
+      expect(mockCorrectUrl).toHaveBeenCalledWith("/apps/test_app/code?line=42&instance=0");
+    });
+  });
+
+  it("corrects negative instance query params on handlers without redirecting to parent overview", async () => {
+    const manifest = createManifest({
+      instance_count: 2,
+      instances: [
+        createInstance({ index: 0, instance_name: "inst_0", status: "running" }),
+        createInstance({ index: 1, instance_name: "inst_1", status: "running" }),
+      ],
+    });
+    setupApi(manifest);
+    mockSearchString = "instance=-1";
+
+    render(<AppDetailPage params={{ key: "test_app", tab: "handlers" }} />, {
+      wrapper: createWrapper(state),
+    });
+
+    await vi.waitFor(() => {
+      expect(mockCorrectUrl).toHaveBeenCalledWith("/apps/test_app/handlers?instance=0");
+    });
+    expect(mockCorrectUrl).not.toHaveBeenCalledWith("/apps/test_app/overview");
+  });
+
   // T03: "view in code" navigates to /apps/:key/code?line=N instead of mutating signal
   it("onSwitchToCode navigates to code tab with ?line= param", async () => {
     setupApi(createManifest());
@@ -522,6 +604,17 @@ describe("AppDetailPage", () => {
     await findByTestId("handlers-tab");
     capturedOnSwitchToCode?.(15);
     expect(mockNavigate).toHaveBeenCalledWith("/apps/test_app/code?line=15&instance=1");
+  });
+
+  it("onSwitchToCode drops invalid instance params", async () => {
+    setupApi(createManifest());
+    mockSearchString = "instance=-1";
+    const { findByTestId } = render(<AppDetailPage params={{ key: "test_app", tab: "handlers" }} />, {
+      wrapper: createWrapper(state),
+    });
+    await findByTestId("handlers-tab");
+    capturedOnSwitchToCode?.(15);
+    expect(mockNavigate).toHaveBeenCalledWith("/apps/test_app/code?line=15");
   });
 
   it("passes selectedHandler prop from params.handler to HandlersTab", async () => {

--- a/frontend/src/pages/app-detail.tsx
+++ b/frontend/src/pages/app-detail.tsx
@@ -25,6 +25,8 @@ import styles from "./app-detail.module.css";
 
 export type TabId = AppDetailTab;
 
+const DECIMAL_INSTANCE_PARAM_RE = /^\d+$/;
+
 interface Props {
   params: { key: string; tab?: TabId; handler?: string; execId?: string };
 }
@@ -32,7 +34,7 @@ interface Props {
 function parseInstanceParam(param: string | null): number | undefined {
   if (param === null) return undefined;
   const trimmed = param.trim();
-  return /^\d+$/.test(trimmed) ? Number(trimmed) : undefined;
+  return DECIMAL_INSTANCE_PARAM_RE.test(trimmed) ? Number(trimmed) : undefined;
 }
 
 function instanceCorrectionUrl(appKey: string, activeTab: TabId, lineParam: string | null): string {

--- a/frontend/src/pages/app-detail.tsx
+++ b/frontend/src/pages/app-detail.tsx
@@ -20,12 +20,26 @@ import { useQueryParams } from "../hooks/use-query-params";
 import { useScopedQuery } from "../hooks/use-scoped-query";
 import { queryKeys } from "../lib/query-keys";
 import { useAppState } from "../state/context";
+import { appDetailPath, type AppDetailTab } from "../utils/app-routes";
 import styles from "./app-detail.module.css";
 
-export type TabId = "overview" | "handlers" | "code" | "logs" | "config";
+export type TabId = AppDetailTab;
 
 interface Props {
   params: { key: string; tab?: TabId; handler?: string; execId?: string };
+}
+
+function parseInstanceParam(param: string | null): number | undefined {
+  if (param === null) return undefined;
+  const trimmed = param.trim();
+  return /^\d+$/.test(trimmed) ? Number(trimmed) : undefined;
+}
+
+function instanceCorrectionUrl(appKey: string, activeTab: TabId, lineParam: string | null): string {
+  return appDetailPath(appKey, activeTab, {
+    line: activeTab === "code" ? lineParam : null,
+    instance: 0,
+  });
 }
 
 function Tab({
@@ -33,18 +47,18 @@ function Tab({
   label,
   badge,
   appKey,
-  instanceQs,
+  instanceIndex,
   activeTab,
 }: {
   id: TabId;
   label: string;
   badge?: number;
   appKey: string;
-  instanceQs: string;
+  instanceIndex?: number;
   activeTab: TabId;
 }) {
   const isActive = activeTab === id;
-  const href = `/apps/${appKey}/${id}${instanceQs}`;
+  const href = appDetailPath(appKey, id, { instance: instanceIndex });
   return (
     <Link
       href={href}
@@ -71,8 +85,8 @@ export function AppDetailPage({ params }: Props) {
   const correctUrl = useCorrectUrl();
 
   const instanceParam = queryParams.get("instance");
-  const parsedInstance = instanceParam !== null ? parseInt(instanceParam, 10) : undefined;
-  const instanceIndex = parsedInstance !== undefined && Number.isFinite(parsedInstance) ? parsedInstance : undefined;
+  const lineParam = queryParams.get("line");
+  const instanceIndex = parseInstanceParam(instanceParam);
 
   const resolvedInstanceIndex = instanceIndex ?? 0;
 
@@ -126,16 +140,20 @@ export function AppDetailPage({ params }: Props) {
 
   useEffect(() => {
     if (initialLoading) return;
-    if (manifest && instanceIndex !== undefined && instanceIndex >= manifest.instance_count) {
-      correctUrl(`/apps/${appKey}/${activeTab}?instance=0`);
+    if (manifest && instanceParam !== null && instanceIndex === undefined) {
+      correctUrl(instanceCorrectionUrl(appKey, activeTab, lineParam));
+      return;
     }
-  }, [initialLoading, manifest, instanceIndex, appKey, activeTab, correctUrl]);
+    if (manifest && instanceIndex !== undefined && instanceIndex >= manifest.instance_count) {
+      correctUrl(instanceCorrectionUrl(appKey, activeTab, lineParam));
+    }
+  }, [initialLoading, manifest, instanceParam, instanceIndex, appKey, activeTab, lineParam, correctUrl]);
 
   useEffect(() => {
-    if (showParentOverview && activeTab === "handlers") {
-      correctUrl(`/apps/${appKey}/overview`);
+    if (showParentOverview && activeTab === "handlers" && instanceParam === null) {
+      correctUrl(appDetailPath(appKey, "overview"));
     }
-  }, [showParentOverview, activeTab, appKey, correctUrl]);
+  }, [showParentOverview, activeTab, appKey, correctUrl, instanceParam]);
 
   if (initialLoading) return <Spinner />;
 
@@ -147,8 +165,8 @@ export function AppDetailPage({ params }: Props) {
     );
   }
 
-  const instanceQs = instanceParam !== null && instanceParam !== "" ? `?instance=${instanceParam}` : "";
-  const tabProps = { appKey, instanceQs, activeTab };
+  const instanceQs = instanceIndex !== undefined ? `?instance=${instanceIndex}` : "";
+  const tabProps = { appKey, instanceIndex, activeTab };
   const handlerCount = (listenersData?.length ?? 0) + (jobsData?.length ?? 0);
 
   return (
@@ -159,7 +177,7 @@ export function AppDetailPage({ params }: Props) {
             instances={manifest.instances}
             currentIndex={resolvedInstanceIndex}
             onNavigate={(idx) => {
-              navigate(`/apps/${appKey}/${activeTab}?instance=${idx}`);
+              navigate(appDetailPath(appKey, activeTab, { instance: idx }));
             }}
           />
         )}
@@ -205,7 +223,7 @@ export function AppDetailPage({ params }: Props) {
               instances={manifest.instances ?? []}
               instanceCount={manifest.instance_count}
               onNavigate={(idx) => {
-                navigate(`/apps/${appKey}/overview?instance=${idx}`);
+                navigate(appDetailPath(appKey, "overview", { instance: idx }));
               }}
             />
           ) : (
@@ -228,13 +246,9 @@ export function AppDetailPage({ params }: Props) {
             selectedHandler={params.handler ?? null}
             selectedExecId={params.execId ?? null}
             appKey={appKey}
-            instanceQs={instanceQs}
+            instanceIndex={instanceIndex}
             onSwitchToCode={(line) => {
-              const qs = new URLSearchParams();
-              if (line !== undefined) qs.set("line", String(line));
-              if (instanceParam) qs.set("instance", instanceParam);
-              const query = qs.toString();
-              navigate(`/apps/${appKey}/code${query ? `?${query}` : ""}`);
+              navigate(appDetailPath(appKey, "code", { line, instance: instanceIndex }));
             }}
           />
         </div>

--- a/frontend/src/utils/app-routes.ts
+++ b/frontend/src/utils/app-routes.ts
@@ -1,14 +1,18 @@
 export type AppDetailTab = "overview" | "handlers" | "code" | "logs" | "config";
 
 type QueryValue = string | number | null | undefined;
-type RouteQuery = Record<string, QueryValue>;
+
+interface AppRouteQuery {
+  instance?: QueryValue;
+  line?: QueryValue;
+}
 
 function appendQuery(path: string, queryString: string): string {
   if (!queryString) return path;
   return `${path}${queryString.startsWith("?") ? queryString : `?${queryString}`}`;
 }
 
-function buildQuery(query?: RouteQuery): string {
+function buildQuery(query?: AppRouteQuery): string {
   if (!query) return "";
 
   const params = new URLSearchParams();
@@ -20,15 +24,15 @@ function buildQuery(query?: RouteQuery): string {
   return queryString ? `?${queryString}` : "";
 }
 
-export function appDetailPath(appKey: string, tab?: AppDetailTab, query?: RouteQuery): string {
+export function appDetailPath(appKey: string, tab?: AppDetailTab, query?: AppRouteQuery): string {
   const path = tab ? `/apps/${appKey}/${tab}` : `/apps/${appKey}`;
   return appendQuery(path, buildQuery(query));
 }
 
-export function appHandlersPath(appKey: string, query?: RouteQuery): string {
+export function appHandlersPath(appKey: string, query?: AppRouteQuery): string {
   return appendQuery(`/apps/${appKey}/handlers`, buildQuery(query));
 }
 
-export function appHandlerDetailPath(appKey: string, handlerSegment: string, query?: RouteQuery): string {
+export function appHandlerDetailPath(appKey: string, handlerSegment: string, query?: AppRouteQuery): string {
   return appendQuery(`/apps/${appKey}/handlers/${handlerSegment}`, buildQuery(query));
 }

--- a/frontend/src/utils/app-routes.ts
+++ b/frontend/src/utils/app-routes.ts
@@ -1,0 +1,34 @@
+export type AppDetailTab = "overview" | "handlers" | "code" | "logs" | "config";
+
+type QueryValue = string | number | null | undefined;
+type RouteQuery = Record<string, QueryValue>;
+
+function appendQuery(path: string, queryString: string): string {
+  if (!queryString) return path;
+  return `${path}${queryString.startsWith("?") ? queryString : `?${queryString}`}`;
+}
+
+function buildQuery(query?: RouteQuery): string {
+  if (!query) return "";
+
+  const params = new URLSearchParams();
+  for (const [key, value] of Object.entries(query)) {
+    if (value !== null && value !== undefined && value !== "") params.set(key, String(value));
+  }
+
+  const queryString = params.toString();
+  return queryString ? `?${queryString}` : "";
+}
+
+export function appDetailPath(appKey: string, tab?: AppDetailTab, query?: RouteQuery): string {
+  const path = tab ? `/apps/${appKey}/${tab}` : `/apps/${appKey}`;
+  return appendQuery(path, buildQuery(query));
+}
+
+export function appHandlersPath(appKey: string, query?: RouteQuery): string {
+  return appendQuery(`/apps/${appKey}/handlers`, buildQuery(query));
+}
+
+export function appHandlerDetailPath(appKey: string, handlerSegment: string, query?: RouteQuery): string {
+  return appendQuery(`/apps/${appKey}/handlers/${handlerSegment}`, buildQuery(query));
+}


### PR DESCRIPTION
### Frontend Audit
- Adds the frontend quality audit and issue map so the remaining UI work has a durable reference instead of being scattered across review notes.
- Documents which findings were resolved in this branch and which broader risks remain tracked in existing issues, including route consolidation debt in #1386 and #1388.
- Preserves the accepted residual risk that broader route/test consolidation should not block this ship.

### Route And Instance Handling
- Rejects malformed and negative `instance` query parameters before they can leak into app-detail listener, job, or log requests.
- Preserves valid deep-link context, including code line links, while canonicalizing invalid instance URLs to a safe default.
- Introduces small app-route builders for app detail and handler URLs to reduce hand-built route drift in the touched flow without attempting the broader route registry work.

### Frontend Fixes
- Keeps the closed mobile drawer inert so keyboard focus cannot enter an off-screen `aria-hidden` subtree.
- Moves log message and exception details above metadata in the log detail drawer so the primary diagnostic evidence appears first.
- Handles localStorage failures when resetting log column visibility, matching the hook's existing degraded-storage behavior.

### Tests
- Adds regression coverage for invalid instance URL correction, handler navigation with instance context, drawer inertness, log drawer ordering, and storage reset failures.
- Updates handler-tab tests to use validated instance indexes instead of passing through raw query strings.

Closes #1378
Closes #1379
Closes #1385
Closes #765
