### PR TITLE
refactor(frontend): centralize route metadata and path builders

### DIFF
--- a/frontend/src/app.tsx
+++ b/frontend/src/app.tsx
@@ -22,6 +22,7 @@ import { LogsPage } from "./pages/logs";
 import { NotFoundPage } from "./pages/not-found";
 import { AppStateContext } from "./state/context";
 import { createAppState, RELATIVE_TIME_TICK_MS } from "./state/create-app-state";
+import { HOME_PATH } from "./utils/app-routes";
 
 export function App() {
   const queryClient = useMemo(() => createQueryClient(), []);
@@ -119,7 +120,7 @@ export function App() {
               <ErrorBoundary resetKey={location}>
                 <Switch>
                   <Route path="/">
-                    <Redirect to="/apps" />
+                    <Redirect to={HOME_PATH} />
                   </Route>
                   {(["listener", "job"] as const).map((kind) => [
                     <Route key={`${kind}-exec`} path={`/apps/:key/handlers/${kind}/:id/exec/:execId`}>

--- a/frontend/src/components/app-detail/error-spotlight.tsx
+++ b/frontend/src/components/app-detail/error-spotlight.tsx
@@ -4,7 +4,7 @@ import { Link } from "wouter";
 
 import { StatusShape } from "../shared/status-shape";
 import styles from "./overview-tab.module.css";
-import { handlerPath, itemErrorMessage, itemErrorType } from "./overview-tab-helpers";
+import { handlerHref, itemErrorMessage, itemErrorType } from "./overview-tab-helpers";
 import type { UnifiedItem } from "./unified-handler-row";
 
 const SPOTLIGHT_LIMIT = 3;
@@ -18,7 +18,7 @@ interface SpotlightEntryProps {
 function SpotlightEntry({ item, appKey, instanceQs }: SpotlightEntryProps) {
   const errorType = itemErrorType(item);
   const errorMessage = itemErrorMessage(item);
-  const href = handlerPath(appKey, item, instanceQs);
+  const href = handlerHref(appKey, item, instanceQs);
 
   return (
     <div class={styles.spotlightEntry} data-testid={`overview-spotlight-entry-${item.kind}-${item.id}`}>

--- a/frontend/src/components/app-detail/execution-detail.tsx
+++ b/frontend/src/components/app-detail/execution-detail.tsx
@@ -8,6 +8,7 @@ import { getExecutionById } from "../../api/endpoints";
 import { useDocumentTitle } from "../../hooks/use-document-title";
 import { useSignal } from "../../hooks/use-signal";
 import { useSubscribe } from "../../hooks/use-subscribe";
+import { type HandlerKind, handlerPath } from "../../utils/app-routes";
 import { STATUS_DOT_SIZE } from "../../utils/constants";
 import { formatDuration, formatTimestamp, truncateId } from "../../utils/format";
 import { executionStatusKind } from "../../utils/status";
@@ -221,7 +222,7 @@ export function ExecutionDetailFetcher({
     queryKey: ["execution-detail", executionId],
     queryFn: ({ signal }) => getExecutionById(executionId, signal),
   });
-  const backHref = `/apps/${appKey}/handlers/${kind}/${handlerId}${instanceQs}`;
+  const backHref = handlerPath(appKey, kind as HandlerKind, handlerId) + instanceQs;
 
   if (isPending) return <Spinner />;
 

--- a/frontend/src/components/app-detail/handler-detail-layout.tsx
+++ b/frontend/src/components/app-detail/handler-detail-layout.tsx
@@ -1,6 +1,7 @@
 import type { ComponentChildren } from "preact";
 import { useState } from "preact/hooks";
 
+import type { HandlerKind } from "../../utils/app-routes";
 import { parseSourceLocation } from "../../utils/format";
 import { Badge } from "../shared/badge";
 import { Button } from "../shared/button";
@@ -43,7 +44,9 @@ interface Props {
   executionTableId: string;
   executionLoading: boolean;
   executionHasData: boolean;
-  execLinkPrefix?: string;
+  appKey?: string;
+  handlerKind?: HandlerKind;
+  handlerId?: number;
   instanceQs?: string;
 }
 
@@ -69,7 +72,9 @@ export function HandlerDetailLayout({
   executionTableId,
   executionLoading,
   executionHasData,
-  execLinkPrefix,
+  appKey,
+  handlerKind,
+  handlerId,
   instanceQs,
 }: Props) {
   const [registrationExpanded, setRegistrationExpanded] = useState(false);
@@ -123,7 +128,9 @@ export function HandlerDetailLayout({
               records={executionRecords}
               kind={executionKind}
               tableId={executionTableId}
-              execLinkPrefix={execLinkPrefix}
+              appKey={appKey}
+              handlerKind={handlerKind}
+              handlerId={handlerId}
               instanceQs={instanceQs}
             />
           )}

--- a/frontend/src/components/app-detail/handler-health-card.tsx
+++ b/frontend/src/components/app-detail/handler-health-card.tsx
@@ -10,7 +10,7 @@ import { StatusShape } from "../shared/status-shape";
 import { Tooltip } from "../shared/tooltip";
 import styles from "./handler-health-card.module.css";
 import {
-  handlerPath,
+  handlerHref,
   isFailing,
   itemErrorMessage,
   itemErrorType,
@@ -29,7 +29,7 @@ interface HandlerHealthCardProps {
 
 export function HandlerHealthCard({ item, appKey, instanceQs, tabIndex }: HandlerHealthCardProps) {
   const [, navigate] = useLocation();
-  const href = handlerPath(appKey, item, instanceQs);
+  const href = handlerHref(appKey, item, instanceQs);
   const failing = isFailing(item);
   const chipLabel = itemKindChip(item);
   const errorType = failing ? itemErrorType(item) : null;

--- a/frontend/src/components/app-detail/handlers-tab.tsx
+++ b/frontend/src/components/app-detail/handlers-tab.tsx
@@ -6,7 +6,7 @@ import type { JobData, ListenerData } from "../../api/endpoints";
 import { useCorrectUrl } from "../../hooks/use-correct-url";
 import { BREAKPOINT_MOBILE } from "../../hooks/use-media-query";
 import { useSignal } from "../../hooks/use-signal";
-import { appHandlerDetailPath, appHandlersPath } from "../../utils/app-routes";
+import { appHandlersPath, handlerPath } from "../../utils/app-routes";
 import { lastDotSegment } from "../../utils/format";
 import { Button } from "../shared/button";
 import { EmptyState } from "../shared/empty-state";
@@ -109,8 +109,7 @@ export function HandlersTab({
   }, [selectedHandler, parsed, selectedExecId, hasItems, listeners, jobs, appKey, instanceIndex, correctUrl]);
 
   const handleSelect = (id: SelectedHandlerId) => {
-    const segment = id.kind === "listener" ? `listener/${id.id}` : `job/${id.id}`;
-    navigate(appHandlerDetailPath(appKey, segment, { instance: instanceIndex }));
+    navigate(handlerPath(appKey, id.kind, id.id, { instance: instanceIndex }));
   };
 
   if (selectedExecId && parsed) {

--- a/frontend/src/components/app-detail/job-detail.tsx
+++ b/frontend/src/components/app-detail/job-detail.tsx
@@ -164,7 +164,9 @@ export function JobDetail({ job, appKey, instanceQs, onSwitchToCode }: Props) {
       executionTableId={`execution-table-${job.job_id}`}
       executionLoading={loading}
       executionHasData={executions !== undefined}
-      execLinkPrefix={`/apps/${appKey}/handlers/job/${job.job_id}`}
+      appKey={appKey}
+      handlerKind="job"
+      handlerId={job.job_id}
       instanceQs={instanceQs}
     />
   );

--- a/frontend/src/components/app-detail/listener-detail.tsx
+++ b/frontend/src/components/app-detail/listener-detail.tsx
@@ -121,7 +121,9 @@ export function ListenerDetail({ listener, appKey, instanceQs, onSwitchToCode }:
       executionTableId={`invocation-table-${listener.listener_id}`}
       executionLoading={loading}
       executionHasData={executions !== undefined}
-      execLinkPrefix={`/apps/${appKey}/handlers/listener/${listener.listener_id}`}
+      appKey={appKey}
+      handlerKind="listener"
+      handlerId={listener.listener_id}
       instanceQs={instanceQs}
     />
   );

--- a/frontend/src/components/app-detail/overview-tab-helpers.ts
+++ b/frontend/src/components/app-detail/overview-tab-helpers.ts
@@ -1,9 +1,15 @@
+import { type HandlerKind, handlerPath } from "../../utils/app-routes";
 import { handlerKindLabel } from "../../utils/status";
 import type { UnifiedItem } from "./unified-handler-row";
 
-export function handlerPath(appKey: string, item: UnifiedItem, instanceQs: string): string {
-  const segment = item.kind === "listener" ? `listener/${item.id}` : `job/${item.id}`;
-  return `/apps/${appKey}/handlers/${segment}${instanceQs}`;
+export function handlerHref(appKey: string, item: UnifiedItem, instanceQs: string): string {
+  const kind: HandlerKind = item.kind === "listener" ? "listener" : "job";
+  return handlerPath(
+    appKey,
+    kind,
+    item.id,
+    instanceQs ? { instance: new URLSearchParams(instanceQs).get("instance") } : undefined,
+  );
 }
 
 export function isFailing(item: UnifiedItem): boolean {

--- a/frontend/src/components/layout/palette-items.ts
+++ b/frontend/src/components/layout/palette-items.ts
@@ -1,5 +1,6 @@
 import type { AppManifest, ListenerData } from "../../api/endpoints";
 import { reloadApp, stopApp } from "../../api/endpoints";
+import { appDetailPath, handlerPath, NAV_PAGES } from "../../utils/app-routes";
 
 const DOCS_URL = "https://hassette.readthedocs.io";
 
@@ -25,43 +26,13 @@ export interface PaletteItem {
 }
 
 export function buildStaticPageItems(navigate: (path: string) => void): PaletteItem[] {
-  return [
-    {
-      id: "page-apps",
-      kind: "page",
-      label: "apps",
-      sub: "/apps",
-      action: () => navigate("/apps"),
-    },
-    {
-      id: "page-handlers",
-      kind: "page",
-      label: "handlers",
-      sub: "/handlers",
-      action: () => navigate("/handlers"),
-    },
-    {
-      id: "page-logs",
-      kind: "page",
-      label: "logs",
-      sub: "/logs",
-      action: () => navigate("/logs"),
-    },
-    {
-      id: "page-config",
-      kind: "page",
-      label: "config",
-      sub: "/config",
-      action: () => navigate("/config"),
-    },
-    {
-      id: "page-diagnostics",
-      kind: "page",
-      label: "diagnostics",
-      sub: "/diagnostics",
-      action: () => navigate("/diagnostics"),
-    },
-  ];
+  return NAV_PAGES.map((page) => ({
+    id: `page-${page.label}`,
+    kind: "page" as const,
+    label: page.label,
+    sub: page.path,
+    action: () => navigate(page.path),
+  }));
 }
 
 export function buildActionItems(manifests: AppManifest[], onClose: () => void): PaletteItem[] {
@@ -113,7 +84,7 @@ export function buildAppItems(
       sub: m.app_key,
       status: m.status,
       action: () => {
-        navigate(`/apps/${m.app_key}`);
+        navigate(appDetailPath(m.app_key));
         onClose();
       },
     });
@@ -126,7 +97,7 @@ export function buildAppItems(
           sub: `${m.app_key} · #${inst.index}`,
           status: inst.status,
           action: () => {
-            navigate(`/apps/${m.app_key}?instance=${inst.index}`);
+            navigate(appDetailPath(m.app_key, undefined, { instance: inst.index }));
             onClose();
           },
         });
@@ -147,7 +118,7 @@ export function buildHandlerItems(
     label: l.handler_method,
     sub: `${l.app_key} · ${l.topic}`,
     action: () => {
-      navigate(`/apps/${l.app_key}/handlers/listener/${l.listener_id}`);
+      navigate(handlerPath(l.app_key, "listener", l.listener_id));
       onClose();
     },
   }));

--- a/frontend/src/components/layout/sidebar.tsx
+++ b/frontend/src/components/layout/sidebar.tsx
@@ -5,6 +5,7 @@ import { Link, useLocation, useSearch } from "wouter";
 import type { components } from "../../api/generated-types";
 import { useManifests } from "../../hooks/use-manifests";
 import { useAppState } from "../../state/context";
+import { appDetailPath, HOME_PATH, NAV_PAGES } from "../../utils/app-routes";
 import { statusToKind } from "../../utils/status";
 import { Chip } from "../shared/chip";
 import { Spinner } from "../shared/spinner";
@@ -27,14 +28,6 @@ function SidebarChevron({ open, class: className }: { open: boolean; class?: str
 const IS_MAC = /Mac|iPhone|iPad/.test(navigator.userAgent);
 const SHORTCUT_HINT = IS_MAC ? "⌘K" : "Ctrl+K";
 
-const NAV_ITEMS = [
-  { path: "/apps", label: "apps", testId: "nav-apps" },
-  { path: "/handlers", label: "handlers", testId: "nav-handlers" },
-  { path: "/logs", label: "logs", testId: "nav-logs" },
-  { path: "/config", label: "config", testId: "nav-config" },
-  { path: "/diagnostics", label: "diagnostics", testId: "nav-diagnostics" },
-] as const;
-
 interface AppEntryProps {
   manifest: AppManifest;
   location: string;
@@ -49,7 +42,7 @@ function AppEntry({ manifest, location, searchString }: AppEntryProps) {
   const isBlocked = displayStatus === "blocked";
 
   // Active when on any sub-path of this app
-  const appPath = `/apps/${manifest.app_key}`;
+  const appPath = appDetailPath(manifest.app_key);
   const isActive = location.startsWith(appPath);
 
   return (
@@ -84,7 +77,7 @@ function AppEntry({ manifest, location, searchString }: AppEntryProps) {
       {isMulti && expanded && (
         <ul class={styles.instanceList} data-testid="instance-list">
           {(manifest.instances ?? []).map((inst) => {
-            const instHref = `/apps/${manifest.app_key}?instance=${inst.index}`;
+            const instHref = appDetailPath(manifest.app_key, undefined, { instance: inst.index });
             const pathMatches = location === appPath || location.startsWith(appPath + "/");
             const instanceParam = new URLSearchParams(searchString).get("instance");
             const instActive = pathMatches && instanceParam === String(inst.index);
@@ -183,7 +176,7 @@ export function Sidebar({ onOpenPalette }: SidebarProps = {}) {
   return (
     <aside class={styles.sidebar} data-testid="sidebar">
       <div class={styles.sidebarBrand}>
-        <Link href="/apps" class={styles.brandLink} aria-label="Hassette home">
+        <Link href={HOME_PATH} class={styles.brandLink} aria-label="Hassette home">
           <span class={styles.wordmark}>hassette</span>
         </Link>
         {version !== null && (
@@ -206,7 +199,7 @@ export function Sidebar({ onOpenPalette }: SidebarProps = {}) {
 
       <nav aria-label="Main navigation">
         <ul class={styles.navList}>
-          {NAV_ITEMS.map((item) => {
+          {NAV_PAGES.map((item) => {
             const isActive = location.startsWith(item.path);
             return (
               <li key={item.path}>

--- a/frontend/src/components/shared/app-link.test.tsx
+++ b/frontend/src/components/shared/app-link.test.tsx
@@ -50,20 +50,20 @@ describe("AppLink — instanceIndex as query param", () => {
   });
 });
 
-describe("AppLink — handlerId prop", () => {
-  it("appends /handlers/:handlerId to the path when handlerId is set", () => {
-    const { container } = render(<AppLink appKey="my_app" handlerId="listener/42" />);
+describe("AppLink — handler props", () => {
+  it("builds handler path when handlerKind and handlerId are set", () => {
+    const { container } = render(<AppLink appKey="my_app" handlerKind="listener" handlerId={42} />);
     const href = container.querySelector("a")?.getAttribute("href");
     expect(href).toBe("/apps/my_app/handlers/listener/42");
   });
 
-  it("combines handlerId path and instance query param", () => {
-    const { container } = render(<AppLink appKey="my_app" handlerId="listener/42" instanceIndex={1} />);
+  it("combines handler path and instance query param", () => {
+    const { container } = render(<AppLink appKey="my_app" handlerKind="listener" handlerId={42} instanceIndex={1} />);
     const href = container.querySelector("a")?.getAttribute("href");
     expect(href).toBe("/apps/my_app/handlers/listener/42?instance=1");
   });
 
-  it("does not append handlers segment when handlerId is undefined", () => {
+  it("does not append handlers segment when handler props are undefined", () => {
     const { container } = render(<AppLink appKey="my_app" />);
     const href = container.querySelector("a")?.getAttribute("href");
     expect(href).not.toContain("handlers");

--- a/frontend/src/components/shared/app-link.tsx
+++ b/frontend/src/components/shared/app-link.tsx
@@ -1,23 +1,22 @@
 import { Link } from "wouter";
 
+import { appDetailPath, type HandlerKind, handlerPath } from "../../utils/app-routes";
 import styles from "./app-link.module.css";
 
 interface Props {
   appKey: string;
   instanceIndex?: number;
-  handlerId?: string;
+  handlerKind?: HandlerKind;
+  handlerId?: number;
   children?: preact.ComponentChildren;
 }
 
-export function AppLink({ appKey, instanceIndex, handlerId, children }: Props) {
-  let path = `/apps/${appKey}`;
-  if (handlerId !== undefined) path += `/handlers/${handlerId}`;
-
-  const params = new URLSearchParams();
-  if (instanceIndex !== undefined) params.set("instance", String(instanceIndex));
-
-  const search = params.toString();
-  const href = search ? `${path}?${search}` : path;
+export function AppLink({ appKey, instanceIndex, handlerKind, handlerId, children }: Props) {
+  const query = instanceIndex !== undefined ? { instance: instanceIndex } : undefined;
+  const href =
+    handlerKind !== undefined && handlerId !== undefined
+      ? handlerPath(appKey, handlerKind, handlerId, query)
+      : appDetailPath(appKey, undefined, query);
 
   return (
     <Link href={href} class={styles.link}>

--- a/frontend/src/components/shared/execution-table.test.tsx
+++ b/frontend/src/components/shared/execution-table.test.tsx
@@ -142,7 +142,7 @@ describe("ExecutionTable", () => {
     expect(queryByRole("button", { name: /show all/i })).toBeNull();
   });
 
-  it("clicking row navigates to execution detail page when execLinkPrefix is set", () => {
+  it("clicking row navigates to execution detail page when handler props are set", () => {
     mockNavigate.mockClear();
     const execId = "abc12345-6789-abcd-ef01-234567890abc";
     const { container } = render(
@@ -150,14 +150,16 @@ describe("ExecutionTable", () => {
         records={[createExecution("job", { execution_id: execId })]}
         kind="job"
         tableId="t"
-        execLinkPrefix="/apps/my_app/handlers/job/1"
+        appKey="my_app"
+        handlerKind="job"
+        handlerId={1}
       />,
     );
     fireEvent.click(container.querySelector("[data-testid='execution-row']")!);
     expect(mockNavigate).toHaveBeenCalledWith(`/apps/my_app/handlers/job/1/exec/${execId}`);
   });
 
-  it("clicking row does not navigate when execLinkPrefix is not set", () => {
+  it("clicking row does not navigate when handler props are not set", () => {
     mockNavigate.mockClear();
     const { container } = render(
       <ExecutionTable records={[createExecution("job", { execution_id: "some-id" })]} kind="job" tableId="t" />,

--- a/frontend/src/components/shared/execution-table.tsx
+++ b/frontend/src/components/shared/execution-table.tsx
@@ -3,6 +3,7 @@ import { useLocation } from "wouter";
 
 import { useRovingTabIndex } from "../../hooks/use-roving-tab-index";
 import { useSignal } from "../../hooks/use-signal";
+import { executionPath, type HandlerKind } from "../../utils/app-routes";
 import { STATUS_DOT_SIZE } from "../../utils/constants";
 import { formatDuration, formatRelativeTime, formatTimestamp, truncateId } from "../../utils/format";
 import { onActivateKeyDown } from "../../utils/keyboard";
@@ -41,11 +42,21 @@ interface ExecutionTableProps {
   records: ExecutionRecord[];
   kind: "handler" | "job";
   tableId: string;
-  execLinkPrefix?: string;
+  appKey?: string;
+  handlerKind?: HandlerKind;
+  handlerId?: number;
   instanceQs?: string;
 }
 
-export function ExecutionTable({ records, kind, tableId, execLinkPrefix, instanceQs }: ExecutionTableProps) {
+export function ExecutionTable({
+  records,
+  kind,
+  tableId,
+  appKey,
+  handlerKind,
+  handlerId,
+  instanceQs,
+}: ExecutionTableProps) {
   const showAll = useSignal(false);
   const visible = showAll.value ? records : records.slice(0, INITIAL_ROWS);
   const { containerRef, onContainerKeyDown, getTabIndex, setActiveIndex } = useRovingTabIndex<HTMLTableSectionElement>(
@@ -94,10 +105,10 @@ export function ExecutionTable({ records, kind, tableId, execLinkPrefix, instanc
             const rowKey = record.execution_id ?? `${kind}-${i}`;
             const statusKind = executionStatusKind(record.status);
             const isThreadLeaked = record.thread_leaked;
-            const canNavigate = execLinkPrefix && record.execution_id;
+            const canNavigate = appKey && handlerKind && handlerId !== undefined && record.execution_id;
             const goToDetail = () => {
               if (canNavigate) {
-                navigate(`${execLinkPrefix}/exec/${record.execution_id}${instanceQs ?? ""}`);
+                navigate(executionPath(appKey, handlerKind, handlerId, record.execution_id!) + (instanceQs ?? ""));
               }
             };
 

--- a/frontend/src/components/shared/log-table/log-detail-drawer.tsx
+++ b/frontend/src/components/shared/log-table/log-detail-drawer.tsx
@@ -6,7 +6,8 @@ import type { LogEntry } from "@/api/endpoints";
 import { BREAKPOINT_MOBILE, BREAKPOINT_TABLET, useMediaQuery } from "@/hooks/use-media-query";
 import { useSignal } from "@/hooks/use-signal";
 import { useSubscribe } from "@/hooks/use-subscribe";
-import { formatTimestamp, logEntryExecutionHref } from "@/utils/format";
+import { appDetailPath, logEntryExecutionHref } from "@/utils/app-routes";
+import { formatTimestamp } from "@/utils/format";
 
 import { COPY_CONFIRM_MS, levelClass } from "./constants";
 import styles from "./log-detail-drawer.module.css";
@@ -192,7 +193,7 @@ export function LogDetailDrawer({ selectedKey, entries, onClose, onNavigate }: P
                 <>
                   <dt>App</dt>
                   <dd>
-                    <Link href={`/apps/${entry.app_key}`} class={styles.appLink}>
+                    <Link href={appDetailPath(entry.app_key)} class={styles.appLink}>
                       {entry.app_key} ↗
                     </Link>
                   </dd>

--- a/frontend/src/components/shared/log-table/log-table-row.tsx
+++ b/frontend/src/components/shared/log-table/log-table-row.tsx
@@ -5,7 +5,8 @@ import { Link } from "wouter";
 import type { LogEntry } from "@/api/endpoints";
 import { BREAKPOINT_MOBILE, useMediaQuery } from "@/hooks/use-media-query";
 import { useRelativeTime } from "@/hooks/use-relative-time";
-import { formatTimestamp, logEntryExecutionHref, truncateId } from "@/utils/format";
+import { logEntryExecutionHref } from "@/utils/app-routes";
+import { formatTimestamp, truncateId } from "@/utils/format";
 import { onActivateKeyDown } from "@/utils/keyboard";
 
 import { AppLink } from "../app-link";

--- a/frontend/src/pages/handlers-rows.test.tsx
+++ b/frontend/src/pages/handlers-rows.test.tsx
@@ -17,6 +17,7 @@ function createRow(overrides: Partial<UnifiedRow> = {}): UnifiedRow {
   return {
     kind: "listener",
     id: "listener/1",
+    handlerId: 1,
     app_key: "my_app",
     name: "on_light_change",
     handler_method: "my_app.MyApp.on_light_change",

--- a/frontend/src/pages/handlers-rows.tsx
+++ b/frontend/src/pages/handlers-rows.tsx
@@ -4,6 +4,7 @@ import { Link } from "wouter";
 import { AppLink } from "../components/shared/app-link";
 import { Chip } from "../components/shared/chip";
 import { useRelativeTime } from "../hooks/use-relative-time";
+import { handlerPath } from "../utils/app-routes";
 import { formatDurationOrDash, formatRate, MS_PER_SECOND } from "../utils/format";
 import type { UnifiedRow } from "../utils/handler-rows";
 import styles from "./handlers.module.css";
@@ -71,7 +72,7 @@ export function HandlerTableRow({ row }: HandlerRowProps) {
         <AppLink appKey={row.app_key} />
       </td>
       <td class="ht-text-mono ht-text-sm" title={row.handler_method}>
-        <AppLink appKey={row.app_key} handlerId={row.id}>
+        <AppLink appKey={row.app_key} handlerKind={row.kind} handlerId={row.handlerId}>
           {row.name}
         </AppLink>
       </td>
@@ -92,7 +93,7 @@ export function HandlerMobileRow({ row }: HandlerRowProps) {
 
   return (
     <MobileCard
-      href={`/apps/${row.app_key}/handlers/${row.id}`}
+      href={handlerPath(row.app_key, row.kind, row.handlerId)}
       appKey={row.app_key}
       name={row.name}
       failing={row.failed > 0}

--- a/frontend/src/pages/not-found.tsx
+++ b/frontend/src/pages/not-found.tsx
@@ -1,6 +1,7 @@
 import { Link } from "wouter";
 
 import { useDocumentTitle } from "../hooks/use-document-title";
+import { HOME_PATH } from "../utils/app-routes";
 import styles from "./not-found.module.css";
 
 export function NotFoundPage() {
@@ -9,7 +10,7 @@ export function NotFoundPage() {
     <div class={`ht-page ${styles.page}`} data-testid="not-found-page">
       <h1>404</h1>
       <p class="ht-text-secondary">Page not found.</p>
-      <Link href="/apps" class={styles.backLink}>
+      <Link href={HOME_PATH} class={styles.backLink}>
         back to apps
       </Link>
     </div>

--- a/frontend/src/utils/app-routes.test.ts
+++ b/frontend/src/utils/app-routes.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from "vitest";
+
+import { appDetailPath, executionPath, handlerPath, HOME_PATH, logEntryExecutionHref, NAV_PAGES } from "./app-routes";
+
+describe("NAV_PAGES", () => {
+  it("contains expected top-level pages", () => {
+    const labels = NAV_PAGES.map((p) => p.label);
+    expect(labels).toEqual(["apps", "handlers", "logs", "config", "diagnostics"]);
+  });
+
+  it("does not include internal pages", () => {
+    const paths = NAV_PAGES.map((p) => p.path);
+    expect(paths).not.toContain("/design");
+  });
+});
+
+describe("HOME_PATH", () => {
+  it("points to apps", () => {
+    expect(HOME_PATH).toBe("/apps");
+  });
+});
+
+describe("appDetailPath", () => {
+  it("builds app root path", () => {
+    expect(appDetailPath("my_app")).toBe("/apps/my_app");
+  });
+
+  it("builds app tab path", () => {
+    expect(appDetailPath("my_app", "handlers")).toBe("/apps/my_app/handlers");
+  });
+
+  it("appends query params", () => {
+    expect(appDetailPath("my_app", undefined, { instance: 2 })).toBe("/apps/my_app?instance=2");
+  });
+
+  it("omits null/undefined query values", () => {
+    expect(appDetailPath("my_app", "logs", { instance: null })).toBe("/apps/my_app/logs");
+  });
+});
+
+describe("handlerPath", () => {
+  it("builds listener path", () => {
+    expect(handlerPath("my_app", "listener", 5)).toBe("/apps/my_app/handlers/listener/5");
+  });
+
+  it("builds job path", () => {
+    expect(handlerPath("my_app", "job", 3)).toBe("/apps/my_app/handlers/job/3");
+  });
+
+  it("appends query params", () => {
+    expect(handlerPath("my_app", "listener", 5, { instance: 1 })).toBe("/apps/my_app/handlers/listener/5?instance=1");
+  });
+});
+
+describe("executionPath", () => {
+  it("builds execution path", () => {
+    expect(executionPath("my_app", "listener", 5, "exec-1")).toBe("/apps/my_app/handlers/listener/5/exec/exec-1");
+  });
+
+  it("appends instance query", () => {
+    expect(executionPath("my_app", "job", 3, "exec-2", { instance: 2 })).toBe(
+      "/apps/my_app/handlers/job/3/exec/exec-2?instance=2",
+    );
+  });
+});
+
+describe("logEntryExecutionHref", () => {
+  const base = { app_key: "my_app", execution_id: "exec-1", instance_index: null };
+
+  it("returns href for handler kind with listener_id", () => {
+    expect(logEntryExecutionHref({ ...base, execution_kind: "handler", listener_id: 5, job_id: null })).toBe(
+      "/apps/my_app/handlers/listener/5/exec/exec-1",
+    );
+  });
+
+  it("returns href for job kind with job_id", () => {
+    expect(logEntryExecutionHref({ ...base, execution_kind: "job", listener_id: null, job_id: 3 })).toBe(
+      "/apps/my_app/handlers/job/3/exec/exec-1",
+    );
+  });
+
+  it("returns null for handler kind with null listener_id", () => {
+    expect(logEntryExecutionHref({ ...base, execution_kind: "handler", listener_id: null, job_id: 3 })).toBeNull();
+  });
+
+  it("returns null for job kind with null job_id", () => {
+    expect(logEntryExecutionHref({ ...base, execution_kind: "job", listener_id: 5, job_id: null })).toBeNull();
+  });
+
+  it("returns null when execution_kind is null", () => {
+    expect(logEntryExecutionHref({ ...base, execution_kind: null, listener_id: 5, job_id: 3 })).toBeNull();
+  });
+
+  it("returns null when execution_kind is undefined", () => {
+    expect(logEntryExecutionHref({ ...base, listener_id: 5, job_id: 3 })).toBeNull();
+  });
+
+  it("appends instance query param when present", () => {
+    expect(
+      logEntryExecutionHref({ ...base, execution_kind: "handler", listener_id: 5, job_id: null, instance_index: 2 }),
+    ).toBe("/apps/my_app/handlers/listener/5/exec/exec-1?instance=2");
+  });
+});

--- a/frontend/src/utils/app-routes.ts
+++ b/frontend/src/utils/app-routes.ts
@@ -2,17 +2,12 @@ export type AppDetailTab = "overview" | "handlers" | "code" | "logs" | "config";
 
 type QueryValue = string | number | null | undefined;
 
-interface AppRouteQuery {
+interface RouteQuery {
   instance?: QueryValue;
   line?: QueryValue;
 }
 
-function appendQuery(path: string, queryString: string): string {
-  if (!queryString) return path;
-  return `${path}${queryString.startsWith("?") ? queryString : `?${queryString}`}`;
-}
-
-function buildQuery(query?: AppRouteQuery): string {
+function buildQuery(query?: RouteQuery): string {
   if (!query) return "";
 
   const params = new URLSearchParams();
@@ -24,15 +19,82 @@ function buildQuery(query?: AppRouteQuery): string {
   return queryString ? `?${queryString}` : "";
 }
 
-export function appDetailPath(appKey: string, tab?: AppDetailTab, query?: AppRouteQuery): string {
+// ---------------------------------------------------------------------------
+// Top-level page metadata
+// ---------------------------------------------------------------------------
+
+export interface NavPage {
+  path: string;
+  label: string;
+  testId: string;
+}
+
+export const NAV_PAGES: readonly NavPage[] = [
+  { path: "/apps", label: "apps", testId: "nav-apps" },
+  { path: "/handlers", label: "handlers", testId: "nav-handlers" },
+  { path: "/logs", label: "logs", testId: "nav-logs" },
+  { path: "/config", label: "config", testId: "nav-config" },
+  { path: "/diagnostics", label: "diagnostics", testId: "nav-diagnostics" },
+];
+
+export const HOME_PATH = "/apps";
+
+// ---------------------------------------------------------------------------
+// App-level paths
+// ---------------------------------------------------------------------------
+
+export function appDetailPath(appKey: string, tab?: AppDetailTab, query?: RouteQuery): string {
   const path = tab ? `/apps/${appKey}/${tab}` : `/apps/${appKey}`;
-  return appendQuery(path, buildQuery(query));
+  return path + buildQuery(query);
 }
 
-export function appHandlersPath(appKey: string, query?: AppRouteQuery): string {
-  return appendQuery(`/apps/${appKey}/handlers`, buildQuery(query));
+export function appHandlersPath(appKey: string, query?: RouteQuery): string {
+  return `/apps/${appKey}/handlers` + buildQuery(query);
 }
 
-export function appHandlerDetailPath(appKey: string, handlerSegment: string, query?: AppRouteQuery): string {
-  return appendQuery(`/apps/${appKey}/handlers/${handlerSegment}`, buildQuery(query));
+// ---------------------------------------------------------------------------
+// Handler-level paths
+// ---------------------------------------------------------------------------
+
+export type HandlerKind = "listener" | "job";
+
+export function handlerPath(appKey: string, kind: HandlerKind, handlerId: number | string, query?: RouteQuery): string {
+  return `/apps/${appKey}/handlers/${kind}/${handlerId}` + buildQuery(query);
+}
+
+// ---------------------------------------------------------------------------
+// Execution-level paths
+// ---------------------------------------------------------------------------
+
+export function executionPath(
+  appKey: string,
+  kind: HandlerKind,
+  handlerId: number | string,
+  executionId: string,
+  query?: RouteQuery,
+): string {
+  return `/apps/${appKey}/handlers/${kind}/${handlerId}/exec/${executionId}` + buildQuery(query);
+}
+
+// execution_kind uses "handler"/"job", but URL segments use the DB entity name "listener"/"job".
+export function logEntryExecutionHref(entry: {
+  app_key?: string | null;
+  execution_kind?: string | null;
+  listener_id?: number | null;
+  job_id?: number | null;
+  execution_id?: string | null;
+  instance_index?: number | null;
+}): string | null {
+  if (!entry.app_key || !entry.execution_id || !entry.execution_kind) return null;
+  if (entry.execution_kind === "handler" && entry.listener_id !== null && entry.listener_id !== undefined) {
+    return executionPath(entry.app_key, "listener", entry.listener_id, entry.execution_id, {
+      instance: entry.instance_index,
+    });
+  }
+  if (entry.execution_kind === "job" && entry.job_id !== null && entry.job_id !== undefined) {
+    return executionPath(entry.app_key, "job", entry.job_id, entry.execution_id, {
+      instance: entry.instance_index,
+    });
+  }
+  return null;
 }

--- a/frontend/src/utils/app-routes.ts
+++ b/frontend/src/utils/app-routes.ts
@@ -19,10 +19,6 @@ function buildQuery(query?: RouteQuery): string {
   return queryString ? `?${queryString}` : "";
 }
 
-// ---------------------------------------------------------------------------
-// Top-level page metadata
-// ---------------------------------------------------------------------------
-
 export interface NavPage {
   path: string;
   label: string;
@@ -39,10 +35,6 @@ export const NAV_PAGES: readonly NavPage[] = [
 
 export const HOME_PATH = "/apps";
 
-// ---------------------------------------------------------------------------
-// App-level paths
-// ---------------------------------------------------------------------------
-
 export function appDetailPath(appKey: string, tab?: AppDetailTab, query?: RouteQuery): string {
   const path = tab ? `/apps/${appKey}/${tab}` : `/apps/${appKey}`;
   return path + buildQuery(query);
@@ -52,19 +44,11 @@ export function appHandlersPath(appKey: string, query?: RouteQuery): string {
   return `/apps/${appKey}/handlers` + buildQuery(query);
 }
 
-// ---------------------------------------------------------------------------
-// Handler-level paths
-// ---------------------------------------------------------------------------
-
 export type HandlerKind = "listener" | "job";
 
 export function handlerPath(appKey: string, kind: HandlerKind, handlerId: number | string, query?: RouteQuery): string {
   return `/apps/${appKey}/handlers/${kind}/${handlerId}` + buildQuery(query);
 }
-
-// ---------------------------------------------------------------------------
-// Execution-level paths
-// ---------------------------------------------------------------------------
 
 export function executionPath(
   appKey: string,

--- a/frontend/src/utils/format.test.ts
+++ b/frontend/src/utils/format.test.ts
@@ -9,7 +9,6 @@ import {
   formatRelativeTime,
   formatTimestamp,
   formatTriggerDetail,
-  logEntryExecutionHref,
   pluralize,
   truncateId,
 } from "./format";
@@ -335,43 +334,5 @@ describe("truncateId", () => {
     expect(truncateId("019f7ae9-0000-0000-0000-000000000001")).not.toBe(
       truncateId("019f7ae9-0000-0000-0000-000000000002"),
     );
-  });
-});
-
-describe("logEntryExecutionHref", () => {
-  const base = { app_key: "my_app", execution_id: "exec-1", instance_index: null };
-
-  it("returns href for handler kind with listener_id", () => {
-    expect(logEntryExecutionHref({ ...base, execution_kind: "handler", listener_id: 5, job_id: null })).toBe(
-      "/apps/my_app/handlers/listener/5/exec/exec-1",
-    );
-  });
-
-  it("returns href for job kind with job_id", () => {
-    expect(logEntryExecutionHref({ ...base, execution_kind: "job", listener_id: null, job_id: 3 })).toBe(
-      "/apps/my_app/handlers/job/3/exec/exec-1",
-    );
-  });
-
-  it("returns null for handler kind with null listener_id", () => {
-    expect(logEntryExecutionHref({ ...base, execution_kind: "handler", listener_id: null, job_id: 3 })).toBeNull();
-  });
-
-  it("returns null for job kind with null job_id", () => {
-    expect(logEntryExecutionHref({ ...base, execution_kind: "job", listener_id: 5, job_id: null })).toBeNull();
-  });
-
-  it("returns null when execution_kind is null", () => {
-    expect(logEntryExecutionHref({ ...base, execution_kind: null, listener_id: 5, job_id: 3 })).toBeNull();
-  });
-
-  it("returns null when execution_kind is undefined", () => {
-    expect(logEntryExecutionHref({ ...base, listener_id: 5, job_id: 3 })).toBeNull();
-  });
-
-  it("appends instance query param when present", () => {
-    expect(
-      logEntryExecutionHref({ ...base, execution_kind: "handler", listener_id: 5, job_id: null, instance_index: 2 }),
-    ).toBe("/apps/my_app/handlers/listener/5/exec/exec-1?instance=2");
   });
 });

--- a/frontend/src/utils/format.ts
+++ b/frontend/src/utils/format.ts
@@ -136,36 +136,6 @@ export function formatRate(failed: number, total: number): string {
   return (fixed.endsWith(".0") ? fixed.slice(0, -2) : fixed) + "%";
 }
 
-// URL segments use "listener"/"job" (the DB entity name), while execution_kind uses "handler"/"job" (the execution type).
-export function executionDetailHref(
-  appKey: string,
-  kind: "handler" | "job",
-  handlerId: number,
-  executionId: string,
-  instanceIndex?: number | null,
-): string {
-  const base = `/apps/${appKey}/handlers/${kind === "handler" ? "listener" : "job"}/${handlerId}/exec/${executionId}`;
-  return instanceIndex !== null && instanceIndex !== undefined ? `${base}?instance=${instanceIndex}` : base;
-}
-
-export function logEntryExecutionHref(entry: {
-  app_key?: string | null;
-  execution_kind?: string | null;
-  listener_id?: number | null;
-  job_id?: number | null;
-  execution_id?: string | null;
-  instance_index?: number | null;
-}): string | null {
-  if (!entry.app_key || !entry.execution_id || !entry.execution_kind) return null;
-  if (entry.execution_kind === "handler" && entry.listener_id !== null && entry.listener_id !== undefined) {
-    return executionDetailHref(entry.app_key, "handler", entry.listener_id, entry.execution_id, entry.instance_index);
-  }
-  if (entry.execution_kind === "job" && entry.job_id !== null && entry.job_id !== undefined) {
-    return executionDetailHref(entry.app_key, "job", entry.job_id, entry.execution_id, entry.instance_index);
-  }
-  return null;
-}
-
 export function formatUptime(seconds: number): string {
   if (seconds < SECONDS_PER_MINUTE) return `${Math.floor(seconds)}s`;
   if (seconds < SECONDS_PER_HOUR) return `${Math.floor(seconds / SECONDS_PER_MINUTE)}m`;

--- a/frontend/src/utils/handler-rows.test.ts
+++ b/frontend/src/utils/handler-rows.test.ts
@@ -171,6 +171,7 @@ function row(overrides: Partial<UnifiedRow>): UnifiedRow {
   return {
     kind: "listener",
     id: "listener/1",
+    handlerId: 1,
     app_key: "app_a",
     name: "handler",
     handler_method: "app.Handler.handler",

--- a/frontend/src/utils/handler-rows.ts
+++ b/frontend/src/utils/handler-rows.ts
@@ -5,6 +5,7 @@ import { lastDotSegment } from "./format";
 export interface UnifiedRow {
   kind: "listener" | "job";
   id: string;
+  handlerId: number;
   app_key: string;
   name: string;
   handler_method: string;
@@ -22,6 +23,7 @@ export function listenerToRow(l: ListenerData): UnifiedRow {
   return {
     kind: "listener",
     id: `listener/${l.listener_id}`,
+    handlerId: l.listener_id,
     app_key: l.app_key,
     name: lastDotSegment(l.handler_method),
     handler_method: l.handler_method,
@@ -40,6 +42,7 @@ export function jobToRow(j: JobData): UnifiedRow {
   return {
     kind: "job",
     id: `job/${j.job_id}`,
+    handlerId: j.job_id,
     app_key: j.app_key,
     name: j.job_name,
     handler_method: j.handler_method,


### PR DESCRIPTION
### Route Registry (`app-routes.ts`)

- Added `NAV_PAGES` — a single metadata array (`path`, `label`, `testId`) that now backs both the sidebar nav list and the command palette's static page items. Previously these were two separately hand-maintained arrays (`NAV_ITEMS` in `sidebar.tsx`, an inline array in `palette-items.ts`) that had to be kept in sync by hand.
- Added `HOME_PATH`, `handlerPath()`, `executionPath()` builders, and moved `logEntryExecutionHref()` (previously `executionDetailHref()` + `logEntryExecutionHref()` in `format.ts`) into `app-routes.ts` so all route construction lives in one file instead of being split across `format.ts` and ad hoc template strings.
- Renamed the internal query type from `AppRouteQuery` to `RouteQuery` and dropped the now-unneeded `appendQuery()` helper — `buildQuery()` already returns an empty string when there's nothing to append, so string concatenation is simpler than a conditional wrapper.
- Added `app-routes.test.ts` covering every builder, including the `handler`→`listener` execution-kind-to-URL-segment mapping that was previously undocumented and untested.

### Typed handler references replace `execLinkPrefix`

- `ExecutionTable`, `HandlerDetailLayout`, and `AppLink` took a pre-built path-prefix string (`execLinkPrefix`, or a bare `handlerId` string) and concatenated route segments onto it at the call site. Replaced with typed `appKey` / `handlerKind` / `handlerId` props, so the component itself builds the URL via `executionPath()`/`handlerPath()` instead of every caller re-deriving the prefix string.
- Added `handlerId` to `UnifiedRow` (`handler-rows.ts`) so decomposed handler rows carry a real ID instead of only the string segment they used for navigation before.

### Migrated call sites

- Sidebar, palette items, error spotlight, execution/job/listener detail pages, handlers tab, overview tab helpers, log table row/drawer, and `not-found.tsx` now call the shared builders instead of hardcoding `/apps/...`, `/handlers/...` template strings. ~86 hardcoded route occurrences across 26 files.

Closes #1386
