### PR TITLE
fix: thread time-window into log fetch and dedupe by row key

### DIFF
--- a/frontend/src/components/shared/log-table/use-log-data.test.ts
+++ b/frontend/src/components/shared/log-table/use-log-data.test.ts
@@ -300,7 +300,7 @@ describe("useLogData", () => {
       });
     });
 
-    it("includes all WS entries above the watermark when no filters are provided", async () => {
+    it("includes all WS entries not in the REST set when no filters are provided", async () => {
       const state = makeState();
 
       server.use(http.get("/api/logs/recent", () => HttpResponse.json([])));

--- a/frontend/src/components/shared/log-table/use-log-data.test.ts
+++ b/frontend/src/components/shared/log-table/use-log-data.test.ts
@@ -7,7 +7,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { WsLogPayload } from "@/api/ws-types";
 import { AppStateContext } from "@/state/context";
-import { type AppState, createAppState } from "@/state/create-app-state";
+import { type AppState, createAppState, type TimePreset } from "@/state/create-app-state";
 import { createTestQueryClient } from "@/test/query-test-utils";
 import { server } from "@/test/server";
 
@@ -26,6 +26,13 @@ function createWrapper(state: AppState) {
   return function Wrapper({ children }: { children: ComponentChildren }) {
     return h(QueryClientProvider, { client }, h(AppStateContext.Provider, { value: state }, children));
   };
+}
+
+function makeState(preset: TimePreset = "1h"): AppState {
+  const state = createAppState();
+  state.timePreset.value = preset;
+  if (preset === "since-restart") state.uptimeSeconds.value = 100;
+  return state;
 }
 
 function makeLogEntry(overrides: Partial<WsLogPayload> = {}): WsLogPayload {
@@ -60,7 +67,7 @@ beforeEach(() => {
 describe("useLogData", () => {
   describe("loading state", () => {
     it("is true initially before REST resolves", () => {
-      const state = createAppState();
+      const state = makeState();
       // Override with a never-resolving handler to freeze the fetch in-flight.
       server.use(http.get("/api/logs/recent", () => new Promise(() => {})));
 
@@ -72,7 +79,7 @@ describe("useLogData", () => {
     });
 
     it("becomes false after REST resolves", async () => {
-      const state = createAppState();
+      const state = makeState();
 
       const { result } = renderHook(() => useLogData({}), {
         wrapper: createWrapper(state),
@@ -84,7 +91,7 @@ describe("useLogData", () => {
 
   describe("REST fetch", () => {
     it("calls the /api/logs/recent endpoint with appKey, executionId, and limit", async () => {
-      const state = createAppState();
+      const state = makeState();
       let capturedUrl: string | undefined;
 
       server.use(
@@ -110,7 +117,7 @@ describe("useLogData", () => {
     });
 
     it("populates restEntries with the fetched entries", async () => {
-      const state = createAppState();
+      const state = makeState();
       const entries = [
         makeLogEntry({ seq: 1, timestamp: 1000, message: "first" }),
         makeLogEntry({ seq: 2, timestamp: 2000, message: "second" }),
@@ -132,7 +139,7 @@ describe("useLogData", () => {
     });
 
     it("includes REST entries in allEntries", async () => {
-      const state = createAppState();
+      const state = makeState();
       const entries = [makeLogEntry({ seq: 1, timestamp: 1000, message: "rest-entry" })];
 
       server.use(http.get("/api/logs/recent", () => HttpResponse.json(entries)));
@@ -151,7 +158,7 @@ describe("useLogData", () => {
 
   describe("WS merge", () => {
     it("prepends WS entries above the REST watermark to keep timestamp-desc order", async () => {
-      const state = createAppState();
+      const state = makeState();
       const restEntry = makeLogEntry({ seq: 1, timestamp: 1000, message: "rest" });
 
       server.use(http.get("/api/logs/recent", () => HttpResponse.json([restEntry])));
@@ -176,7 +183,7 @@ describe("useLogData", () => {
     });
 
     it("orders multiple WS entries newest first before REST entries", async () => {
-      const state = createAppState();
+      const state = makeState();
       const restEntry = makeLogEntry({ seq: 1, timestamp: 1000, message: "rest" });
 
       server.use(http.get("/api/logs/recent", () => HttpResponse.json([restEntry])));
@@ -197,8 +204,8 @@ describe("useLogData", () => {
       });
     });
 
-    it("does not include WS entries at or below the REST watermark (deduplication)", async () => {
-      const state = createAppState();
+    it("excludes WS entries whose rowKey matches a REST entry (deduplication)", async () => {
+      const state = makeState();
       const restEntry = makeLogEntry({ seq: 1, timestamp: 5000, message: "rest" });
 
       server.use(http.get("/api/logs/recent", () => HttpResponse.json([restEntry])));
@@ -210,21 +217,49 @@ describe("useLogData", () => {
       await waitForLoaded(result);
 
       act(() => {
-        state.logs.push(makeLogEntry({ seq: 2, timestamp: 5000, message: "dup-at-watermark" }));
-        state.logs.push(makeLogEntry({ seq: 3, timestamp: 3000, message: "dup-below-watermark" }));
-        state.logs.push(makeLogEntry({ seq: 4, timestamp: 6000, message: "valid-after-watermark" }));
+        // Same seq+timestamp as REST entry → same rowKey → excluded
+        state.logs.push(makeLogEntry({ seq: 1, timestamp: 5000, message: "exact-dup" }));
+        // Different seq → different rowKey → included
+        state.logs.push(makeLogEntry({ seq: 2, timestamp: 5000, message: "same-ts-diff-seq" }));
+        state.logs.push(makeLogEntry({ seq: 3, timestamp: 6000, message: "newer" }));
       });
 
       await vi.waitFor(() => {
         const messages = result.current.allEntries.map((e) => e.message);
-        expect(messages).toContain("valid-after-watermark");
-        expect(messages).not.toContain("dup-at-watermark");
-        expect(messages).not.toContain("dup-below-watermark");
+        expect(messages).toContain("same-ts-diff-seq");
+        expect(messages).toContain("newer");
+        expect(messages).not.toContain("exact-dup");
+      });
+    });
+
+    it("preserves distinct records that share a timestamp (same-timestamp dedup fix)", async () => {
+      const state = makeState();
+
+      server.use(http.get("/api/logs/recent", () => HttpResponse.json([])));
+
+      const { result } = renderHook(() => useLogData({}), {
+        wrapper: createWrapper(state),
+      });
+
+      await waitForLoaded(result);
+
+      act(() => {
+        state.logs.push(makeLogEntry({ seq: 10, timestamp: 9000, message: "first" }));
+        state.logs.push(makeLogEntry({ seq: 11, timestamp: 9000, message: "second" }));
+        state.logs.push(makeLogEntry({ seq: 12, timestamp: 9000, message: "third" }));
+      });
+
+      await vi.waitFor(() => {
+        const messages = result.current.allEntries.map((e) => e.message);
+        expect(messages).toHaveLength(3);
+        expect(messages).toContain("first");
+        expect(messages).toContain("second");
+        expect(messages).toContain("third");
       });
     });
 
     it("excludes WS entries for a different app_key when appKey is provided", async () => {
-      const state = createAppState();
+      const state = makeState();
 
       server.use(http.get("/api/logs/recent", () => HttpResponse.json([])));
 
@@ -245,7 +280,7 @@ describe("useLogData", () => {
     });
 
     it("excludes WS entries for a different execution_id when executionId is provided", async () => {
-      const state = createAppState();
+      const state = makeState();
 
       server.use(http.get("/api/logs/recent", () => HttpResponse.json([])));
 
@@ -266,7 +301,7 @@ describe("useLogData", () => {
     });
 
     it("includes all WS entries above the watermark when no filters are provided", async () => {
-      const state = createAppState();
+      const state = makeState();
 
       server.use(http.get("/api/logs/recent", () => HttpResponse.json([])));
 
@@ -289,7 +324,7 @@ describe("useLogData", () => {
     });
 
     it("throttles live WS entries before exposing them to the table", async () => {
-      const state = createAppState();
+      const state = makeState();
 
       server.use(http.get("/api/logs/recent", () => HttpResponse.json([])));
 
@@ -322,9 +357,86 @@ describe("useLogData", () => {
     });
   });
 
+  describe("time-window filtering", () => {
+    it("passes the since parameter to the REST fetch", async () => {
+      const state = makeState("1h");
+      let capturedUrl: string | undefined;
+
+      server.use(
+        http.get("/api/logs/recent", ({ request }) => {
+          capturedUrl = request.url;
+          return HttpResponse.json([]);
+        }),
+      );
+
+      const { result } = renderHook(() => useLogData({}), {
+        wrapper: createWrapper(state),
+      });
+
+      await waitForLoaded(result);
+
+      expect(capturedUrl).toBeDefined();
+      const url = new URL(capturedUrl!);
+      const since = Number(url.searchParams.get("since"));
+      expect(since).toBeGreaterThan(0);
+      // 1h preset: since should be within ~1h of now
+      const nowSeconds = Date.now() / 1000;
+      expect(since).toBeGreaterThan(nowSeconds - 3700);
+      expect(since).toBeLessThan(nowSeconds);
+    });
+
+    it("refetches when the time preset changes", async () => {
+      const state = makeState("1h");
+      let fetchCount = 0;
+
+      server.use(
+        http.get("/api/logs/recent", () => {
+          fetchCount++;
+          return HttpResponse.json([]);
+        }),
+      );
+
+      const { result } = renderHook(() => useLogData({}), {
+        wrapper: createWrapper(state),
+      });
+
+      await waitForLoaded(result);
+      const firstFetchCount = fetchCount;
+
+      await act(() => {
+        state.timePreset.value = "24h";
+      });
+
+      await vi.waitFor(() => {
+        expect(fetchCount).toBeGreaterThan(firstFetchCount);
+      });
+    });
+
+    it("gates fetching until uptimeSeconds is available for since-restart", async () => {
+      const state = createAppState();
+      // Default: since-restart with null uptime → should not fetch
+
+      server.use(http.get("/api/logs/recent", () => HttpResponse.json([])));
+
+      const { result } = renderHook(() => useLogData({}), {
+        wrapper: createWrapper(state),
+      });
+
+      // Should stay in loading state because fetching is disabled
+      expect(result.current.loading).toBe(true);
+
+      // Provide uptime → unblocks fetch
+      await act(() => {
+        state.uptimeSeconds.value = 60;
+      });
+
+      await waitForLoaded(result);
+    });
+  });
+
   describe("error handling", () => {
     it("shows a toast error and sets loading to false when the REST fetch rejects", async () => {
-      const state = createAppState();
+      const state = makeState();
 
       server.use(http.get("/api/logs/recent", () => HttpResponse.error()));
 

--- a/frontend/src/components/shared/log-table/use-log-data.ts
+++ b/frontend/src/components/shared/log-table/use-log-data.ts
@@ -76,10 +76,10 @@ export function useLogData({ appKey, executionId }: UseLogDataParams): UseLogDat
   const allEntries = useMemo(() => {
     if (!data) return [];
 
-    const wsEntries = (logs.toArray() as LogEntry[]).filter((e) => {
-      if (restKeys.has(rowKey(e))) return false;
-      if (appKey && e.app_key !== appKey) return false;
-      if (executionId && e.execution_id !== executionId) return false;
+    const wsEntries = (logs.toArray() as LogEntry[]).filter((entry) => {
+      if (restKeys.has(rowKey(entry))) return false;
+      if (appKey && entry.app_key !== appKey) return false;
+      if (executionId && entry.execution_id !== executionId) return false;
       return true;
     });
 

--- a/frontend/src/components/shared/log-table/use-log-data.ts
+++ b/frontend/src/components/shared/log-table/use-log-data.ts
@@ -1,13 +1,14 @@
 import { useSignalEffect } from "@preact/signals";
-import { useQuery } from "@tanstack/preact-query";
 import { useEffect, useMemo, useRef, useState } from "preact/hooks";
 import { toast } from "sonner";
 
 import { getRecentLogs, type LogEntry } from "@/api/endpoints";
+import { useScopedQuery } from "@/hooks/use-scoped-query";
 import { queryKeys } from "@/lib/query-keys";
 import { useAppState } from "@/state/context";
 
 import { LIVE_LOG_UPDATE_INTERVAL_MS, REST_FETCH_LIMIT } from "./constants";
+import { rowKey } from "./types";
 
 interface UseLogDataParams {
   appKey?: string;
@@ -15,7 +16,7 @@ interface UseLogDataParams {
 }
 
 interface UseLogDataResult {
-  /** REST + WS entries combined, deduped by timestamp watermark. */
+  /** REST + WS entries combined, deduped by row key identity. */
   allEntries: LogEntry[];
   /** REST-only entries (used when live-paused to exclude WS stream). */
   restEntries: LogEntry[];
@@ -54,14 +55,13 @@ function useThrottledLogVersion(): number {
 
 export function useLogData({ appKey, executionId }: UseLogDataParams): UseLogDataResult {
   const { logs } = useAppState();
-  // Drives recomputation from a throttled view of the live WS buffer.
   const logsVersion = useThrottledLogVersion();
 
-  const { data, isPending, isError, error } = useQuery({
-    queryKey: queryKeys.recentLogs(appKey, executionId),
-    queryFn: ({ signal }) =>
-      getRecentLogs({ app_key: appKey, limit: REST_FETCH_LIMIT, execution_id: executionId }, signal),
-  });
+  const { data, isPending, isError, error } = useScopedQuery(
+    queryKeys.recentLogs(appKey, executionId),
+    (since, signal) =>
+      getRecentLogs({ app_key: appKey, limit: REST_FETCH_LIMIT, execution_id: executionId, since }, signal),
+  );
 
   useEffect(() => {
     if (isError && error) {
@@ -71,23 +71,21 @@ export function useLogData({ appKey, executionId }: UseLogDataParams): UseLogDat
 
   const restEntries = useMemo<LogEntry[]>(() => data ?? [], [data]);
 
-  // Watermark: highest timestamp in the REST batch. WS entries must be strictly
-  // above this to be included, preventing duplicates.
-  const watermark = useMemo(() => restEntries.reduce((max, e) => Math.max(max, e.timestamp), 0), [restEntries]);
+  const restKeys = useMemo(() => new Set(restEntries.map(rowKey)), [restEntries]);
 
   const allEntries = useMemo(() => {
     if (!data) return [];
 
-    const wsEntries = logs.toArray().filter((e) => {
-      if (e.timestamp <= watermark) return false;
+    const wsEntries = (logs.toArray() as LogEntry[]).filter((e) => {
+      if (restKeys.has(rowKey(e))) return false;
       if (appKey && e.app_key !== appKey) return false;
       if (executionId && e.execution_id !== executionId) return false;
       return true;
-    }) as LogEntry[];
+    });
 
     return [...wsEntries.reverse(), ...restEntries];
     // eslint-disable-next-line react-hooks-configurable/exhaustive-deps -- logs is a stable ring-buffer ref; logsVersion drives recomputation
-  }, [data, restEntries, watermark, logsVersion, appKey, executionId]);
+  }, [data, restEntries, restKeys, logsVersion, appKey, executionId]);
 
   return { allEntries, restEntries, loading: isPending };
 }


### PR DESCRIPTION
### Log time-window fix

- `useLogData` ignored the selected time window (1h/24h/7d/since-restart) when fetching recent logs — it called `useQuery` directly instead of the shared `useScopedQuery` hook, so the `since` parameter never reached the REST request. It now delegates to `useScopedQuery`, matching every other scoped query consumer, so the REST fetch respects the selected preset and refetches when the preset changes.
- Replaced the REST-timestamp watermark used for WS/REST dedup with a `Set` of REST row keys (`rowKey(entry)`). The watermark silently dropped any WS record that happened to share the REST batch's highest timestamp, even when it was a distinct log line — row-key identity preserves those records instead.
- Added tests covering preset-triggered refetch, `since` parameter threading, uptime-gating for the `since-restart` preset, and same-timestamp record preservation.

Closes #1387
