### PR TITLE
fix: key appStatus WS state per app instance

### DIFF
--- a/frontend/src/hooks/use-websocket.ts
+++ b/frontend/src/hooks/use-websocket.ts
@@ -5,7 +5,7 @@ import { useEffect, useRef } from "preact/hooks";
 import { WS_PATH } from "../api/endpoints";
 import type { WsServerMessage } from "../api/ws-types";
 import { validateWsMessage, WsValidationError } from "../api/ws-validator";
-import type { AppState } from "../state/create-app-state";
+import { type AppState, appStatusKey } from "../state/create-app-state";
 
 const MAX_BACKOFF_MS = 30_000;
 const INITIAL_BACKOFF_MS = 1_000;
@@ -110,7 +110,7 @@ export function useWebSocket(state: AppState): void {
             case "app_status_changed":
               state.appStatus.value = {
                 ...state.appStatus.value,
-                [msg.data.app_key]: {
+                [appStatusKey(msg.data.app_key, msg.data.index)]: {
                   status: msg.data.status,
                   index: msg.data.index,
                   previous_status: msg.data.previous_status,

--- a/frontend/src/pages/app-detail.tsx
+++ b/frontend/src/pages/app-detail.tsx
@@ -20,6 +20,7 @@ import { useQueryParams } from "../hooks/use-query-params";
 import { useScopedQuery } from "../hooks/use-scoped-query";
 import { queryKeys } from "../lib/query-keys";
 import { useAppState } from "../state/context";
+import { appStatusKey } from "../state/create-app-state";
 import { appDetailPath, type AppDetailTab } from "../utils/app-routes";
 import styles from "./app-detail.module.css";
 
@@ -133,7 +134,7 @@ export function AppDetailPage({ params }: Props) {
   const currentInstance = !showParentOverview
     ? manifest?.instances?.find((i) => i.index === resolvedInstanceIndex)
     : undefined;
-  const wsStatus = appStatus.value[appKey]?.status;
+  const wsStatus = appStatus.value[appStatusKey(appKey, resolvedInstanceIndex)]?.status;
   const instanceStatus = wsStatus ?? currentInstance?.status ?? manifest?.status ?? "unknown";
   const liveStatus = showParentOverview ? (manifest?.status ?? "unknown") : instanceStatus;
 

--- a/frontend/src/pages/app-detail.tsx
+++ b/frontend/src/pages/app-detail.tsx
@@ -21,6 +21,7 @@ import { useScopedQuery } from "../hooks/use-scoped-query";
 import { queryKeys } from "../lib/query-keys";
 import { useAppState } from "../state/context";
 import { appStatusKey } from "../state/create-app-state";
+import { appLiveStatus } from "../utils/app-data";
 import { appDetailPath, type AppDetailTab } from "../utils/app-routes";
 import styles from "./app-detail.module.css";
 
@@ -136,7 +137,11 @@ export function AppDetailPage({ params }: Props) {
     : undefined;
   const wsStatus = appStatus.value[appStatusKey(appKey, resolvedInstanceIndex)]?.status;
   const instanceStatus = wsStatus ?? currentInstance?.status ?? manifest?.status ?? "unknown";
-  const liveStatus = showParentOverview ? (manifest?.status ?? "unknown") : instanceStatus;
+  const liveStatus = showParentOverview
+    ? manifest
+      ? appLiveStatus(appStatus.value, manifest)
+      : "unknown"
+    : instanceStatus;
 
   const hasData = !manifestLoading && listenersData !== undefined && jobsData !== undefined;
   const initialLoading = !hasData && (listenersLoading || jobsLoading || manifestLoading);

--- a/frontend/src/pages/apps-table-row.test.tsx
+++ b/frontend/src/pages/apps-table-row.test.tsx
@@ -1,6 +1,7 @@
 import { fireEvent } from "@testing-library/preact";
 import { describe, expect, it, vi } from "vitest";
 
+import { type AppStatusEntry, appStatusKey } from "../state/create-app-state";
 import { renderWithAppState } from "../test/render-helpers";
 import type { AppRow } from "../utils/app-data";
 import { INACTIVE_STATUSES } from "../utils/status";
@@ -55,7 +56,7 @@ function createAppRow(overrides: Partial<AppRow> = {}): AppRow {
 }
 
 function renderRow(props: Partial<Parameters<typeof AppTableRow>[0]> = {}) {
-  const defaults = { app: createAppRow(), isExpanded: false, onToggle: vi.fn() };
+  const defaults = { app: createAppRow(), appStatuses: {}, isExpanded: false, onToggle: vi.fn() };
   return renderWithAppState(
     <table>
       <tbody>
@@ -148,10 +149,11 @@ describe("AppTableRow", () => {
     expect(errorCell.getAttribute("aria-label")).toMatch(/^collapse error/i);
   });
 
-  it("liveStatus overrides app.status in the badge", () => {
+  it("appStatuses overrides app.status in the badge", () => {
+    const entry: AppStatusEntry = { status: "running", index: 0 };
     const { getByTestId } = renderRow({
-      app: createAppRow({ status: "stopped" }),
-      liveStatus: "running",
+      app: createAppRow({ app_key: "my_app", status: "stopped" }),
+      appStatuses: { [appStatusKey("my_app", 0)]: entry },
     });
     expect(getByTestId("status-pill").textContent).toBe("running");
   });
@@ -205,6 +207,42 @@ describe("AppTableRow", () => {
     const { getByTestId } = renderRow({ app, isExpanded: true });
     expect(getByTestId("instance-row-my_app-0")).toBeDefined();
     expect(getByTestId("instance-row-my_app-1")).toBeDefined();
+  });
+
+  it("expanded instance rows show per-instance live status", () => {
+    const app = createAppRow({
+      app_key: "my_app",
+      instance_count: 2,
+      instances: [
+        {
+          app_key: "my_app",
+          class_name: "MyApp",
+          index: 0,
+          instance_name: "my_app[0]",
+          status: "stopped",
+          error_message: null,
+        },
+        {
+          app_key: "my_app",
+          class_name: "MyApp",
+          index: 1,
+          instance_name: "my_app[1]",
+          status: "stopped",
+          error_message: null,
+        },
+      ],
+    });
+    const appStatuses: Record<string, AppStatusEntry> = {
+      [appStatusKey("my_app", 0)]: { status: "running", index: 0 },
+      [appStatusKey("my_app", 1)]: { status: "failed", index: 1 },
+    };
+    const { getByTestId } = renderRow({ app, appStatuses, isExpanded: true });
+    const row0 = getByTestId("instance-row-my_app-0");
+    const row1 = getByTestId("instance-row-my_app-1");
+    expect(row0.textContent).toContain("running");
+    expect(row0.textContent).not.toContain("stopped");
+    expect(row1.textContent).toContain("failed");
+    expect(row1.textContent).not.toContain("stopped");
   });
 
   it("does not show instance rows when isExpanded is false", () => {

--- a/frontend/src/pages/apps-table-row.tsx
+++ b/frontend/src/pages/apps-table-row.tsx
@@ -9,7 +9,8 @@ import { IconChevron } from "../components/shared/icons";
 import { MiniSparkline } from "../components/shared/mini-sparkline";
 import { StatusShape } from "../components/shared/status-shape";
 import { useRelativeTime } from "../hooks/use-relative-time";
-import { type AppRow } from "../utils/app-data";
+import { type AppStatusEntry, appStatusKey } from "../state/create-app-state";
+import { appLiveStatus, type AppRow } from "../utils/app-data";
 import { formatTimestamp } from "../utils/format";
 import { onActivateKeyDown } from "../utils/keyboard";
 import { INACTIVE_STATUSES, statusToKind, statusToVariant } from "../utils/status";
@@ -17,13 +18,13 @@ import styles from "./apps.module.css";
 
 export function AppTableRow({
   app,
-  liveStatus,
+  appStatuses,
   isExpanded,
   onToggle,
   muteStatus = false,
 }: {
   app: AppRow;
-  liveStatus?: string;
+  appStatuses: Record<string, AppStatusEntry>;
   isExpanded: boolean;
   onToggle: () => void;
   muteStatus?: boolean;
@@ -32,7 +33,7 @@ export function AppTableRow({
   const showErrorExpanded = errorExpanded && !!app.error_message;
   const lastErrorLabel = useRelativeTime(app.last_error_ts ?? null);
   const lastActivityLabel = useRelativeTime(app.last_activity_ts ?? null);
-  const status = liveStatus ?? app.status;
+  const status = appLiveStatus(appStatuses, app);
   const kind = statusToKind(status);
   const isMulti = app.instance_count > 1;
   const isDimmed = INACTIVE_STATUSES.has(status);
@@ -120,7 +121,7 @@ export function AppTableRow({
       {isMulti &&
         isExpanded &&
         app.instances?.map((inst) => {
-          const instStatus = liveStatus ?? inst.status;
+          const instStatus = appStatuses[appStatusKey(app.app_key, inst.index)]?.status ?? inst.status;
           const instKind = statusToKind(instStatus);
           return (
             <tr

--- a/frontend/src/pages/apps.tsx
+++ b/frontend/src/pages/apps.tsx
@@ -20,7 +20,13 @@ import { useScopedQuery } from "../hooks/use-scoped-query";
 import { useSignal } from "../hooks/use-signal";
 import { queryKeys } from "../lib/query-keys";
 import { useAppState } from "../state/context";
-import { type AppRow, type AppSortState, compareAppRows, mergeManifestsAndGrid } from "../utils/app-data";
+import {
+  appLiveStatus,
+  type AppRow,
+  type AppSortState,
+  compareAppRows,
+  mergeManifestsAndGrid,
+} from "../utils/app-data";
 import { pluralize } from "../utils/format";
 import { type StatusKind } from "../utils/status";
 import { PRESET_WINDOW_SECONDS } from "../utils/time-window";
@@ -159,7 +165,7 @@ export function AppsPage() {
 
   const statusCounts: Record<string, number> = {};
   for (const a of allApps) {
-    const liveStatus = appStatus.value[a.app_key]?.status ?? a.status;
+    const liveStatus = appLiveStatus(appStatus.value, a);
     statusCounts[liveStatus] = (statusCounts[liveStatus] ?? 0) + 1;
   }
 
@@ -185,7 +191,7 @@ export function AppsPage() {
   const searchLower = search.toLowerCase();
   const filtered = allApps
     .filter((a) => {
-      const liveStatus = appStatus.value[a.app_key]?.status ?? a.status;
+      const liveStatus = appLiveStatus(appStatus.value, a);
       if (filter !== "all" && liveStatus !== filter) return false;
       if (
         searchLower &&
@@ -293,7 +299,7 @@ export function AppsPage() {
                   <AppTableRow
                     key={app.app_key}
                     app={app}
-                    liveStatus={appStatus.value[app.app_key]?.status}
+                    appStatuses={appStatus.value}
                     isExpanded={app.instance_count > 1 && expanded.value.has(app.app_key)}
                     onToggle={() => toggleExpand(app.app_key)}
                     muteStatus={allSameStatus}

--- a/frontend/src/pages/apps.tsx
+++ b/frontend/src/pages/apps.tsx
@@ -20,6 +20,7 @@ import { useScopedQuery } from "../hooks/use-scoped-query";
 import { useSignal } from "../hooks/use-signal";
 import { queryKeys } from "../lib/query-keys";
 import { useAppState } from "../state/context";
+import type { AppStatusEntry } from "../state/create-app-state";
 import {
   appLiveStatus,
   type AppRow,
@@ -48,12 +49,18 @@ const FILTER_TONES: Record<FilterId, StatusKind | null> = {
 const MIN_WINDOW_FOR_RATE_CALC = 60;
 const VALID_SORT_KEYS: ReadonlySet<string> = new Set<AppSortState["key"]>(["name", "status", "error", "runs", "last"]);
 
-function buildAppsCells(apps: AppRow[], windowSeconds: number | null, isMobile: boolean): StatsStripCell[] {
+function buildAppsCells(
+  apps: AppRow[],
+  appStatuses: Record<string, AppStatusEntry>,
+  windowSeconds: number | null,
+  isMobile: boolean,
+): StatsStripCell[] {
   const statusCounts: Record<string, number> = { running: 0, failed: 0, stopped: 0, disabled: 0, blocked: 0 };
   let totalHandlers = 0;
   let totalRuns = 0;
   for (const a of apps) {
-    if (a.status in statusCounts) statusCounts[a.status]++;
+    const live = appLiveStatus(appStatuses, a);
+    if (live in statusCounts) statusCounts[live]++;
     totalHandlers += a.handler_count + a.job_count;
     totalRuns += a.total_invocations + a.total_executions;
   }
@@ -246,7 +253,10 @@ export function AppsPage() {
       </div>
 
       <div class="ht-table-section">
-        <StatsStrip cells={buildAppsCells(allApps, windowSeconds, isMobile)} data-testid="apps-stats-strip" />
+        <StatsStrip
+          cells={buildAppsCells(allApps, appStatus.value, windowSeconds, isMobile)}
+          data-testid="apps-stats-strip"
+        />
         {searchInput}
         <TableCard footer={footer}>
           {filtered.length === 0 ? (

--- a/frontend/src/state/create-app-state.ts
+++ b/frontend/src/state/create-app-state.ts
@@ -27,6 +27,10 @@ export interface AppStatusEntry {
   exception?: string | null;
 }
 
+export function appStatusKey(appKey: string, index: number): string {
+  return `${appKey}:${index}`;
+}
+
 export interface ServiceStatusEntry {
   resource_name: string;
   role: string;
@@ -91,7 +95,7 @@ export function createAppState() {
 
   return {
     /**
-     * Per-app status keyed by app_key, updated via WS.
+     * Per-instance app status keyed by `appStatusKey(app_key, index)`, updated via WS.
      *
      * INVARIANT: appStatus changes trigger *debounced* cache invalidation
      * (via useQueryInvalidator in page components). This is intentionally separate

--- a/frontend/src/utils/app-data.ts
+++ b/frontend/src/utils/app-data.ts
@@ -73,15 +73,16 @@ export type AppSortState = SortState<AppSortKey>;
 /** Resolve the live status for an app row's parent view.
  *  Single-instance: WS status for index 0.
  *  Multi-instance: worst status across all instances (lower priority = worse). */
-export function appLiveStatus(appStatuses: Record<string, AppStatusEntry>, row: AppRow): string {
+export function appLiveStatus(
+  appStatuses: Record<string, AppStatusEntry>,
+  row: Pick<AppRow, "app_key" | "status"> & { instances?: AppRow["instances"] },
+): string {
   const instances = row.instances ?? [];
   if (instances.length <= 1) {
     return appStatuses[appStatusKey(row.app_key, 0)]?.status ?? row.status;
   }
-  return instances.reduce<string>((worst, inst) => {
-    const live = appStatuses[appStatusKey(row.app_key, inst.index)]?.status ?? inst.status;
-    return statusPriority(live) < statusPriority(worst) ? live : worst;
-  }, row.status);
+  const statuses = instances.map((inst) => appStatuses[appStatusKey(row.app_key, inst.index)]?.status ?? inst.status);
+  return statuses.reduce((worst, live) => (statusPriority(live) < statusPriority(worst) ? live : worst));
 }
 
 export function compareAppRows(

--- a/frontend/src/utils/app-data.ts
+++ b/frontend/src/utils/app-data.ts
@@ -1,5 +1,6 @@
 import type { AppManifest, DashboardAppGridEntry } from "../api/endpoints";
 import type { SortState } from "../components/shared/sort-header";
+import { type AppStatusEntry, appStatusKey } from "../state/create-app-state";
 import { statusPriority } from "./status-priority";
 
 export interface AppRow {
@@ -69,15 +70,29 @@ export function mergeManifestsAndGrid(manifests: AppManifest[], gridEntries: Das
 export type AppSortKey = "name" | "status" | "error" | "runs" | "last";
 export type AppSortState = SortState<AppSortKey>;
 
+/** Resolve the live status for an app row's parent view.
+ *  Single-instance: WS status for index 0.
+ *  Multi-instance: worst status across all instances (lower priority = worse). */
+export function appLiveStatus(appStatuses: Record<string, AppStatusEntry>, row: AppRow): string {
+  const instances = row.instances ?? [];
+  if (instances.length <= 1) {
+    return appStatuses[appStatusKey(row.app_key, 0)]?.status ?? row.status;
+  }
+  return instances.reduce<string>((worst, inst) => {
+    const live = appStatuses[appStatusKey(row.app_key, inst.index)]?.status ?? inst.status;
+    return statusPriority(live) < statusPriority(worst) ? live : worst;
+  }, row.status);
+}
+
 export function compareAppRows(
   a: AppRow,
   b: AppRow,
   sort: AppSortState,
-  liveStatuses: Record<string, { status: string } | undefined>,
+  appStatuses: Record<string, AppStatusEntry>,
 ): number {
   const dir = sort.dir === "asc" ? 1 : -1;
-  const aStatus = liveStatuses[a.app_key]?.status ?? a.status;
-  const bStatus = liveStatuses[b.app_key]?.status ?? b.status;
+  const aStatus = appLiveStatus(appStatuses, a);
+  const bStatus = appLiveStatus(appStatuses, b);
   switch (sort.key) {
     case "name":
       return dir * a.app_key.localeCompare(b.app_key);


### PR DESCRIPTION
### Bug Fix

- The `appStatus` WebSocket signal keyed live per-app status by `app_key` alone, so every instance of a multi-instance app wrote to the same key — each `app_status_changed` event overwrote the previous instance's entry, making the status badge flash the wrong state and expanded instance rows all show the last-updated instance's status instead of their own.
- Introduce `appStatusKey(app_key, index)` to build a compound `app_key:index` key, and thread it through everywhere WS status is stored or read (`use-websocket.ts`, `app-detail.tsx`, `apps-table-row.tsx`).
- Add `appLiveStatus()` in `app-data.ts` to compute a worst-of-instances status for aggregate views (parent row badge, status-count chips, filter/sort comparisons) — mirrors the existing `worstStatus` pattern in `sidebar-groups.ts` so single- and multi-instance apps share one resolution path instead of two.
- `AppTableRow` now takes `appStatuses: Record<string, AppStatusEntry>` instead of a single `liveStatus?: string` prop, so each expanded instance row resolves its own live status independently rather than inheriting the parent's.

Closes #754
