### PR TITLE
fix: resolve @/ path aliases in Vite dev server

### DIFF
--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,3 +1,4 @@
+import path from "node:path";
 import preact from "@preact/preset-vite";
 import { defineConfig } from "vite";
 import { patchCssModules } from "vite-css-modules";
@@ -6,6 +7,12 @@ const apiTarget = process.env.VITE_PROXY_TARGET || "http://localhost:8126";
 
 export default defineConfig({
   plugins: [preact(), patchCssModules({ generateSourceTypes: true })],
+  // Match tsconfig.json paths["@/*"] so the dev server resolves @/ imports
+  resolve: {
+    alias: {
+      "@": path.resolve(import.meta.dirname, "src"),
+    },
+  },
   // Enable SPA history fallback so direct URL access (pasting a deep URL into
   // the browser) serves index.html instead of 404 during development.
   // The /api and /api/ws proxies are unaffected — Vite applies proxy rules


### PR DESCRIPTION
### Vite dev server

- Add `resolve.alias` to `frontend/vite.config.ts` mapping `@` to `src/`, matching the `@/*` path already declared in `tsconfig.json`. Without it, the Vite dev server couldn't resolve `@/` imports even though the TypeScript compiler and editor tooling accepted them, since Vite has no built-in awareness of `tsconfig.json` path mappings.

Closes #1402
