### PR TITLE
fix: move tomli-w to production dependencies to fix Docker crash

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,6 +62,7 @@ dependencies = [
     "uvicorn[standard]>=0.34.0",
     "watchfiles>=1.1.0",
     "whenever==0.10.*",
+    "tomli-w>=1.2.0",
 ]
 
 [project.optional-dependencies]
@@ -82,7 +83,6 @@ dev = [
     "pyright>=1.1.408",
     "shot-scraper>=1.5",
     "slotscheck>=0.19.1",
-    "tomli-w>=1.2.0",
 ]
 test = [
     "coverage[toml]>=7.10.7",

--- a/uv.lock
+++ b/uv.lock
@@ -994,6 +994,7 @@ dependencies = [
     { name = "starlette" },
     { name = "structlog" },
     { name = "tenacity" },
+    { name = "tomli-w" },
     { name = "typing-extensions" },
     { name = "uuid-utils" },
     { name = "uvicorn", extra = ["standard"] },
@@ -1014,7 +1015,6 @@ dev = [
     { name = "pyright" },
     { name = "shot-scraper" },
     { name = "slotscheck" },
-    { name = "tomli-w" },
 ]
 docs = [
     { name = "mkdocs" },
@@ -1071,6 +1071,7 @@ requires-dist = [
     { name = "starlette", specifier = ">=1.3.1" },
     { name = "structlog", specifier = ">=24.4" },
     { name = "tenacity", specifier = ">=9.1.2" },
+    { name = "tomli-w", specifier = ">=1.2.0" },
     { name = "typing-extensions", specifier = "==4.15.*" },
     { name = "uuid-utils", specifier = ">=0.9.0" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.34.0" },
@@ -1086,7 +1087,6 @@ dev = [
     { name = "pyright", specifier = ">=1.1.408" },
     { name = "shot-scraper", specifier = ">=1.5" },
     { name = "slotscheck", specifier = ">=0.19.1" },
-    { name = "tomli-w", specifier = ">=1.2.0" },
 ]
 docs = [
     { name = "mkdocs", specifier = ">=1.6.0" },


### PR DESCRIPTION
### Fix Docker startup crash

- Moved `tomli-w` from `[dependency-groups] dev` to `[project] dependencies`. Production code imports it at module level (`web/routes/apps.py`, added in #1405, for TOML config rendering, plus `test_utils/`), but the Docker image installs with `--no-default-groups`, so the `dev` group — and `tomli-w` with it — was never installed at runtime. This caused a `ModuleNotFoundError` on container startup.
