### PR TITLE
feat: add notify() and get_notify_services() to Api

### DIFF
--- a/docs/pages/core-concepts/api/methods.md
+++ b/docs/pages/core-concepts/api/methods.md
@@ -196,7 +196,7 @@ Same as `get_states`, but returns a list of untyped `HassStateDict` dicts instea
 ## Calling Services
 
 !!! warning "Service methods must be awaited"
-    `call_service`, `fire_event`, `set_state`, `turn_on`, `turn_off`, and `toggle` all return coroutines. Without `await`, the call is never sent and no error is raised at the call site. A forgotten `await` produces a [`HassetteForgottenAwaitWarning`][hassette.exceptions.HassetteForgottenAwaitWarning] naming the offending app when the coroutine is GC'd (subject to [configuration](../../troubleshooting.md#forgotten-await)). Pyright's `reportUnusedCoroutine` catches this at edit time — see [Enabling Pyright](../../troubleshooting.md#enabling-pyright).
+    `call_service`, `fire_event`, `set_state`, `turn_on`, `turn_off`, `toggle`, and `notify` all return coroutines. Without `await`, the call is never sent and no error is raised at the call site. A forgotten `await` produces a [`HassetteForgottenAwaitWarning`][hassette.exceptions.HassetteForgottenAwaitWarning] naming the offending app when the coroutine is GC'd (subject to [configuration](../../troubleshooting.md#forgotten-await)). Pyright's `reportUnusedCoroutine` catches this at edit time — see [Enabling Pyright](../../troubleshooting.md#enabling-pyright).
 
 ### `call_service(domain, service, ...)`
 
@@ -259,6 +259,40 @@ on/off state. Extra keyword arguments pass through as service data.
 
 ```python
 --8<-- "pages/core-concepts/api/snippets/api_helpers.py:toggle"
+```
+
+### `notify(message, notifier, title=None, data=None)`
+
+Shorthand for `call_service("notify", notifier, ...)`. Every Home Assistant notifier — a
+phone running the companion app, a chat integration, `persistent_notification` — is a
+service in the `notify` domain, so the notifier name is the only routing detail the call
+needs.
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `message` | `str` | — | The notification body. |
+| `notifier` | `str` | — | Notify service name, with or without the `notify.` prefix. |
+| `title` | `str \| None` | `None` | Optional title. Omitted from the call when `None`. |
+| `data` | `dict \| None` | `None` | Platform-specific payload (push sounds, actions, images). Omitted when `None`. |
+
+`notifier` accepts either form: `"mobile_app_phone"` and `"notify.mobile_app_phone"`
+produce the same call. Anything else (a blank name, or another domain like
+`"light.kitchen"`) raises `ValueError` at the call site rather than failing silently in
+Home Assistant.
+
+```python
+--8<-- "pages/core-concepts/api/snippets/api_notify.py"
+```
+
+### `get_notify_services()`
+
+Returns the notify service names registered on the connected Home Assistant instance,
+sorted and stripped of the `notify.` prefix, so each value passes straight to `notify()`.
+Checking a notifier name against this list at startup surfaces a typo there rather than
+at send time.
+
+```python
+--8<-- "pages/core-concepts/api/snippets/api_notify_services.py"
 ```
 
 ### Getting a response

--- a/docs/pages/core-concepts/api/snippets/api_notify.py
+++ b/docs/pages/core-concepts/api/snippets/api_notify.py
@@ -1,0 +1,14 @@
+from hassette import App
+
+
+class NotifyApp(App):
+    async def on_initialize(self):
+        await self.api.notify("The garage door is still open", "mobile_app_phone")
+
+        # A title and platform-specific push options
+        await self.api.notify(
+            "Motion in the driveway",
+            "notify.mobile_app_phone",
+            title="Security",
+            data={"push": {"sound": "alarm.caf"}},
+        )

--- a/docs/pages/core-concepts/api/snippets/api_notify_services.py
+++ b/docs/pages/core-concepts/api/snippets/api_notify_services.py
@@ -1,0 +1,12 @@
+from hassette import App
+
+NOTIFIER = "mobile_app_phone"
+
+
+class AlertApp(App):
+    async def on_initialize(self):
+        available = await self.api.get_notify_services()
+        if NOTIFIER not in available:
+            raise ValueError(f"Unknown notifier {NOTIFIER!r}. Available: {available}")
+
+        await self.api.notify("Alerts are wired up", NOTIFIER)

--- a/docs/pages/migration/api.md
+++ b/docs/pages/migration/api.md
@@ -64,6 +64,27 @@ AppDaemon uses a single `domain/service` string. Hassette splits them into two a
 
 Two signature differences from AppDaemon: the entity belongs in the `target` dict (`target={"entity_id": "light.kitchen"}`) rather than AppDaemon's bare `entity_id=` keyword, and Hassette handlers don't take `**kwargs` — event data arrives through typed parameters instead (see [Bus & Events](bus.md)).
 
+## Sending Notifications
+
+AppDaemon's `self.notify()` defaults to the `notify` service. Hassette's `notify()` lives on
+`self.api` and requires the notifier explicitly, so there is no implicit default target.
+
+=== "AppDaemon"
+
+    ```python
+    --8<-- "pages/migration/snippets/api_appdaemon_notify.py"
+    ```
+
+=== "Hassette"
+
+    ```python
+    --8<-- "pages/migration/snippets/api_hassette_notify.py"
+    ```
+
+The notifier accepts both `"mobile_app_phone"` and `"notify.mobile_app_phone"`.
+[`get_notify_services()`](../core-concepts/api/methods.md#get_notify_services) lists the
+notifiers registered on the connected instance.
+
 ## Setting States
 
 === "AppDaemon"

--- a/docs/pages/migration/snippets/api_appdaemon_notify.py
+++ b/docs/pages/migration/snippets/api_appdaemon_notify.py
@@ -1,0 +1,2 @@
+def my_callback(self, **kwargs):
+    self.notify("Garage door left open", name="mobile_app_phone", title="Alert")

--- a/docs/pages/migration/snippets/api_hassette_notify.py
+++ b/docs/pages/migration/snippets/api_hassette_notify.py
@@ -1,0 +1,10 @@
+from hassette import App
+
+
+class MyApp(App):
+    async def my_callback(self):
+        await self.api.notify(
+            "Garage door left open",
+            "mobile_app_phone",
+            title="Alert",
+        )

--- a/src/hassette/api/api.py
+++ b/src/hassette/api/api.py
@@ -5,7 +5,7 @@ state management, service calls, event firing, and data retrieval. Automatically
 authentication, retries, and type conversion for a seamless developer experience.
 
 Fire-and-forget methods (``call_service``, ``fire_event``, ``set_state``, ``turn_on``,
-``turn_off``, ``toggle``) return a ``Coroutine`` and must be awaited.
+``turn_off``, ``toggle``, ``notify``) return a ``Coroutine`` and must be awaited.
 
 Examples:
     Getting entity states
@@ -52,6 +52,9 @@ Examples:
     await self.api.turn_on("light.kitchen", brightness=150)
     await self.api.turn_off("light.living_room")
     await self.api.toggle("switch.fan")
+
+    # Send a notification through notify.<notifier>
+    await self.api.notify("The garage door is still open", "mobile_app_phone")
     ```
 
     Setting states
@@ -181,6 +184,9 @@ from hassette.utils.await_guard import guard_await
 from hassette.utils.request_utils import format_time_param
 from hassette.utils.source_capture import capture_source_location
 
+NOTIFY_DOMAIN = "notify"
+"""Home Assistant service domain that hosts every notifier (``notify.<notifier>``)."""
+
 
 def _expect_list(val: Any, context: str) -> list:
     """Assert that *val* is a list, raising TypeError with context if not.
@@ -198,6 +204,38 @@ def _expect_dict(val: Any, context: str) -> dict:
     if not isinstance(val, dict):
         raise TypeError(f"Expected dict from {context}, got {type(val).__name__}: {val!r}")
     return val
+
+
+def normalize_notifier(notifier: str) -> str:
+    """Return the bare notify service name for *notifier*.
+
+    Accepts either a bare name (``"mobile_app_phone"``) or a fully-qualified one
+    (``"notify.mobile_app_phone"``), so users can paste whichever form they see in
+    Home Assistant's developer tools.
+
+    Args:
+        notifier: The notify service name, with or without the ``notify.`` prefix.
+
+    Returns:
+        The service name without the ``notify.`` prefix.
+
+    Raises:
+        ValueError: If *notifier* is blank, or qualified with a domain other than ``notify``.
+    """
+    name = notifier.strip()
+    if not name:
+        raise ValueError("notifier must be a non-empty notify service name, e.g. 'mobile_app_phone'.")
+
+    if "." not in name:
+        return name
+
+    domain, _, service = name.partition(".")
+    if domain != NOTIFY_DOMAIN or not service or "." in service:
+        raise ValueError(
+            f"Invalid notifier {notifier!r}: expected a bare service name (e.g. 'mobile_app_phone') "
+            "or a 'notify.'-qualified one (e.g. 'notify.mobile_app_phone')."
+        )
+    return service
 
 
 # Only imported by hassette.api.helpers (cross-module) — pyright's reportUnusedFunction does not
@@ -602,6 +640,45 @@ class Api(Resource):
         if domain is None:
             domain = entity_id.split(".", 1)[0]
         return self.call_service(domain=domain, service="toggle", target={"entity_id": entity_id}, **data)
+
+    def notify(
+        self,
+        message: str,
+        notifier: str,
+        title: str | None = None,
+        data: dict[str, Any] | None = None,
+    ) -> "Coroutine[Any, Any, None]":
+        """Send a notification through a Home Assistant notify service.
+
+        Shorthand for ``call_service("notify", notifier, message=..., title=..., data=...)``.
+
+        Must be awaited — a forgotten ``await`` is reported per ``forgotten_await_behavior`` (default: warn).
+
+        Args:
+            message: The notification body.
+            notifier: The notify service to send through. Accepts a bare name
+                (``"mobile_app_phone"``) or a fully-qualified one
+                (``"notify.mobile_app_phone"``). Call :meth:`get_notify_services`
+                to discover which notifiers exist on your instance.
+            title: Optional notification title. Omitted from the service call when None.
+            data: Optional platform-specific payload (e.g. Android/iOS push options),
+                forwarded as the service's ``data`` field. Omitted when None.
+
+        Raises:
+            ValueError: If ``notifier`` is blank, or qualified with a domain other than ``notify``.
+        """
+        service = normalize_notifier(notifier)
+        return self.call_service(NOTIFY_DOMAIN, service, message=message, title=title, data=data)
+
+    async def get_notify_services(self) -> list[str]:
+        """Get the notify services available on this Home Assistant instance.
+
+        Returns:
+            Sorted bare service names (without the ``notify.`` prefix), ready to pass
+            straight to :meth:`notify` — e.g. ``["mobile_app_phone", "persistent_notification"]``.
+        """
+        services = await self.get_services()
+        return sorted(services.get(NOTIFY_DOMAIN, {}).keys())
 
     async def get_state_raw(self, entity_id: str) -> "HassStateDict":
         """Get the state of a specific entity.

--- a/src/hassette/api/sync.py
+++ b/src/hassette/api/sync.py
@@ -238,6 +238,35 @@ class ApiSyncFacade(Resource):
         """
         return self.task_bucket.run_sync(self._api.toggle(entity_id, domain, **data))
 
+    def notify(self, message: str, notifier: str, title: str | None = None, data: dict[str, Any] | None = None) -> None:
+        """Send a notification through a Home Assistant notify service.
+
+        Shorthand for ``call_service("notify", notifier, message=..., title=..., data=...)``.
+
+        Args:
+            message: The notification body.
+            notifier: The notify service to send through. Accepts a bare name
+                (``"mobile_app_phone"``) or a fully-qualified one
+                (``"notify.mobile_app_phone"``). Call :meth:`get_notify_services`
+                to discover which notifiers exist on your instance.
+            title: Optional notification title. Omitted from the service call when None.
+            data: Optional platform-specific payload (e.g. Android/iOS push options),
+                forwarded as the service's ``data`` field. Omitted when None.
+
+        Raises:
+            ValueError: If ``notifier`` is blank, or qualified with a domain other than ``notify``.
+        """
+        return self.task_bucket.run_sync(self._api.notify(message, notifier, title, data))
+
+    def get_notify_services(self) -> list[str]:
+        """Get the notify services available on this Home Assistant instance.
+
+        Returns:
+            Sorted bare service names (without the ``notify.`` prefix), ready to pass
+            straight to :meth:`notify` — e.g. ``["mobile_app_phone", "persistent_notification"]``.
+        """
+        return self.task_bucket.run_sync(self._api.get_notify_services())
+
     def get_state_raw(self, entity_id: str) -> "HassStateDict":
         """Get the state of a specific entity.
 

--- a/src/hassette/test_utils/recording_api.py
+++ b/src/hassette/test_utils/recording_api.py
@@ -18,6 +18,7 @@ from pydantic import BaseModel
 from slugify import slugify as _py_slugify
 from whenever import Date, PlainDateTime, ZonedDateTime
 
+from hassette.api.api import normalize_notifier
 from hassette.const.misc import FalseySentinel
 from hassette.exceptions import EntityNotFoundError, FailedMessageError
 from hassette.models.entities.base import BaseEntity
@@ -232,6 +233,13 @@ class ApiProtocol(Protocol):
         event_data: dict[str, Any] | None = None,
     ) -> dict[str, Any]: ...
     async def delete_entity(self, entity_id: str) -> None: ...
+    async def notify(
+        self,
+        message: str,
+        notifier: str,
+        title: str | None = None,
+        data: dict[str, Any] | None = None,
+    ) -> None: ...
 
     # Read methods
     async def get_state(self, entity_id: str) -> BaseState: ...
@@ -248,6 +256,7 @@ class ApiProtocol(Protocol):
     # Configuration and metadata
     async def get_config(self) -> dict[str, Any]: ...
     async def get_services(self) -> dict[str, Any]: ...
+    async def get_notify_services(self) -> list[str]: ...
     async def get_panels(self) -> dict[str, Any]: ...
 
     # History, logbook, calendars, camera, template
@@ -544,6 +553,8 @@ class RecordingApi(Resource):
     """
 
     calls: list[ApiCall]
+    notify_services: list[str]
+    """Notifier names returned by ``get_notify_services()``. Seed it in tests: ``api.notify_services = [...]``."""
     # Access via `harness.api_recorder.helpers`; do not import the type directly.
     helpers: "RecordingHelperClient"
     # Access via `harness.api_recorder.sync`; do not import the type directly.
@@ -569,6 +580,7 @@ class RecordingApi(Resource):
         # lazily from hassette._state_proxy (when created via App.add_child()).
         self._state_proxy_override = state_proxy
         self.calls = []
+        self.notify_services = []
         self.helpers = RecordingHelperClient(self)
         self.sync = RecordingSyncFacade(self)
 
@@ -654,6 +666,36 @@ class RecordingApi(Resource):
         if return_response:
             return ServiceResponse(context=Context(id=None, parent_id=None, user_id=None))
         return None
+
+    async def notify(
+        self,
+        message: str,
+        notifier: str,
+        title: str | None = None,
+        data: dict[str, Any] | None = None,
+    ) -> None:
+        """Record a notify call directly under its own method name.
+
+        ``notifier`` is normalized the same way the real ``Api.notify`` normalizes it, so
+        assertions match on the bare service name regardless of which form the app passed.
+        """
+        notifier = normalize_notifier(notifier)
+        self._record_call(
+            ApiCall(
+                method="notify",
+                args=(message, notifier),
+                kwargs={
+                    "message": message,
+                    "notifier": notifier,
+                    "title": title,
+                    "data": copy.deepcopy(data),
+                },
+            )
+        )
+
+    async def get_notify_services(self) -> list[str]:
+        """Return the notifier names seeded on ``notify_services`` (empty by default)."""
+        return sorted(self.notify_services)
 
     async def set_state(
         self,
@@ -1104,7 +1146,7 @@ class RecordingApi(Resource):
             )
 
     def reset(self) -> None:
-        """Clear all recorded calls and reset self.helpers to empty-per-domain state.
+        """Clear all recorded calls and reset seeded state (helpers, notifiers).
 
         Replaces the calls list with a new empty list rather than mutating the
         existing list in place. This preserves any snapshots callers hold
@@ -1113,7 +1155,8 @@ class RecordingApi(Resource):
 
         Replaces ``self.helpers`` with a fresh ``RecordingHelperClient`` rather than
         mutating its ``helper_definitions`` dict in place, for the same snapshot-
-        preservation reason.
+        preservation reason. ``notify_services`` is replaced for the same reason.
         """
         self.calls = []
+        self.notify_services = []
         self.helpers = RecordingHelperClient(self)

--- a/src/hassette/test_utils/sync_facade.py
+++ b/src/hassette/test_utils/sync_facade.py
@@ -15,6 +15,7 @@ import aiohttp
 from pydantic import BaseModel
 from whenever import Date, PlainDateTime, ZonedDateTime
 
+from hassette.api.api import normalize_notifier
 from hassette.api.helpers import HelperDomain
 from hassette.const.misc import FalseySentinel
 from hassette.exceptions import EntityNotFoundError
@@ -47,6 +48,7 @@ RECORDED_API_METHODS = frozenset(
         "delete_input_text",
         "delete_timer",
         "fire_event",
+        "notify",
         "set_state",
         "toggle",
         "turn_off",
@@ -217,6 +219,25 @@ class RecordingSyncFacade:  # pyright: ignore[reportUnusedClass]
         self._parent._record_call(
             ApiCall(method="toggle", args=(entity_id,), kwargs={"entity_id": entity_id, "domain": domain, **data})
         )
+
+    def notify(self, message: str, notifier: str, title: str | None = None, data: dict[str, Any] | None = None) -> None:
+        """Record a notify call directly under its own method name.
+
+        ``notifier`` is normalized the same way the real ``Api.notify`` normalizes it, so
+        assertions match on the bare service name regardless of which form the app passed.
+        """
+        notifier = normalize_notifier(notifier)
+        self._parent._record_call(
+            ApiCall(
+                method="notify",
+                args=(message, notifier),
+                kwargs={"message": message, "notifier": notifier, "title": title, "data": copy.deepcopy(data)},
+            )
+        )
+
+    def get_notify_services(self) -> list[str]:
+        """Return the notifier names seeded on ``notify_services`` (empty by default)."""
+        return sorted(self._parent.notify_services)
 
     def get_state_raw(self, entity_id: str) -> "HassStateDict":
         raise NotImplementedError(STUB_MSG_GENERIC.format(name="get_state_raw"))

--- a/tests/unit/test_api_coroutine_conversion.py
+++ b/tests/unit/test_api_coroutine_conversion.py
@@ -31,6 +31,7 @@ _API_METHODS = [
     pytest.param(lambda a: a.turn_on("light.kitchen"), id="turn_on"),
     pytest.param(lambda a: a.turn_off("light.kitchen"), id="turn_off"),
     pytest.param(lambda a: a.toggle("switch.fan"), id="toggle"),
+    pytest.param(lambda a: a.notify("hi", "mobile_app_test"), id="notify"),
 ]
 
 
@@ -65,6 +66,7 @@ def test_converted_method_is_plain_def(method_name: str) -> None:
         pytest.param(lambda a: a.turn_on("light.kitchen"), id="turn_on"),
         pytest.param(lambda a: a.turn_off("light.kitchen"), id="turn_off"),
         pytest.param(lambda a: a.toggle("switch.fan"), id="toggle"),
+        pytest.param(lambda a: a.notify("hi", "mobile_app_test"), id="notify"),
     ],
 )
 async def test_await_returns_none(call) -> None:

--- a/tests/unit/test_api_notify.py
+++ b/tests/unit/test_api_notify.py
@@ -1,0 +1,125 @@
+"""Unit tests for Api.notify, Api.get_notify_services, and notifier normalization.
+
+Tests cover:
+- notify() sends a notify.<notifier> service call with the expected service_data
+- Bare and fully-qualified notifier names normalize to the same service call
+- Blank and wrong-domain notifiers raise ValueError at the call site
+- title/data are omitted from the wire payload when None
+- get_notify_services() returns sorted bare names, and [] when HA exposes no notifiers
+"""
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from hassette.api.api import normalize_notifier
+from tests.unit.conftest import make_api
+
+
+@pytest.fixture(autouse=True)
+def drain(drain_forgotten_await_handles: None) -> None:
+    """Drain dropped handles after each test (shared fixture in tests/unit/conftest.py)."""
+
+
+def sent_payload(api) -> dict:
+    """Return the single payload passed to the mocked ws_send_json."""
+    assert api.ws_send_json.await_count == 1, (
+        f"Expected exactly one ws_send_json call, got {api.ws_send_json.await_count}"
+    )
+    return api.ws_send_json.await_args.kwargs
+
+
+async def test_notify_calls_notify_domain_service() -> None:
+    """notify() targets notify.<notifier> and passes message as service data."""
+    api = make_api()
+
+    await api.notify("The garage door is still open", "mobile_app_phone")
+
+    payload = sent_payload(api)
+    assert payload["type"] == "call_service"
+    assert payload["domain"] == "notify"
+    assert payload["service"] == "mobile_app_phone"
+    assert payload["service_data"] == {"message": "The garage door is still open"}
+
+
+async def test_notify_includes_title_and_data() -> None:
+    """Title and data are forwarded as service data fields."""
+    api = make_api()
+
+    await api.notify(
+        "Motion in the driveway",
+        "mobile_app_phone",
+        title="Security",
+        data={"push": {"sound": "alarm.caf"}},
+    )
+
+    assert sent_payload(api)["service_data"] == {
+        "message": "Motion in the driveway",
+        "title": "Security",
+        "data": {"push": {"sound": "alarm.caf"}},
+    }
+
+
+async def test_notify_omits_unset_title_and_data() -> None:
+    """Unset title/data are dropped rather than sent as nulls."""
+    api = make_api()
+
+    await api.notify("hello", "mobile_app_phone")
+
+    assert sent_payload(api)["service_data"] == {"message": "hello"}
+
+
+async def test_notify_accepts_fully_qualified_notifier() -> None:
+    """A 'notify.'-qualified notifier produces the same call as the bare name."""
+    api = make_api()
+
+    await api.notify("hello", "notify.mobile_app_phone")
+
+    payload = sent_payload(api)
+    assert payload["domain"] == "notify"
+    assert payload["service"] == "mobile_app_phone"
+
+
+@pytest.mark.parametrize("notifier", ["", "   ", "notify.", "light.kitchen", "notify.foo.bar"])
+async def test_notify_rejects_invalid_notifier(notifier: str) -> None:
+    """Blank or wrong-domain notifiers raise ValueError before anything is sent."""
+    api = make_api()
+
+    with pytest.raises(ValueError, match="notifier"):
+        await api.notify("hello", notifier)
+
+    assert api.ws_send_json.await_count == 0, "No service call should be sent for an invalid notifier"
+
+
+@pytest.mark.parametrize(
+    ("notifier", "expected"),
+    [
+        ("mobile_app_phone", "mobile_app_phone"),
+        ("notify.mobile_app_phone", "mobile_app_phone"),
+        ("  notify.persistent_notification  ", "persistent_notification"),
+    ],
+)
+def test_normalize_notifier(notifier: str, expected: str) -> None:
+    """normalize_notifier strips whitespace and the optional notify. prefix."""
+    assert normalize_notifier(notifier) == expected
+
+
+async def test_get_notify_services_returns_sorted_bare_names() -> None:
+    """get_notify_services returns the notify domain's service names, sorted."""
+    api = make_api()
+    api.get_services = AsyncMock(
+        return_value={
+            "light": {"turn_on": {}},
+            "notify": {"mobile_app_phone": {}, "persistent_notification": {}, "alexa_media": {}},
+        }
+    )
+
+    assert await api.get_notify_services() == ["alexa_media", "mobile_app_phone", "persistent_notification"]
+
+
+async def test_get_notify_services_without_notify_domain() -> None:
+    """An instance with no notify services yields an empty list, not a KeyError."""
+    api = make_api()
+    api.get_services = AsyncMock(return_value={"light": {"turn_on": {}}})
+
+    assert await api.get_notify_services() == []

--- a/tests/unit/test_forgotten_await_completeness.py
+++ b/tests/unit/test_forgotten_await_completeness.py
@@ -87,6 +87,7 @@ CANONICAL_PROTECTED: dict[type, set[str]] = {
         "turn_on",
         "turn_off",
         "toggle",
+        "notify",
     },
 }
 
@@ -141,6 +142,7 @@ DOCUMENTED_EXCLUSIONS: dict[type, set[str]] = {
         "get_histories",
         "get_history",
         "get_logbook",
+        "get_notify_services",
         "get_panels",
         "get_services",
         "get_state",

--- a/tests/unit/test_recording_api.py
+++ b/tests/unit/test_recording_api.py
@@ -10,6 +10,7 @@ Tests cover:
 - ApiProtocol conformance (smoke test)
 - ApiCall extraction to api_call module
 - StrEnum coercion for turn_on, turn_off, toggle
+- notify recording, notifier normalization, and seeded get_notify_services
 - Tailored __getattr__ messages
 - get_entity_or_none BaseEntity subclass path (regression for inline refactor)
 """
@@ -381,6 +382,59 @@ async def test_get_calls_filtered():
     assert turn_on_calls[0].method == "turn_on"
     set_state_calls = api.get_calls("set_state")
     assert len(set_state_calls) == 1
+
+
+async def test_notify_records_call():
+    api = make_recording_api()
+    await api.notify("door open", "mobile_app_phone", title="Alert", data={"push": {"sound": "alarm.caf"}})
+    assert len(api.calls) == 1
+    call = api.calls[0]
+    assert call.method == "notify"
+    assert call.args == ("door open", "mobile_app_phone")
+    assert call.kwargs == {
+        "message": "door open",
+        "notifier": "mobile_app_phone",
+        "title": "Alert",
+        "data": {"push": {"sound": "alarm.caf"}},
+    }
+
+
+async def test_notify_normalizes_fully_qualified_notifier():
+    """A 'notify.'-qualified notifier is recorded under its bare name, matching the real Api."""
+    api = make_recording_api()
+    await api.notify("hello", "notify.mobile_app_phone")
+    api.assert_called("notify", notifier="mobile_app_phone", message="hello")
+
+
+async def test_notify_rejects_invalid_notifier():
+    api = make_recording_api()
+    with pytest.raises(ValueError, match="notifier"):
+        await api.notify("hello", "light.kitchen")
+    assert api.calls == []
+
+
+async def test_notify_deep_copies_data():
+    """Mutating the caller's data dict after the call must not rewrite the recorded call."""
+    api = make_recording_api()
+    data = {"push": {"sound": "alarm.caf"}}
+    await api.notify("hello", "mobile_app_phone", data=data)
+    data["push"]["sound"] = "changed.caf"
+    assert api.calls[0].kwargs["data"] == {"push": {"sound": "alarm.caf"}}
+
+
+async def test_get_notify_services_returns_seeded_notifiers():
+    api = make_recording_api()
+    assert await api.get_notify_services() == []
+
+    api.notify_services = ["mobile_app_phone", "alexa_media"]
+    assert await api.get_notify_services() == ["alexa_media", "mobile_app_phone"]
+
+
+async def test_reset_clears_notify_services():
+    api = make_recording_api()
+    api.notify_services = ["mobile_app_phone"]
+    api.reset()
+    assert await api.get_notify_services() == []
 
 
 async def test_reset_clears_calls():

--- a/tests/unit/test_recording_api_write_parity.py
+++ b/tests/unit/test_recording_api_write_parity.py
@@ -33,6 +33,7 @@ KNOWN_READ_METHODS: frozenset[str] = frozenset(
         "get_states_raw",
         "get_config",
         "get_services",
+        "get_notify_services",
         "get_panels",
         "get_history",
         "get_histories",

--- a/tests/unit/test_recording_sync_facade.py
+++ b/tests/unit/test_recording_sync_facade.py
@@ -252,8 +252,8 @@ async def test_body_copied_methods_are_sync():
 
     Body-copied methods (keep in sync with the generator's output):
     call_service, entity_exists, fire_event, get_entity, get_entity_or_none,
-    get_state, get_state_or_none, get_states, set_state, toggle,
-    turn_off, turn_on
+    get_notify_services, get_state, get_state_or_none, get_states, notify,
+    set_state, toggle, turn_off, turn_on
     """
     # Seed both a sensor (for get_state-style calls) and a light (for get_entity
     # calls that require a real BaseEntity subclass).
@@ -269,9 +269,11 @@ async def test_body_copied_methods_are_sync():
         ("fire_event", ("custom_event",), {}),
         ("get_entity", ("light.test", LightEntity), {}),
         ("get_entity_or_none", ("light.test", LightEntity), {}),
+        ("get_notify_services", (), {}),
         ("get_state", ("sensor.test",), {}),
         ("get_state_or_none", ("sensor.test",), {}),
         ("get_states", (), {}),
+        ("notify", ("hello", "mobile_app_test"), {}),
         ("set_state", ("sensor.test", "off"), {}),
         ("toggle", ("sensor.test",), {}),
         ("turn_off", ("sensor.test",), {}),


### PR DESCRIPTION
## Summary

Adds a typed, discoverable wrapper for Home Assistant's notify services. Calling a notifier previously meant reaching for the raw transport (`await self.api.call_service("notify", "mobile_app_phone", message="hi")`) — workable, but undiscoverable via autocomplete and easy to get subtly wrong. AppDaemon exposes `self.notify()` as a first-class method; this closes that parity gap.

## What changed

**`Api.notify(message, notifier, title=None, data=None)`** — calls `notify.<notifier>`. Unset `title`/`data` are dropped from the service payload rather than sent as explicit nulls (`_call_service` already strips `None` values from service data).

**Notifier normalization** — `notifier` accepts either the bare name (`"mobile_app_phone"`) or the fully-qualified form (`"notify.mobile_app_phone"`), so users can paste whichever form they see in HA's developer tools. Blank values and wrong-domain values (`"light.kitchen"`) raise `ValueError` at the call site, where the traceback points at the caller, instead of failing silently inside Home Assistant.

**`Api.get_notify_services()`** — lists the notifiers registered on the connected instance, sorted and stripped of the `notify.` prefix so results can be passed straight back into `notify()`.

**Test harness** — `RecordingApi` and `ApiProtocol` gain both methods, so harness users can assert on notify calls without a real HA connection and seed available notifiers via `api_recorder.notify_services`.

**Sync facades** — `api/sync.py` and `test_utils/sync_facade.py` regenerated so the sync API stays in step.

## Docs

- `docs/pages/core-concepts/api/methods.md` — reference entries for both methods, with runnable snippets.
- `docs/pages/migration/api.md` — new "Sending Notifications" section. Worth calling out for reviewers: AppDaemon's `notify()` defaults `name` to the `notify` service, while Hassette requires the notifier explicitly. That divergence is deliberate — an implicit default target is the kind of thing that silently sends to the wrong place — so the migration guide names it rather than papering over it.

No frontend surface is touched.

## Testing

- `uv run nox -s dev` — 8170 passed, 1 skipped, 2 xfailed.
- `prek -a` — all hooks pass.
- `prek pyright -a --stage pre-push` — passes.

New coverage in `tests/unit/test_api_notify.py` (happy path, title/data omission, bare vs. qualified normalization, blank and wrong-domain `ValueError`s) and `tests/unit/test_recording_api.py` (recording and seeding through the harness). The existing signature-parity suites — `test_api_coroutine_conversion.py`, `test_forgotten_await_completeness.py`, `test_recording_api_write_parity.py`, `test_recording_sync_facade.py` — pick up the new methods automatically, which is what keeps the sync facades and `RecordingApi` honest.

Closes #949