### PR TITLE
fix: prevent filter panel layout shift on open

### DIFF
--- a/frontend/src/components/shared/column-filter-popover/index.module.css
+++ b/frontend/src/components/shared/column-filter-popover/index.module.css
@@ -7,6 +7,7 @@
   left: 0;
   top: 0;
   opacity: 0;
+  pointer-events: none;
   z-index: var(--z-drawer);
   background: var(--bg-surface);
   border: var(--sp-px) solid var(--line-1);
@@ -22,6 +23,7 @@
 
 .positioned {
   opacity: 1;
+  pointer-events: auto;
 }
 
 .popover select,

--- a/frontend/src/components/shared/column-filter-popover/index.module.css
+++ b/frontend/src/components/shared/column-filter-popover/index.module.css
@@ -1,5 +1,12 @@
 .popover {
   position: fixed;
+  /* Anchor the first frame: computePosition() is async, so without an explicit origin the
+     popover paints at its static position before the computed one lands. Kept invisible until
+     .positioned so that frame is never seen. Opacity (not visibility) so the focus-on-open
+     effect can still reach the children. */
+  left: 0;
+  top: 0;
+  opacity: 0;
   z-index: var(--z-drawer);
   background: var(--bg-surface);
   border: var(--sp-px) solid var(--line-1);
@@ -11,6 +18,10 @@
   /* size() middleware in index.tsx sets a tighter max-height at runtime */
   max-height: 90vh;
   overflow: hidden auto;
+}
+
+.positioned {
+  opacity: 1;
 }
 
 .popover select,

--- a/frontend/src/components/shared/column-filter-popover/index.test.tsx
+++ b/frontend/src/components/shared/column-filter-popover/index.test.tsx
@@ -3,6 +3,14 @@ import { useRef } from "preact/hooks";
 import { describe, expect, it, vi } from "vitest";
 
 import { ColumnFilterPopover } from "./index";
+import styles from "./index.module.css";
+
+/** floating-ui positions on an animation frame, so a microtask flush alone is not enough. */
+async function flushPositioning() {
+  await act(async () => {
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  });
+}
 
 // Wrapper that exposes a trigger button and the popover under test
 function PopoverHarness({ open, onClose }: { open: boolean; onClose: () => void }) {
@@ -126,6 +134,35 @@ describe("ColumnFilterPopover", () => {
       render(<PopoverHarness open={true} onClose={vi.fn()} />);
       const dialog = screen.getByRole("dialog");
       expect(dialog).toBeTruthy();
+    });
+
+    it("stays unpositioned (hidden) until computePosition resolves", () => {
+      render(<PopoverHarness open={true} onClose={vi.fn()} />);
+      // computePosition is async — on the mount frame the popover must not be visible yet,
+      // otherwise it paints at its pre-computation origin and then jumps.
+      expect(screen.getByRole("dialog").classList.contains(styles.positioned)).toBe(false);
+    });
+
+    it("marks the popover positioned and sets inline coordinates once computePosition resolves", async () => {
+      render(<PopoverHarness open={true} onClose={vi.fn()} />);
+      await flushPositioning();
+      const dialog = screen.getByRole("dialog") as HTMLElement;
+      expect(dialog.classList.contains(styles.positioned)).toBe(true);
+      expect(dialog.style.left).not.toBe("");
+      expect(dialog.style.top).not.toBe("");
+    });
+
+    it("starts unpositioned again when reopened", async () => {
+      const onClose = vi.fn();
+      const { rerender } = render(<PopoverHarness open={true} onClose={onClose} />);
+      await flushPositioning();
+      expect(screen.getByRole("dialog").classList.contains(styles.positioned)).toBe(true);
+
+      rerender(<PopoverHarness open={false} onClose={onClose} />);
+      await flushPositioning();
+      rerender(<PopoverHarness open={true} onClose={onClose} />);
+
+      expect(screen.getByRole("dialog").classList.contains(styles.positioned)).toBe(false);
     });
   });
 });

--- a/frontend/src/components/shared/column-filter-popover/index.test.tsx
+++ b/frontend/src/components/shared/column-filter-popover/index.test.tsx
@@ -146,7 +146,7 @@ describe("ColumnFilterPopover", () => {
     it("marks the popover positioned and sets inline coordinates once computePosition resolves", async () => {
       render(<PopoverHarness open={true} onClose={vi.fn()} />);
       await flushPositioning();
-      const dialog = screen.getByRole("dialog") as HTMLElement;
+      const dialog = screen.getByRole("dialog");
       expect(dialog.classList.contains(styles.positioned)).toBe(true);
       expect(dialog.style.left).not.toBe("");
       expect(dialog.style.top).not.toBe("");

--- a/frontend/src/components/shared/column-filter-popover/index.tsx
+++ b/frontend/src/components/shared/column-filter-popover/index.tsx
@@ -1,6 +1,7 @@
 import { autoUpdate, computePosition, flip, offset, shift, size } from "@floating-ui/dom";
+import clsx from "clsx";
 import type { ComponentChildren } from "preact";
-import { useEffect, useRef } from "preact/hooks";
+import { useEffect, useRef, useState } from "preact/hooks";
 
 import styles from "./index.module.css";
 
@@ -29,13 +30,22 @@ export function ColumnFilterPopover({ open, onClose, triggerRef, label, children
   const popoverRef = useRef<HTMLDivElement>(null);
   const ignoreNextClick = useRef(false);
   const wasOpen = useRef(false);
+  // Gates visibility until computePosition() lands, so the popover is never painted at its
+  // pre-computation origin.
+  const [positioned, setPositioned] = useState(false);
 
   // Floating-ui position management
   useEffect(() => {
-    if (!open || !triggerRef.current || !popoverRef.current) return;
+    if (!open || !triggerRef.current || !popoverRef.current) {
+      setPositioned(false);
+      return;
+    }
 
     const trigger = triggerRef.current;
     const popover = popoverRef.current;
+    // A computePosition() promise can resolve after close; without this the next open would
+    // start already-visible and paint at the stale position for a frame.
+    let closed = false;
 
     const cleanup = autoUpdate(trigger, popover, () => {
       void computePosition(trigger, popover, {
@@ -54,12 +64,17 @@ export function ColumnFilterPopover({ open, onClose, triggerRef, label, children
           }),
         ],
       }).then(({ x, y }) => {
+        if (closed) return;
         popover.style.left = `${x}px`;
         popover.style.top = `${y}px`;
+        setPositioned(true);
       });
     });
 
-    return cleanup;
+    return () => {
+      closed = true;
+      cleanup();
+    };
   }, [open, triggerRef]);
 
   // Focus management: focus first focusable child on open
@@ -145,7 +160,7 @@ export function ColumnFilterPopover({ open, onClose, triggerRef, label, children
   return (
     <div
       ref={popoverRef}
-      class={styles.popover}
+      class={clsx(styles.popover, positioned && styles.positioned)}
       role="dialog"
       aria-label={label ?? "Column filter"}
       tabIndex={-1}

--- a/frontend/src/components/shared/info-popover.module.css
+++ b/frontend/src/components/shared/info-popover.module.css
@@ -34,6 +34,12 @@
    absolute would break the positioning. */
 .pop {
   position: fixed;
+  /* Anchor the first frame: computePosition() is async, so without an explicit origin the
+     popover paints at its static position before the computed one lands. Kept invisible until
+     .positioned so that frame is never seen. */
+  left: 0;
+  top: 0;
+  opacity: 0;
   z-index: var(--z-tooltip);
   max-width: var(--sz-popover-max);
   max-height: 60vh;
@@ -47,4 +53,8 @@
   border: var(--sp-px) solid var(--line-strong);
   border-radius: var(--r-md);
   box-shadow: var(--shadow-3);
+}
+
+.positioned {
+  opacity: 1;
 }

--- a/frontend/src/components/shared/info-popover.module.css
+++ b/frontend/src/components/shared/info-popover.module.css
@@ -40,6 +40,7 @@
   left: 0;
   top: 0;
   opacity: 0;
+  pointer-events: none;
   z-index: var(--z-tooltip);
   max-width: var(--sz-popover-max);
   max-height: 60vh;
@@ -57,4 +58,5 @@
 
 .positioned {
   opacity: 1;
+  pointer-events: auto;
 }

--- a/frontend/src/components/shared/info-popover.tsx
+++ b/frontend/src/components/shared/info-popover.tsx
@@ -1,4 +1,5 @@
 import { autoUpdate, computePosition, flip, offset, shift } from "@floating-ui/dom";
+import clsx from "clsx";
 import { useEffect, useId, useRef, useState } from "preact/hooks";
 
 import styles from "./info-popover.module.css";
@@ -23,21 +24,39 @@ export function InfoPopover({ text, label = "field" }: Props) {
   const triggerRef = useRef<HTMLButtonElement>(null);
   const popRef = useRef<HTMLDivElement>(null);
 
+  // Gates visibility until computePosition() lands, so the popover is never painted at its
+  // pre-computation origin.
+  const [positioned, setPositioned] = useState(false);
+
   // Position the popover under the trigger and keep it anchored on scroll/resize.
   useEffect(() => {
-    if (!open || !triggerRef.current || !popRef.current) return;
+    if (!open || !triggerRef.current || !popRef.current) {
+      setPositioned(false);
+      return;
+    }
     const trigger = triggerRef.current;
     const pop = popRef.current;
-    return autoUpdate(trigger, pop, () => {
+    // A computePosition() promise can resolve after close; without this the next open would
+    // start already-visible and paint at the stale position for a frame.
+    let closed = false;
+
+    const cleanup = autoUpdate(trigger, pop, () => {
       void computePosition(trigger, pop, {
         strategy: "fixed",
         placement: "bottom",
         middleware: [offset(6), flip(), shift({ padding: 8 })],
       }).then(({ x, y }) => {
+        if (closed) return;
         pop.style.left = `${x}px`;
         pop.style.top = `${y}px`;
+        setPositioned(true);
       });
     });
+
+    return () => {
+      closed = true;
+      cleanup();
+    };
   }, [open]);
 
   // Dismiss on Escape or a click outside the trigger/popover.
@@ -86,7 +105,13 @@ export function InfoPopover({ text, label = "field" }: Props) {
         </svg>
       </button>
       {open && (
-        <div id={popId} ref={popRef} class={styles.pop} role="note" data-testid="field-help">
+        <div
+          id={popId}
+          ref={popRef}
+          class={clsx(styles.pop, positioned && styles.positioned)}
+          role="note"
+          data-testid="field-help"
+        >
           {text}
         </div>
       )}

--- a/frontend/src/styles/layout.css
+++ b/frontend/src/styles/layout.css
@@ -30,6 +30,9 @@
   border-radius: var(--r-lg) var(--r-lg) 0 0;
   box-shadow: var(--shadow-2);
   overflow-y: auto;
+  /* Reserve the scrollbar track always — otherwise content jumps horizontally the moment a page
+     grows tall enough to scroll. */
+  scrollbar-gutter: stable;
   min-width: 0;
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
## Summary

The filter panel jumped down and to the right when it appeared. Two independent causes, both fixed here.

**Popover paints before it is positioned.** `ColumnFilterPopover` anchors itself with floating-ui's `computePosition()`, which is async. The element mounts and paints at its static origin for a frame or two, then snaps to the anchored position once the promise resolves. The popover now carries an explicit `left: 0; top: 0` origin and sits at `opacity: 0` until the first computed position lands, at which point a `.positioned` class reveals it. Opacity rather than `visibility: hidden` so the existing focus-on-open effect can still reach the popover's children.

The effect also tracks a `closed` flag in its cleanup. A `computePosition()` promise can resolve after the popover closes; without the guard, the next open would start already-visible and paint one frame at the stale coordinates — the same bug in a less obvious disguise.

**Scrollbar appearance shifts content horizontally.** `.ht-main` uses `overflow-y: auto`, so the 15px scrollbar track appears the moment a page grows tall enough to scroll, pushing content sideways. `scrollbar-gutter: stable` reserves the track permanently instead.

## Testing

Three tests added to `column-filter-popover/index.test.tsx`, covering the popover's positioning lifecycle:

- it is unpositioned (hidden) on the mount frame, before `computePosition` resolves
- it gains `.positioned` and inline `left`/`top` once positioning lands
- it returns to unpositioned when closed and reopened — the regression the `closed` guard prevents

Verification run on this branch:

- `uv run nox -s dev` — 8134 passed, 1 skipped, 2 xfailed
- `npm run test` (frontend) — 95 files, 1451 tests passed
- `prek -a` — all hooks pass
- `prek -a --hook-stage pre-push` — all hooks pass, including pyright and schema freshness

## Visual evidence

No screenshots attached, and I want to be explicit about why rather than quietly skipping the gate.

The popover fix is a transient-frame bug: the steady-state rendering before and after this change is identical, so a still image cannot show the difference. The `scrollbar-gutter: stable` change *is* a real static change — content in `.ht-main` now sits 15px narrower on pages that do not scroll — so the `no-visual-change` label would be inaccurate.

`pr-screenshots.yml` will flag this PR. Reviewer's call on how to satisfy it: capture a before/after of a non-scrolling page to document the gutter change, or accept the label as close enough.

Closes #956
