### PR TITLE
ci: add CLI surface drift detection check

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -112,19 +112,6 @@ jobs:
             - name: Check coordinator-internal annotations in core tests
               run: uv run python tools/check_coordinator_internal.py
 
-            - name: Check CLI surface for drift
-              # The "regenerate docs" step below is manual today — automatic Cog-based
-              # doc generation is tracked separately (#855) and not yet wired up.
-              run: |
-                  if ! uv run python tools/check_cli_drift.py; then
-                    echo ""
-                    echo "ERROR: CLI surface changed but docs were not regenerated."
-                    echo "  Re-run: uv run python tools/check_cli_drift.py --update"
-                    echo "  Then update docs/pages/cli/commands.md and docs/pages/cli/index.md by hand to match."
-                    echo ""
-                    exit 1
-                  fi
-
             - name: Check file sizes (non-blocking)
               continue-on-error: true
               run: uv run python tools/check_file_size.py

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -112,6 +112,19 @@ jobs:
             - name: Check coordinator-internal annotations in core tests
               run: uv run python tools/check_coordinator_internal.py
 
+            - name: Check CLI surface for drift
+              # The "regenerate docs" step below is manual today — automatic Cog-based
+              # doc generation is tracked separately (#855) and not yet wired up.
+              run: |
+                  if ! uv run python tools/check_cli_drift.py; then
+                    echo ""
+                    echo "ERROR: CLI surface changed but docs were not regenerated."
+                    echo "  Re-run: uv run python tools/check_cli_drift.py --update"
+                    echo "  Then update docs/pages/cli/commands.md and docs/pages/cli/index.md by hand to match."
+                    echo ""
+                    exit 1
+                  fi
+
             - name: Check file sizes (non-blocking)
               continue-on-error: true
               run: uv run python tools/check_file_size.py

--- a/prek.toml
+++ b/prek.toml
@@ -270,6 +270,15 @@ files = "^src/hassette/(web/|config/)"
 stages = ["pre-push"]
 
 [[repos.hooks]]
+id = "check-cli-drift"
+name = "Check CLI surface for drift"
+language = "system"
+entry = "tools/check_cli_drift.py"
+pass_filenames = false
+files = "^(src/hassette/cli/|tests/snapshots/cli_)"
+stages = ["pre-push"]
+
+[[repos.hooks]]
 id = "check-missing-attribute"
 name = "Check for missing 'attributes' in State classes"
 language = "system"

--- a/tests/snapshots/cli_columns.json
+++ b/tests/snapshots/cli_columns.json
@@ -1,0 +1,543 @@
+{
+  "app": {
+    "APP_ACTIVITY_COLUMNS": [
+      {
+        "field": "row_id",
+        "formatter": null,
+        "header": "ID",
+        "max_width": 10,
+        "overflow": "ellipsis"
+      },
+      {
+        "field": "kind",
+        "formatter": null,
+        "header": "Kind",
+        "max_width": 8,
+        "overflow": "ellipsis"
+      },
+      {
+        "field": "status",
+        "formatter": null,
+        "header": "Status",
+        "max_width": 10,
+        "overflow": "ellipsis"
+      },
+      {
+        "field": "app_key",
+        "formatter": null,
+        "header": "App",
+        "max_width": 16,
+        "overflow": "ellipsis"
+      },
+      {
+        "field": "handler_name",
+        "formatter": null,
+        "header": "Handler",
+        "max_width": 22,
+        "overflow": "ellipsis"
+      },
+      {
+        "field": "duration_ms",
+        "formatter": "fmt_duration_ms",
+        "header": "Duration",
+        "max_width": 9,
+        "overflow": "ellipsis"
+      },
+      {
+        "field": "timestamp",
+        "formatter": "fmt_relative_time",
+        "header": "When",
+        "max_width": 11,
+        "overflow": "ellipsis"
+      },
+      {
+        "field": "error_type",
+        "formatter": null,
+        "header": "Error",
+        "max_width": 16,
+        "overflow": "ellipsis"
+      }
+    ],
+    "APP_HEALTH_COLUMNS": [
+      {
+        "field": "health_status",
+        "formatter": null,
+        "header": "Health",
+        "max_width": 10,
+        "overflow": "ellipsis"
+      },
+      {
+        "field": "error_rate",
+        "formatter": null,
+        "header": "Error Rate",
+        "max_width": 10,
+        "overflow": "ellipsis"
+      },
+      {
+        "field": "error_rate_class",
+        "formatter": null,
+        "header": "Rate Class",
+        "max_width": 10,
+        "overflow": "ellipsis"
+      },
+      {
+        "field": "handler_avg_duration",
+        "formatter": "fmt_duration_ms",
+        "header": "Handler Avg",
+        "max_width": 11,
+        "overflow": "ellipsis"
+      },
+      {
+        "field": "job_avg_duration",
+        "formatter": "fmt_duration_ms",
+        "header": "Job Avg",
+        "max_width": 9,
+        "overflow": "ellipsis"
+      },
+      {
+        "field": "last_activity_ts",
+        "formatter": "fmt_relative_time",
+        "header": "Last Active",
+        "max_width": 11,
+        "overflow": "ellipsis"
+      }
+    ],
+    "APP_LIST_COLUMNS": [
+      {
+        "field": "app_key",
+        "formatter": null,
+        "header": "App Key",
+        "max_width": 20,
+        "overflow": "ellipsis"
+      },
+      {
+        "field": "status",
+        "formatter": null,
+        "header": "Status",
+        "max_width": 10,
+        "overflow": "ellipsis"
+      },
+      {
+        "field": "display_name",
+        "formatter": null,
+        "header": "Display Name",
+        "max_width": 22,
+        "overflow": "ellipsis"
+      },
+      {
+        "field": "instance_count",
+        "formatter": null,
+        "header": "Instances",
+        "max_width": 9,
+        "overflow": "ellipsis"
+      },
+      {
+        "field": "recent_invocations_1h",
+        "formatter": null,
+        "header": "Invoc/1h",
+        "max_width": 8,
+        "overflow": "ellipsis"
+      },
+      {
+        "field": "enabled",
+        "formatter": null,
+        "header": "Enabled",
+        "max_width": 7,
+        "overflow": "ellipsis"
+      },
+      {
+        "field": "autostart",
+        "formatter": null,
+        "header": "Autostart",
+        "max_width": 9,
+        "overflow": "ellipsis"
+      },
+      {
+        "field": "filename",
+        "formatter": null,
+        "header": "File",
+        "max_width": 20,
+        "overflow": "ellipsis"
+      }
+    ]
+  },
+  "job": {
+    "JOB_EXECUTION_COLUMNS": [
+      {
+        "field": "status",
+        "formatter": null,
+        "header": "Status",
+        "max_width": 10,
+        "overflow": "ellipsis"
+      },
+      {
+        "field": "duration_ms",
+        "formatter": "fmt_duration_ms",
+        "header": "Duration",
+        "max_width": 9,
+        "overflow": "ellipsis"
+      },
+      {
+        "field": "error_type",
+        "formatter": null,
+        "header": "Error Type",
+        "max_width": 20,
+        "overflow": "ellipsis"
+      },
+      {
+        "field": "error_message",
+        "formatter": null,
+        "header": "Error Message",
+        "max_width": 28,
+        "overflow": "ellipsis"
+      },
+      {
+        "field": "execution_start_ts",
+        "formatter": "fmt_relative_time",
+        "header": "When",
+        "max_width": 11,
+        "overflow": "ellipsis"
+      },
+      {
+        "field": "execution_id",
+        "formatter": null,
+        "header": "Execution ID",
+        "max_width": 14,
+        "overflow": "ellipsis"
+      }
+    ],
+    "JOB_LIST_COLUMNS": [
+      {
+        "field": "job_id",
+        "formatter": null,
+        "header": "ID",
+        "max_width": 6,
+        "overflow": "ellipsis"
+      },
+      {
+        "field": "app_key",
+        "formatter": null,
+        "header": "App",
+        "max_width": 18,
+        "overflow": "ellipsis"
+      },
+      {
+        "field": "job_name",
+        "formatter": null,
+        "header": "Handler",
+        "max_width": 22,
+        "overflow": "ellipsis"
+      },
+      {
+        "field": "trigger_type",
+        "formatter": null,
+        "header": "Trigger",
+        "max_width": 10,
+        "overflow": "ellipsis"
+      },
+      {
+        "field": "trigger_detail",
+        "formatter": null,
+        "header": "Schedule",
+        "max_width": 20,
+        "overflow": "ellipsis"
+      },
+      {
+        "field": "mode",
+        "formatter": null,
+        "header": "Mode",
+        "max_width": 9,
+        "overflow": "ellipsis"
+      },
+      {
+        "field": "total_executions",
+        "formatter": null,
+        "header": "Total",
+        "max_width": 7,
+        "overflow": "ellipsis"
+      },
+      {
+        "field": "successful",
+        "formatter": null,
+        "header": "OK",
+        "max_width": 6,
+        "overflow": "ellipsis"
+      },
+      {
+        "field": "failed",
+        "formatter": null,
+        "header": "Fail",
+        "max_width": 6,
+        "overflow": "ellipsis"
+      },
+      {
+        "field": "avg_duration_ms",
+        "formatter": "fmt_duration_ms",
+        "header": "Avg",
+        "max_width": 7,
+        "overflow": "ellipsis"
+      },
+      {
+        "field": "next_run",
+        "formatter": "fmt_next_run",
+        "header": "Next Run",
+        "max_width": 11,
+        "overflow": "ellipsis"
+      }
+    ]
+  },
+  "listener": {
+    "LISTENER_INVOCATION_COLUMNS": [
+      {
+        "field": "status",
+        "formatter": null,
+        "header": "Status",
+        "max_width": 10,
+        "overflow": "ellipsis"
+      },
+      {
+        "field": "duration_ms",
+        "formatter": "fmt_duration_ms",
+        "header": "Duration",
+        "max_width": 9,
+        "overflow": "ellipsis"
+      },
+      {
+        "field": "error_type",
+        "formatter": null,
+        "header": "Error Type",
+        "max_width": 20,
+        "overflow": "ellipsis"
+      },
+      {
+        "field": "error_message",
+        "formatter": null,
+        "header": "Error Message",
+        "max_width": 28,
+        "overflow": "ellipsis"
+      },
+      {
+        "field": "execution_start_ts",
+        "formatter": "fmt_relative_time",
+        "header": "When",
+        "max_width": 11,
+        "overflow": "ellipsis"
+      },
+      {
+        "field": "execution_id",
+        "formatter": null,
+        "header": "Execution ID",
+        "max_width": 14,
+        "overflow": "ellipsis"
+      }
+    ],
+    "LISTENER_LIST_COLUMNS": [
+      {
+        "field": "listener_id",
+        "formatter": null,
+        "header": "ID",
+        "max_width": 6,
+        "overflow": "ellipsis"
+      },
+      {
+        "field": "app_key",
+        "formatter": null,
+        "header": "App",
+        "max_width": 18,
+        "overflow": "ellipsis"
+      },
+      {
+        "field": "entity_id",
+        "formatter": null,
+        "header": "Target",
+        "max_width": 26,
+        "overflow": "ellipsis"
+      },
+      {
+        "field": "listener_kind",
+        "formatter": null,
+        "header": "Kind",
+        "max_width": 12,
+        "overflow": "ellipsis"
+      },
+      {
+        "field": "handler_method",
+        "formatter": "fmt_handler_short",
+        "header": "Handler",
+        "max_width": 22,
+        "overflow": "ellipsis"
+      },
+      {
+        "field": "total_invocations",
+        "formatter": null,
+        "header": "Total",
+        "max_width": 7,
+        "overflow": "ellipsis"
+      },
+      {
+        "field": "successful",
+        "formatter": null,
+        "header": "OK",
+        "max_width": 6,
+        "overflow": "ellipsis"
+      },
+      {
+        "field": "failed",
+        "formatter": null,
+        "header": "Fail",
+        "max_width": 6,
+        "overflow": "ellipsis"
+      },
+      {
+        "field": "avg_duration_ms",
+        "formatter": "fmt_duration_ms",
+        "header": "Avg",
+        "max_width": 7,
+        "overflow": "ellipsis"
+      },
+      {
+        "field": "last_invoked_at",
+        "formatter": "fmt_relative_time",
+        "header": "Last",
+        "max_width": 9,
+        "overflow": "ellipsis"
+      }
+    ]
+  },
+  "log": {
+    "EXECUTION_LOG_COLUMNS": [
+      {
+        "field": "timestamp",
+        "formatter": "fmt_relative_time",
+        "header": "When",
+        "max_width": null,
+        "overflow": "ellipsis"
+      },
+      {
+        "field": "level",
+        "formatter": null,
+        "header": "Level",
+        "max_width": null,
+        "overflow": "ellipsis"
+      },
+      {
+        "field": "func_name",
+        "formatter": null,
+        "header": "Function",
+        "max_width": null,
+        "overflow": "ellipsis"
+      },
+      {
+        "field": "lineno",
+        "formatter": null,
+        "header": "Line",
+        "max_width": null,
+        "overflow": "ellipsis"
+      },
+      {
+        "field": "message",
+        "formatter": null,
+        "header": "Message",
+        "max_width": null,
+        "overflow": "ellipsis"
+      }
+    ],
+    "LOG_COLUMNS": [
+      {
+        "field": "timestamp",
+        "formatter": "fmt_relative_time",
+        "header": "When",
+        "max_width": null,
+        "overflow": "ellipsis"
+      },
+      {
+        "field": "level",
+        "formatter": null,
+        "header": "Level",
+        "max_width": null,
+        "overflow": "ellipsis"
+      },
+      {
+        "field": "app_key",
+        "formatter": null,
+        "header": "App",
+        "max_width": null,
+        "overflow": "ellipsis"
+      },
+      {
+        "field": "instance_name",
+        "formatter": null,
+        "header": "Instance",
+        "max_width": null,
+        "overflow": "ellipsis"
+      },
+      {
+        "field": "func_name",
+        "formatter": null,
+        "header": "Function",
+        "max_width": null,
+        "overflow": "ellipsis"
+      },
+      {
+        "field": "message",
+        "formatter": null,
+        "header": "Message",
+        "max_width": null,
+        "overflow": "ellipsis"
+      }
+    ]
+  },
+  "status": {
+    "DASHBOARD_COLUMNS": [
+      {
+        "field": "app_key",
+        "formatter": null,
+        "header": "App",
+        "max_width": 20,
+        "overflow": "ellipsis"
+      },
+      {
+        "field": "status",
+        "formatter": null,
+        "header": "Status",
+        "max_width": 8,
+        "overflow": "ellipsis"
+      },
+      {
+        "field": "total_invocations",
+        "formatter": null,
+        "header": "Invoc",
+        "max_width": 6,
+        "overflow": "ellipsis"
+      },
+      {
+        "field": "total_errors",
+        "formatter": null,
+        "header": "Errs",
+        "max_width": 5,
+        "overflow": "ellipsis"
+      },
+      {
+        "field": "avg_duration_ms",
+        "formatter": "fmt_duration_ms",
+        "header": "Avg Dur",
+        "max_width": 8,
+        "overflow": "ellipsis"
+      },
+      {
+        "field": "last_activity_ts",
+        "formatter": "fmt_relative_time",
+        "header": "Last Active",
+        "max_width": 11,
+        "overflow": "ellipsis"
+      },
+      {
+        "field": "health_status",
+        "formatter": null,
+        "header": "Health",
+        "max_width": 9,
+        "overflow": "ellipsis"
+      }
+    ]
+  }
+}

--- a/tests/snapshots/cli_help.txt
+++ b/tests/snapshots/cli_help.txt
@@ -1,0 +1,276 @@
+$ hassette --help
+Usage: hassette COMMAND [OPTIONS]
+
+Hassette — async-first Home Assistant automation framework.
+
+╭─ Commands ───────────────────────────────────────────────────────────────────────────────────────╮
+│ app                    List and inspect apps.                                                    │
+│ config                 Show current configuration.                                               │
+│ dashboard              Show app dashboard grid.                                                  │
+│ execution              Show logs for a specific execution.                                       │
+│ job                    List scheduled jobs and execution history.                                │
+│ listener               List listeners and invocation history.                                    │
+│ log                    Show recent log entries.                                                  │
+│ run                    Start the Hassette framework server.                                      │
+│ status                 Show system status.                                                       │
+│ telemetry              Show telemetry status.                                                    │
+│ --generate-completion  Print shell completion script to stdout.                                  │
+│ --help (-h)            Display this message and exit.                                            │
+│ --install-completion   Install shell completion for this application.                            │
+│ --version (-v)         Display application version.                                              │
+╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
+╭─ Global Options ─────────────────────────────────────────────────────────────────────────────────╮
+│ --config-file -c     Path to the TOML configuration file.                                        │
+│ --env-file --env -e  Path to the .env file.                                                      │
+│ --json               Output results as JSON. [default: False]                                    │
+│ --debug              Show full HTTP response on CLI errors. [default: False]                     │
+╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
+
+$ hassette app --help
+Usage: hassette app COMMAND [OPTIONS]
+
+List and inspect apps.
+
+╭─ Commands ───────────────────────────────────────────────────────────────────────────────────────╮
+│ activity  Show recent activity for an app (GET /api/telemetry/app/{key}/activity).               │
+│ config    Show app configuration (GET /api/apps/{key}/config).                                   │
+│ health    Show health metrics for an app instance (GET /api/telemetry/app/{key}/health).         │
+│ source    Show app source code (GET /api/apps/{key}/source).                                     │
+╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
+╭─ Global Options ─────────────────────────────────────────────────────────────────────────────────╮
+│ --config-file -c     Path to the TOML configuration file.                                        │
+│ --env-file --env -e  Path to the .env file.                                                      │
+│ --json               Output results as JSON. [default: False]                                    │
+│ --debug              Show full HTTP response on CLI errors. [default: False]                     │
+╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
+
+$ hassette app activity --help
+Usage: hassette app activity [OPTIONS] KEY [ARGS]
+
+Show recent activity for an app (GET /api/telemetry/app/{key}/activity).
+
+╭─ Parameters ─────────────────────────────────────────────────────────────────────────────────────╮
+│ *  KEY --key            [required]                                                               │
+│    INSTANCE --instance  Filter by app instance (integer index or instance name). Requires --app. │
+│    SINCE --since        Filter by time. Accepts relative (1h, 7d, 30m, 2w, 30s) or absolute      │
+│                         (2026-05-22, 2026-05-22T14:00:00) timestamps. Naive timestamps use local │
+│                         time.                                                                    │
+│    LIMIT --limit        Maximum number of results to return.                                     │
+╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
+╭─ Global Options ─────────────────────────────────────────────────────────────────────────────────╮
+│ --config-file -c     Path to the TOML configuration file.                                        │
+│ --env-file --env -e  Path to the .env file.                                                      │
+│ --json               Output results as JSON. [default: False]                                    │
+│ --debug              Show full HTTP response on CLI errors. [default: False]                     │
+╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
+
+$ hassette app config --help
+Usage: hassette app config [OPTIONS] KEY
+
+Show app configuration (GET /api/apps/{key}/config).
+
+Renders the app's metadata and masked config values. The fully-inlined config_schema is part of the
+response but is intentionally not shown — it is a large machine-oriented blob, not something a CLI
+reader needs.
+
+╭─ Parameters ─────────────────────────────────────────────────────────────────────────────────────╮
+│ *  KEY --key  [required]                                                                         │
+╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
+╭─ Global Options ─────────────────────────────────────────────────────────────────────────────────╮
+│ --config-file -c     Path to the TOML configuration file.                                        │
+│ --env-file --env -e  Path to the .env file.                                                      │
+│ --json               Output results as JSON. [default: False]                                    │
+│ --debug              Show full HTTP response on CLI errors. [default: False]                     │
+╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
+
+$ hassette app health --help
+Usage: hassette app health [OPTIONS] KEY [ARGS]
+
+Show health metrics for an app instance (GET /api/telemetry/app/{key}/health).
+
+╭─ Parameters ─────────────────────────────────────────────────────────────────────────────────────╮
+│ *  KEY --key                  [required]                                                         │
+│    INSTANCE --instance        Filter by app instance (integer index or instance name). Requires  │
+│                               --app.                                                             │
+│    SINCE --since              Filter by time. Accepts relative (1h, 7d, 30m, 2w, 30s) or         │
+│                               absolute (2026-05-22, 2026-05-22T14:00:00) timestamps. Naive       │
+│                               timestamps use local time.                                         │
+│    SOURCE-TIER --source-tier  Filter by telemetry source tier: 'app', 'framework', or 'all'.     │
+│                               [choices: app, framework, all]                                     │
+╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
+╭─ Global Options ─────────────────────────────────────────────────────────────────────────────────╮
+│ --config-file -c     Path to the TOML configuration file.                                        │
+│ --env-file --env -e  Path to the .env file.                                                      │
+│ --json               Output results as JSON. [default: False]                                    │
+│ --debug              Show full HTTP response on CLI errors. [default: False]                     │
+╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
+
+$ hassette app source --help
+Usage: hassette app source [OPTIONS] KEY
+
+Show app source code (GET /api/apps/{key}/source).
+
+╭─ Parameters ─────────────────────────────────────────────────────────────────────────────────────╮
+│ *  KEY --key  [required]                                                                         │
+╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
+╭─ Global Options ─────────────────────────────────────────────────────────────────────────────────╮
+│ --config-file -c     Path to the TOML configuration file.                                        │
+│ --env-file --env -e  Path to the .env file.                                                      │
+│ --json               Output results as JSON. [default: False]                                    │
+│ --debug              Show full HTTP response on CLI errors. [default: False]                     │
+╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
+
+$ hassette config --help
+Usage: hassette config [OPTIONS]
+
+Show current configuration.
+
+╭─ Global Options ─────────────────────────────────────────────────────────────────────────────────╮
+│ --config-file -c     Path to the TOML configuration file.                                        │
+│ --env-file --env -e  Path to the .env file.                                                      │
+│ --json               Output results as JSON. [default: False]                                    │
+│ --debug              Show full HTTP response on CLI errors. [default: False]                     │
+╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
+
+$ hassette dashboard --help
+Usage: hassette dashboard [OPTIONS]
+
+Show app dashboard grid.
+
+╭─ Global Options ─────────────────────────────────────────────────────────────────────────────────╮
+│ --config-file -c     Path to the TOML configuration file.                                        │
+│ --env-file --env -e  Path to the .env file.                                                      │
+│ --json               Output results as JSON. [default: False]                                    │
+│ --debug              Show full HTTP response on CLI errors. [default: False]                     │
+╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
+
+$ hassette execution --help
+Usage: hassette execution [OPTIONS] UUID [ARGS]
+
+Show logs for a specific execution.
+
+╭─ Parameters ─────────────────────────────────────────────────────────────────────────────────────╮
+│ *  UUID --uuid    [required]                                                                     │
+│    LIMIT --limit  Maximum number of results to return.                                           │
+╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
+╭─ Global Options ─────────────────────────────────────────────────────────────────────────────────╮
+│ --config-file -c     Path to the TOML configuration file.                                        │
+│ --env-file --env -e  Path to the .env file.                                                      │
+│ --json               Output results as JSON. [default: False]                                    │
+│ --debug              Show full HTTP response on CLI errors. [default: False]                     │
+╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
+
+$ hassette job --help
+Usage: hassette job [OPTIONS] [ARGS]
+
+List scheduled jobs and execution history.
+
+╭─ Parameters ─────────────────────────────────────────────────────────────────────────────────────╮
+│ JOB-ID --job-id                                                                                  │
+│ APP --app                  Filter by app key.                                                    │
+│ INSTANCE --instance        Filter by app instance (integer index or instance name). Requires     │
+│                            --app.                                                                │
+│ SINCE --since              Filter by time. Accepts relative (1h, 7d, 30m, 2w, 30s) or absolute   │
+│                            (2026-05-22, 2026-05-22T14:00:00) timestamps. Naive timestamps use    │
+│                            local time.                                                           │
+│ SOURCE-TIER --source-tier  Filter by telemetry source tier: 'app', 'framework', or 'all'.        │
+│                            [choices: app, framework, all]                                        │
+│ LIMIT --limit              Maximum number of results to return.                                  │
+╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
+╭─ Global Options ─────────────────────────────────────────────────────────────────────────────────╮
+│ --config-file -c     Path to the TOML configuration file.                                        │
+│ --env-file --env -e  Path to the .env file.                                                      │
+│ --json               Output results as JSON. [default: False]                                    │
+│ --debug              Show full HTTP response on CLI errors. [default: False]                     │
+╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
+
+$ hassette listener --help
+Usage: hassette listener [OPTIONS] [ARGS]
+
+List listeners and invocation history.
+
+╭─ Parameters ─────────────────────────────────────────────────────────────────────────────────────╮
+│ LISTENER-ID --listener-id                                                                        │
+│ APP --app                  Filter by app key.                                                    │
+│ INSTANCE --instance        Filter by app instance (integer index or instance name). Requires     │
+│                            --app.                                                                │
+│ SINCE --since              Filter by time. Accepts relative (1h, 7d, 30m, 2w, 30s) or absolute   │
+│                            (2026-05-22, 2026-05-22T14:00:00) timestamps. Naive timestamps use    │
+│                            local time.                                                           │
+│ SOURCE-TIER --source-tier  Filter by telemetry source tier: 'app', 'framework', or 'all'.        │
+│                            [choices: app, framework, all]                                        │
+│ LIMIT --limit              Maximum number of results to return.                                  │
+╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
+╭─ Global Options ─────────────────────────────────────────────────────────────────────────────────╮
+│ --config-file -c     Path to the TOML configuration file.                                        │
+│ --env-file --env -e  Path to the .env file.                                                      │
+│ --json               Output results as JSON. [default: False]                                    │
+│ --debug              Show full HTTP response on CLI errors. [default: False]                     │
+╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
+
+$ hassette log --help
+Usage: hassette log [OPTIONS] [ARGS]
+
+Show recent log entries.
+
+╭─ Parameters ─────────────────────────────────────────────────────────────────────────────────────╮
+│ APP --app                  Filter by app key.                                                    │
+│ INSTANCE --instance        Filter by app instance (integer index or instance name). Requires     │
+│                            --app.                                                                │
+│ SINCE --since              Filter by time. Accepts relative (1h, 7d, 30m, 2w, 30s) or absolute   │
+│                            (2026-05-22, 2026-05-22T14:00:00) timestamps. Naive timestamps use    │
+│                            local time.                                                           │
+│ LIMIT --limit              Maximum number of results to return.                                  │
+│ SOURCE-TIER --source-tier  Filter by telemetry source tier: 'app', 'framework', or 'all'.        │
+│                            [choices: app, framework, all]                                        │
+╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
+╭─ Global Options ─────────────────────────────────────────────────────────────────────────────────╮
+│ --config-file -c     Path to the TOML configuration file.                                        │
+│ --env-file --env -e  Path to the .env file.                                                      │
+│ --json               Output results as JSON. [default: False]                                    │
+│ --debug              Show full HTTP response on CLI errors. [default: False]                     │
+╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
+
+$ hassette run --help
+Usage: hassette run [OPTIONS] [ARGS]
+
+Start the Hassette framework server.
+
+╭─ Parameters ─────────────────────────────────────────────────────────────────────────────────────╮
+│ TOKEN --token -t              Home Assistant access token.                                       │
+│ BASE-URL --base-url --url -u  Base URL of the Home Assistant instance.                           │
+│ VERIFY-SSL --verify-ssl       Whether to verify SSL certificates.                                │
+│ DEV-MODE --dev-mode           Enable developer mode.                                             │
+│ APP --app -a                  Run only this app key, excluding all others. Repeatable, or        │
+│                               comma-separated.                                                   │
+╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
+╭─ Global Options ─────────────────────────────────────────────────────────────────────────────────╮
+│ --config-file -c     Path to the TOML configuration file.                                        │
+│ --env-file --env -e  Path to the .env file.                                                      │
+│ --json               Output results as JSON. [default: False]                                    │
+│ --debug              Show full HTTP response on CLI errors. [default: False]                     │
+╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
+
+$ hassette status --help
+Usage: hassette status [OPTIONS]
+
+Show system status.
+
+╭─ Global Options ─────────────────────────────────────────────────────────────────────────────────╮
+│ --config-file -c     Path to the TOML configuration file.                                        │
+│ --env-file --env -e  Path to the .env file.                                                      │
+│ --json               Output results as JSON. [default: False]                                    │
+│ --debug              Show full HTTP response on CLI errors. [default: False]                     │
+╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
+
+$ hassette telemetry --help
+Usage: hassette telemetry [OPTIONS]
+
+Show telemetry status.
+
+╭─ Global Options ─────────────────────────────────────────────────────────────────────────────────╮
+│ --config-file -c     Path to the TOML configuration file.                                        │
+│ --env-file --env -e  Path to the .env file.                                                      │
+│ --json               Output results as JSON. [default: False]                                    │
+│ --debug              Show full HTTP response on CLI errors. [default: False]                     │
+╰──────────────────────────────────────────────────────────────────────────────────────────────────╯

--- a/tests/unit/tools/test_check_cli_drift.py
+++ b/tests/unit/tools/test_check_cli_drift.py
@@ -1,0 +1,124 @@
+"""Characterization tests for tools/check_cli_drift.py.
+
+Command/column discovery is exercised against the real ``hassette.cli`` package
+(spot-checked for known, stable entries) since that introspection is the point of
+the tool. The ``--check``/``--update`` CLI flow is isolated from the real CLI
+surface via monkeypatched snapshot builders so it stays fast and immune to CLI
+surface changes elsewhere in the codebase.
+"""
+
+import sys
+from pathlib import Path
+
+import check_cli_drift
+import pytest
+from check_cli_drift import (
+    _unified_diff,
+    build_columns_snapshot,
+    build_help_snapshot,
+    discover_command_paths,
+    main,
+)
+
+
+def test_discover_command_paths_includes_known_commands() -> None:
+    paths = discover_command_paths()
+
+    assert () in paths
+    assert ("app",) in paths
+    assert ("app", "health") in paths
+    assert ("job",) in paths
+    assert paths == sorted(paths)
+
+
+def test_discover_command_paths_excludes_flag_like_entries() -> None:
+    paths = discover_command_paths()
+
+    assert not any(segment.startswith("-") for path in paths for segment in path)
+
+
+def test_build_help_snapshot_is_deterministic_and_covers_known_commands() -> None:
+    first = build_help_snapshot()
+    second = build_help_snapshot()
+
+    assert first == second
+    assert "$ hassette --help" in first
+    assert "$ hassette app health --help" in first
+
+
+def test_build_columns_snapshot_includes_known_module_and_column() -> None:
+    columns = build_columns_snapshot()
+
+    assert "job" in columns
+    assert "JOB_LIST_COLUMNS" in columns["job"]
+    fields = [col["field"] for col in columns["job"]["JOB_LIST_COLUMNS"]]
+    assert "app_key" in fields
+
+
+def test_build_columns_snapshot_serializes_formatter_by_name() -> None:
+    columns = build_columns_snapshot()
+
+    avg_col = next(col for col in columns["job"]["JOB_LIST_COLUMNS"] if col["field"] == "avg_duration_ms")
+    assert avg_col["formatter"] == "fmt_duration_ms"
+
+    id_col = next(col for col in columns["job"]["JOB_LIST_COLUMNS"] if col["field"] == "job_id")
+    assert id_col["formatter"] is None
+
+
+def test_unified_diff_empty_when_equal() -> None:
+    assert _unified_diff("label", "same\n", "same\n") == ""
+
+
+def test_unified_diff_reports_added_and_removed_lines() -> None:
+    diff = _unified_diff("cli_help.txt", "old line\n", "new line\n")
+
+    assert "cli_help.txt (committed)" in diff
+    assert "cli_help.txt (current)" in diff
+    assert "-old line" in diff
+    assert "+new line" in diff
+
+
+@pytest.fixture
+def isolated_snapshots(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """Point the module's snapshot paths at tmp_path and stub the (slow, live) builders."""
+    monkeypatch.setattr(check_cli_drift, "REPO_ROOT", tmp_path)
+    monkeypatch.setattr(check_cli_drift, "HELP_SNAPSHOT", tmp_path / "cli_help.txt")
+    monkeypatch.setattr(check_cli_drift, "COLUMNS_SNAPSHOT", tmp_path / "cli_columns.json")
+    monkeypatch.setattr(check_cli_drift, "build_help_snapshot", lambda: "help-text-v1\n")
+    monkeypatch.setattr(check_cli_drift, "build_columns_snapshot", lambda: {"mod": {"COLS": []}})
+
+
+@pytest.mark.usefixtures("isolated_snapshots")
+def test_main_check_fails_when_snapshots_missing(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.setattr(sys, "argv", ["check_cli_drift.py", "--check"])
+
+    assert main() == 1
+    out = capsys.readouterr().out
+    assert "does not exist" in out
+
+
+@pytest.mark.usefixtures("isolated_snapshots")
+def test_main_update_then_check_passes(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(sys, "argv", ["check_cli_drift.py", "--update"])
+    assert main() == 0
+
+    monkeypatch.setattr(sys, "argv", ["check_cli_drift.py", "--check"])
+    assert main() == 0
+
+
+@pytest.mark.usefixtures("isolated_snapshots")
+def test_main_check_fails_on_drift(monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]) -> None:
+    monkeypatch.setattr(sys, "argv", ["check_cli_drift.py", "--update"])
+    assert main() == 0
+
+    # Simulate an intentional CLI change that wasn't followed by --update.
+    monkeypatch.setattr(check_cli_drift, "build_help_snapshot", lambda: "help-text-v2\n")
+
+    monkeypatch.setattr(sys, "argv", ["check_cli_drift.py", "--check"])
+    assert main() == 1
+    out = capsys.readouterr().out
+    assert "-help-text-v1" in out
+    assert "+help-text-v2" in out
+    assert "Re-run: uv run python tools/check_cli_drift.py --update" in out

--- a/tests/unit/tools/test_check_cli_drift.py
+++ b/tests/unit/tools/test_check_cli_drift.py
@@ -13,11 +13,11 @@ from pathlib import Path
 import check_cli_drift
 import pytest
 from check_cli_drift import (
-    _unified_diff,
     build_columns_snapshot,
     build_help_snapshot,
     discover_command_paths,
     main,
+    unified_diff,
 )
 
 
@@ -66,11 +66,11 @@ def test_build_columns_snapshot_serializes_formatter_by_name() -> None:
 
 
 def test_unified_diff_empty_when_equal() -> None:
-    assert _unified_diff("label", "same\n", "same\n") == ""
+    assert unified_diff("label", "same\n", "same\n") == ""
 
 
 def test_unified_diff_reports_added_and_removed_lines() -> None:
-    diff = _unified_diff("cli_help.txt", "old line\n", "new line\n")
+    diff = unified_diff("cli_help.txt", "old line\n", "new line\n")
 
     assert "cli_help.txt (committed)" in diff
     assert "cli_help.txt (current)" in diff

--- a/tools/check_cli_drift.py
+++ b/tools/check_cli_drift.py
@@ -1,0 +1,166 @@
+#!/usr/bin/env -S uv run
+"""CI/pre-push check: detect hassette CLI surface drift.
+
+Regenerates two "CLI shape" snapshots in memory and compares them against the
+committed baselines in ``tests/snapshots/``:
+
+- ``cli_help.txt`` — ``--help`` output for every command and subcommand,
+  captured in-process via cyclopts (no subprocess, no running instance).
+- ``cli_columns.json`` — the ``Column(...)`` table definitions declared in
+  ``hassette.cli.commands.*``, serialized field-by-field.
+
+A mismatch means the CLI surface changed (new command, renamed flag, changed
+help text, added/removed/renamed table column) without the docs being
+updated to match. This catches the common case cheaply; pure formatting
+changes in ``output.py`` that don't change any signature are not caught
+here — those are expected to surface during normal doc maintenance instead
+(currently a manual doc edit; see #855 for tracked Cog-based automation).
+
+Usage:
+    uv run python tools/check_cli_drift.py            # check (default)
+    uv run python tools/check_cli_drift.py --check     # check, explicit
+    uv run python tools/check_cli_drift.py --update    # write fresh snapshots
+"""
+
+import argparse
+import difflib
+import importlib
+import io
+import json
+import pkgutil
+import sys
+from pathlib import Path
+
+from rich.console import Console
+
+import hassette.cli.commands as commands_pkg
+from hassette.cli import app as root_app
+from hassette.cli.output import Column
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SNAPSHOT_DIR = REPO_ROOT / "tests" / "snapshots"
+HELP_SNAPSHOT = SNAPSHOT_DIR / "cli_help.txt"
+COLUMNS_SNAPSHOT = SNAPSHOT_DIR / "cli_columns.json"
+
+# Fixed so the snapshot doesn't depend on the invoking terminal's width.
+HELP_CONSOLE_WIDTH = 100
+
+
+def discover_command_paths() -> list[tuple[str, ...]]:
+    """Return every command path (including the root) as a sorted list of tuples.
+
+    Walks the cyclopts command tree (``App.resolved_commands()``) recursively.
+    Flag-like entries (``--help``, ``-h``, ``--version``, etc.) are not real
+    subcommands and are skipped.
+    """
+
+    def walk(node, prefix: tuple[str, ...]) -> list[tuple[str, ...]]:
+        paths = []
+        for name, sub in node.resolved_commands().items():
+            if name.startswith("-"):
+                continue
+            path = (*prefix, name)
+            paths.append(path)
+            paths.extend(walk(sub, path))
+        return paths
+
+    return sorted([(), *walk(root_app, ())])
+
+
+def build_help_snapshot() -> str:
+    """Render ``--help`` for every discovered command path, in-process.
+
+    Trailing whitespace is stripped per line — Rich right-pads wrapped
+    description text to the console width, which the repo's trailing-whitespace
+    hook would otherwise strip back out from the committed file, and any
+    ``--update`` run would then never produce a byte-identical result.
+    """
+    sections = []
+    for path in discover_command_paths():
+        buf = io.StringIO()
+        console = Console(file=buf, no_color=True, width=HELP_CONSOLE_WIDTH, highlight=False, legacy_windows=False)
+        root_app.help_print(list(path), console=console)
+        rendered = "\n".join(line.rstrip() for line in buf.getvalue().splitlines())
+        label = "hassette " + " ".join((*path, "--help"))
+        sections.append(f"$ {label}\n{rendered}\n")
+    return "\n".join(sections)
+
+
+def build_columns_snapshot() -> dict[str, dict[str, list[dict[str, object]]]]:
+    """Serialize every module-level ``list[Column]`` in ``hassette.cli.commands.*``."""
+    result: dict[str, dict[str, list[dict[str, object]]]] = {}
+    for module_info in sorted(pkgutil.iter_modules(commands_pkg.__path__), key=lambda m: m.name):
+        if module_info.name == "__init__":
+            continue
+        module = importlib.import_module(f"{commands_pkg.__name__}.{module_info.name}")
+        module_columns = {}
+        for name in sorted(vars(module)):
+            value = getattr(module, name)
+            if isinstance(value, list) and value and all(isinstance(v, Column) for v in value):
+                module_columns[name] = [
+                    {
+                        "field": col.field,
+                        "header": col.header,
+                        "max_width": col.max_width,
+                        "overflow": col.overflow,
+                        "formatter": col.formatter.__name__ if col.formatter is not None else None,
+                    }
+                    for col in value
+                ]
+        if module_columns:
+            result[module_info.name] = module_columns
+    return result
+
+
+def _unified_diff(label: str, committed: str, current: str) -> str:
+    diff = difflib.unified_diff(
+        committed.splitlines(keepends=True),
+        current.splitlines(keepends=True),
+        fromfile=f"{label} (committed)",
+        tofile=f"{label} (current)",
+    )
+    return "".join(diff)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Detect hassette CLI surface drift (help text, table columns).")
+    mode = parser.add_mutually_exclusive_group()
+    # --check is the implicit default (see the `if args.update` branch below); accepted
+    # explicitly too so `--check` reads clearly in docs and CI invocations.
+    mode.add_argument("--check", action="store_true", help="Check snapshots match the current CLI surface (default).")
+    mode.add_argument("--update", action="store_true", help="Write fresh snapshots to disk.")
+    args = parser.parse_args()
+
+    help_text = build_help_snapshot()
+    columns_json = json.dumps(build_columns_snapshot(), indent=2, sort_keys=True) + "\n"
+
+    if args.update:
+        SNAPSHOT_DIR.mkdir(parents=True, exist_ok=True)
+        HELP_SNAPSHOT.write_text(help_text)
+        COLUMNS_SNAPSHOT.write_text(columns_json)
+        print(f"Updated {HELP_SNAPSHOT.relative_to(REPO_ROOT)} and {COLUMNS_SNAPSHOT.relative_to(REPO_ROOT)}")
+        return 0
+
+    problems: list[str] = []
+
+    if not HELP_SNAPSHOT.exists():
+        problems.append(f"{HELP_SNAPSHOT.relative_to(REPO_ROOT)} does not exist")
+    elif (committed := HELP_SNAPSHOT.read_text()) != help_text:
+        problems.append(_unified_diff("cli_help.txt", committed, help_text))
+
+    if not COLUMNS_SNAPSHOT.exists():
+        problems.append(f"{COLUMNS_SNAPSHOT.relative_to(REPO_ROOT)} does not exist")
+    elif (committed := COLUMNS_SNAPSHOT.read_text()) != columns_json:
+        problems.append(_unified_diff("cli_columns.json", committed, columns_json))
+
+    if problems:
+        print("CLI surface drift detected:\n")
+        print("\n".join(problems))
+        print("Re-run: uv run python tools/check_cli_drift.py --update")
+        return 1
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/check_cli_drift.py
+++ b/tools/check_cli_drift.py
@@ -31,6 +31,7 @@ import pkgutil
 import sys
 from pathlib import Path
 
+from cyclopts import App as CycloptsApp
 from rich.console import Console
 
 import hassette.cli.commands as commands_pkg
@@ -54,7 +55,7 @@ def discover_command_paths() -> list[tuple[str, ...]]:
     subcommands and are skipped.
     """
 
-    def walk(node, prefix: tuple[str, ...]) -> list[tuple[str, ...]]:
+    def walk(node: CycloptsApp, prefix: tuple[str, ...]) -> list[tuple[str, ...]]:
         paths = []
         for name, sub in node.resolved_commands().items():
             if name.startswith("-"):
@@ -112,7 +113,7 @@ def build_columns_snapshot() -> dict[str, dict[str, list[dict[str, object]]]]:
     return result
 
 
-def _unified_diff(label: str, committed: str, current: str) -> str:
+def unified_diff(label: str, committed: str, current: str) -> str:
     diff = difflib.unified_diff(
         committed.splitlines(keepends=True),
         current.splitlines(keepends=True),
@@ -136,27 +137,27 @@ def main() -> int:
 
     if args.update:
         SNAPSHOT_DIR.mkdir(parents=True, exist_ok=True)
-        HELP_SNAPSHOT.write_text(help_text)
-        COLUMNS_SNAPSHOT.write_text(columns_json)
+        HELP_SNAPSHOT.write_text(help_text, encoding="utf-8")
+        COLUMNS_SNAPSHOT.write_text(columns_json, encoding="utf-8")
         print(f"Updated {HELP_SNAPSHOT.relative_to(REPO_ROOT)} and {COLUMNS_SNAPSHOT.relative_to(REPO_ROOT)}")
         return 0
 
     problems: list[str] = []
 
-    if not HELP_SNAPSHOT.exists():
-        problems.append(f"{HELP_SNAPSHOT.relative_to(REPO_ROOT)} does not exist")
-    elif (committed := HELP_SNAPSHOT.read_text()) != help_text:
-        problems.append(_unified_diff("cli_help.txt", committed, help_text))
-
-    if not COLUMNS_SNAPSHOT.exists():
-        problems.append(f"{COLUMNS_SNAPSHOT.relative_to(REPO_ROOT)} does not exist")
-    elif (committed := COLUMNS_SNAPSHOT.read_text()) != columns_json:
-        problems.append(_unified_diff("cli_columns.json", committed, columns_json))
+    for snapshot, label, expected in [
+        (HELP_SNAPSHOT, "cli_help.txt", help_text),
+        (COLUMNS_SNAPSHOT, "cli_columns.json", columns_json),
+    ]:
+        if not snapshot.exists():
+            problems.append(f"{snapshot.relative_to(REPO_ROOT)} does not exist")
+        elif (committed := snapshot.read_text(encoding="utf-8")) != expected:
+            problems.append(unified_diff(label, committed, expected))
 
     if problems:
         print("CLI surface drift detected:\n")
         print("\n".join(problems))
         print("Re-run: uv run python tools/check_cli_drift.py --update")
+        print("Then update docs/pages/cli/commands.md and docs/pages/cli/index.md to match.")
         return 1
 
     return 0


### PR DESCRIPTION
## Summary

Adds `tools/check_cli_drift.py`, a fast (~1.5s) in-process checker that detects unintended changes to the CLI's public surface — both `--help` output for every command and the `Column(...)` table definitions declared across `hassette.cli.commands.*`.

The checker regenerates two snapshots (captured via cyclopts in-process, no subprocess spawn) and diffs them against committed baselines in `tests/snapshots/`:

- `tests/snapshots/cli_help.txt` — `--help` output for every CLI command
- `tests/snapshots/cli_columns.json` — table column definitions declared in CLI command modules

When a CLI change alters either surface, the baselines must be regenerated and committed alongside the change, making CLI-shape drift visible in the diff instead of surfacing later as an undocumented breaking change.

## Wiring

- `.github/workflows/lint.yml` — runs the check in the `python` job
- `prek.toml` — added at the `pre-push` stage, alongside the existing `check-schemas-fresh` hook, so drift surfaces locally before push without needing Docker or a running instance

## Testing

- `tests/unit/tools/test_check_cli_drift.py` — new unit tests covering the checker itself
- Full suite: `uv run nox -s dev` — 8197 passed, 2 xfailed
- Full lint/type check: `prek -a && prek pyright -a --stage pre-push` — all hooks passed, including the new `Check CLI surface for drift` hook itself (confirmed working against a clean tree during `git push`)

Closes #856
