### PR TITLE
feat: resolve CliFormat metadata as render_table fallback

### DIFF
--- a/src/hassette/cli/commands/job.py
+++ b/src/hassette/cli/commands/job.py
@@ -4,7 +4,7 @@ from typing import Any
 
 from hassette.cli.client import make_client
 from hassette.cli.context import DEFAULT_CLI_CONTEXT, CLIContextParam
-from hassette.cli.output import Column, fmt_duration_ms, fmt_next_run, fmt_relative_time, render_table
+from hassette.cli.output import Column, fmt_duration_ms, fmt_relative_time, render_table
 from hassette.cli.types import AppKeyArg, InstanceArg, LimitArg, SinceArg, SourceTierArg
 from hassette.schemas.telemetry_models import Execution, JobSummary
 
@@ -19,7 +19,7 @@ JOB_LIST_COLUMNS: list[Column] = [
     Column("successful", "OK", max_width=6),
     Column("failed", "Fail", max_width=6),
     Column("avg_duration_ms", "Avg", max_width=7, formatter=fmt_duration_ms),
-    Column("next_run", "Next Run", max_width=11, formatter=fmt_next_run),
+    Column("next_run", "Next Run", max_width=11),
 ]
 
 JOB_EXECUTION_COLUMNS: list[Column] = [

--- a/src/hassette/cli/output.py
+++ b/src/hassette/cli/output.py
@@ -107,13 +107,6 @@ def fmt_duration_s(value: Any) -> str:
     return f"{num:.1f}s"
 
 
-def fmt_next_run(value: Any) -> str:
-    """Format a next-run timestamp: ``None`` → ``'done'``, otherwise relative time."""
-    if value is None:
-        return "done"
-    return fmt_relative_time(value)
-
-
 def fmt_handler_short(value: Any) -> str:
     """Extract just the method name from a fully qualified handler path."""
     if value is None:
@@ -193,15 +186,24 @@ def _extract_field(item: Any, field_path: str) -> Any:
     return value
 
 
-def _cell_text(value: Any, col: Column) -> str:
+def _cell_text(value: Any, col: Column, fallback_meta: CliFormat | None = None) -> str:
     """Convert a raw field value to a table cell string (blank for None).
 
     Tables use empty string for missing values so cells stay visually clean.
     Detail panels use ``_format_detail_value`` which shows "—" instead.
+
+    When ``col.formatter`` is unset, ``fallback_meta`` — a :class:`CliFormat` resolved
+    from the model field's annotation metadata — is used instead. An explicit
+    ``Column.formatter`` always takes precedence over model metadata.
     """
     if col.formatter is not None:
         try:
             return col.formatter(value)
+        except (TypeError, ValueError):
+            return str(value) if value is not None else ""
+    if fallback_meta is not None:
+        try:
+            return _apply_cli_format(value, fallback_meta, none_default="")
         except (TypeError, ValueError):
             return str(value) if value is not None else ""
     if value is None:
@@ -215,6 +217,11 @@ def render_table(
     json_mode: bool,
 ) -> None:
     """Render a list of Pydantic models as a table or JSON array.
+
+    Columns without an explicit ``formatter`` fall back to the :class:`CliFormat`
+    metadata annotated on the matching model field, if any (see
+    :func:`_resolve_cli_format_meta`). An explicit ``Column.formatter`` always
+    takes precedence over model metadata.
 
     Args:
         items: List of Pydantic models to render.
@@ -234,8 +241,9 @@ def render_table(
 
     is_terminal = stdout_console.is_terminal
     table = _build_table(columns, is_terminal)
+    fallback_meta = _resolve_cli_format_meta(type(items[0]))
     for item in items:
-        row = [_cell_text(_extract_field(item, col.field), col) for col in columns]
+        row = [_cell_text(_extract_field(item, col.field), col, fallback_meta.get(col.field)) for col in columns]
         table.add_row(*row)
 
     stdout_console.print(table)
@@ -259,8 +267,8 @@ def render_detail(
 
     display_title = _humanize_model_name(type(item).__name__)
     data = item.model_dump(mode="json")
-    field_formatters = _resolve_cli_formatters(type(item))
-    _render_detail_panel(data, display_title, field_formatters)
+    field_meta = _resolve_cli_format_meta(type(item))
+    _render_detail_panel(data, display_title, field_meta)
 
 
 def render_detail_dict(data: dict[str, Any], title: str, json_mode: bool) -> None:
@@ -286,16 +294,17 @@ def render_detail_dict(data: dict[str, Any], title: str, json_mode: bool) -> Non
 def _render_detail_panel(
     data: dict[str, Any],
     title: str,
-    field_formatters: dict[str, Callable[[Any], str]] | None = None,
+    field_meta: dict[str, CliFormat] | None = None,
 ) -> None:
     """Render a values dict as a key-value Rich panel (shared human-mode body).
 
     Nested non-empty dicts render as labeled sections with indented key-value rows;
     empty dicts are skipped so no orphaned section header appears. When sections
     exist, scalar fields are indented under a "General" header. Fields whose key is
-    in ``field_formatters`` are formatted via that callable in place of the default.
+    in ``field_meta`` are formatted via the matching :class:`CliFormat` in place of
+    the default.
     """
-    formatters = field_formatters or {}
+    meta_map = field_meta or {}
 
     table = Table(show_header=False, box=None, padding=(0, 1))
     table.add_column("key", style="bold", no_wrap=True)
@@ -316,8 +325,9 @@ def _render_detail_panel(
             if has_sections and not general_header_emitted:
                 table.add_row("[bold cyan]General[/bold cyan]", "")
                 general_header_emitted = True
-            if key in formatters and value is not None:
-                formatted = formatters[key](value)
+            meta = meta_map.get(key)
+            if meta is not None:
+                formatted = _apply_cli_format(value, meta, none_default=_format_detail_value(None))
             else:
                 formatted = _format_detail_value(value)
             table.add_row(f"  {key}" if has_sections else key, formatted)
@@ -386,12 +396,19 @@ def _scalar_str(value: Any) -> str:
     return str(value)
 
 
-def _resolve_cli_formatters(model_cls: type[BaseModel]) -> dict[str, Callable[[Any], str]]:
-    """Build a field-name → formatter mapping from CliFormat annotations on a model."""
-    result: dict[str, Callable[[Any], str]] = {}
+def _resolve_cli_format_meta(model_cls: type[BaseModel]) -> dict[str, CliFormat]:
+    """Build a field-name → CliFormat mapping from annotations on a model's fields."""
+    result: dict[str, CliFormat] = {}
     for name, field_info in model_cls.model_fields.items():
         for meta in field_info.metadata:
             if isinstance(meta, CliFormat) and meta.style in CLI_FORMATTERS:
-                result[name] = CLI_FORMATTERS[meta.style]
+                result[name] = meta
                 break
     return result
+
+
+def _apply_cli_format(value: Any, meta: CliFormat, none_default: str) -> str:
+    """Apply a CliFormat's style formatter, using ``meta.none_text`` (or ``none_default``) for None."""
+    if value is None:
+        return meta.none_text if meta.none_text is not None else none_default
+    return CLI_FORMATTERS[meta.style](value)

--- a/src/hassette/schemas/telemetry_models.py
+++ b/src/hassette/schemas/telemetry_models.py
@@ -11,12 +11,12 @@ Separation rationale
 - ``domain_models.py`` — live state snapshots and WS event payloads
 """
 
-from typing import Literal, NamedTuple
+from typing import Annotated, Literal, NamedTuple
 
 from pydantic import BaseModel
 
 from hassette.types.enums import DEFAULT_BACKPRESSURE_POLICY, DEFAULT_OVERLAP_MODE, BackpressurePolicy, ExecutionMode
-from hassette.types.types import LOG_LEVEL_TYPE, BlockingAttributionReason, ExecutionStatus, SourceTier
+from hassette.types.types import LOG_LEVEL_TYPE, BlockingAttributionReason, CliFormat, ExecutionStatus, SourceTier
 
 _BlockingTier = Literal["watchdog", "monkeypatch"]
 
@@ -183,7 +183,7 @@ class JobSummary(BaseModel):
     avg_duration_ms: float
     group: str | None = None
     """Scheduler group name, persisted at registration."""
-    next_run: float | None = None
+    next_run: Annotated[float | None, CliFormat("relative_time", none_text="done")] = None
     """Unix epoch seconds of the next scheduled fire time (unjittered); sourced from live heap."""
     fire_at: float | None = None
     """Unix epoch seconds of actual dispatch time when jitter applied; sourced from live heap."""

--- a/src/hassette/types/types.py
+++ b/src/hassette/types/types.py
@@ -53,6 +53,10 @@ class CliFormat:
     """
 
     style: CliFormatStyle
+    none_text: str | None = None
+    """Display text to use when the field value is ``None``, overriding the render layer's default
+    placeholder (``""`` in tables, ``"—"`` in detail panels). E.g. ``none_text="done"`` for a
+    ``next_run`` field that reads ``None`` once a one-shot job has fired."""
 
 
 SourceTier = Literal["app", "framework"]

--- a/tests/unit/cli/test_output.py
+++ b/tests/unit/cli/test_output.py
@@ -3,7 +3,7 @@
 import json
 import time
 from io import StringIO
-from typing import Any
+from typing import Annotated, Any
 from unittest.mock import patch
 
 import pytest
@@ -23,6 +23,7 @@ from hassette.cli.output import (
     render_detail,
     render_table,
 )
+from hassette.types.types import CliFormat
 from tests.unit.cli.conftest import capture_human
 
 # Simple test models
@@ -33,6 +34,12 @@ class SimpleItem(BaseModel):
     count: int
     active: bool = True
     note: str | None = None
+
+
+class AnnotatedTableItem(BaseModel):
+    name: str
+    avg_duration_ms: Annotated[float, CliFormat("duration_ms")]
+    next_run: Annotated[float | None, CliFormat("relative_time", none_text="done")] = None
 
 
 class NestedItem(BaseModel):
@@ -226,6 +233,26 @@ class TestCellText:
         result = _cell_text("raw", col)
         assert result == "raw"
 
+    def test_fallback_meta_used_when_no_formatter(self) -> None:
+        col = Column(field="avg_duration_ms", header="Avg")
+        meta = CliFormat("duration_ms")
+        assert _cell_text(450.0, col, meta) == "450ms"
+
+    def test_explicit_formatter_overrides_fallback_meta(self) -> None:
+        col = Column(field="avg_duration_ms", header="Avg", formatter=lambda v: f"~{v}")
+        meta = CliFormat("duration_ms")
+        assert _cell_text(450.0, col, meta) == "~450.0"
+
+    def test_fallback_meta_none_text(self) -> None:
+        col = Column(field="next_run", header="Next Run")
+        meta = CliFormat("relative_time", none_text="done")
+        assert _cell_text(None, col, meta) == "done"
+
+    def test_fallback_meta_none_without_none_text_returns_empty(self) -> None:
+        col = Column(field="next_run", header="Next Run")
+        meta = CliFormat("relative_time")
+        assert _cell_text(None, col, meta) == ""
+
 
 # render_table — JSON mode
 
@@ -340,6 +367,39 @@ class TestRenderTableHumanMode:
         assert "alpha" in stdout
         assert "beta" in stdout
         assert "gamma" in stdout
+
+
+# render_table — CliFormat metadata fallback
+
+
+class TestRenderTableCliFormatFallback:
+    def test_column_without_formatter_uses_model_metadata(self) -> None:
+        items = [AnnotatedTableItem(name="job1", avg_duration_ms=450.0)]
+        columns = [Column("name", "Name"), Column("avg_duration_ms", "Avg")]
+        stdout, _stderr = capture_human(render_table, items, columns, json_mode=False)
+        assert "450ms" in stdout
+
+    def test_explicit_column_formatter_overrides_metadata(self) -> None:
+        items = [AnnotatedTableItem(name="job1", avg_duration_ms=450.0)]
+        columns = [Column("avg_duration_ms", "Avg", formatter=lambda v: f"custom:{v}")]
+        stdout, _stderr = capture_human(render_table, items, columns, json_mode=False)
+        assert "custom:450.0" in stdout
+        assert "450ms" not in stdout
+
+    def test_none_text_used_for_none_value(self) -> None:
+        items = [AnnotatedTableItem(name="job1", avg_duration_ms=450.0, next_run=None)]
+        columns = [Column("next_run", "Next Run")]
+        stdout, _stderr = capture_human(render_table, items, columns, json_mode=False)
+        assert "done" in stdout
+
+    def test_json_mode_ignores_metadata(self, capsys: pytest.CaptureFixture[str]) -> None:
+        items = [AnnotatedTableItem(name="job1", avg_duration_ms=450.0, next_run=None)]
+        columns = [Column("avg_duration_ms", "Avg"), Column("next_run", "Next Run")]
+        render_table(items, columns, json_mode=True)
+        captured = capsys.readouterr()
+        parsed = json.loads(captured.out)
+        assert parsed[0]["avg_duration_ms"] == 450.0
+        assert parsed[0]["next_run"] is None
 
 
 # render_table — pipe detection

--- a/tests/unit/cli/test_output_detail.py
+++ b/tests/unit/cli/test_output_detail.py
@@ -12,9 +12,8 @@ from hassette.cli.output import (
     _format_list_inline,
     _humanize_key,
     _humanize_model_name,
-    _resolve_cli_formatters,
+    _resolve_cli_format_meta,
     fmt_handler_short,
-    fmt_next_run,
     fmt_uptime,
     render_detail,
     render_detail_dict,
@@ -36,6 +35,11 @@ class AnnotatedModel(BaseModel):
     avg_duration: Annotated[float, CliFormat("duration_ms")]
     last_seen: Annotated[float | None, CliFormat("relative_time")]
     plain_float: float = 1.5
+
+
+class NoneTextModel(BaseModel):
+    name: str
+    next_run: Annotated[float | None, CliFormat("relative_time", none_text="done")] = None
 
 
 class TestHumanizeModelName:
@@ -150,15 +154,6 @@ class TestFmtUptime:
         assert fmt_uptime("invalid") == "invalid"
 
 
-class TestFmtNextRun:
-    def test_none_returns_done(self) -> None:
-        assert fmt_next_run(None) == "done"
-
-    def test_delegates_to_relative_time(self) -> None:
-        result = fmt_next_run(time.time() - 120)
-        assert "ago" in result
-
-
 class TestFmtHandlerShort:
     def test_extracts_method_name(self) -> None:
         assert fmt_handler_short("hautomate.meeting_app.MeetingApp.on_light_changed") == "on_light_changed"
@@ -170,26 +165,26 @@ class TestFmtHandlerShort:
         assert fmt_handler_short("simple") == "simple"
 
 
-class TestResolveCliFormatters:
-    def test_annotated_model_resolves_formatters(self) -> None:
-        result = _resolve_cli_formatters(AnnotatedModel)
+class TestResolveCliFormatMeta:
+    def test_annotated_model_resolves_meta(self) -> None:
+        result = _resolve_cli_format_meta(AnnotatedModel)
         assert "uptime_seconds" in result
         assert "avg_duration" in result
         assert "last_seen" in result
 
     def test_unannotated_fields_excluded(self) -> None:
-        result = _resolve_cli_formatters(AnnotatedModel)
+        result = _resolve_cli_format_meta(AnnotatedModel)
         assert "name" not in result
         assert "plain_float" not in result
 
     def test_model_without_annotations_returns_empty(self) -> None:
-        result = _resolve_cli_formatters(SimpleItem)
+        result = _resolve_cli_format_meta(SimpleItem)
         assert result == {}
 
-    def test_resolved_formatters_are_callable(self) -> None:
-        result = _resolve_cli_formatters(AnnotatedModel)
-        assert result["uptime_seconds"](9005) == "2h 30m 5s"
-        assert result["avg_duration"](450) == "450ms"
+    def test_resolved_meta_carries_style(self) -> None:
+        result = _resolve_cli_format_meta(AnnotatedModel)
+        assert result["uptime_seconds"].style == "uptime"
+        assert result["avg_duration"].style == "duration_ms"
 
 
 class TestRenderDetailCliFormat:
@@ -228,6 +223,18 @@ class TestRenderDetailCliFormat:
         parsed = json.loads(captured.out)
         assert parsed["uptime_seconds"] == 9005.0
         assert parsed["avg_duration"] == 450.0
+
+    def test_none_text_used_for_none_value(self) -> None:
+        item = NoneTextModel(name="job1", next_run=None)
+        stdout, _stderr = capture_human(render_detail, item, json_mode=False)
+        assert "done" in stdout
+        assert "—" not in stdout
+
+    def test_none_text_not_used_when_value_present(self) -> None:
+        item = NoneTextModel(name="job1", next_run=time.time() - 120)
+        stdout, _stderr = capture_human(render_detail, item, json_mode=False)
+        assert "done" not in stdout
+        assert "ago" in stdout
 
 
 class TestRenderDetailDict:


### PR DESCRIPTION
## Summary

`render_table()` only used explicit `Column` formatters, so `CliFormat` model-field annotations (already respected by `render_detail()`) couldn't drive table formatting — table columns had to duplicate formatting logic locally via one-off wrapper functions like `fmt_next_run`.

This PR makes `render_table` resolve `CliFormat` metadata as a fallback when a `Column` has no explicit `formatter`. An explicit `Column.formatter` still always wins.

- `_cell_text` gains an optional `fallback_meta: CliFormat | None` parameter, applied via a new shared `_apply_cli_format` helper (also used by `render_detail`'s panel rendering)
- `_resolve_cli_formatters` (which returned raw callables) is replaced by `_resolve_cli_format_meta`, which returns the `CliFormat` metadata itself — needed so both table and detail rendering can access `none_text`
- Re-added `CliFormat.none_text: str | None`, letting a field declare its own null-display text (overriding the render layer's default placeholder — `""` in tables, `"—"` in detail panels)
- `JobSummary.next_run` is now annotated with `CliFormat("relative_time", none_text="done")`
- The local `fmt_next_run` wrapper in `job.py` is removed; the `next_run` column now relies on the fallback

## Testing

- `uv run nox -s dev` — 8190 passed, 2 xfailed
- `prek -a` — all hooks pass (ruff, pyright pre-push stage, eslint/tsc, custom lint checks)
- New unit tests cover: fallback metadata resolution in `_cell_text`, explicit-formatter precedence, `none_text` behavior in both table and detail rendering, and JSON-mode bypass of metadata formatting

Closes #878
