### PR TITLE
fix!: rename ListenerWithSummary.entity_id to target and populate it for event listeners

### DIFF
--- a/docs/pages/cli/commands.md
+++ b/docs/pages/cli/commands.md
@@ -154,7 +154,7 @@ $ hassette listener
 └────┴──────────────────┴───────────────────────────┴────────────┴──────────────────────┴───────┴────┴──────┴─────┴──────┘
 ```
 
-Each row shows the listener ID, app key, target (the entity ID for state/attribute listeners, or the event name for event listeners), listener kind, handler method, invocation counts (total, successful, failed), average duration, and last invocation time.
+Each row shows the listener ID, app key, target, listener kind, handler, counts, duration, and last invocation time. State and attribute listeners use the entity ID as target; event listeners use the event name.
 
 Passing a listener ID shows its invocation history:
 

--- a/docs/pages/cli/commands.md
+++ b/docs/pages/cli/commands.md
@@ -154,7 +154,7 @@ $ hassette listener
 └────┴──────────────────┴───────────────────────────┴────────────┴──────────────────────┴───────┴────┴──────┴─────┴──────┘
 ```
 
-Each row shows the listener ID, app key, target entity, listener kind, handler method, invocation counts (total, successful, failed), average duration, and last invocation time.
+Each row shows the listener ID, app key, target (the entity ID for state/attribute listeners, or the event name for event listeners), listener kind, handler method, invocation counts (total, successful, failed), average duration, and last invocation time.
 
 Passing a listener ID shows its invocation history:
 

--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -3154,7 +3154,8 @@
                 "type": "null"
               }
             ],
-            "title": "Target"
+            "title": "Target",
+            "description": "What the listener is watching: an HA entity ID, or the topic's last segment for event listeners."
           },
           "mode": {
             "$ref": "#/components/schemas/ExecutionMode",

--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -3145,7 +3145,7 @@
             ],
             "title": "Duration"
           },
-          "entity_id": {
+          "target": {
             "anyOf": [
               {
                 "type": "string"
@@ -3154,7 +3154,7 @@
                 "type": "null"
               }
             ],
-            "title": "Entity Id"
+            "title": "Target"
           },
           "mode": {
             "$ref": "#/components/schemas/ExecutionMode",

--- a/frontend/src/api/generated-types.ts
+++ b/frontend/src/api/generated-types.ts
@@ -1264,8 +1264,8 @@ export interface components {
             immediate: number;
             /** Duration */
             duration?: number | null;
-            /** Entity Id */
-            entity_id?: string | null;
+            /** Target */
+            target?: string | null;
             /** @default single */
             mode: components["schemas"]["ExecutionMode"];
             /**

--- a/frontend/src/api/generated-types.ts
+++ b/frontend/src/api/generated-types.ts
@@ -1264,7 +1264,10 @@ export interface components {
             immediate: number;
             /** Duration */
             duration?: number | null;
-            /** Target */
+            /**
+             * Target
+             * @description What the listener is watching: an HA entity ID, or the topic's last segment for event listeners.
+             */
             target?: string | null;
             /** @default single */
             mode: components["schemas"]["ExecutionMode"];

--- a/frontend/src/test/factories.ts
+++ b/frontend/src/test/factories.ts
@@ -138,7 +138,7 @@ export function createListener(overrides: Partial<ListenerWithSummary> = {}): Li
     source_tier: "app",
     immediate: 0,
     duration: null,
-    entity_id: null,
+    target: null,
     last_error_traceback: null,
     ...overrides,
   } satisfies ListenerWithSummary;

--- a/src/hassette/cli/commands/listener.py
+++ b/src/hassette/cli/commands/listener.py
@@ -12,7 +12,7 @@ from hassette.web.models import ListenerWithSummary
 LISTENER_LIST_COLUMNS: list[Column] = [
     Column("listener_id", "ID", max_width=6),
     Column("app_key", "App", max_width=18),
-    Column("entity_id", "Target", max_width=26),
+    Column("target", "Target", max_width=26),
     Column("listener_kind", "Kind", max_width=12),
     Column("handler_method", "Handler", max_width=22, formatter=fmt_handler_short),
     Column("total_invocations", "Total", max_width=7),

--- a/src/hassette/test_utils/web_helpers.py
+++ b/src/hassette/test_utils/web_helpers.py
@@ -482,7 +482,7 @@ def make_listener_with_summary(
     last_invoked_at: float | None = SYNTHETIC_TIMESTAMP,
     last_error_type: str | None = None,
     last_error_message: str | None = None,
-    entity_id: str | None = None,
+    target: str | None = None,
 ) -> ListenerWithSummary:
     """Build a ListenerWithSummary with sensible defaults."""
     return ListenerWithSummary(
@@ -501,7 +501,7 @@ def make_listener_with_summary(
         last_invoked_at=last_invoked_at,
         last_error_type=last_error_type,
         last_error_message=last_error_message,
-        entity_id=entity_id,
+        target=target,
     )
 
 

--- a/src/hassette/web/mappers.py
+++ b/src/hassette/web/mappers.py
@@ -160,6 +160,16 @@ def listener_kind_from_topic(topic: str) -> ListenerKind:
     return "event"
 
 
+def event_name_from_topic(topic: str) -> str:
+    """Derive a display name for an event-type listener from its topic.
+
+    Every internal topic follows a ``<namespace>.event.<name>`` shape (see ``Topic``), so the
+    last dot-separated segment is the event name (e.g. ``service_status`` from
+    ``hassette.event.service_status``). A topic with no dots is returned unchanged.
+    """
+    return topic.rsplit(".", 1)[-1]
+
+
 def to_listener_with_summary(
     listener: ListenerSummary,
     live_counts: dict[int, LiveCounts] | None = None,
@@ -168,6 +178,9 @@ def to_listener_with_summary(
 
     Copies every field from the summary and appends a computed
     ``handler_summary`` string via :func:`~hassette.web.telemetry_helpers.format_handler_summary`.
+    ``target`` is also computed: it is the summary's ``entity_id`` for state/attribute listeners,
+    or (since ``entity_id`` is ``None`` for event listeners) falls back to
+    :func:`event_name_from_topic`.
 
     Args:
         listener: The persisted listener summary from the telemetry DB.
@@ -177,12 +190,13 @@ def to_listener_with_summary(
     """
     suppressed, dropped, backpressure_dropped = (live_counts or {}).get(listener.listener_id, LiveCounts(0, 0, 0))
     # Every ListenerSummary field has a same-named field on ListenerWithSummary, so
-    # from_attributes copies them 1:1. The five fields below have no source attribute
+    # from_attributes copies them 1:1. The six fields below have no source attribute
     # (they are computed or sourced from live_counts) and are set via model_copy.
     return ListenerWithSummary.model_validate(listener, from_attributes=True).model_copy(
         update={
             "listener_kind": listener_kind_from_topic(listener.topic),
             "handler_summary": format_handler_summary(listener),
+            "target": listener.entity_id or event_name_from_topic(listener.topic),
             "suppressed_count": suppressed,
             "dropped_count": dropped,
             "backpressure_dropped_count": backpressure_dropped,

--- a/src/hassette/web/models.py
+++ b/src/hassette/web/models.py
@@ -2,7 +2,7 @@
 
 from typing import Annotated, Any, Literal
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 
 from hassette.schemas.domain_models import AppStatusChangedData, ConnectivityData, ServiceStatusData, StateChangedData
 from hassette.types.enums import (
@@ -297,6 +297,8 @@ class AppHealthResponse(BaseModel):
 
 class ListenerWithSummary(BaseModel):
     """Listener metrics enriched with human-readable handler summary."""
+
+    model_config = ConfigDict(use_attribute_docstrings=True)
 
     listener_id: int
     app_key: str

--- a/src/hassette/web/models.py
+++ b/src/hassette/web/models.py
@@ -331,7 +331,8 @@ class ListenerWithSummary(BaseModel):
     source_tier: SourceTier = "app"
     immediate: int = 0
     duration: float | None = None
-    entity_id: str | None = None
+    target: str | None = None
+    """What the listener is watching: an HA entity ID, or the topic's last segment for event listeners."""
     mode: ExecutionMode = DEFAULT_OVERLAP_MODE
     suppressed_count: int = 0
     dropped_count: int = 0

--- a/tests/unit/cli/test_commands_listener.py
+++ b/tests/unit/cli/test_commands_listener.py
@@ -107,8 +107,8 @@ class TestCmdListener:
         assert listeners_call["params"]["source_tier"] == "app"
 
     def test_human_mode_renders_table(self, cli_client_factory: CLIClientFactory) -> None:
-        """Listener renders a table with listener_id and entity_id."""
-        listener = make_listener_with_summary(listener_id=42, entity_id="light.kitchen")
+        """Listener renders a table with listener_id and target."""
+        listener = make_listener_with_summary(listener_id=42, target="light.kitchen")
         client = cli_client_factory.build_with_routes([("GET", "/api/bus/listeners", 200, [listener.model_dump()])])
         with (
             capture_stdout() as buf,
@@ -152,7 +152,7 @@ class TestCmdListener:
         field_names = [c.field for c in LISTENER_LIST_COLUMNS]
         assert "listener_id" in field_names
         assert "app_key" in field_names
-        assert "entity_id" in field_names
+        assert "target" in field_names
         assert "handler_method" in field_names
         assert "total_invocations" in field_names
 

--- a/tests/unit/cli/test_commands_listener.py
+++ b/tests/unit/cli/test_commands_listener.py
@@ -118,6 +118,7 @@ class TestCmdListener:
 
         output = buf.getvalue()
         assert "42" in output
+        assert "light" in output
         assert "test_" in output
 
     def test_json_mode_outputs_list(self, cli_client_factory: CLIClientFactory) -> None:

--- a/tests/unit/web/test_mappers.py
+++ b/tests/unit/web/test_mappers.py
@@ -76,14 +76,18 @@ def test_instance_response_from_ignores_source_error_attribute():
 
 
 def test_listener_summary_fields_are_subset_of_response():
-    """Every ListenerSummary field exists on ListenerWithSummary.
+    """Every ListenerSummary field exists on ListenerWithSummary, with one documented exception.
 
     Guards the from_attributes mapper: a field added to ListenerSummary but
     missing from ListenerWithSummary would silently drop instead of surfacing.
+    ``entity_id`` is the one intentional exception — the mapper consumes it (falling
+    back to the topic's last segment when unset) to populate ``target`` instead of
+    copying it through 1:1.
     """
+    consumed_by_mapper = {"entity_id"}
     summary_fields = set(ListenerSummary.model_fields)
     response_fields = set(ListenerWithSummary.model_fields)
-    missing = summary_fields - response_fields
+    missing = summary_fields - response_fields - consumed_by_mapper
     assert not missing, f"ListenerSummary fields not present on ListenerWithSummary: {missing}"
 
 
@@ -463,6 +467,24 @@ def test_to_listener_with_summary_min_max_numeric_passthrough():
 
     assert result.min_duration_ms == 5.0
     assert result.max_duration_ms == 100.0
+
+
+def test_to_listener_with_summary_target_uses_entity_id_when_present():
+    """Target is the entity ID for state/attribute listeners."""
+    summary = make_listener_summary(entity_id="light.kitchen", topic="hass.event.state_changed")
+
+    result = to_listener_with_summary(summary)
+
+    assert result.target == "light.kitchen"
+
+
+def test_to_listener_with_summary_target_falls_back_to_topic_last_segment():
+    """Target falls back to the topic's last segment when entity_id is None (event listeners)."""
+    summary = make_listener_summary(entity_id=None, topic="hassette.event.service_status")
+
+    result = to_listener_with_summary(summary)
+
+    assert result.target == "service_status"
 
 
 # LivenessResponse and ReadinessResponse


### PR DESCRIPTION
## Summary

`ListenerWithSummary.entity_id` was `None` for event-type listeners, leaving the CLI/web "Target" column blank even though it was already labeled "Target." This renames the field to `target` and populates it for event listeners by falling back to the last segment of the topic (e.g. `service_status` from `hassette.event.service_status`).

## Changes

- Renamed `ListenerWithSummary.entity_id` → `target` in `web/models.py`
- Updated `to_listener_with_summary` mapper in `web/mappers.py` to derive `target` from the topic's last segment when the listener has no entity ID
- Updated CLI column definition in `cli/commands/listener.py`
- Regenerated OpenAPI schema and frontend TypeScript types
- Updated tests and frontend test factories

## Breaking Changes

This renames a web API response field consumed by `GET /api/bus/listeners` and `GET /api/telemetry/app/{key}/listeners`. Any external client reading `entity_id` from those responses must switch to `target`.

## Testing

- `uv run nox -s dev` — 8184 passed, 2 xfailed
- `prek -a` — all hooks passed (ruff, eslint, stylelint, tsc, CSS/schema guards)
- `prek run pyright -a --hook-stage pre-push` — passed

Closes #879

BREAKING CHANGE: `ListenerWithSummary.entity_id` (web API response field, `GET /api/bus/listeners` and `GET /api/telemetry/app/{key}/listeners`) is renamed to `target`. API clients reading `entity_id` must switch to `target`; event-type listeners now populate it with a topic-derived name instead of `null`.
