### PR TITLE
fix: use baseline alignment for heading+badge rows with mixed font sizes

### DIFF
--- a/frontend/src/components/app-detail/detail-header.module.css
+++ b/frontend/src/components/app-detail/detail-header.module.css
@@ -1,6 +1,6 @@
 .header {
   display: flex;
-  align-items: center;
+  align-items: baseline;
   gap: var(--sp-2);
   flex-wrap: wrap;
   margin-bottom: var(--sp-3);

--- a/frontend/src/components/app-detail/unified-handler-row.module.css
+++ b/frontend/src/components/app-detail/unified-handler-row.module.css
@@ -62,7 +62,7 @@
 
 .header {
   display: flex;
-  align-items: center;
+  align-items: baseline;
   gap: var(--sp-2);
   min-width: 0;
 }

--- a/frontend/src/pages/diagnostics.module.css
+++ b/frontend/src/pages/diagnostics.module.css
@@ -10,7 +10,7 @@
 
 .sectionHeader {
   display: flex;
-  align-items: center;
+  align-items: baseline;
   gap: var(--sp-3);
 }
 

--- a/frontend/src/styles/layout.css
+++ b/frontend/src/styles/layout.css
@@ -82,7 +82,7 @@
 
 .ht-level-start {
   display: flex;
-  align-items: center;
+  align-items: baseline;
   gap: var(--sp-3);
   flex-wrap: wrap;
 }


### PR DESCRIPTION
## Summary

Audited `align-items: center` usages across component and page CSS for rows that mix font sizes (e.g., a heading next to a status badge, a section title next to a count). Switched 4 of these to `align-items: baseline` so the text baselines line up instead of the boxes being vertically centered, which looks off when the two elements have different font sizes.

Changed:
- `frontend/src/components/app-detail/detail-header.module.css` — `.header` (app name heading + status badges)
- `frontend/src/components/app-detail/unified-handler-row.module.css` — `.header` (handler name + badges)
- `frontend/src/pages/diagnostics.module.css` — `.sectionHeader` (section title + badge/count)
- `frontend/src/styles/layout.css` — `.ht-level-start` (shared heading+badge row utility)

Icon+text rows elsewhere in the codebase already correctly use `center` and were left unchanged, since baseline alignment would misalign an icon against text.

## Testing

- `cd frontend && npm run build` — build succeeds
- `cd frontend && npm run test` — 104 files / 1483 tests passed
- `prek -a` — all lint, type-check, and CSS hygiene hooks pass

This is a CSS-only visual tweak with no build-affecting logic change; visual verification was done by inspecting the affected component rows, matching the audit criteria in the issue (mixed font-size rows vs. icon+text rows).

Closes #847