### PR TITLE
feat: compose predicates with &, |, and ~ operators

### DIFF
--- a/docs/pages/core-concepts/bus/filtering.md
+++ b/docs/pages/core-concepts/bus/filtering.md
@@ -114,6 +114,20 @@ Both `P.AttrTo` predicates must match. The `changed=False` parameter is also req
 
 `P.AllOf` is an explicit AND combinator — it does the same thing as passing a list to `where=`, but can be nested inside `P.AnyOf` or `P.Not` where a plain list is not accepted. `P.Not` negates any predicate: `P.Not(P.StateTo("on"))` fires when the new state is anything except `"on"`. All three compose freely.
 
+### Operator Shorthand: `&`, `|`, `~`
+
+Predicates support Python's boolean operators as shorthand for the three combinators. `a & b` is `P.AllOf((a, b))`, `a | b` is `P.AnyOf((a, b))`, and `~a` is `P.Not(a)`.
+
+```python
+--8<-- "pages/core-concepts/bus/snippets/filtering_operators.py"
+```
+
+The handler fires when a light turns on or goes unavailable, unless the entity is `light.office`. `&` binds tighter than `|`, the same precedence Python gives them everywhere else, so the `|` branch needs its parentheses.
+
+Chains flatten instead of nesting: `a & b & c` builds `P.AllOf((a, b, c))`, so the summary shown by `hassette listener` reads the same as the explicit form. The result is an ordinary predicate, so operators and explicit combinators mix freely. Anywhere `where=` accepts `P.AllOf`, it accepts `a & b`.
+
+Conditions (`C.*`) do not support these operators. They test extracted values, not events, so they compose through predicates instead.
+
 ## Filtering Service Calls
 
 `on_call_service` accepts `domain=` and `service=` for coarse filtering, and `where=` for fine-grained control. `where=` on `on_call_service` also accepts a plain dict, which matches against the service data payload.

--- a/docs/pages/core-concepts/bus/filtering.md
+++ b/docs/pages/core-concepts/bus/filtering.md
@@ -116,15 +116,15 @@ Both `P.AttrTo` predicates must match. The `changed=False` parameter is also req
 
 ### Operator Shorthand: `&`, `|`, `~`
 
-Predicates support Python's boolean operators as shorthand for the three combinators. `a & b` is `P.AllOf((a, b))`, `a | b` is `P.AnyOf((a, b))`, and `~a` is `P.Not(a)`.
+Built-in `P.*` predicate objects overload Python's bitwise operators as shorthand for the three combinators. `a & b` is `P.AllOf((a, b))`, `a | b` is `P.AnyOf((a, b))`, and `~a` is `P.Not(a)`.
 
 ```python
 --8<-- "pages/core-concepts/bus/snippets/filtering_operators.py"
 ```
 
-The handler fires when a light turns on or goes unavailable, unless the entity is `light.office`. `&` binds tighter than `|`, the same precedence Python gives them everywhere else, so the `|` branch needs its parentheses.
+The handler fires when a light turns on or goes unavailable, except for `light.office`. Python gives `&` higher precedence than `|`, so the OR branch needs parentheses.
 
-Chains flatten instead of nesting: `a & b & c` builds `P.AllOf((a, b, c))`, so the summary shown by `hassette listener` reads the same as the explicit form. The result is an ordinary predicate, so operators and explicit combinators mix freely. Anywhere `where=` accepts `P.AllOf`, it accepts `a & b`.
+Chains flatten instead of nesting: `a & b & c` builds `P.AllOf((a, b, c))`, so the summary shown by `hassette listener` reads the same as the explicit form. The result is an ordinary predicate, so operators and explicit combinators mix freely. Wrap a custom callable in `P.Guard` when you want it to participate in operator chains.
 
 Conditions (`C.*`) do not support these operators. They test extracted values, not events, so they compose through predicates instead.
 

--- a/docs/pages/core-concepts/bus/predicate-reference.md
+++ b/docs/pages/core-concepts/bus/predicate-reference.md
@@ -30,7 +30,7 @@ Works with: any event type.
 
 `AllOf` and `AnyOf` each have a classmethod `ensure_iterable(where)` that wraps a single predicate or sequence into the combinator.
 
-Every predicate also supports operator shorthand for these three: `a & b` builds `AllOf((a, b))`, `a | b` builds `AnyOf((a, b))`, and `~a` builds `Not(a)`. Chains flatten: `a & b & c` is `AllOf((a, b, c))`, not a nested pair. Conditions (`C.*`) have no operator support.
+Built-in `P.*` predicate objects also support operator shorthand for these three: `a & b` builds `AllOf((a, b))`, `a | b` builds `AnyOf((a, b))`, and `~a` builds `Not(a)`. Chains flatten: `a & b & c` is `AllOf((a, b, c))`, not a nested pair. Wrap custom callables in `P.Guard` when you want them to participate in operator chains. Conditions (`C.*`) have no operator support.
 
 ### Value / Field Matching
 

--- a/docs/pages/core-concepts/bus/predicate-reference.md
+++ b/docs/pages/core-concepts/bus/predicate-reference.md
@@ -30,6 +30,8 @@ Works with: any event type.
 
 `AllOf` and `AnyOf` each have a classmethod `ensure_iterable(where)` that wraps a single predicate or sequence into the combinator.
 
+Every predicate also supports operator shorthand for these three: `a & b` builds `AllOf((a, b))`, `a | b` builds `AnyOf((a, b))`, and `~a` builds `Not(a)`. Chains flatten: `a & b & c` is `AllOf((a, b, c))`, not a nested pair. Conditions (`C.*`) have no operator support.
+
 ### Value / Field Matching
 
 Works with: any event type.

--- a/docs/pages/core-concepts/bus/snippets/filtering_operators.py
+++ b/docs/pages/core-concepts/bus/snippets/filtering_operators.py
@@ -1,0 +1,16 @@
+from hassette import App, P, RawStateChangeEvent
+
+
+class LightApp(App):
+    async def on_initialize(self):
+        # `&` is AllOf, `|` is AnyOf, `~` is Not
+        await self.bus.on_state_change(
+            "light.*",
+            handler=self.on_light_change,
+            where=(P.StateTo("on") | P.StateTo("unavailable"))
+            & ~P.EntityMatches("light.office"),
+            name="lights_except_office",
+        )
+
+    async def on_light_change(self, event: RawStateChangeEvent):
+        self.logger.info("Light changed: %s", event.payload.data.entity_id)

--- a/docs/pages/core-concepts/bus/snippets/filtering_operators.py
+++ b/docs/pages/core-concepts/bus/snippets/filtering_operators.py
@@ -12,5 +12,5 @@ class LightApp(App):
             name="lights_except_office",
         )
 
-    async def on_light_change(self, event: RawStateChangeEvent):
+    async def on_light_change(self, event: RawStateChangeEvent) -> None:
         self.logger.info("Light changed: %s", event.payload.data.entity_id)

--- a/src/hassette/event_handling/predicates.py
+++ b/src/hassette/event_handling/predicates.py
@@ -77,12 +77,80 @@ if typing.TYPE_CHECKING:
     from hassette.types import Predicate
 
 V = TypeVar("V")
+CombinatorT = TypeVar("CombinatorT", bound="_PredicateCombinator")
 
 LOGGER = getLogger(__name__)
 
 
+class PredicateOps:
+    """Adds ``&``, ``|``, and ``~`` composition to the predicate types in this module.
+
+    ``a & b`` builds an `AllOf`, ``a | b`` builds an `AnyOf`, and ``~a`` builds a `Not`.
+    The result is an ordinary predicate object, so it can be passed to ``where=`` or nested
+    inside the explicit combinators.
+
+    Chains flatten rather than nest: ``a & b & c`` produces ``AllOf((a, b, c))``, which keeps
+    ``summarize()`` identical to the explicit form.
+
+    ``AllOf``, ``AnyOf``, and ``Not`` are defined further down this module; the operators resolve
+    them at call time, not at class-definition time.
+
+    Examples:
+        ```python
+        P.StateTo("on") & P.DomainMatches("light")
+        P.StateTo("on") | P.StateTo("unavailable")
+        ~P.StateTo("off")
+        ```
+    """
+
+    if typing.TYPE_CHECKING:
+        # Type-checking only, with no runtime counterpart: every class mixing this in defines
+        # its own __call__, and declaring the signature here lets type checkers treat `self`
+        # as a Predicate when building the combinators below.
+        def __call__(self, value: Any, /) -> bool: ...
+
+    def __and__(self, other: "Predicate") -> "AllOf":
+        if not callable(other):
+            return NotImplemented
+        return _combine(AllOf, self, other)
+
+    def __rand__(self, other: "Predicate") -> "AllOf":
+        if not callable(other):
+            return NotImplemented
+        return _combine(AllOf, other, self)
+
+    def __or__(self, other: "Predicate") -> "AnyOf":
+        if not callable(other):
+            return NotImplemented
+        return _combine(AnyOf, self, other)
+
+    def __ror__(self, other: "Predicate") -> "AnyOf":
+        if not callable(other):
+            return NotImplemented
+        return _combine(AnyOf, other, self)
+
+    def __invert__(self) -> "Not":
+        return Not(self)
+
+
+def _combine(combinator: type[CombinatorT], left: "Predicate", right: "Predicate") -> CombinatorT:
+    """Build ``combinator`` from two operands, absorbing operands of the same combinator type.
+
+    Absorption is what flattens chains, and it applies to explicitly constructed combinators too:
+    ``AllOf((a, b)) & c`` yields ``AllOf((a, b, c))``, not a nested pair. The two forms evaluate
+    identically, so the grouping carries no meaning worth preserving.
+    """
+    predicates: list[Predicate] = []
+    for operand in (left, right):
+        if isinstance(operand, combinator):
+            predicates.extend(operand.predicates)
+        else:
+            predicates.append(operand)
+    return combinator(tuple(predicates))
+
+
 @dataclass(frozen=True)
-class Guard(typing.Generic[EventT]):
+class Guard(PredicateOps, typing.Generic[EventT]):
     """Wraps a predicate function to be used in combinators.
 
     Allows for passing any callable as a predicate. Generic over EventT to allow type checkers to understand the
@@ -166,7 +234,7 @@ def _glob_or_literal(value: str) -> "str | Glob":
 
 
 @dataclass(frozen=True)
-class _PredicateCombinator:
+class _PredicateCombinator(PredicateOps):
     """Base for combinators that wrap a tuple of predicates.
 
     Provides the shared ``ensure_iterable`` constructor that flattens a single predicate
@@ -210,7 +278,7 @@ class AnyOf(_PredicateCombinator):
 
 
 @dataclass(frozen=True)
-class Not:
+class Not(PredicateOps):
     """Negates the result of the predicate."""
 
     predicate: "Predicate"
@@ -223,7 +291,7 @@ class Not:
 
 
 @dataclass(frozen=True)
-class ValueIs(Generic[EventT, V]):
+class ValueIs(PredicateOps, Generic[EventT, V]):
     """Checks whether a value extracted from an event satisfies a condition.
 
     Args:
@@ -248,7 +316,7 @@ class ValueIs(Generic[EventT, V]):
 
 
 @dataclass(frozen=True)
-class DidChange(Generic[EventT]):
+class DidChange(PredicateOps, Generic[EventT]):
     """Predicate that is True when two extracted values differ.
 
     Typical use is an accessor that returns (old_value, new_value).
@@ -265,7 +333,7 @@ class DidChange(Generic[EventT]):
 
 
 @dataclass(frozen=True)
-class IsPresent:
+class IsPresent(PredicateOps):
     """Checks if a value extracted from an event is present (not MISSING_VALUE).
 
     This will generally be used when comparing state changes, where either the old or new state may be missing.
@@ -282,7 +350,7 @@ class IsPresent:
 
 
 @dataclass(frozen=True)
-class IsMissing:
+class IsMissing(PredicateOps):
     """Checks if a value extracted from an event is missing (MISSING_VALUE).
 
     This will generally be used when comparing state changes, where either the old or new state may be missing.
@@ -299,7 +367,7 @@ class IsMissing:
 
 
 @dataclass(frozen=True)
-class StateFrom:
+class StateFrom(PredicateOps):
     """Checks if a value extracted from a RawStateChangeEvent satisfies a condition on the 'old' value."""
 
     condition: "ChangeType"
@@ -312,7 +380,7 @@ class StateFrom:
 
 
 @dataclass(frozen=True)
-class StateTo:
+class StateTo(PredicateOps):
     """Checks if a value extracted from a RawStateChangeEvent satisfies a condition on the 'new' value."""
 
     condition: "ChangeType"
@@ -325,7 +393,7 @@ class StateTo:
 
 
 @dataclass(frozen=True)
-class StateComparison:
+class StateComparison(PredicateOps):
     """Checks if a comparison between from_state and to_state satisfies a condition."""
 
     condition: ComparisonCondition
@@ -343,7 +411,7 @@ class StateComparison:
 
 
 @dataclass(frozen=True)
-class AttrFrom:
+class AttrFrom(PredicateOps):
     """Checks if a specific attribute changed in a RawStateChangeEvent."""
 
     attr_name: str
@@ -357,7 +425,7 @@ class AttrFrom:
 
 
 @dataclass(frozen=True)
-class AttrTo:
+class AttrTo(PredicateOps):
     """Checks if a specific attribute changed in a RawStateChangeEvent."""
 
     attr_name: str
@@ -371,7 +439,7 @@ class AttrTo:
 
 
 @dataclass(frozen=True)
-class AttrComparison:
+class AttrComparison(PredicateOps):
     """Checks if a comparison between from_attr and to_attr satisfies a condition."""
 
     attr_name: str
@@ -392,7 +460,7 @@ class AttrComparison:
 
 
 @dataclass(frozen=True)
-class StateDidChange:
+class StateDidChange(PredicateOps):
     """Checks if the state changed in a RawStateChangeEvent."""
 
     def __call__(self, value: "RawStateChangeEvent", /) -> bool:
@@ -403,7 +471,7 @@ class StateDidChange:
 
 
 @dataclass(frozen=True)
-class AttrDidChange:
+class AttrDidChange(PredicateOps):
     """Checks if a specific attribute changed in a RawStateChangeEvent.
 
     When ``old_state`` is None, the attribute is treated as having changed
@@ -429,7 +497,7 @@ class AttrDidChange:
 
 
 @dataclass(frozen=True)
-class DomainMatches:
+class DomainMatches(PredicateOps):
     """Checks if the event domain matches a specific value."""
 
     domain: str
@@ -445,7 +513,7 @@ class DomainMatches:
 
 
 @dataclass(frozen=True)
-class EntityMatches:
+class EntityMatches(PredicateOps):
     """Checks if the event entity_id matches a specific value."""
 
     entity_id: str
@@ -461,7 +529,7 @@ class EntityMatches:
 
 
 @dataclass(frozen=True)
-class ServiceMatches:
+class ServiceMatches(PredicateOps):
     """Checks if the event service matches a specific value."""
 
     service: str
@@ -477,7 +545,7 @@ class ServiceMatches:
 
 
 @dataclass(frozen=True)
-class ServiceDataWhere:
+class ServiceDataWhere(PredicateOps):
     """Predicate that applies a mapping of service_data conditions to a CallServiceEvent.
 
     Examples:

--- a/src/hassette/event_handling/predicates.py
+++ b/src/hassette/event_handling/predicates.py
@@ -82,7 +82,7 @@ CombinatorT = TypeVar("CombinatorT", bound="_PredicateCombinator")
 LOGGER = getLogger(__name__)
 
 
-class PredicateOps:
+class _PredicateOps:
     """Adds ``&``, ``|``, and ``~`` composition to the predicate types in this module.
 
     ``a & b`` builds an `AllOf`, ``a | b`` builds an `AnyOf`, and ``~a`` builds a `Not`.
@@ -150,7 +150,7 @@ def _combine(combinator: type[CombinatorT], left: "Predicate", right: "Predicate
 
 
 @dataclass(frozen=True)
-class Guard(PredicateOps, typing.Generic[EventT]):
+class Guard(_PredicateOps, typing.Generic[EventT]):
     """Wraps a predicate function to be used in combinators.
 
     Allows for passing any callable as a predicate. Generic over EventT to allow type checkers to understand the
@@ -234,7 +234,7 @@ def _glob_or_literal(value: str) -> "str | Glob":
 
 
 @dataclass(frozen=True)
-class _PredicateCombinator(PredicateOps):
+class _PredicateCombinator(_PredicateOps):
     """Base for combinators that wrap a tuple of predicates.
 
     Provides the shared ``ensure_iterable`` constructor that flattens a single predicate
@@ -278,7 +278,7 @@ class AnyOf(_PredicateCombinator):
 
 
 @dataclass(frozen=True)
-class Not(PredicateOps):
+class Not(_PredicateOps):
     """Negates the result of the predicate."""
 
     predicate: "Predicate"
@@ -291,7 +291,7 @@ class Not(PredicateOps):
 
 
 @dataclass(frozen=True)
-class ValueIs(PredicateOps, Generic[EventT, V]):
+class ValueIs(_PredicateOps, Generic[EventT, V]):
     """Checks whether a value extracted from an event satisfies a condition.
 
     Args:
@@ -316,7 +316,7 @@ class ValueIs(PredicateOps, Generic[EventT, V]):
 
 
 @dataclass(frozen=True)
-class DidChange(PredicateOps, Generic[EventT]):
+class DidChange(_PredicateOps, Generic[EventT]):
     """Predicate that is True when two extracted values differ.
 
     Typical use is an accessor that returns (old_value, new_value).
@@ -333,7 +333,7 @@ class DidChange(PredicateOps, Generic[EventT]):
 
 
 @dataclass(frozen=True)
-class IsPresent(PredicateOps):
+class IsPresent(_PredicateOps):
     """Checks if a value extracted from an event is present (not MISSING_VALUE).
 
     This will generally be used when comparing state changes, where either the old or new state may be missing.
@@ -350,7 +350,7 @@ class IsPresent(PredicateOps):
 
 
 @dataclass(frozen=True)
-class IsMissing(PredicateOps):
+class IsMissing(_PredicateOps):
     """Checks if a value extracted from an event is missing (MISSING_VALUE).
 
     This will generally be used when comparing state changes, where either the old or new state may be missing.
@@ -367,7 +367,7 @@ class IsMissing(PredicateOps):
 
 
 @dataclass(frozen=True)
-class StateFrom(PredicateOps):
+class StateFrom(_PredicateOps):
     """Checks if a value extracted from a RawStateChangeEvent satisfies a condition on the 'old' value."""
 
     condition: "ChangeType"
@@ -380,7 +380,7 @@ class StateFrom(PredicateOps):
 
 
 @dataclass(frozen=True)
-class StateTo(PredicateOps):
+class StateTo(_PredicateOps):
     """Checks if a value extracted from a RawStateChangeEvent satisfies a condition on the 'new' value."""
 
     condition: "ChangeType"
@@ -393,7 +393,7 @@ class StateTo(PredicateOps):
 
 
 @dataclass(frozen=True)
-class StateComparison(PredicateOps):
+class StateComparison(_PredicateOps):
     """Checks if a comparison between from_state and to_state satisfies a condition."""
 
     condition: ComparisonCondition
@@ -411,7 +411,7 @@ class StateComparison(PredicateOps):
 
 
 @dataclass(frozen=True)
-class AttrFrom(PredicateOps):
+class AttrFrom(_PredicateOps):
     """Checks if a specific attribute changed in a RawStateChangeEvent."""
 
     attr_name: str
@@ -425,7 +425,7 @@ class AttrFrom(PredicateOps):
 
 
 @dataclass(frozen=True)
-class AttrTo(PredicateOps):
+class AttrTo(_PredicateOps):
     """Checks if a specific attribute changed in a RawStateChangeEvent."""
 
     attr_name: str
@@ -439,7 +439,7 @@ class AttrTo(PredicateOps):
 
 
 @dataclass(frozen=True)
-class AttrComparison(PredicateOps):
+class AttrComparison(_PredicateOps):
     """Checks if a comparison between from_attr and to_attr satisfies a condition."""
 
     attr_name: str
@@ -460,7 +460,7 @@ class AttrComparison(PredicateOps):
 
 
 @dataclass(frozen=True)
-class StateDidChange(PredicateOps):
+class StateDidChange(_PredicateOps):
     """Checks if the state changed in a RawStateChangeEvent."""
 
     def __call__(self, value: "RawStateChangeEvent", /) -> bool:
@@ -471,7 +471,7 @@ class StateDidChange(PredicateOps):
 
 
 @dataclass(frozen=True)
-class AttrDidChange(PredicateOps):
+class AttrDidChange(_PredicateOps):
     """Checks if a specific attribute changed in a RawStateChangeEvent.
 
     When ``old_state`` is None, the attribute is treated as having changed
@@ -497,7 +497,7 @@ class AttrDidChange(PredicateOps):
 
 
 @dataclass(frozen=True)
-class DomainMatches(PredicateOps):
+class DomainMatches(_PredicateOps):
     """Checks if the event domain matches a specific value."""
 
     domain: str
@@ -513,7 +513,7 @@ class DomainMatches(PredicateOps):
 
 
 @dataclass(frozen=True)
-class EntityMatches(PredicateOps):
+class EntityMatches(_PredicateOps):
     """Checks if the event entity_id matches a specific value."""
 
     entity_id: str
@@ -529,7 +529,7 @@ class EntityMatches(PredicateOps):
 
 
 @dataclass(frozen=True)
-class ServiceMatches(PredicateOps):
+class ServiceMatches(_PredicateOps):
     """Checks if the event service matches a specific value."""
 
     service: str
@@ -545,7 +545,7 @@ class ServiceMatches(PredicateOps):
 
 
 @dataclass(frozen=True)
-class ServiceDataWhere(PredicateOps):
+class ServiceDataWhere(_PredicateOps):
     """Predicate that applies a mapping of service_data conditions to a CallServiceEvent.
 
     Examples:

--- a/tests/unit/bus/test_combinator_predicates.py
+++ b/tests/unit/bus/test_combinator_predicates.py
@@ -1,10 +1,13 @@
 """Tests for predicate combinators and utility functions.
 
-Tests the base combinators (AllOf, AnyOf, Not, Guard) and utility functions
-for composing and normalizing predicates.
+Tests the base combinators (AllOf, AnyOf, Not, Guard), the ``&``/``|``/``~``
+operators that build them, and utility functions for composing and normalizing
+predicates.
 """
 
 from types import SimpleNamespace
+
+import pytest
 
 from hassette.event_handling.predicates import (
     AllOf,
@@ -77,6 +80,103 @@ def test_guard_wraps_callable() -> None:
     guard = Guard(check_identity)
     assert guard(sentinel) is True
     assert guard(object()) is False
+
+
+# Operator composition tests
+def test_and_operator_builds_allof() -> None:
+    """`&` produces an AllOf with AND semantics."""
+    mock_event = SimpleNamespace()
+
+    predicate = Guard(always_true) & Guard(always_false)
+    assert isinstance(predicate, AllOf)
+    assert predicate == AllOf((Guard(always_true), Guard(always_false)))
+    assert predicate(mock_event) is False
+    assert (Guard(always_true) & Guard(always_true))(mock_event) is True
+
+
+def test_or_operator_builds_anyof() -> None:
+    """`|` produces an AnyOf with OR semantics."""
+    mock_event = SimpleNamespace()
+
+    predicate = Guard(always_false) | Guard(always_true)
+    assert isinstance(predicate, AnyOf)
+    assert predicate == AnyOf((Guard(always_false), Guard(always_true)))
+    assert predicate(mock_event) is True
+    assert (Guard(always_false) | Guard(always_false))(mock_event) is False
+
+
+def test_invert_operator_builds_not() -> None:
+    """`~` produces a Not with NOT semantics."""
+    mock_event = SimpleNamespace()
+
+    predicate = ~Guard(always_true)
+    assert isinstance(predicate, Not)
+    assert predicate == Not(Guard(always_true))
+    assert predicate(mock_event) is False
+    assert (~Guard(always_false))(mock_event) is True
+
+
+def test_chained_and_flattens() -> None:
+    """`a & b & c` produces a flat AllOf, not a nested one."""
+    a, b, c = Guard(always_true), Guard(always_false), Guard(always_true)
+
+    assert a & b & c == AllOf((a, b, c))
+    assert a & (b & c) == AllOf((a, b, c))
+
+
+def test_chained_or_flattens() -> None:
+    """`a | b | c` produces a flat AnyOf, not a nested one."""
+    a, b, c = Guard(always_true), Guard(always_false), Guard(always_true)
+
+    assert a | b | c == AnyOf((a, b, c))
+    assert a | (b | c) == AnyOf((a, b, c))
+
+
+def test_mixed_operators_nest_by_precedence() -> None:
+    """`&` binds tighter than `|`, and unlike combinators do not flatten into each other."""
+    mock_event = SimpleNamespace()
+    a, b, c = Guard(always_true), Guard(always_false), Guard(always_true)
+
+    assert a & b | c == AnyOf((AllOf((a, b)), c))
+    assert (a & b) | c == AnyOf((AllOf((a, b)), c))
+    assert (a & b | c)(mock_event) is True
+
+
+def test_operators_compose_with_explicit_combinators() -> None:
+    """Operator results and explicitly constructed combinators mix freely."""
+    a, b, c = Guard(always_true), Guard(always_false), Guard(always_true)
+
+    assert AllOf((a, b)) & c == AllOf((a, b, c))
+    assert ~AllOf((a, b)) == Not(AllOf((a, b)))
+    assert AnyOf((a & b, c)) == AnyOf((AllOf((a, b)), c))
+
+
+def test_operators_accept_plain_callables() -> None:
+    """Bare predicate functions work on either side of the operator, keeping operand order."""
+    assert Guard(always_true) & always_false == AllOf((Guard(always_true), always_false))
+    assert Guard(always_true) | always_false == AnyOf((Guard(always_true), always_false))
+    assert always_false & Guard(always_true) == AllOf((always_false, Guard(always_true)))
+    assert always_false | Guard(always_true) == AnyOf((always_false, Guard(always_true)))
+
+
+def test_operators_reject_non_callables() -> None:
+    """Non-callable operands raise TypeError instead of building a broken predicate."""
+    with pytest.raises(TypeError):
+        Guard(always_true) & 5  # pyright: ignore[reportArgumentType]
+
+    with pytest.raises(TypeError):
+        Guard(always_true) | "on"  # pyright: ignore[reportArgumentType]
+
+
+def test_operator_composed_predicate_passes_through_normalize_where() -> None:
+    """normalize_where returns an operator-composed predicate untouched — no double-wrapping."""
+    predicate = Guard(always_true) & Guard(always_false)
+
+    result = normalize_where(predicate)
+
+    assert result is predicate
+    assert isinstance(result, AllOf)
+    assert len(result.predicates) == 2
 
 
 # Utility function tests

--- a/tests/unit/bus/test_predicates.py
+++ b/tests/unit/bus/test_predicates.py
@@ -662,3 +662,32 @@ def test_predicate_summarize_top_level_preserves_inner_parens() -> None:
 def test_predicate_summarize_top_level_no_parens_passthrough() -> None:
     pred = StateTo("on")
     assert summarize_top_level(pred) == "→ on"
+
+
+# Operator composition on concrete predicate types
+def test_operators_on_concrete_predicates_match_explicit_combinators() -> None:
+    combined = EntityMatches("light.kitchen") & StateTo("on")
+    assert combined == AllOf(predicates=(EntityMatches("light.kitchen"), StateTo("on")))
+
+    either = StateTo("on") | StateTo("off")
+    assert either == AnyOf(predicates=(StateTo("on"), StateTo("off")))
+
+    assert ~StateTo("on") == Not(predicate=StateTo("on"))
+
+
+def test_operator_composed_predicate_evaluates() -> None:
+    event = create_state_change_event(entity_id="light.kitchen", old_value="off", new_value="on")
+
+    assert (EntityMatches("light.kitchen") & StateTo("on"))(event) is True
+    assert (EntityMatches("light.office") & StateTo("on"))(event) is False
+    assert (EntityMatches("light.office") | StateTo("on"))(event) is True
+    assert (~StateTo("on"))(event) is False
+
+
+def test_operator_summarize_matches_explicit_combinators() -> None:
+    assert (EntityMatches("light.kitchen") & StateTo("on")).summarize() == "(entity light.kitchen and → on)"
+    assert (StateTo("on") | StateTo("off") | StateTo("unavailable")).summarize() == "(→ on or → off or → unavailable)"
+    assert (~AllOf(predicates=(EntityMatches("light.kitchen"), StateTo("on")))).summarize() == (
+        "not (entity light.kitchen and → on)"
+    )
+    assert summarize_top_level(EntityMatches("light.kitchen") & StateTo("on")) == "entity light.kitchen and → on"


### PR DESCRIPTION
## Summary

Predicates (`P.*`) now support Python's boolean operators as shorthand for the existing combinators:

- `a & b` → `P.AllOf((a, b))`
- `a | b` → `P.AnyOf((a, b))`
- `~a` → `P.Not(a)`

This is sugar over the combinators that already existed, not a new filtering capability. The motivation is readability at the call site — a nested `P.AllOf((P.AnyOf((...)), P.Not(...)))` is hard to scan, while the operator form reads like the boolean expression it is:

```python
where=(P.StateTo("on") | P.StateTo("unavailable")) & ~P.EntityMatches("light.office")
```

## What changed

- **`PredicateOps` mixin** (`src/hassette/event_handling/predicates.py`) provides `__and__`, `__or__`, `__invert__` and the reflected `__rand__`/`__ror__`. Every predicate type in the module mixes it in, including `_PredicateCombinator` itself, so explicit and operator forms nest in either direction.
- **Chains flatten instead of nesting.** `a & b & c` produces `AllOf((a, b, c))`, not `AllOf((AllOf((a, b)), c))`. Absorption applies to explicitly constructed combinators too — `P.AllOf((a, b)) & c` yields `AllOf((a, b, c))`. The two shapes evaluate identically, so the grouping carries no meaning worth keeping, and flattening means `summarize()` (what `hassette listener` displays) reads the same for the operator form as for the explicit one.
- **Reflected operators** let a bare callable sit on either side of the operator, so `some_lambda & P.StateTo("on")` works.
- **Non-callable operands return `NotImplemented`**, so Python raises its usual `TypeError` rather than building a predicate that fails later at dispatch time.
- **Conditions (`C.*`) are deliberately untouched.** They test extracted values, not events, so they compose through predicates rather than with each other.

## Docs

- `docs/pages/core-concepts/bus/filtering.md` — new "Operator Shorthand" section covering precedence (`&` binds tighter than `|`, hence the parentheses in the example), flattening behavior, and the `C.*` exclusion.
- `docs/pages/core-concepts/bus/predicate-reference.md` — one-paragraph note in the combinator section.
- `docs/pages/core-concepts/bus/snippets/filtering_operators.py` — new runnable snippet embedded in the filtering page.

## Testing

- New tests in `tests/unit/bus/test_combinator_predicates.py` and `tests/unit/bus/test_predicates.py` cover each operator, flattening on both sides, mixing operators with explicit combinators, reflected operands, and `TypeError` on non-callables.
- Full local suite: `uv run nox -s dev` → **8356 passed, 1 skipped, 2 xfailed**.
- Lint/type: `prek -a` → all 37 hooks pass; `prek pyright -a --stage pre-push` → pass.

No frontend files are touched, so there is no visual change to evidence.

Closes #963
