### PR TITLE
feat: add EntityTime trigger for schedules driven by an entity's time

### DIFF
--- a/docs/pages/core-concepts/scheduler/snippets/scheduler_entity_time.py
+++ b/docs/pages/core-concepts/scheduler/snippets/scheduler_entity_time.py
@@ -1,0 +1,41 @@
+from whenever import TimeDelta
+
+from hassette import App, AppConfig
+from hassette.scheduler import EntityTime
+
+
+class WakeUpApp(App[AppConfig]):
+    async def on_initialize(self) -> None:
+        # --8<-- [start:alarm]
+        await self.scheduler.schedule(
+            self.start_the_day,
+            EntityTime("sensor.phone_next_alarm"),
+            name="phone_alarm",
+        )
+        # --8<-- [end:alarm]
+
+        # --8<-- [start:offset_daily]
+        await self.scheduler.schedule(
+            self.preheat_coffee,
+            EntityTime(
+                "input_datetime.morning_routine",
+                offset=TimeDelta(minutes=-30),
+                daily=True,
+            ),
+            name="preheat_coffee",
+        )
+        # --8<-- [end:offset_daily]
+
+        # --8<-- [start:attribute]
+        await self.scheduler.schedule(
+            self.open_blinds,
+            EntityTime("sun.sun", attribute="next_dawn"),
+            name="open_blinds_at_dawn",
+        )
+        # --8<-- [end:attribute]
+
+    async def start_the_day(self) -> None: ...
+
+    async def preheat_coffee(self) -> None: ...
+
+    async def open_blinds(self) -> None: ...

--- a/docs/pages/core-concepts/scheduler/snippets/scheduler_trigger_imports.py
+++ b/docs/pages/core-concepts/scheduler/snippets/scheduler_trigger_imports.py
@@ -1,0 +1,1 @@
+from hassette.scheduler import After, Once, Every, Daily, Cron, EntityTime, TriggerProtocol

--- a/docs/pages/core-concepts/scheduler/triggers.md
+++ b/docs/pages/core-concepts/scheduler/triggers.md
@@ -2,10 +2,10 @@
 
 A trigger determines when a scheduled job fires. Each built-in scheduling method creates a trigger internally. `schedule()` accepts a trigger directly for patterns the convenience methods do not cover.
 
-All five built-in trigger types and [`TriggerProtocol`][hassette.types.types.TriggerProtocol] are importable from `hassette.scheduler`:
+All six built-in trigger types and [`TriggerProtocol`][hassette.types.types.TriggerProtocol] are importable from `hassette.scheduler`:
 
 ```python
-from hassette.scheduler import After, Once, Every, Daily, Cron, TriggerProtocol
+from hassette.scheduler import After, Once, Every, Daily, Cron, EntityTime, TriggerProtocol
 ```
 
 ## Built-in Triggers
@@ -17,6 +17,7 @@ from hassette.scheduler import After, Once, Every, Daily, Cron, TriggerProtocol
 | `Every(seconds=N)` | Repeatedly on a fixed interval | No |
 | `Daily(at="HH:MM")` | Once per day at a wall-clock time (DST-safe) | No |
 | `Cron("expr")` | On a cron schedule (5- or 6-field) | No |
+| `EntityTime("sensor.x")` | At a time read from an entity, rescheduling when it changes | No |
 
 `After` also accepts `minutes=` or a `whenever.TimeDelta` via `timedelta=` — `After(minutes=5)` reads better than `After(seconds=300)`. `Every` accepts an optional `start=` anchor (a `ZonedDateTime` from the [`whenever`](https://whenever.readthedocs.io/) library, which ships with Hassette): with `Every(minutes=15, start=anchor)`, runs align to the anchor's minute marks (`:00`, `:15`, `:30`, `:45`) instead of starting from registration time.
 
@@ -34,6 +35,50 @@ Each convenience method on the scheduler maps to one trigger:
 | `run_cron(func, expr)` | `Cron(expr)` |
 
 Triggers are passed to `schedule()` when the convenience methods do not fit. See [Scheduling Methods](methods.md) for the full method reference.
+
+`EntityTime` has no convenience method — it is only available through `schedule()`.
+
+## Entity-Driven Times
+
+`EntityTime` reads its fire time from a Home Assistant entity and moves the job whenever that entity changes. The alarm on a phone, a time set through an `input_datetime` helper, and the next dawn on `sun.sun` all name a time that moves on its own; `EntityTime` follows it without a separate listener to cancel and reschedule the job by hand.
+
+```python
+--8<-- "pages/core-concepts/scheduler/snippets/scheduler_entity_time.py:alarm"
+```
+
+The job fires when `sensor.phone_next_alarm` says it should. Set the alarm for an hour earlier and the job moves an hour earlier.
+
+| Parameter | Effect |
+|---|---|
+| `entity_id` | The entity holding the time. Required. |
+| `attribute` | Read the time from this attribute instead of the entity's state. |
+| `offset` | A `TimeDelta` (`from whenever import TimeDelta`) shifting the fire time. Negative values fire early. |
+| `daily` | Keep only the time of day and fire at it every day. |
+
+`offset` covers the common "do something before the alarm" case, and `daily=True` turns an entity that names one absolute moment into a recurring wall-clock schedule:
+
+```python
+--8<-- "pages/core-concepts/scheduler/snippets/scheduler_entity_time.py:offset_daily"
+```
+
+That fires 30 minutes before the configured routine time, every day, at minute resolution. Without `daily=True`, the trigger fires once at the entity's absolute date and time and then waits for the entity to name a new one — which is what a phone alarm sensor does on its own.
+
+`attribute=` reaches times that live outside an entity's state:
+
+```python
+--8<-- "pages/core-concepts/scheduler/snippets/scheduler_entity_time.py:attribute"
+```
+
+`EntityTime` parses the value shapes Home Assistant uses for times: offset-aware ISO strings, naive ISO date-times (what `input_datetime` puts in its state), time-only strings such as `"07:00:00"`, and unix timestamps. Naive and time-only values are read in the configured timezone.
+
+### When the entity has no time
+
+An entity can be unavailable, report `unknown`, or hold a value that is not a time at all — a phone with no alarm set does exactly this. The job stays registered and simply has nowhere to fire: Hassette parks it at a time it will never reach, and the entity's next change puts it back on a real schedule. Nothing is lost and nothing needs restarting.
+
+The parking time is the year 9999, and both [`hassette job`](../../cli/commands.md#hassette-job) and the web UI render next runs as relative times — so a parked job reads as millions of days away. An absurd next run is the tell that the entity currently names no time.
+
+!!! warning "Entity-driven times still use the configured timezone"
+    A time-only or naive value from an entity is read in the configured timezone, the same as `Daily(at="07:00")`. See the warning above — a container defaulting to UTC while Home Assistant runs in a local zone will fire at the wrong hour.
 
 ## Custom Triggers
 

--- a/docs/pages/core-concepts/scheduler/triggers.md
+++ b/docs/pages/core-concepts/scheduler/triggers.md
@@ -5,7 +5,7 @@ A trigger determines when a scheduled job fires. Each built-in scheduling method
 All six built-in trigger types and [`TriggerProtocol`][hassette.types.types.TriggerProtocol] are importable from `hassette.scheduler`:
 
 ```python
-from hassette.scheduler import After, Once, Every, Daily, Cron, EntityTime, TriggerProtocol
+--8<-- "pages/core-concepts/scheduler/snippets/scheduler_trigger_imports.py"
 ```
 
 ## Built-in Triggers
@@ -40,13 +40,13 @@ Triggers are passed to `schedule()` when the convenience methods do not fit. See
 
 ## Entity-Driven Times
 
-`EntityTime` reads its fire time from a Home Assistant entity and moves the job whenever that entity changes. The alarm on a phone, a time set through an `input_datetime` helper, and the next dawn on `sun.sun` all name a time that moves on its own; `EntityTime` follows it without a separate listener to cancel and reschedule the job by hand.
+`EntityTime` reads its fire time from a Home Assistant entity. The scheduler moves the job whenever that entity changes. Phone alarms, `input_datetime` helpers, and `sun.sun` attributes all name moving times. `EntityTime` follows those times without app-level cancel-and-reschedule code.
 
 ```python
 --8<-- "pages/core-concepts/scheduler/snippets/scheduler_entity_time.py:alarm"
 ```
 
-The job fires when `sensor.phone_next_alarm` says it should. Set the alarm for an hour earlier and the job moves an hour earlier.
+The job fires when `sensor.phone_next_alarm` says it should. An earlier alarm moves the job earlier.
 
 | Parameter | Effect |
 |---|---|
@@ -55,13 +55,13 @@ The job fires when `sensor.phone_next_alarm` says it should. Set the alarm for a
 | `offset` | A `TimeDelta` (`from whenever import TimeDelta`) shifting the fire time. Negative values fire early. |
 | `daily` | Keep only the time of day and fire at it every day. |
 
-`offset` covers the common "do something before the alarm" case, and `daily=True` turns an entity that names one absolute moment into a recurring wall-clock schedule:
+`offset` covers the common "before the alarm" case. `daily=True` turns one absolute moment into a recurring wall-clock schedule:
 
 ```python
 --8<-- "pages/core-concepts/scheduler/snippets/scheduler_entity_time.py:offset_daily"
 ```
 
-That fires 30 minutes before the configured routine time, every day, at minute resolution. Without `daily=True`, the trigger fires once at the entity's absolute date and time and then waits for the entity to name a new one — which is what a phone alarm sensor does on its own.
+That job fires 30 minutes before the configured routine time each day. Without `daily=True`, the trigger fires once at the entity's absolute date and time. It then waits until the entity names a new time.
 
 `attribute=` reaches times that live outside an entity's state:
 
@@ -69,16 +69,16 @@ That fires 30 minutes before the configured routine time, every day, at minute r
 --8<-- "pages/core-concepts/scheduler/snippets/scheduler_entity_time.py:attribute"
 ```
 
-`EntityTime` parses the value shapes Home Assistant uses for times: offset-aware ISO strings, naive ISO date-times (what `input_datetime` puts in its state), time-only strings such as `"07:00:00"`, and unix timestamps. Naive and time-only values are read in the configured timezone.
+`EntityTime` parses the value shapes Home Assistant uses for times. It accepts offset-aware ISO strings, naive ISO date-times, time-only strings, and unix timestamps. Naive and time-only values are read in the configured timezone.
 
 ### When the entity has no time
 
-An entity can be unavailable, report `unknown`, or hold a value that is not a time at all — a phone with no alarm set does exactly this. The job stays registered and simply has nowhere to fire: Hassette parks it at a time it will never reach, and the entity's next change puts it back on a real schedule. Nothing is lost and nothing needs restarting.
+An entity can be unavailable, report `unknown`, or hold a non-time value. A phone with no alarm set does exactly this. The job stays registered and has nowhere to fire. Hassette parks it at a time it will never reach. The entity's next change puts it back on a real schedule.
 
-The parking time is the year 9999, and both [`hassette job`](../../cli/commands.md#hassette-job) and the web UI render next runs as relative times — so a parked job reads as millions of days away. An absurd next run is the tell that the entity currently names no time.
+The parking time is in the year 9999. [`hassette job`](../../cli/commands.md#hassette-job) and the web UI render relative next runs. A parked job therefore reads as millions of days away. An absurd next run means the entity currently names no time.
 
 !!! warning "Entity-driven times still use the configured timezone"
-    A time-only or naive value from an entity is read in the configured timezone, the same as `Daily(at="07:00")`. See the warning above — a container defaulting to UTC while Home Assistant runs in a local zone will fire at the wrong hour.
+    A time-only or naive value uses the configured timezone, like `Daily(at="07:00")`. A container defaulting to UTC can disagree with Home Assistant's local zone. That mismatch makes jobs fire at the wrong hour.
 
 ## Custom Triggers
 

--- a/src/hassette/core/scheduler_service.py
+++ b/src/hassette/core/scheduler_service.py
@@ -197,7 +197,10 @@ class SchedulerService(Service):
         """
         if job.jitter is not None:
             offset = random.uniform(0, job.jitter)
-            jittered_time = job.next_run.add(seconds=offset)
+            try:
+                jittered_time = job.next_run.add(seconds=offset)
+            except ValueError:
+                jittered_time = job.next_run
             job.fire_at = jittered_time
             job.sort_index = (jittered_time.timestamp_nanos(), id(job))
             self.logger.debug(

--- a/src/hassette/core/scheduler_service.py
+++ b/src/hassette/core/scheduler_service.py
@@ -113,6 +113,32 @@ class SchedulerService(Service):
         await self._job_queue.add(job)
         self.kick()
 
+    async def reschedule_job(self, job: "ScheduledJob", next_run: ZonedDateTime) -> None:
+        """Move a queued job to a new fire time without deregistering it.
+
+        Unlike ``dequeue_job``/``_remove_job``, no removal callbacks fire and the job keeps
+        its ``db_id`` — it stays a registered job that simply moves to a different slot in
+        the heap. Used by ``Scheduler`` when an entity-driven trigger's source entity changes.
+
+        Does nothing when the job is not on the heap, which means it was either cancelled or
+        already popped for dispatch. A popped job is about to consult its trigger in
+        ``dispatch_and_log``, so it picks up the new time there; re-pushing it here would put
+        the same job on the heap twice and fire it twice.
+
+        Args:
+            job: The job to move.
+            next_run: The new logical fire time.
+        """
+        if job._dequeued:
+            return
+        if not await self._job_queue.remove_job(job):
+            self.logger.debug("Job %s not on heap (cancelled or mid-dispatch); skipping reschedule", job)
+            return
+
+        job.set_next_run(next_run)
+        await self.enqueue_job(job)
+        self.logger.debug("Rescheduled job %s to %s", job, job.next_run)
+
     async def _remove_jobs_by_owner(self, owner: str) -> None:
         """Remove all jobs for an owner and wake the scheduler if necessary."""
         removed = await self._job_queue.remove_owner(owner)

--- a/src/hassette/core/scheduler_service.py
+++ b/src/hassette/core/scheduler_service.py
@@ -120,10 +120,9 @@ class SchedulerService(Service):
         its ``db_id`` — it stays a registered job that simply moves to a different slot in
         the heap. Used by ``Scheduler`` when an entity-driven trigger's source entity changes.
 
-        Does nothing when the job is not on the heap, which means it was either cancelled or
-        already popped for dispatch. A popped job is about to consult its trigger in
-        ``dispatch_and_log``, so it picks up the new time there; re-pushing it here would put
-        the same job on the heap twice and fire it twice.
+        If the job was already popped for dispatch, stores the new time on the job so
+        ``dispatch_and_log`` can consume it before consulting the trigger. Re-pushing it here
+        would put the same job on the heap twice and fire it twice.
 
         Args:
             job: The job to move.
@@ -132,7 +131,8 @@ class SchedulerService(Service):
         if job._dequeued:
             return
         if not await self._job_queue.remove_job(job):
-            self.logger.debug("Job %s not on heap (cancelled or mid-dispatch); skipping reschedule", job)
+            job._pending_next_run = next_run
+            self.logger.debug("Job %s not on heap; stored pending reschedule to %s", job, next_run)
             return
 
         job.set_next_run(next_run)
@@ -355,7 +355,11 @@ class SchedulerService(Service):
         remove_after_fire = False
         if job.trigger is not None:
             try:
-                next_run = job.trigger.next_run_time(job.next_run, date_utils.now())
+                if job._pending_next_run is not None:
+                    next_run = job._pending_next_run
+                    job._pending_next_run = None
+                else:
+                    next_run = job.trigger.next_run_time(job.next_run, date_utils.now())
             except Exception:
                 self.logger.exception(
                     "dispatch_and_log: trigger raised for db_id=%s callable=%s trigger=%r — "
@@ -387,6 +391,10 @@ class SchedulerService(Service):
                 # The in-lock _dequeued re-check inside _job_queue.add guards
                 # against a cancel landing between here and the push.
                 await self.enqueue_job(job)
+                if job._pending_next_run is not None:
+                    pending_next_run = job._pending_next_run
+                    job._pending_next_run = None
+                    await self.reschedule_job(job, pending_next_run)
             elif not remove_after_fire:
                 # next_run_time() returned None (trigger exhausted) — remove after fire.
                 remove_after_fire = True

--- a/src/hassette/scheduler/__init__.py
+++ b/src/hassette/scheduler/__init__.py
@@ -13,12 +13,14 @@ from .classes import ScheduledJob
 from .error_context import SchedulerErrorContext
 from .scheduler import Scheduler
 from .sync import SchedulerSyncFacade
-from .triggers import After, Cron, Daily, Every, Once
+from .triggers import NO_OCCURRENCE, After, Cron, Daily, EntityTime, Every, Once
 
 __all__ = [
+    "NO_OCCURRENCE",
     "After",
     "Cron",
     "Daily",
+    "EntityTime",
     "Every",
     "Once",
     "ScheduledJob",

--- a/src/hassette/scheduler/classes.py
+++ b/src/hassette/scheduler/classes.py
@@ -261,6 +261,9 @@ class ScheduledJob:
     _dequeued: bool = field(default=False, repr=False, compare=False)
     """True after the job has been synchronously removed from the heap via dequeue_job()."""
 
+    _pending_next_run: ZonedDateTime | None = field(default=None, repr=False, compare=False)
+    """Event-derived next run to apply when the job was popped before a reschedule landed."""
+
     pending_done: "set[asyncio.Future[None]]" = field(default_factory=set, init=False, repr=False, compare=False)
     """Unresolved per-invocation completion futures for non-parallel modes.
 

--- a/src/hassette/scheduler/scheduler.py
+++ b/src/hassette/scheduler/scheduler.py
@@ -55,6 +55,15 @@ Examples:
         )
         job = await self.scheduler.schedule(self.my_func, Cron("0 9 * * 1-5"), name="my_func_cron")
 
+    Scheduling from an entity's time::
+
+        from hassette.scheduler import EntityTime
+
+        # Fires when the phone alarm goes off, and moves whenever the alarm changes
+        job = await self.scheduler.schedule(
+            self.start_the_day, EntityTime("sensor.phone_next_alarm"), name="phone_alarm"
+        )
+
     Job management::
 
         # Named job for easier management
@@ -74,6 +83,7 @@ from whenever import ZonedDateTime
 
 import hassette.utils.date_utils as date_utils
 from hassette.di import CallableInvoker, TypeMatcher, build_injection_plan
+from hassette.events import RawStateChangeEvent
 from hassette.exceptions import SchedulerNameRequiredError
 from hassette.resources.base import Resource
 from hassette.resources.lifecycle import mark_ready
@@ -87,10 +97,12 @@ from hassette.utils.type_utils import get_typed_signature
 
 from .classes import ScheduledJob
 from .sync import SchedulerSyncFacade
-from .triggers import After, Cron, Daily, Every, Once
+from .triggers import NO_OCCURRENCE, After, Cron, Daily, EntityTime, Every, Once
 
 if typing.TYPE_CHECKING:
     from hassette import Hassette
+    from hassette.bus import Subscription
+    from hassette.events import HassStateDict
     from hassette.types import JobCallable
     from hassette.types.types import SchedulerErrorHandlerType, SchedulerPredicate
 
@@ -117,6 +129,13 @@ class Scheduler(Resource):
     is based on ``job_id``, which is unique and immutable after construction.
     """
 
+    _entity_time_subs: dict[str, "Subscription"]
+    """State-change subscriptions that reschedule ``EntityTime`` jobs, keyed by job name.
+
+    One subscription per entity-driven job, cancelled by ``_on_job_removed`` when the job goes
+    away so a hot-reload does not leave the listener behind.
+    """
+
     def __init__(self, hassette: "Hassette", *, parent: Resource | None = None) -> None:
         super().__init__(hassette, parent=parent)
         assert self.parent is not None, (
@@ -126,6 +145,7 @@ class Scheduler(Resource):
         self._jobs_by_name = {}
         self._jobs_by_group: dict[str, set[ScheduledJob]] = {}
         self._error_handler: SchedulerErrorHandlerType | None = None
+        self._entity_time_subs = {}
         self.sync = self.add_child(SchedulerSyncFacade, scheduler=self)
 
         # Register removal callback so exhausted one-shot jobs are removed from _jobs_by_group
@@ -136,9 +156,13 @@ class Scheduler(Resource):
         """Callback invoked by SchedulerService when a job is auto-exhausted.
 
         Keeps _jobs_by_group and _jobs_by_name in sync when SchedulerService removes a
-        one-shot job after it fires or when a job is dequeued via cancel_job.
+        one-shot job after it fires or when a job is dequeued via cancel_job. Also cancels
+        the entity-watch subscription of an ``EntityTime`` job so it does not outlive the job.
         """
         self._jobs_by_name.pop(job.name, None)
+        sub = self._entity_time_subs.pop(job.name, None)
+        if sub is not None:
+            sub.cancel()
         if job.group is not None:
             group_set = self._jobs_by_group.get(job.group)
             if group_set is not None:
@@ -325,6 +349,9 @@ class Scheduler(Resource):
         """Remove all jobs for the owner of this scheduler."""
         self._jobs_by_name.clear()
         self._jobs_by_group.clear()
+        for sub in self._entity_time_subs.values():
+            sub.cancel()
+        self._entity_time_subs.clear()
         return self.scheduler_service.remove_jobs_by_owner(self.owner_id)
 
     def cancel_group(self, group: str) -> None:
@@ -398,7 +425,10 @@ class Scheduler(Resource):
         Args:
             func: The function to run.
             trigger: A trigger object implementing ``TriggerProtocol``. Determines
-                both the first run time and subsequent recurrences.
+                both the first run time and subsequent recurrences. An
+                :class:`~hassette.scheduler.triggers.EntityTime` trigger additionally
+                gets a state-change listener registered for its entity, so the job
+                moves whenever the entity's time changes.
             name: Required stable name for the job. Used for uniqueness validation
                 within this scheduler instance and for logging/telemetry.
             group: Optional group name for bulk management (see ``cancel_group``).
@@ -457,7 +487,7 @@ class Scheduler(Resource):
         if not isinstance(trigger, TriggerProtocol):
             raise TypeError(
                 f"trigger must implement TriggerProtocol; got {type(trigger).__name__}. "
-                "Use hassette.scheduler.triggers (After, Once, Every, Daily, Cron)"
+                "Use hassette.scheduler.triggers (After, Once, Every, Daily, Cron, EntityTime)"
             )
 
         predicate, predicate_invoker = _normalize_where(where)
@@ -482,6 +512,11 @@ class Scheduler(Resource):
             except ValueError as exc:
                 valid = ", ".join(repr(m.value) for m in ExecutionMode)
                 raise ValueError(f"Invalid execution mode {mode!r}; must be one of {valid}") from exc
+
+        if isinstance(trigger, EntityTime):
+            # Bind before first_run_time — an unbound EntityTime resolves to NO_OCCURRENCE.
+            # read_entity_state absorbs every state-read failure and returns None.
+            trigger.bind_state_reader(self.hassette.bus_service.read_entity_state)
 
         run_at = trigger.first_run_time(date_utils.now())
 
@@ -513,7 +548,64 @@ class Scheduler(Resource):
         # Shape B delegate — returns the callee's handle directly (no await, no second guard_await).
         # The single guard_await lives at add_job (the true primary). See design/071.
         # source_location/registration_source are NOT passed here; add_job backfills them.
+        if isinstance(trigger, EntityTime):
+            # Not a Shape B delegate: the entity path wraps add_job in its own coroutine, so it
+            # needs its own guard to keep the forgotten-await warning pointing at the user's frame.
+            source_location, _ = capture_registration_source()
+            return guard_await(
+                self._add_job_and_watch_entity(job, trigger, if_exists=if_exists),
+                owner=self.parent,
+                source_location=source_location,
+                method_name="schedule",
+            )
         return self.add_job(job, if_exists=if_exists)
+
+    async def _add_job_and_watch_entity(
+        self, job: "ScheduledJob", trigger: EntityTime, *, if_exists: IfExistsPolicy
+    ) -> "ScheduledJob":
+        """Register an entity-driven job and the state-change listener that keeps it current.
+
+        The listener lives on the framework bus rather than the owning app's bus: it is
+        scheduler plumbing, not an app handler, and its lifetime is tied to the job through
+        ``_entity_time_subs`` instead of to the app's own subscriptions.
+        """
+        registered = await self.add_job(job, if_exists=if_exists)
+        if registered is not job:
+            # if_exists="skip" returned the pre-existing job; its listener is already running.
+            return registered
+
+        async def on_entity_change(event: RawStateChangeEvent) -> None:
+            await self._reschedule_entity_time_job(job, trigger, event.payload.data.new_state)
+
+        self._entity_time_subs[job.name] = await self.hassette.bus.on_state_change(
+            trigger.entity_id,
+            handler=on_entity_change,
+            name=f"scheduler.entity_time.{self.owner_id}.{job.name}",
+            if_exists="replace",
+        )
+
+        # schedule() read the entity before add_job awaited a database write, and the listener
+        # only exists now — a change landing in that window reached neither. Re-read once so it
+        # is picked up here instead of waiting for whenever the entity next changes, which for
+        # something like an alarm sensor could be a day away.
+        current = trigger.resolve(date_utils.now()) or NO_OCCURRENCE
+        if current != job.next_run:
+            await self.scheduler_service.reschedule_job(job, current)
+        return registered
+
+    async def _reschedule_entity_time_job(
+        self, job: "ScheduledJob", trigger: EntityTime, new_state: "HassStateDict | None"
+    ) -> None:
+        """Move an entity-driven job to the time the entity's new state reports.
+
+        Parks the job at ``NO_OCCURRENCE`` when the new state names no usable time — the
+        alarm was cleared, the entity went unavailable — so the job survives to be
+        rescheduled by a later change.
+        """
+        next_run = trigger.resolve_from_state(new_state, date_utils.now()) or NO_OCCURRENCE
+        if next_run == job.next_run:
+            return
+        await self.scheduler_service.reschedule_job(job, next_run)
 
     def run_in(
         self,

--- a/src/hassette/scheduler/scheduler.py
+++ b/src/hassette/scheduler/scheduler.py
@@ -577,12 +577,16 @@ class Scheduler(Resource):
         async def on_entity_change(event: RawStateChangeEvent) -> None:
             await self._reschedule_entity_time_job(job, trigger, event.payload.data.new_state)
 
-        self._entity_time_subs[job.name] = await self.hassette.bus.on_state_change(
-            trigger.entity_id,
-            handler=on_entity_change,
-            name=f"scheduler.entity_time.{self.owner_id}.{job.name}",
-            if_exists="replace",
-        )
+        try:
+            self._entity_time_subs[job.name] = await self.hassette.bus.on_state_change(
+                trigger.entity_id,
+                handler=on_entity_change,
+                name=f"scheduler.entity_time.{self.owner_id}.{job.name}",
+                if_exists="replace",
+            )
+        except Exception:
+            self.cancel_job(job)
+            raise
 
         # schedule() read the entity before add_job awaited a database write, and the listener
         # only exists now — a change landing in that window reached neither. Re-read once so it

--- a/src/hassette/scheduler/sync.py
+++ b/src/hassette/scheduler/sync.py
@@ -109,7 +109,10 @@ class SchedulerSyncFacade(Resource):
         Args:
             func: The function to run.
             trigger: A trigger object implementing ``TriggerProtocol``. Determines
-                both the first run time and subsequent recurrences.
+                both the first run time and subsequent recurrences. An
+                :class:`~hassette.scheduler.triggers.EntityTime` trigger additionally
+                gets a state-change listener registered for its entity, so the job
+                moves whenever the entity's time changes.
             name: Required stable name for the job. Used for uniqueness validation
                 within this scheduler instance and for logging/telemetry.
             group: Optional group name for bulk management (see ``cancel_group``).

--- a/src/hassette/scheduler/triggers.py
+++ b/src/hassette/scheduler/triggers.py
@@ -8,9 +8,10 @@ import typing
 from logging import getLogger
 from typing import Any, Literal
 
-from whenever import PlainDateTime, Time, TimeDelta, ZonedDateTime
+from whenever import Time, TimeDelta, ZonedDateTime
 
 import hassette.utils.date_utils as date_utils
+from hassette.conversion.type_registry import from_string_to_zoned_date_time
 from hassette.utils.hass_utils import valid_entity_id
 
 from .classes import CronTrigger
@@ -68,12 +69,7 @@ def parse_entity_time(value: Any) -> ZonedDateTime | None:
         return None
 
     try:
-        return date_utils.convert_datetime_str_to_tz(text)
-    except ValueError:
-        pass
-
-    try:
-        return date_utils.assume_tz(PlainDateTime.parse_iso(text))
+        return from_string_to_zoned_date_time(text)
     except ValueError:
         pass
 

--- a/src/hassette/scheduler/triggers.py
+++ b/src/hassette/scheduler/triggers.py
@@ -4,16 +4,95 @@ Each trigger encapsulates a scheduling strategy (fixed delay, wall-clock time,
 cron expression, etc.) and exposes a uniform interface via TriggerProtocol.
 """
 
+import typing
 from logging import getLogger
-from typing import Literal
+from typing import Any, Literal
 
-from whenever import TimeDelta, ZonedDateTime
+from whenever import PlainDateTime, Time, TimeDelta, ZonedDateTime
 
 import hassette.utils.date_utils as date_utils
+from hassette.utils.hass_utils import valid_entity_id
 
 from .classes import CronTrigger
 
+if typing.TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from hassette.events import HassStateDict
+
 LOGGER = getLogger(__name__)
+
+NO_OCCURRENCE = ZonedDateTime(9999, 12, 31, 23, 59, 59, tz="UTC")
+"""Fire time used by :class:`EntityTime` when the entity carries no usable time.
+
+The scheduler heap has no "registered but unscheduled" state, so a trigger that
+currently has nowhere to fire parks the job at a time it will never reach. The job
+keeps its database row and its telemetry, and the state-change listener that
+``Scheduler`` registers alongside it moves the job back to a real time as soon as
+the entity reports one.
+"""
+
+UNUSABLE_STATE_VALUES = frozenset({"", "unknown", "unavailable", "none", "null"})
+"""Entity state strings that carry no time value."""
+
+
+def parse_entity_time(value: Any) -> ZonedDateTime | None:
+    """Parse a Home Assistant state or attribute value into a ``ZonedDateTime``.
+
+    Covers the shapes Home Assistant uses for times: offset-aware ISO strings
+    (``"2026-07-28T07:00:00-05:00"``, what most sensors report), naive ISO
+    date-times (``"2026-07-28 07:00:00"``, what ``input_datetime`` puts in its
+    state), time-only strings (``"07:00:00"``, an ``input_datetime`` with no date
+    component), and unix timestamps (the ``timestamp`` attribute on
+    ``input_datetime``). Naive and time-only values are interpreted in the
+    configured timezone; time-only values resolve against today's date.
+
+    Args:
+        value: The raw state or attribute value.
+
+    Returns:
+        The parsed time, or ``None`` when the value carries none — an unavailable
+        entity, an empty state, or a string in a format that is not a time.
+    """
+    if value is None or isinstance(value, bool):
+        return None
+    if isinstance(value, ZonedDateTime):
+        return value
+    if isinstance(value, int | float):
+        return date_utils.convert_utc_timestamp_to_tz(value)
+    if not isinstance(value, str):
+        return None
+
+    text = value.strip()
+    if text.lower() in UNUSABLE_STATE_VALUES:
+        return None
+
+    try:
+        return date_utils.convert_datetime_str_to_tz(text)
+    except ValueError:
+        pass
+
+    try:
+        return date_utils.assume_tz(PlainDateTime.parse_iso(text))
+    except ValueError:
+        pass
+
+    try:
+        time_of_day = Time.parse_iso(text)
+    except ValueError:
+        LOGGER.warning("Could not parse %r as a time value", value)
+        return None
+
+    today = date_utils.now()
+    return ZonedDateTime(
+        today.year,
+        today.month,
+        today.day,
+        time_of_day.hour,
+        time_of_day.minute,
+        time_of_day.second,
+        tz=today.tz,
+    )
 
 
 def parse_hh_mm(at: str, label: str) -> tuple[int, int]:
@@ -325,3 +404,132 @@ class Cron:
 
     def trigger_id(self) -> str:
         return f"cron:{self._expression}"
+
+
+class EntityTime:
+    """Trigger that fires at a time read from a Home Assistant entity.
+
+    The entity holds the schedule: a phone alarm sensor, an ``input_datetime``
+    helper, or any entity whose state or attribute is a time. Whenever that value
+    changes, ``Scheduler`` moves the job to the new time — no manual cancel and
+    reschedule.
+
+    An entity with no usable value (unavailable, ``unknown``, no alarm set) parks
+    the job at :data:`NO_OCCURRENCE` instead of removing it. The job stays
+    registered and starts firing again as soon as the entity reports a time.
+
+    Args:
+        entity_id: The entity holding the time, e.g. ``"sensor.phone_next_alarm"``.
+        attribute: Read the time from this attribute instead of the entity's state.
+        offset: Shift the fire time. Negative values fire before the entity's time
+            (``TimeDelta(minutes=-30)`` fires 30 minutes early).
+        daily: Keep only the time of day and fire at it every day. Without this, the
+            trigger fires at the entity's absolute date and time and then waits for
+            the entity to name a new one.
+
+    Example:
+        EntityTime("sensor.phone_next_alarm")
+        EntityTime("input_datetime.morning_routine", offset=TimeDelta(minutes=-30), daily=True)
+        EntityTime("sun.sun", attribute="next_dawn")
+    """
+
+    def __init__(
+        self,
+        entity_id: str,
+        *,
+        attribute: str | None = None,
+        offset: TimeDelta | None = None,
+        daily: bool = False,
+    ) -> None:
+        if not valid_entity_id(entity_id):
+            raise ValueError(f"EntityTime entity_id must be '<domain>.<object_id>', got {entity_id!r}")
+        self.entity_id = entity_id
+        self.attribute = attribute
+        self.offset = offset if offset is not None else TimeDelta()
+        self.daily = daily
+        self._state_reader: Callable[[str], HassStateDict | None] | None = None
+
+    def __repr__(self) -> str:
+        return f"EntityTime({self.trigger_detail()})"
+
+    def bind_state_reader(self, reader: "Callable[[str], HassStateDict | None]") -> None:
+        """Attach the state source used to read the entity.
+
+        Called by ``Scheduler.schedule()`` before the first run time is computed.
+        An unbound trigger resolves to :data:`NO_OCCURRENCE`, so a trigger used
+        outside the scheduler never fires rather than raising.
+        """
+        self._state_reader = reader
+
+    def resolve(self, current_time: ZonedDateTime) -> ZonedDateTime | None:
+        """Return the next fire time read from the bound state source, or ``None``."""
+        if self._state_reader is None:
+            LOGGER.debug("EntityTime(%s): no state reader bound", self.entity_id)
+            return None
+        return self.resolve_from_state(self._state_reader(self.entity_id), current_time)
+
+    def resolve_from_state(self, state: "HassStateDict | None", current_time: ZonedDateTime) -> ZonedDateTime | None:
+        """Return the next fire time for an explicit state, or ``None`` when there is none.
+
+        Returns ``None`` for a state that carries no parsable time, and for an absolute
+        time at or before ``current_time`` — in both cases the trigger has nowhere to fire
+        until the entity changes. Treating the boundary as past keeps a restart from
+        re-firing an alarm that already went off; the cost is that an entity reporting the
+        current second exactly parks instead of firing, and waits for its next change.
+
+        Taking the state as an argument lets the rescheduling path use the state carried on
+        the state-change event. The scheduler's listener and the StateProxy's cache update
+        are dispatched concurrently, so reading the cache there could see the old value.
+        """
+        if state is None:
+            return None
+        raw = state.get("attributes", {}).get(self.attribute) if self.attribute is not None else state.get("state")
+
+        parsed = parse_entity_time(raw)
+        if parsed is None:
+            return None
+
+        target = parsed.add(seconds=self.offset.total("seconds"))
+        if self.daily:
+            # Delegate the daily rollover to cron so it stays wall-clock aligned across
+            # DST transitions, the same way Daily does.
+            time_of_day = target.time()
+            expression = f"{time_of_day.minute} {time_of_day.hour} * * * {time_of_day.second}"
+            return CronTrigger(expression).first_run_time(current_time)
+
+        if target <= current_time:
+            return None
+        return target.round("second")
+
+    def first_run_time(self, current_time: ZonedDateTime) -> ZonedDateTime:
+        """Return the entity's next time, or ``NO_OCCURRENCE`` when it has none."""
+        return self.resolve(current_time) or NO_OCCURRENCE
+
+    def next_run_time(self, previous_run: ZonedDateTime, current_time: ZonedDateTime) -> ZonedDateTime:
+        """Re-read the entity and return its next time, or ``NO_OCCURRENCE`` when it has none.
+
+        Never returns ``None``: the job outlives any individual fire so the entity can
+        schedule it again.
+        """
+        return self.resolve(current_time) or NO_OCCURRENCE
+
+    def trigger_label(self) -> str:
+        return "entity_time"
+
+    def trigger_detail(self) -> str | None:
+        detail = self.entity_id
+        if self.attribute is not None:
+            detail += f".{self.attribute}"
+        offset_seconds = int(self.offset.total("seconds"))
+        if offset_seconds:
+            detail += f" {offset_seconds:+d}s"
+        if self.daily:
+            detail += " daily"
+        return detail
+
+    def trigger_db_type(self) -> Literal["custom"]:
+        return "custom"
+
+    def trigger_id(self) -> str:
+        offset_seconds = int(self.offset.total("seconds"))
+        return f"entity_time:{self.entity_id}:{self.attribute or ''}:{offset_seconds}:{int(self.daily)}"

--- a/src/hassette/test_utils/factories.py
+++ b/src/hassette/test_utils/factories.py
@@ -277,10 +277,15 @@ def make_scheduler(
     async def _add_job(job: ScheduledJob) -> None:
         job.mark_registered(1)
 
+    async def _reschedule_job(job: ScheduledJob, next_run: ZonedDateTime) -> None:
+        job.set_next_run(next_run)
+
     mock_service.add_job = AsyncMock(side_effect=_add_job)
+    mock_service.reschedule_job = AsyncMock(side_effect=_reschedule_job)
     scheduler.scheduler_service = mock_service
     scheduler._jobs_by_name = {}
     scheduler._jobs_by_group = {}
+    scheduler._entity_time_subs = {}
     scheduler._error_handler = None
     scheduler._unique_name = f"test_scheduler_{app_key}"
     scheduler.logger = Mock()

--- a/src/hassette/types/types.py
+++ b/src/hassette/types/types.py
@@ -228,7 +228,7 @@ class SchedulerServiceProtocol(Protocol):
     """Protocol for the scheduler-service surface consumed by Scheduler.
 
     Describes the surface Scheduler calls on its scheduler_service: the
-    ``task_bucket`` attribute plus six async/sync methods. SchedulerService
+    ``task_bucket`` attribute plus seven async/sync methods. SchedulerService
     satisfies this protocol structurally — no changes to the concrete class
     are required.
     """
@@ -238,6 +238,8 @@ class SchedulerServiceProtocol(Protocol):
     async def add_job(self, job: "ScheduledJob") -> None: ...
 
     def dequeue_job(self, job: "ScheduledJob") -> bool: ...
+
+    async def reschedule_job(self, job: "ScheduledJob", next_run: "ZonedDateTime") -> None: ...
 
     def register_removal_callback(self, owner_id: str, callback: "Callable[[ScheduledJob], None]") -> None: ...
 

--- a/tests/integration/test_scheduler_entity_time.py
+++ b/tests/integration/test_scheduler_entity_time.py
@@ -205,6 +205,84 @@ async def test_change_during_registration_is_picked_up(entity_time_harness: Hass
     job.cancel()
 
 
+async def test_change_while_job_is_mid_dispatch_is_not_lost(entity_time_harness: HassetteHarness) -> None:
+    """A reschedule that lands after heap-pop is applied by dispatch_and_log."""
+    first_alarm = iso_in(60)
+    second_alarm = iso_in(15)
+    await seed_alarm(entity_time_harness, first_alarm)
+
+    job = await entity_time_harness.scheduler.schedule(
+        noop, EntityTime(ALARM_ENTITY), name="entity_time_mid_dispatch_reschedule"
+    )
+    expected = date_utils.convert_datetime_str_to_tz(second_alarm)
+
+    removed = await entity_time_harness.scheduler_service._job_queue.remove_job(job)
+    assert removed is True
+
+    await change_alarm(entity_time_harness, first_alarm, second_alarm)
+    assert job._pending_next_run == expected
+
+    await entity_time_harness.scheduler_service.dispatch_and_log(job)
+
+    assert job.next_run == expected
+    assert job._pending_next_run is None
+    job.cancel()
+
+
+async def test_change_during_dispatch_reenqueue_is_not_lost(entity_time_harness: HassetteHarness) -> None:
+    """A reschedule after next-run computation still moves the re-enqueued job."""
+    first_alarm = iso_in(60)
+    second_alarm = iso_in(15)
+    await seed_alarm(entity_time_harness, first_alarm)
+
+    job = await entity_time_harness.scheduler.schedule(
+        noop, EntityTime(ALARM_ENTITY), name="entity_time_reenqueue_window"
+    )
+    expected = date_utils.convert_datetime_str_to_tz(second_alarm)
+
+    removed = await entity_time_harness.scheduler_service._job_queue.remove_job(job)
+    assert removed is True
+
+    original_enqueue = entity_time_harness.scheduler_service.enqueue_job
+    injected = False
+
+    async def enqueue_after_change(enqueued_job):
+        nonlocal injected
+        if not injected:
+            injected = True
+            await entity_time_harness.scheduler_service.reschedule_job(enqueued_job, expected)
+        await original_enqueue(enqueued_job)
+
+    entity_time_harness.scheduler_service.enqueue_job = enqueue_after_change  # pyright: ignore[reportAttributeAccessIssue]
+    try:
+        await entity_time_harness.scheduler_service.dispatch_and_log(job)
+    finally:
+        entity_time_harness.scheduler_service.enqueue_job = original_enqueue  # pyright: ignore[reportAttributeAccessIssue]
+
+    assert job.next_run == expected
+    assert job._pending_next_run is None
+    job.cancel()
+
+
+async def test_watcher_registration_failure_cleans_up_job(
+    entity_time_harness: HassetteHarness, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """schedule() must not leave a live job when the entity watcher cannot register."""
+    await seed_alarm(entity_time_harness, iso_in(60))
+
+    async def fail_on_state_change(*_args, **_kwargs):
+        raise RuntimeError("listener registration failed")
+
+    monkeypatch.setattr(entity_time_harness.hassette.bus, "on_state_change", fail_on_state_change)
+
+    with pytest.raises(RuntimeError, match="listener registration failed"):
+        await entity_time_harness.scheduler.schedule(
+            noop, EntityTime(ALARM_ENTITY), name="entity_time_watcher_failure_cleanup"
+        )
+
+    assert entity_time_harness.scheduler.list_jobs() == []
+
+
 async def test_watch_listener_is_registered_and_cancelled_with_the_job(
     entity_time_harness: HassetteHarness,
 ) -> None:

--- a/tests/integration/test_scheduler_entity_time.py
+++ b/tests/integration/test_scheduler_entity_time.py
@@ -1,0 +1,240 @@
+"""Integration tests for entity-driven scheduling with the EntityTime trigger.
+
+Exercises the full path: Scheduler.schedule() binds the trigger to live state, registers a
+state-change listener for the entity, and moves the job on the heap when the entity reports a
+new time — including the parked state an entity with no usable time produces.
+"""
+
+import typing
+from collections.abc import AsyncIterator
+from unittest.mock import AsyncMock
+
+import pytest
+from whenever import TimeDelta
+
+import hassette.utils.date_utils as date_utils
+from hassette.resources.lifecycle import mark_ready
+from hassette.scheduler.triggers import NO_OCCURRENCE, EntityTime
+from hassette.test_utils.harness import HassetteHarness
+from hassette.test_utils.helpers import create_state_change_event, make_state_dict, noop
+from hassette.types import Topic
+
+if typing.TYPE_CHECKING:
+    from hassette import Hassette
+
+ALARM_ENTITY = "sensor.phone_next_alarm"
+
+
+@pytest.fixture
+async def entity_time_harness(test_config) -> AsyncIterator[HassetteHarness]:
+    """Harness with bus + scheduler + state proxy, so entity-driven jobs can be scheduled."""
+    harness = HassetteHarness(test_config, skip_global_set=False)
+    harness.with_bus().with_scheduler().with_state_proxy().with_state_registry()
+
+    api_mock = AsyncMock()
+    api_mock.sync = AsyncMock()
+    api_mock.get_states_raw = AsyncMock(return_value=[])
+    harness.hassette._api = api_mock
+
+    await harness.start()
+    mark_ready(harness.state_proxy, reason="entity_time_harness: mark ready for test")
+
+    try:
+        yield harness
+    finally:
+        await harness.stop()
+
+
+async def seed_alarm(harness: HassetteHarness, value: str) -> None:
+    """Put an alarm time into the StateProxy cache."""
+    await harness.seed_state(ALARM_ENTITY, make_state_dict(ALARM_ENTITY, value))
+
+
+async def change_alarm(harness: HassetteHarness, old_value: str, new_value: str) -> None:
+    """Send a state change for the alarm entity and wait for dispatch to settle."""
+    event = create_state_change_event(entity_id=ALARM_ENTITY, old_value=old_value, new_value=new_value)
+    await harness.hassette.send_event(event)
+    await harness.bus_service.await_dispatch_idle()
+
+
+def iso_in(minutes: int) -> str:
+    """Return an ISO timestamp the given number of minutes from now."""
+    return date_utils.now().add(minutes=minutes).round("second").format_iso()
+
+
+def watch_listener_names(hassette: "Hassette") -> list[str]:
+    """Return the names of the scheduler's entity-watch listeners for the alarm entity."""
+    topic = f"{Topic.HASS_EVENT_STATE_CHANGED!s}.{ALARM_ENTITY}"
+    return [listener.identity.name for listener in hassette.bus_service.router.get_topic_listeners(topic)]
+
+
+async def test_schedule_uses_the_entity_time(entity_time_harness: HassetteHarness) -> None:
+    """A future alarm time becomes the job's next run."""
+    alarm = iso_in(30)
+    await seed_alarm(entity_time_harness, alarm)
+
+    job = await entity_time_harness.scheduler.schedule(
+        noop, EntityTime(ALARM_ENTITY), name="entity_time_uses_entity_time"
+    )
+
+    assert job.next_run == date_utils.convert_datetime_str_to_tz(alarm)
+    job.cancel()
+
+
+async def test_schedule_applies_offset(entity_time_harness: HassetteHarness) -> None:
+    """A negative offset moves the job earlier than the entity's time."""
+    alarm = iso_in(60)
+    await seed_alarm(entity_time_harness, alarm)
+
+    job = await entity_time_harness.scheduler.schedule(
+        noop,
+        EntityTime(ALARM_ENTITY, offset=TimeDelta(minutes=-30)),
+        name="entity_time_applies_offset",
+    )
+
+    expected = date_utils.convert_datetime_str_to_tz(alarm).add(minutes=-30)
+    assert job.next_run == expected
+    job.cancel()
+
+
+async def test_unavailable_entity_parks_the_job(entity_time_harness: HassetteHarness) -> None:
+    """An unavailable entity registers the job parked rather than failing or removing it."""
+    await seed_alarm(entity_time_harness, "unavailable")
+
+    job = await entity_time_harness.scheduler.schedule(
+        noop, EntityTime(ALARM_ENTITY), name="entity_time_unavailable_parks"
+    )
+
+    assert job.next_run == NO_OCCURRENCE
+    assert job.db_id is not None, "a parked job is still a registered job"
+    job.cancel()
+
+
+async def test_entity_change_moves_the_job(entity_time_harness: HassetteHarness) -> None:
+    """Changing the alarm entity mid-schedule reschedules the pending job."""
+    first_alarm = iso_in(60)
+    await seed_alarm(entity_time_harness, first_alarm)
+
+    job = await entity_time_harness.scheduler.schedule(
+        noop, EntityTime(ALARM_ENTITY), name="entity_time_change_moves_job"
+    )
+    assert job.next_run == date_utils.convert_datetime_str_to_tz(first_alarm)
+
+    second_alarm = iso_in(15)
+    await change_alarm(entity_time_harness, first_alarm, second_alarm)
+
+    assert job.next_run == date_utils.convert_datetime_str_to_tz(second_alarm)
+    job.cancel()
+
+
+async def test_entity_going_unavailable_parks_a_scheduled_job(entity_time_harness: HassetteHarness) -> None:
+    """Clearing the alarm parks the job instead of leaving it queued at a stale time."""
+    alarm = iso_in(60)
+    await seed_alarm(entity_time_harness, alarm)
+
+    job = await entity_time_harness.scheduler.schedule(
+        noop, EntityTime(ALARM_ENTITY), name="entity_time_unavailable_parks_running"
+    )
+    assert job.next_run != NO_OCCURRENCE
+
+    await change_alarm(entity_time_harness, alarm, "unavailable")
+
+    assert job.next_run == NO_OCCURRENCE
+    job.cancel()
+
+
+async def test_parked_job_recovers_when_entity_reports_a_time(entity_time_harness: HassetteHarness) -> None:
+    """A job parked at registration starts firing once the entity gets a time."""
+    await seed_alarm(entity_time_harness, "unavailable")
+
+    job = await entity_time_harness.scheduler.schedule(
+        noop, EntityTime(ALARM_ENTITY), name="entity_time_parked_recovers"
+    )
+    assert job.next_run == NO_OCCURRENCE
+
+    alarm = iso_in(45)
+    await change_alarm(entity_time_harness, "unavailable", alarm)
+
+    assert job.next_run == date_utils.convert_datetime_str_to_tz(alarm)
+    job.cancel()
+
+
+async def test_daily_mode_ignores_the_entity_date(entity_time_harness: HassetteHarness) -> None:
+    """daily=True keeps only the time of day, so a stale date still schedules today or tomorrow."""
+    target = date_utils.now().add(minutes=90).round("second")
+    stale = target.add(hours=-24 * 400)
+    await seed_alarm(entity_time_harness, stale.format_iso())
+
+    job = await entity_time_harness.scheduler.schedule(
+        noop, EntityTime(ALARM_ENTITY, daily=True), name="entity_time_daily_ignores_date"
+    )
+
+    # Cron granularity is whole minutes, so compare the wall-clock minute.
+    assert (job.next_run.hour, job.next_run.minute) == (target.hour, target.minute)
+    assert job.next_run > date_utils.now()
+    job.cancel()
+
+
+async def test_change_during_registration_is_picked_up(entity_time_harness: HassetteHarness) -> None:
+    """A change landing while the job is being registered is reconciled, not lost.
+
+    Registration awaits a database write before the state-change listener exists, so a change
+    arriving in that window reaches neither the initial read nor the listener. Simulated here
+    by moving the entity from inside the awaited add_job call.
+    """
+    first_alarm = iso_in(60)
+    second_alarm = iso_in(15)
+    await seed_alarm(entity_time_harness, first_alarm)
+
+    scheduler_service = entity_time_harness.scheduler_service
+    original_add_job = scheduler_service.add_job
+
+    async def add_job_then_move_the_entity(job):
+        await original_add_job(job)
+        await seed_alarm(entity_time_harness, second_alarm)
+
+    scheduler_service.add_job = add_job_then_move_the_entity  # pyright: ignore[reportAttributeAccessIssue]
+    try:
+        job = await entity_time_harness.scheduler.schedule(
+            noop, EntityTime(ALARM_ENTITY), name="entity_time_registration_window"
+        )
+    finally:
+        scheduler_service.add_job = original_add_job  # pyright: ignore[reportAttributeAccessIssue]
+
+    assert job.next_run == date_utils.convert_datetime_str_to_tz(second_alarm)
+    job.cancel()
+
+
+async def test_watch_listener_is_registered_and_cancelled_with_the_job(
+    entity_time_harness: HassetteHarness,
+) -> None:
+    """The entity-watch listener exists for the job's lifetime and no longer."""
+    await seed_alarm(entity_time_harness, iso_in(30))
+    hassette = typing.cast("Hassette", entity_time_harness.hassette)
+
+    job = await entity_time_harness.scheduler.schedule(
+        noop, EntityTime(ALARM_ENTITY), name="entity_time_watch_listener"
+    )
+
+    expected_name = f"scheduler.entity_time.{entity_time_harness.scheduler.owner_id}.{job.name}"
+    assert expected_name in watch_listener_names(hassette)
+
+    job.cancel()
+
+    assert expected_name not in watch_listener_names(hassette)
+
+
+async def test_cancelled_job_is_not_rescheduled(entity_time_harness: HassetteHarness) -> None:
+    """A change arriving after cancellation does not resurrect the job."""
+    alarm = iso_in(60)
+    await seed_alarm(entity_time_harness, alarm)
+
+    job = await entity_time_harness.scheduler.schedule(
+        noop, EntityTime(ALARM_ENTITY), name="entity_time_cancelled_not_rescheduled"
+    )
+    original_next_run = job.next_run
+    job.cancel()
+
+    await change_alarm(entity_time_harness, alarm, iso_in(5))
+
+    assert job.next_run == original_next_run

--- a/tests/integration/test_scheduler_entity_time.py
+++ b/tests/integration/test_scheduler_entity_time.py
@@ -12,6 +12,7 @@ from unittest.mock import AsyncMock
 import pytest
 from whenever import TimeDelta
 
+import hassette.core.scheduler_service as scheduler_service_module
 import hassette.utils.date_utils as date_utils
 from hassette.resources.lifecycle import mark_ready
 from hassette.scheduler.triggers import NO_OCCURRENCE, EntityTime
@@ -107,6 +108,22 @@ async def test_unavailable_entity_parks_the_job(entity_time_harness: HassetteHar
 
     assert job.next_run == NO_OCCURRENCE
     assert job.db_id is not None, "a parked job is still a registered job"
+    job.cancel()
+
+
+async def test_unavailable_entity_with_jitter_stays_parked(
+    entity_time_harness: HassetteHarness, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Jitter does not overflow the far-future parking timestamp."""
+    await seed_alarm(entity_time_harness, "unavailable")
+    monkeypatch.setattr(scheduler_service_module.random, "uniform", lambda _start, _stop: 5.0)
+
+    job = await entity_time_harness.scheduler.schedule(
+        noop, EntityTime(ALARM_ENTITY), name="entity_time_unavailable_jitter", jitter=5.0
+    )
+
+    assert job.next_run == NO_OCCURRENCE
+    assert job.fire_at == NO_OCCURRENCE
     job.cancel()
 
 

--- a/tests/unit/scheduler/test_entity_time_trigger.py
+++ b/tests/unit/scheduler/test_entity_time_trigger.py
@@ -1,0 +1,258 @@
+"""Tests for the EntityTime trigger and the state-value parsing it relies on.
+
+Covers value parsing (parse_entity_time), resolution against a bound state reader,
+the NO_OCCURRENCE parking behaviour for entities with no usable time, daily rollover,
+and the telemetry/dedup metadata methods.
+"""
+
+import re
+from typing import TYPE_CHECKING, Any
+
+import pytest
+from whenever import TimeDelta, ZonedDateTime
+
+import hassette.utils.date_utils as date_utils
+from hassette.scheduler.triggers import NO_OCCURRENCE, EntityTime, parse_entity_time
+from hassette.types import TriggerProtocol
+
+from .conftest import TZ, zdt
+
+if TYPE_CHECKING:
+    from hassette.events import HassStateDict
+
+ENTITY_ID = "sensor.phone_next_alarm"
+
+
+def make_reader(states: dict[str, Any]):
+    """Return a state reader over a plain dict, matching BusService.read_entity_state."""
+
+    def reader(entity_id: str) -> "HassStateDict | None":
+        return states.get(entity_id)
+
+    return reader
+
+
+def bound_trigger(
+    state: Any = None,
+    *,
+    attributes: dict[str, Any] | None = None,
+    present: bool = True,
+    **kwargs: Any,
+) -> EntityTime:
+    """Build an EntityTime bound to a single-entity state reader."""
+    states: dict[str, Any] = {}
+    if present:
+        states[ENTITY_ID] = {"entity_id": ENTITY_ID, "state": state, "attributes": attributes or {}}
+    trigger = EntityTime(ENTITY_ID, **kwargs)
+    trigger.bind_state_reader(make_reader(states))
+    return trigger
+
+
+@pytest.fixture(autouse=True)
+def configured_timezone():
+    """Pin the process timezone so naive and time-only values parse deterministically."""
+    previous = date_utils._configured_tz
+    date_utils.configure(TZ)
+    yield
+    date_utils.configure(previous)
+
+
+class TestParseEntityTime:
+    def test_offset_aware_iso_string(self) -> None:
+        """An offset-aware ISO string — what most HA sensors report — parses to that instant."""
+        assert parse_entity_time("2026-07-28T07:00:00-05:00") == zdt(2026, 7, 28, 7, 0)
+
+    def test_naive_iso_string_uses_configured_timezone(self) -> None:
+        """A naive date-time, as input_datetime stores it, is read in the configured timezone."""
+        assert parse_entity_time("2026-07-28 07:00:00") == zdt(2026, 7, 28, 7, 0)
+
+    def test_time_only_string_resolves_against_today(self) -> None:
+        """A time-only value resolves against today's date in the configured timezone."""
+        today = date_utils.now()
+        parsed = parse_entity_time("07:00:00")
+        assert parsed is not None
+        assert (parsed.year, parsed.month, parsed.day) == (today.year, today.month, today.day)
+        assert (parsed.hour, parsed.minute) == (7, 0)
+
+    def test_unix_timestamp(self) -> None:
+        """A numeric value is a unix timestamp, as on input_datetime's `timestamp` attribute."""
+        expected = zdt(2026, 7, 28, 7, 0)
+        assert parse_entity_time(expected.timestamp()) == expected
+
+    def test_zoned_datetime_passes_through(self) -> None:
+        """An already-parsed ZonedDateTime is returned unchanged."""
+        value = zdt(2026, 7, 28, 7, 0)
+        assert parse_entity_time(value) is value
+
+    @pytest.mark.parametrize("value", ["unknown", "unavailable", "", "   ", "none", "UNAVAILABLE"])
+    def test_unusable_state_strings_return_none(self, value: str) -> None:
+        """States that carry no time — unavailable, unknown, empty — resolve to None."""
+        assert parse_entity_time(value) is None
+
+    @pytest.mark.parametrize("value", [None, True, False, ["07:00"], {"at": "07:00"}])
+    def test_non_time_values_return_none(self, value: Any) -> None:
+        """Values that are not times (including bools, which are ints) resolve to None."""
+        assert parse_entity_time(value) is None
+
+    def test_unparsable_string_returns_none(self) -> None:
+        """A string in no recognised time format resolves to None rather than raising."""
+        assert parse_entity_time("not a time at all") is None
+
+
+class TestEntityTimeConstruction:
+    def test_invalid_entity_id_raises(self) -> None:
+        """An entity_id without a domain is rejected at construction."""
+        with pytest.raises(ValueError, match=re.escape("must be '<domain>.<object_id>'")):
+            EntityTime("phone_next_alarm")
+
+    def test_defaults(self) -> None:
+        """Offset defaults to zero, attribute to None, daily to False."""
+        trigger = EntityTime(ENTITY_ID)
+        assert trigger.offset == TimeDelta()
+        assert trigger.attribute is None
+        assert trigger.daily is False
+
+
+class TestEntityTimeResolve:
+    def test_unbound_trigger_resolves_to_none(self) -> None:
+        """A trigger used outside the scheduler has no state source and never fires."""
+        trigger = EntityTime(ENTITY_ID)
+        assert trigger.resolve(zdt(2026, 7, 28, 6, 0)) is None
+
+    def test_missing_entity_resolves_to_none(self) -> None:
+        """An entity absent from the state cache resolves to None."""
+        trigger = bound_trigger(present=False)
+        assert trigger.resolve(zdt(2026, 7, 28, 6, 0)) is None
+
+    def test_future_time_resolves_to_that_time(self) -> None:
+        """A future alarm time is the fire time."""
+        trigger = bound_trigger("2026-07-28T07:00:00-05:00")
+        assert trigger.resolve(zdt(2026, 7, 28, 6, 0)) == zdt(2026, 7, 28, 7, 0)
+
+    def test_past_time_resolves_to_none(self) -> None:
+        """An alarm time that has already passed leaves nothing to schedule."""
+        trigger = bound_trigger("2026-07-28T07:00:00-05:00")
+        assert trigger.resolve(zdt(2026, 7, 28, 8, 0)) is None
+
+    def test_negative_offset_fires_early(self) -> None:
+        """A negative offset moves the fire time before the entity's time."""
+        trigger = bound_trigger("2026-07-28T07:00:00-05:00", offset=TimeDelta(minutes=-30))
+        assert trigger.resolve(zdt(2026, 7, 28, 6, 0)) == zdt(2026, 7, 28, 6, 30)
+
+    def test_positive_offset_fires_late(self) -> None:
+        """A positive offset moves the fire time after the entity's time."""
+        trigger = bound_trigger("2026-07-28T07:00:00-05:00", offset=TimeDelta(minutes=15))
+        assert trigger.resolve(zdt(2026, 7, 28, 6, 0)) == zdt(2026, 7, 28, 7, 15)
+
+    def test_attribute_is_read_instead_of_state(self) -> None:
+        """attribute= reads the time from an attribute, as on sun.sun."""
+        trigger = bound_trigger(
+            "above_horizon",
+            attributes={"next_dawn": "2026-07-28T05:45:00-05:00"},
+            attribute="next_dawn",
+        )
+        assert trigger.resolve(zdt(2026, 7, 28, 4, 0)) == zdt(2026, 7, 28, 5, 45)
+
+    def test_missing_attribute_resolves_to_none(self) -> None:
+        """An attribute the entity does not expose resolves to None."""
+        trigger = bound_trigger("above_horizon", attribute="next_dawn")
+        assert trigger.resolve(zdt(2026, 7, 28, 4, 0)) is None
+
+
+class TestEntityTimeDaily:
+    def test_daily_fires_today_when_time_is_ahead(self) -> None:
+        """Daily mode keeps only the time of day and fires at today's occurrence."""
+        trigger = bound_trigger("2026-01-05T07:00:00-06:00", daily=True)
+        assert trigger.resolve(zdt(2026, 7, 28, 6, 0)) == zdt(2026, 7, 28, 7, 0)
+
+    def test_daily_rolls_over_when_time_has_passed(self) -> None:
+        """Once today's occurrence has passed, daily mode fires tomorrow."""
+        trigger = bound_trigger("2026-01-05T07:00:00-06:00", daily=True)
+        assert trigger.resolve(zdt(2026, 7, 28, 8, 0)) == zdt(2026, 7, 29, 7, 0)
+
+    def test_daily_applies_offset_before_extracting_time_of_day(self) -> None:
+        """The offset shifts the wall-clock time the daily schedule repeats at."""
+        trigger = bound_trigger("2026-01-05T07:00:00-06:00", offset=TimeDelta(minutes=-30), daily=True)
+        assert trigger.resolve(zdt(2026, 7, 28, 6, 0)) == zdt(2026, 7, 28, 6, 30)
+
+    def test_daily_next_run_after_firing_is_tomorrow(self) -> None:
+        """next_run_time after today's fire returns tomorrow's occurrence."""
+        trigger = bound_trigger("2026-01-05T07:00:00-06:00", daily=True)
+        previous = zdt(2026, 7, 28, 7, 0)
+        assert trigger.next_run_time(previous, zdt(2026, 7, 28, 7, 0, 1)) == zdt(2026, 7, 29, 7, 0)
+
+
+class TestEntityTimeParking:
+    def test_first_run_time_parks_when_unresolvable(self) -> None:
+        """An unavailable entity parks the job instead of failing registration."""
+        trigger = bound_trigger("unavailable")
+        assert trigger.first_run_time(zdt(2026, 7, 28, 6, 0)) == NO_OCCURRENCE
+
+    def test_next_run_time_parks_instead_of_returning_none(self) -> None:
+        """Returning None would remove the job; the entity must be able to schedule it again."""
+        trigger = bound_trigger("2026-07-28T07:00:00-05:00")
+        result = trigger.next_run_time(zdt(2026, 7, 28, 7, 0), zdt(2026, 7, 28, 7, 0, 1))
+        assert result == NO_OCCURRENCE
+
+    def test_parked_trigger_recovers_when_entity_reports_a_time(self) -> None:
+        """A parked trigger returns a real time as soon as the entity has one."""
+        states: dict[str, Any] = {ENTITY_ID: {"entity_id": ENTITY_ID, "state": "unavailable", "attributes": {}}}
+        trigger = EntityTime(ENTITY_ID)
+        trigger.bind_state_reader(make_reader(states))
+        now = zdt(2026, 7, 28, 6, 0)
+        assert trigger.first_run_time(now) == NO_OCCURRENCE
+
+        states[ENTITY_ID] = {
+            "entity_id": ENTITY_ID,
+            "state": "2026-07-28T07:00:00-05:00",
+            "attributes": {},
+        }
+        assert trigger.first_run_time(now) == zdt(2026, 7, 28, 7, 0)
+
+    def test_no_occurrence_is_far_enough_out_to_never_fire(self) -> None:
+        """The parking time must never come due while the process is running."""
+        assert date_utils.now().add(hours=24 * 365 * 100) < NO_OCCURRENCE
+
+
+class TestEntityTimeMetadata:
+    def test_label_is_not_a_reserved_builtin_name(self) -> None:
+        """Custom triggers must not claim a built-in trigger label."""
+        assert EntityTime(ENTITY_ID).trigger_label() == "entity_time"
+
+    def test_db_type_is_custom(self) -> None:
+        """EntityTime is not one of the DB's built-in trigger types."""
+        assert EntityTime(ENTITY_ID).trigger_db_type() == "custom"
+
+    def test_detail_names_entity_attribute_offset_and_mode(self) -> None:
+        """The detail string carries everything that distinguishes one EntityTime from another."""
+        trigger = EntityTime(ENTITY_ID, attribute="next_dawn", offset=TimeDelta(minutes=-30), daily=True)
+        assert trigger.trigger_detail() == f"{ENTITY_ID}.next_dawn -1800s daily"
+
+    def test_detail_omits_zero_offset(self) -> None:
+        """A zero offset is left out of the detail string."""
+        assert EntityTime(ENTITY_ID).trigger_detail() == ENTITY_ID
+
+    def test_trigger_id_differs_per_configuration(self) -> None:
+        """if_exists='skip' dedup relies on configuration differences changing trigger_id."""
+        base = EntityTime(ENTITY_ID).trigger_id()
+        assert EntityTime(ENTITY_ID).trigger_id() == base
+        assert EntityTime(ENTITY_ID, daily=True).trigger_id() != base
+        assert EntityTime(ENTITY_ID, offset=TimeDelta(minutes=5)).trigger_id() != base
+        assert EntityTime(ENTITY_ID, attribute="next_dawn").trigger_id() != base
+        assert EntityTime("sensor.other_alarm").trigger_id() != base
+
+    def test_repr_includes_detail(self) -> None:
+        """Repr is used in scheduler error messages, so it must name the entity."""
+        assert repr(EntityTime(ENTITY_ID)) == f"EntityTime({ENTITY_ID})"
+
+
+def test_trigger_satisfies_protocol() -> None:
+    """Scheduler.schedule() rejects anything that is not a TriggerProtocol."""
+    assert isinstance(EntityTime(ENTITY_ID), TriggerProtocol)
+
+
+def test_resolve_rounds_to_whole_seconds() -> None:
+    """Fire times are second-aligned, matching every other trigger."""
+    trigger = bound_trigger("2026-07-28T07:00:00.750-05:00")
+    resolved = trigger.resolve(zdt(2026, 7, 28, 6, 0))
+    assert resolved == ZonedDateTime(2026, 7, 28, 7, 0, 1, tz=TZ)


### PR DESCRIPTION
## Summary

Adds `EntityTime` to `hassette.scheduler` — a trigger that reads its fire time from a Home Assistant entity and moves the job whenever that entity changes.

This covers the "run when my phone alarm goes off" and "fire 30 minutes before a user-configured time" cases. Today those require hand-wiring a state listener to a scheduler job and manually cancelling/rescheduling on every entity change; this makes the pattern first-class.

```python
# Fire when the alarm goes off
await self.scheduler.schedule(self.on_alarm, EntityTime("sensor.phone_next_alarm"))

# Fire 30 minutes before a user-configured time, every day
await self.scheduler.schedule(
    self.pre_routine,
    EntityTime("input_datetime.morning_routine", offset=TimeDelta(minutes=-30), daily=True),
)

# Read from an attribute rather than the state
await self.scheduler.schedule(self.at_dawn, EntityTime("sun.sun", attribute="next_dawn"))
```

## What changed

**`src/hassette/scheduler/triggers.py`** — the `EntityTime` trigger.

- `entity_id`, plus `attribute=` to read a time out of an attribute instead of the state, `offset=` (a `whenever.TimeDelta`, negative fires early), and `daily=` to keep only the time of day and repeat.
- `daily=True` goes through the same cron machinery `Daily` uses, so the repeat is DST-safe.
- Parses the value shapes HA actually emits for times: offset-aware ISO strings, naive ISO date-times, time-only strings, and unix timestamps.
- An entity with no usable time (unavailable, `unknown`, no alarm set) parks the job at `NO_OCCURRENCE` rather than removing it, so the job stays registered and resumes on the entity's next change.
- An absolute time at or before now also resolves to no occurrence — that keeps a restart from re-firing an alarm that already went off.
- The trigger resolves through a bound state reader; unbound (used outside the scheduler) it resolves to no occurrence instead of raising.

**`src/hassette/scheduler/scheduler.py`** — `schedule()` registers a framework-bus state listener per entity-driven job, tracked in `_entity_time_subs` and cancelled along with the job. The listener reads the new state off the event rather than from the `StateProxy` cache, whose update is dispatched concurrently and so may not be visible yet.

**`src/hassette/core/scheduler_service.py`** — `reschedule_job()` moves an already-queued job to a new time without deregistering it. It no-ops for a job that isn't on the heap (cancelled, or mid-dispatch — in that case `dispatch_and_log` consults the trigger itself).

**Docs** — `EntityTime` section in `docs/pages/core-concepts/scheduler/triggers.md` plus a runnable snippet at `docs/pages/core-concepts/scheduler/snippets/scheduler_entity_time.py`.

## Testing

- `tests/unit/scheduler/test_entity_time_trigger.py` (new) — resolution across the supported value shapes, offset and `daily=` behavior, past/boundary times, unparsable and unavailable states, unbound triggers, `entity_id` validation.
- `tests/integration/test_scheduler_entity_time.py` (new) — end-to-end through a real scheduler: the job moves when the entity changes, parks and recovers across an unavailable state, and the listener is torn down when the job is cancelled.
- `uv run nox -s dev` — 8402 passed, 1 skipped, 2 xfailed.
- `prek -a` and `prek run -a --hook-stage pre-push` (ruff, pyright, schema freshness, all repo linters) — clean.

No frontend files touched.

Closes #969
