### PR TITLE
fix: publish docker semver images for releases

### DIFF
--- a/.github/workflows/build_and_publish_image.yml
+++ b/.github/workflows/build_and_publish_image.yml
@@ -11,6 +11,16 @@ on:
                 description: "Release tag (e.g. v0.24.0) — passed by release-please"
                 required: true
                 type: string
+            is_release:
+                # workflow_call inherits github.event_name from the top-level caller (e.g. "push"),
+                # not "workflow_call" itself — so event_name can't distinguish a release invocation
+                # from an ordinary push. The caller must say so explicitly instead. Getting this
+                # wrong reproduces issue #1473: false on a real release silently drops the semver/
+                # latest tags (and collapses the build matrix to a single Python version); true on
+                # a non-release call publishes release tags for what should be a dev/PR build.
+                description: "Whether this call publishes a real release (semver + latest tags)"
+                required: true
+                type: boolean
     workflow_dispatch: # manual trigger
         inputs:
             tag_name:
@@ -27,24 +37,31 @@ jobs:
     build:
         runs-on: ubuntu-latest
         timeout-minutes: 60
-        # Concurrency is keyed by event_name so PR, push-to-main, and release runs
-        # never share a bucket and therefore never cancel each other. Only mutable-tag
-        # paths (pull_request, push) enable cancel-in-progress — releases must run to
-        # completion so version/latest tags are never published half-finished.
+        # Release/dispatch predicate — true for a real release build (workflow_call from
+        # release-please with is_release=true, or a manual workflow_dispatch), false for
+        # PR/push dev builds. github.event_name alone can't tell these apart: workflow_call
+        # inherits event_name from the top-level caller (e.g. "push"), not "workflow_call"
+        # itself — the root cause of issue #1473 (releases silently degraded to a single-
+        # python dev build with no semver tags). The same `inputs.is_release == true ||
+        # github.event_name == 'workflow_dispatch'` expression is repeated below in
+        # cancel-in-progress, matrix.python-version, and env.IS_RELEASE — GitHub Actions
+        # can't share an expression across those three scopes, so keep all three in sync
+        # if this predicate ever changes.
         concurrency:
             group: ${{ github.workflow }}-${{ github.event_name }}-${{ inputs.tag_name || github.event.pull_request.number || github.ref }}-${{ matrix.python-version }}
-            cancel-in-progress: ${{ github.event_name == 'pull_request' || github.event_name == 'push' }}
+            # Releases must run to completion so version/latest tags are never published half-finished.
+            cancel-in-progress: ${{ !(inputs.is_release == true || github.event_name == 'workflow_dispatch') }}
         strategy:
             fail-fast: false
             matrix:
                 # PRs and main-branch pushes build only 3.13 for speed; releases build all supported versions
-                python-version: ${{ (github.event_name == 'pull_request' || github.event_name == 'push') && fromJSON('["3.13"]') || fromJSON('["3.11", "3.12", "3.13", "3.14"]') }}
+                python-version: ${{ (inputs.is_release == true || github.event_name == 'workflow_dispatch') && fromJSON('["3.11", "3.12", "3.13", "3.14"]') || fromJSON('["3.13"]') }}
         env:
             IMAGE_NAME: hassette
             REGISTRY: ghcr.io
             OWNER: ${{ github.repository_owner }}
             PYTHON_VERSION: ${{ matrix.python-version }}
-            IS_RELEASE: ${{ github.event_name == 'workflow_call' || github.event_name == 'workflow_dispatch' }}
+            IS_RELEASE: ${{ inputs.is_release == true || github.event_name == 'workflow_dispatch' }}
         steps:
             - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
               with:

--- a/.github/workflows/docker-drift-check.yml
+++ b/.github/workflows/docker-drift-check.yml
@@ -1,0 +1,90 @@
+name: Docker Drift Check
+
+# Structural sibling of pypi-drift-check.yml (same compare/dedup/file-issue shape, applied
+# to GHCR instead of PyPI) and ha-version-drift.yml. Keep drift-check behavior changes
+# (dedup logic, label creation, exit semantics) in sync across all three.
+on:
+    schedule:
+        - cron: "0 12 * * *" # daily at noon UTC
+    workflow_dispatch: {}
+
+jobs:
+    check-drift:
+        runs-on: ubuntu-latest
+        timeout-minutes: 5
+        permissions:
+            issues: write
+            packages: read
+        steps:
+            - name: Compare GitHub release to GHCR image tags
+              env:
+                  GH_TOKEN: ${{ github.token }}
+              run: |
+                  set -euo pipefail
+
+                  # Get latest GitHub release tag
+                  GITHUB_TAG=$(gh release view --repo "$GITHUB_REPOSITORY" --json tagName -q .tagName 2>/dev/null || echo "")
+                  if [ -z "$GITHUB_TAG" ]; then
+                      echo "No GitHub releases found, skipping"
+                      exit 0
+                  fi
+                  GITHUB_VERSION="${GITHUB_TAG#v}"
+                  EXPECTED_TAG="${GITHUB_VERSION}-py3.13"
+
+                  echo "GitHub release: v${GITHUB_VERSION}"
+                  echo "Checking GHCR for tag: ${EXPECTED_TAG}"
+
+                  # Query GHCR package versions. Uses the /users/ endpoint since this repo is
+                  # user-owned, not org-owned — if it's ever transferred to an org this needs
+                  # /orgs/ instead, and would otherwise silently no-op via the warning below.
+                  # A failure here (e.g. permission hiccup) is not evidence of drift — warn and
+                  # exit clean rather than filing a false alarm.
+                  if ! TAGS=$(gh api "/users/${GITHUB_REPOSITORY_OWNER}/packages/container/hassette/versions" \
+                      --paginate --jq '.[].metadata.container.tags[]' 2>&1); then
+                      echo "::warning::Failed to query GHCR package versions API: $TAGS"
+                      exit 0
+                  fi
+
+                  if echo "$TAGS" | grep -qx "$EXPECTED_TAG"; then
+                      echo "GHCR has ${EXPECTED_TAG} — no drift detected"
+                      exit 0
+                  fi
+
+                  echo "::error::Docker drift detected! GitHub has v${GITHUB_VERSION} but GHCR has no ${EXPECTED_TAG} image"
+
+                  # Check if an issue already exists (label-based dedup, not search-text)
+                  EXISTING=$(gh issue list --repo "$GITHUB_REPOSITORY" --label "docker-drift" --state open --json number -q '.[0].number' 2>/dev/null || echo "")
+                  if [ -n "$EXISTING" ]; then
+                      echo "Issue #${EXISTING} already open for this drift"
+                      exit 0
+                  fi
+
+                  # Ensure the label exists
+                  gh label create "docker-drift" \
+                      --repo "$GITHUB_REPOSITORY" \
+                      --description "Docker image publish is missing for the latest release" \
+                      --color "d93f0b" \
+                      2>/dev/null || true
+
+                  gh issue create --repo "$GITHUB_REPOSITORY" \
+                      --title "Docker publish drift: GitHub v${GITHUB_VERSION} missing from GHCR" \
+                      --label "type:bug" \
+                      --label "area:core" \
+                      --label "priority:high" \
+                      --label "docker-drift" \
+                      --body "## Docker Image Drift Detected
+
+                  The latest GitHub release (\`v${GITHUB_VERSION}\`) does not have a corresponding image on GHCR (expected tag \`${EXPECTED_TAG}\`).
+
+                  This likely means the Docker publish step failed or was not triggered for the latest release.
+
+                  ### Recovery
+
+                  1. Check the [Build & Publish Image workflow runs](https://github.com/${GITHUB_REPOSITORY}/actions/workflows/build_and_publish_image.yml) for failures
+                  2. Re-trigger: \`gh workflow run 'Build & Publish Image' -f tag_name=v${GITHUB_VERSION}\`
+
+                  ### Details
+
+                  - GitHub release: [v${GITHUB_VERSION}](https://github.com/${GITHUB_REPOSITORY}/releases/tag/v${GITHUB_VERSION})
+                  - GHCR: https://github.com/${GITHUB_REPOSITORY}/pkgs/container/hassette
+                  - Detected by: [docker-drift-check workflow](https://github.com/${GITHUB_REPOSITORY}/actions/workflows/docker-drift-check.yml)"

--- a/.github/workflows/ha-version-drift.yml
+++ b/.github/workflows/ha-version-drift.yml
@@ -61,7 +61,7 @@ jobs:
                       gh issue comment "$EXISTING" --repo "$GITHUB_REPOSITORY" \
                           --body "Still behind: pinned \`$PINNED\`, latest \`$LATEST\` (checked $(date -u +%Y-%m-%d))"
                       echo "Updated existing issue #${EXISTING}"
-                      exit 1
+                      exit 0
                   fi
 
                   # Ensure the label exists
@@ -98,5 +98,3 @@ jobs:
                   - Detected by: [ha-version-drift workflow](https://github.com/$GITHUB_REPOSITORY/actions/workflows/ha-version-drift.yml)
 
                   This issue will be updated daily until the pin is bumped, and closed automatically when versions match."
-
-                  exit 1

--- a/.github/workflows/pypi-drift-check.yml
+++ b/.github/workflows/pypi-drift-check.yml
@@ -52,7 +52,7 @@ jobs:
                   EXISTING=$(gh issue list --repo "$GITHUB_REPOSITORY" --label "pypi-drift" --state open --json number -q '.[0].number' 2>/dev/null || echo "")
                   if [ -n "$EXISTING" ]; then
                       echo "Issue #${EXISTING} already open for this drift"
-                      exit 1
+                      exit 0
                   fi
 
                   gh issue create --repo "$GITHUB_REPOSITORY" \
@@ -77,5 +77,3 @@ jobs:
                   - GitHub release: [v${GITHUB_VERSION}](https://github.com/${GITHUB_REPOSITORY}/releases/tag/v${GITHUB_VERSION})
                   - PyPI: https://pypi.org/project/hassette/${PYPI_VERSION}/
                   - Detected by: [pypi-drift-check workflow](https://github.com/${GITHUB_REPOSITORY}/actions/workflows/pypi-drift-check.yml)"
-
-                  exit 1

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -226,6 +226,7 @@ jobs:
         uses: ./.github/workflows/build_and_publish_image.yml
         with:
             tag_name: ${{ needs.release-please.outputs.tag_name || inputs.tag_name }}
+            is_release: true
         permissions:
             contents: read
             packages: write


### PR DESCRIPTION
### Root Cause

`build_and_publish_image.yml` decided release-vs-dev builds by checking `github.event_name`,
but a `workflow_call` invocation inherits `event_name` from the top-level caller (`push`, in
`release-please.yml`'s case) rather than reporting `workflow_call` itself. This silently
degraded every release build since v0.42.0 to a dev-style build: no semver/`latest` tags, and
the Python build matrix collapsed to 3.13-only instead of all 4 supported versions.

- Add an explicit, required `is_release` boolean input to `build_and_publish_image.yml`'s
  `workflow_call` trigger. `release-please.yml` now passes `is_release: true` explicitly
  instead of relying on `event_name` inference, which can't distinguish a release invocation
  from an ordinary push.
- GHCR semver images for v0.42.0 through v0.50.0 have been backfilled via
  `workflow_dispatch` (unaffected by this bug, since `event_name` is not inherited for manual
  dispatch) — no code change, noted here for the record.

### Drift Detection

- Add `docker-drift-check.yml`, modeled on the existing `pypi-drift-check.yml`, to catch a
  future recurrence of this class of bug by comparing the latest GitHub release tag against
  GHCR's published image tags on a daily schedule.

### Housekeeping

- Drop `exit 1` from the already-tracked-issue path in all three drift-check workflows (pypi,
  ha-version, docker) — the filed/updated GitHub issue is the intended visible signal, not a
  red Actions run, which was easy to miss and added no information once the issue existed.

Closes #1473
