### PR TITLE
feat: expose state and type registries on App instances

### DIFF
--- a/design/specs/010-lifecycle-extraction/design.md
+++ b/design/specs/010-lifecycle-extraction/design.md
@@ -7,7 +7,7 @@
 
 ## Problem
 
-App inherits ~54 public names from Resource and LifecycleMixin. Only ~20 are app-author API; the remaining ~34 are framework plumbing — lifecycle state machines, child-resource wiring, readiness signaling, task bucket registration. These names appear in IDE autocomplete, create a false impression of stable API surface, and risk app authors calling sequence-unsafe methods that corrupt lifecycle state. Before the 1.0 API freeze, the public surface must reflect only what app authors should use.
+App inherits ~54 public names from Resource and LifecycleMixin. Only a curated subset is app-author API; the remaining names are framework plumbing — lifecycle state machines, child-resource wiring, readiness signaling, task bucket registration. These names appear in IDE autocomplete, create a false impression of stable API surface, and risk app authors calling sequence-unsafe methods that corrupt lifecycle state. Before the 1.0 API freeze, the public surface must reflect only what app authors should use.
 
 ## Goals
 
@@ -55,7 +55,7 @@ App inherits ~54 public names from Resource and LifecycleMixin. Only ~20 are app
 - **FR#1** All 11 lifecycle state-transition methods (`handle_failed`, `handle_crash`, `handle_stop`, `handle_starting`, `handle_running`, `create_service_status_event`, `mark_ready`, `mark_not_ready`, `request_shutdown`, `start`, `cancel`) are module-level functions in `src/hassette/resources/lifecycle.py`, not methods on any class.
 - **FR#2** Five structural-operation methods (`start_children_and_wait`, `restart`, `register_task_bucket_factory`, `run_hooks`, `ordered_children_for_shutdown`) are module-level functions in `src/hassette/resources/operations.py`, not methods on any class. The current method names `_run_hooks` and `_ordered_children_for_shutdown` drop the underscore prefix — they are no longer private methods on a class.
 - **FR#8** `add_child` remains a method on Resource (used by `App.__init__` for child construction) but is excluded from `dir(app_instance)`.
-- **FR#3** `dir()` on an App instance returns only the app-author API names: `logger`, `api`, `scheduler`, `bus`, `states`, `app_config`, `instance_name`, `unique_name`, `index`, `now`, `on_initialize`, `on_shutdown`, `before_initialize`, `after_initialize`, `before_shutdown`, `after_shutdown`, `task_bucket`, `cache`, `is_ready`, `wait_ready`. `dir()` on an AppSync instance returns the same 20 names plus the 6 sync hooks: `before_initialize_sync`, `on_initialize_sync`, `after_initialize_sync`, `before_shutdown_sync`, `on_shutdown_sync`, `after_shutdown_sync`.
+- **FR#3** `dir()` on an App instance returns only the app-author API names: `logger`, `api`, `scheduler`, `bus`, `states`, `state_registry`, `type_registry`, `app_config`, `instance_name`, `unique_name`, `index`, `now`, `on_initialize`, `on_shutdown`, `before_initialize`, `after_initialize`, `before_shutdown`, `after_shutdown`, `task_bucket`, `cache`, `cache_key`, `is_ready`, `wait_ready`. `dir()` on an AppSync instance returns the same 23 names plus the 6 sync hooks: `before_initialize_sync`, `on_initialize_sync`, `after_initialize_sync`, `before_shutdown_sync`, `on_shutdown_sync`, `after_shutdown_sync`.
 - **FR#4** All framework call sites in `src/` that previously called `self.method()` or `instance.method()` for extracted methods now call the module-level function with the resource as the first argument.
 - **FR#5** The `_LifecycleHostP` Protocol in `mixins.py` no longer requires `create_service_status_event` as a method — it is removed from the Protocol since the free function accesses the resource's attributes directly.
 - **FR#6** A test asserts that `set(dir(app_instance))` matches the declared app-author API allowlist, catching future regressions.
@@ -122,7 +122,8 @@ The `_LifecycleHostP` Protocol stays in `mixins.py` but is imported by `lifecycl
 
 ```python
 _APP_PUBLIC_API: frozenset[str] = frozenset({
-    "logger", "api", "scheduler", "bus", "states", "app_config",
+    "logger", "api", "scheduler", "bus", "states",
+    "state_registry", "type_registry", "app_config",
     "instance_name", "unique_name", "index", "now",
     "on_initialize", "on_shutdown",
     "before_initialize", "after_initialize",

--- a/docs/pages/core-concepts/states/conversion.md
+++ b/docs/pages/core-concepts/states/conversion.md
@@ -2,7 +2,7 @@
 
 Home Assistant sends state data as untyped dicts with string values. Two registries cooperate to produce typed Python objects: the [`StateRegistry`][hassette.conversion.state_registry.StateRegistry] maps domains to state classes, and the [`TypeRegistry`][hassette.conversion.type_registry.TypeRegistry] converts string values to typed Python values. This conversion runs automatically whenever a handler receives state via [dependency injection](../bus/dependency-injection.md) — the mechanism that fills in handler parameters like `D.StateNew[T]` from the event. Most apps benefit from it without touching either registry directly.
 
-The registries become relevant when overriding domain mappings, registering custom converters, or debugging unexpected types.
+The registries become relevant when overriding domain mappings, registering custom converters, or debugging unexpected types. `self.state_registry` and `self.type_registry` reach the same registry instances from any `App` — reach for those inside app code. `STATE_REGISTRY` and `TYPE_REGISTRY` stay available as top-level imports for use outside an app, such as in tests or data scripts.
 
 ## The Conversion Pipeline
 
@@ -81,13 +81,14 @@ effect at class definition time.
 !!! warning
     The registry replaces the previous mapping silently and globally — a typo in the
     `Literal` domain overrides a built-in with no warning. Use
-    `STATE_REGISTRY.resolve(domain="sensor")` to confirm which class is registered.
+    `self.state_registry.resolve(domain="sensor")` to confirm which class is registered.
 
 All subsequent state events for `sensor` entities produce `CustomSensorState` instances.
 
 For classes that can't declare a `Literal` domain — built dynamically, or registered conditionally at runtime — [`register_state_converter`][hassette.conversion.register_state_converter] registers a class with the registry explicitly. It is the imperative equivalent of the `Literal`-based auto-registration.
 
-`STATE_REGISTRY` is available as a top-level import for direct access outside an app:
+`self.state_registry` reaches the same registry from any `App`. `STATE_REGISTRY` is also
+available as a top-level import for direct access outside an app:
 `from hassette import STATE_REGISTRY`.
 
 ### Union Type Support
@@ -286,7 +287,9 @@ Custom error messages with `{value}` make failures easier to diagnose:
 
 ## Inspection and Debugging
 
-`TYPE_REGISTRY` and `STATE_REGISTRY` are both available as top-level imports.
+`self.type_registry` and `self.state_registry` reach the registries from any `App`.
+`TYPE_REGISTRY` and `STATE_REGISTRY` are also available as top-level imports, for use
+outside an app.
 
 **List all registered value converters:**
 
@@ -311,7 +314,7 @@ is a `TypeConverterEntry` with `func`, `from_type`, `to_type`, `error_types`, an
 `error_message` fields.
 
 !!! tip "Unexpected state type at runtime?"
-    `STATE_REGISTRY.resolve(domain="the_domain")` confirms which class is registered.
+    `self.state_registry.resolve(domain="the_domain")` confirms which class is registered.
     If a custom class override does not take effect, import order is the likely cause.
     The override class must be imported after the module that defines the original.
 

--- a/docs/pages/core-concepts/states/conversion.md
+++ b/docs/pages/core-concepts/states/conversion.md
@@ -2,7 +2,7 @@
 
 Home Assistant sends state data as untyped dicts with string values. Two registries cooperate to produce typed Python objects: the [`StateRegistry`][hassette.conversion.state_registry.StateRegistry] maps domains to state classes, and the [`TypeRegistry`][hassette.conversion.type_registry.TypeRegistry] converts string values to typed Python values. This conversion runs automatically whenever a handler receives state via [dependency injection](../bus/dependency-injection.md) — the mechanism that fills in handler parameters like `D.StateNew[T]` from the event. Most apps benefit from it without touching either registry directly.
 
-The registries become relevant when overriding domain mappings, registering custom converters, or debugging unexpected types. `self.state_registry` and `self.type_registry` reach the same registry instances from any `App` — reach for those inside app code. `STATE_REGISTRY` and `TYPE_REGISTRY` stay available as top-level imports for use outside an app, such as in tests or data scripts.
+The registries become relevant when overriding domain mappings, registering custom converters, or debugging unexpected types. `self.state_registry` and `self.type_registry` reach the same registry instances from any `App`. App code uses those instance properties. `STATE_REGISTRY` and `TYPE_REGISTRY` stay available as top-level imports for use outside an app, such as in tests or data scripts.
 
 ## The Conversion Pipeline
 
@@ -80,8 +80,8 @@ effect at class definition time.
 
 !!! warning
     The registry replaces the previous mapping silently and globally — a typo in the
-    `Literal` domain overrides a built-in with no warning. Use
-    `self.state_registry.resolve(domain="sensor")` to confirm which class is registered.
+    `Literal` domain overrides a built-in with no warning.
+    `self.state_registry.resolve(domain="sensor")` confirms which class is registered.
 
 All subsequent state events for `sensor` entities produce `CustomSensorState` instances.
 

--- a/docs/pages/core-concepts/states/snippets/state-registry/domain_lookup.py
+++ b/docs/pages/core-concepts/states/snippets/state-registry/domain_lookup.py
@@ -4,5 +4,6 @@ from hassette import App
 class LightApp(App):
     async def on_initialize(self):
         # Get class for a domain
-        state_class = self.state_registry.resolve(domain="light")
-        # Returns: LightState
+        light_state_class = self.state_registry.resolve(domain="light")
+        assert light_state_class is not None
+        self.logger.info("Light states use %s", light_state_class.__name__)

--- a/docs/pages/core-concepts/states/snippets/state-registry/domain_lookup.py
+++ b/docs/pages/core-concepts/states/snippets/state-registry/domain_lookup.py
@@ -1,5 +1,8 @@
-from hassette import STATE_REGISTRY
+from hassette import App
 
-# Get class for a domain
-state_class = STATE_REGISTRY.resolve(domain="light")
-# Returns: LightState
+
+class LightApp(App):
+    async def on_initialize(self):
+        # Get class for a domain
+        state_class = self.state_registry.resolve(domain="light")
+        # Returns: LightState

--- a/docs/pages/core-concepts/states/snippets/type-registry/inspect_check.py
+++ b/docs/pages/core-concepts/states/snippets/type-registry/inspect_check.py
@@ -4,9 +4,9 @@ from hassette import App
 class ConversionApp(App):
     async def on_initialize(self):
         # Check if a converter exists
-        key = (str, int)
-        if key in self.type_registry.conversion_map:
-            entry = self.type_registry.conversion_map[key]
-            self.logger.info("Converter found for %s -> %s", str, int)
+        converter_key = (str, int)
+        if converter_key in self.type_registry.conversion_map:
+            converter_entry = self.type_registry.conversion_map[converter_key]
+            self.logger.info("Converter found: %s", converter_entry)
         else:
             self.logger.info("No converter registered")

--- a/docs/pages/core-concepts/states/snippets/type-registry/inspect_check.py
+++ b/docs/pages/core-concepts/states/snippets/type-registry/inspect_check.py
@@ -1,9 +1,12 @@
-from hassette import TYPE_REGISTRY
+from hassette import App
 
-# Check if a converter exists
-key = (str, int)
-if key in TYPE_REGISTRY.conversion_map:
-    entry = TYPE_REGISTRY.conversion_map[key]
-    print(f"Converter found for {str} -> {int}")
-else:
-    print("No converter registered")
+
+class ConversionApp(App):
+    async def on_initialize(self):
+        # Check if a converter exists
+        key = (str, int)
+        if key in self.type_registry.conversion_map:
+            entry = self.type_registry.conversion_map[key]
+            self.logger.info("Converter found for %s -> %s", str, int)
+        else:
+            self.logger.info("No converter registered")

--- a/docs/pages/core-concepts/states/snippets/type-registry/lookup_example.py
+++ b/docs/pages/core-concepts/states/snippets/type-registry/lookup_example.py
@@ -4,4 +4,5 @@ from hassette import App
 class ConversionApp(App):
     async def on_initialize(self):
         # Convert a value
-        result = self.type_registry.convert("42", int)  # Returns 42 as int
+        converted_value = self.type_registry.convert("42", int)
+        self.logger.info("Converted value: %s", converted_value)

--- a/docs/pages/core-concepts/states/snippets/type-registry/lookup_example.py
+++ b/docs/pages/core-concepts/states/snippets/type-registry/lookup_example.py
@@ -1,4 +1,7 @@
-from hassette import TYPE_REGISTRY
+from hassette import App
 
-# Convert a value
-result = TYPE_REGISTRY.convert("42", int)  # Returns 42 as int
+
+class ConversionApp(App):
+    async def on_initialize(self):
+        # Convert a value
+        result = self.type_registry.convert("42", int)  # Returns 42 as int

--- a/src/hassette/app/app.py
+++ b/src/hassette/app/app.py
@@ -9,6 +9,7 @@ from hassette.api import Api
 from hassette.bus import Bus
 from hassette.cache import AsyncCache, CacheProtocol
 from hassette.config.classes import AppManifest
+from hassette.conversion import StateRegistry, TypeRegistry
 from hassette.resources.base import FinalMeta, Resource
 from hassette.scheduler import Scheduler
 from hassette.state_manager import StateManager
@@ -48,6 +49,8 @@ _APP_PUBLIC_API: frozenset[str] = frozenset(
         "cache_key",
         "is_ready",
         "wait_ready",
+        "state_registry",
+        "type_registry",
     }
 )
 """App-author API allowlist — see design/specs/010-lifecycle-extraction/design.md.
@@ -205,6 +208,16 @@ class App(Generic[AppConfigT], Resource, metaclass=FinalMeta):
         if self.app_manifest and self.app_manifest.cache_key:
             return self.app_manifest.cache_key
         return f"{self.app_key}/{self.index}"
+
+    @property
+    def state_registry(self) -> StateRegistry:
+        """State registry for managing state class registrations and conversions."""
+        return self.hassette.state_registry
+
+    @property
+    def type_registry(self) -> TypeRegistry:
+        """Type registry for managing state value type conversions."""
+        return self.hassette.type_registry
 
     def now(self) -> ZonedDateTime:
         """Return the current date and time."""

--- a/tests/unit/app/test_app_dir.py
+++ b/tests/unit/app/test_app_dir.py
@@ -42,12 +42,12 @@ class TestAppDir:
         # still callable — extraction hasn't happened yet, __dir__ just hides it
         assert hasattr(app, "add_child")
 
-    def test_public_api_allowlist_has_exactly_21_names(self) -> None:
+    def test_public_api_allowlist_has_exactly_23_names(self) -> None:
         """Regression guard: the App allowlist size is a deliberate design decision (see
         design/specs/010-lifecycle-extraction/design.md), not incidental. A size change here
         signals the allowlist drifted without updating the design doc.
         """
-        assert len(_APP_PUBLIC_API) == 21
+        assert len(_APP_PUBLIC_API) == 23
 
     def test_hasattr_handle_failed_is_false(self) -> None:
         """Extracted lifecycle methods are deleted from the class entirely — not just hidden
@@ -78,6 +78,6 @@ class TestAppSyncDir:
 
         assert set(dir(app)) == _APP_PUBLIC_API | _APPSYNC_HOOKS
 
-    def test_appsync_allowlist_has_exactly_27_names(self) -> None:
-        """Regression guard: 21 base names + 6 sync hooks = 27."""
-        assert len(_APP_PUBLIC_API | _APPSYNC_HOOKS) == 27
+    def test_appsync_allowlist_has_exactly_29_names(self) -> None:
+        """Regression guard: 23 base names + 6 sync hooks = 29."""
+        assert len(_APP_PUBLIC_API | _APPSYNC_HOOKS) == 29

--- a/tests/unit/app/test_app_registries.py
+++ b/tests/unit/app/test_app_registries.py
@@ -1,0 +1,32 @@
+"""Unit tests for App.state_registry / App.type_registry accessors (issue #971).
+
+Confirms App exposes the registries via `self.state_registry` / `self.type_registry`,
+delegating to the parent Hassette instance rather than duplicating registry state.
+"""
+
+from hassette.app.app import App
+from hassette.app.app_config import AppConfig
+from hassette.conversion import StateRegistry, TypeRegistry
+from hassette.test_utils import make_mock_hassette
+
+
+def _make_app_config(name: str = "kitchen") -> AppConfig:
+    return AppConfig(instance_name=name)
+
+
+class TestAppRegistries:
+    def test_state_registry_delegates_to_hassette(self) -> None:
+        """App.state_registry returns the exact StateRegistry instance owned by hassette."""
+        hassette = make_mock_hassette(sealed=False)
+        hassette.state_registry = StateRegistry()
+        app = App(hassette, app_config=_make_app_config(), index=0, app_key="kitchen_lights")
+
+        assert app.state_registry is hassette.state_registry
+
+    def test_type_registry_delegates_to_hassette(self) -> None:
+        """App.type_registry returns the exact TypeRegistry instance owned by hassette."""
+        hassette = make_mock_hassette(sealed=False)
+        hassette.type_registry = TypeRegistry()
+        app = App(hassette, app_config=_make_app_config(), index=0, app_key="kitchen_lights")
+
+        assert app.type_registry is hassette.type_registry


### PR DESCRIPTION
## Summary

Adds `self.state_registry` and `self.type_registry` properties to `App`, delegating to the parent `Hassette` instance. This aligns registry access with the framework's existing dependency-injection pattern (`self.bus`, `self.scheduler`, `self.api`, `self.states`) instead of requiring app authors to reach for a module-level import (`from hassette import STATE_REGISTRY`) inside app code.

`STATE_REGISTRY` and `TYPE_REGISTRY` remain available as top-level imports for use outside an app (tests, data scripts).

## Changes

- `src/hassette/app/app.py` — add `state_registry` and `type_registry` properties on `App`, added to the `_APP_PUBLIC_API` allowlist (21 → 23 base names, 27 → 29 with sync hooks)
- `tests/unit/app/test_app_registries.py` — new unit tests confirming both properties delegate to the parent `Hassette` instance
- `tests/unit/app/test_app_dir.py` — updated allowlist-size regression guards to match the new count
- `docs/pages/core-concepts/states/conversion.md` and its code snippets — updated to show `self.state_registry` / `self.type_registry` as the in-app access pattern, with the top-level imports documented as the out-of-app alternative

## Testing

- `ptest -n 4` (equivalent to `nox -s dev`, same marker filter from `pyproject.toml`) — 8445 passed, 1 skipped, 2 xfailed
- `prek -a` — all hooks passed (ruff, eslint, tsc, custom lint checks, etc.)
- `prek pyright -a --stage pre-push` — passed

Closes #971