### PR TITLE
fix: wait for initial WebSocket before state sync

### DIFF
--- a/src/hassette/core/state_proxy.py
+++ b/src/hassette/core/state_proxy.py
@@ -43,6 +43,7 @@ class StateProxy(Resource):
     scheduler: Scheduler
     state_change_sub: "Subscription | None"
     poll_job: "ScheduledJob | None"
+    _initialized: bool
 
     def __init__(self, hassette: "Hassette", *, parent: Resource | None = None) -> None:
         super().__init__(hassette, parent=parent)
@@ -53,6 +54,7 @@ class StateProxy(Resource):
         self.scheduler = self.add_child(Scheduler)
         self.state_change_sub = None
         self.poll_job = None
+        self._initialized = False
 
     @property
     def config_log_level(self) -> LOG_LEVEL_TYPE:
@@ -85,6 +87,8 @@ class StateProxy(Resource):
         except Exception as exc:
             self.logger.warning("Failed to perform initial state sync, starting with empty cache: %s", exc)
             mark_ready(self, reason="Started with empty state cache")
+
+        self._initialized = True
 
     async def _wait_for_initial_websocket_connection(self) -> None:
         websocket_service = self.hassette.websocket_service
@@ -124,6 +128,7 @@ class StateProxy(Resource):
 
     async def on_shutdown(self) -> None:
         """Shutdown the state proxy and clean up resources."""
+        self._initialized = False
         mark_not_ready(self, reason="Shutting down")
         # Null out subscription/job references to guard against on_disconnect() race.
         self.poll_job = None
@@ -318,6 +323,10 @@ class StateProxy(Resource):
         Serialized via _reconnect_lock to prevent duplicate subscriptions
         when WebSocket flaps rapidly (#993).
         """
+        if not self._initialized:
+            self.logger.debug("Ignoring WebSocket connected event during initial state sync")
+            return
+
         async with self._reconnect_lock:
             self.logger.info("WebSocket reconnected, performing state resync")
 

--- a/src/hassette/core/state_proxy.py
+++ b/src/hassette/core/state_proxy.py
@@ -90,7 +90,7 @@ class StateProxy(Resource):
         websocket_service = self.hassette.websocket_service
         timeout = websocket_service.total_timeout_seconds
         self.logger.debug("Waiting up to %.1fs for initial WebSocket connection before state sync", timeout)
-        connected = await websocket_service.wait_connected(timeout=timeout)
+        connected = await websocket_service.wait_initial_connection(timeout=timeout)
         if not connected:
             self.logger.warning("Initial WebSocket connection did not complete within %.1fs", timeout)
 

--- a/src/hassette/core/state_proxy.py
+++ b/src/hassette/core/state_proxy.py
@@ -72,6 +72,8 @@ class StateProxy(Resource):
         await self.bus.on_websocket_connected(handler=self.on_reconnect, name="hassette.state_proxy.on_reconnect")
         await self.bus.on_websocket_disconnected(handler=self.on_disconnect, name="hassette.state_proxy.on_disconnect")
 
+        await self._wait_for_initial_websocket_connection()
+
         # Perform initial state sync. Non-fatal: if HA is unreachable at startup, mark
         # ready with an empty cache so the dashboard still serves. get_state() returns
         # None (not ResourceNotReadyError) once is_ready() is True, even with an empty cache.
@@ -83,6 +85,14 @@ class StateProxy(Resource):
         except Exception as exc:
             self.logger.warning("Failed to perform initial state sync, starting with empty cache: %s", exc)
             mark_ready(self, reason="Started with empty state cache")
+
+    async def _wait_for_initial_websocket_connection(self) -> None:
+        websocket_service = self.hassette.websocket_service
+        timeout = websocket_service.total_timeout_seconds
+        self.logger.debug("Waiting up to %.1fs for initial WebSocket connection before state sync", timeout)
+        connected = await websocket_service.wait_connected(timeout=timeout)
+        if not connected:
+            self.logger.warning("Initial WebSocket connection did not complete within %.1fs", timeout)
 
     async def subscribe_to_events(self) -> None:
         # Cancel existing subscriptions to prevent leaks on rapid reconnect

--- a/src/hassette/core/websocket_service.py
+++ b/src/hassette/core/websocket_service.py
@@ -127,6 +127,7 @@ class WebsocketService(Service):
         self._recv_task = None
         self._subscription_ids = set()
         self._connect_lock = asyncio.Lock()
+        self._connected_event = asyncio.Event()
         self._connected_at = None
         self._connection_state: ConnectionState = ConnectionState.DISCONNECTED
         self._ever_connected: bool = False
@@ -195,6 +196,9 @@ class WebsocketService(Service):
         self._connection_state = new
         if new == ConnectionState.CONNECTED:
             self._ever_connected = True
+        else:
+            if hasattr(self, "_connected_event"):
+                self._connected_event.clear()
 
     @property
     def resp_timeout_seconds(self) -> int:
@@ -223,6 +227,20 @@ class WebsocketService(Service):
     @property
     def is_connected(self) -> bool:
         return self._connection_state == ConnectionState.CONNECTED
+
+    async def wait_connected(self, *, timeout: float | None = None) -> bool:
+        """Wait until the Home Assistant WebSocket reaches CONNECTED.
+
+        Resource readiness only means this service is running and attempting to connect;
+        callers that need HA data should wait on the connection state explicitly.
+        """
+        if self.is_connected and self._connected_event.is_set():
+            return True
+        try:
+            await asyncio.wait_for(self._connected_event.wait(), timeout=timeout)
+        except TimeoutError:
+            return False
+        return self.is_connected
 
     def get_next_message_id(self) -> int:
         """Get the next message ID."""
@@ -368,6 +386,8 @@ class WebsocketService(Service):
 
         await self.send_connection_established_event()
         self._subscription_ids.add(await self.subscribe_events())
+
+        self._connected_event.set()
 
         mark_ready(self, reason="WebSocket connected, authenticated, and subscribed")
         await self._emit_readiness_event()

--- a/src/hassette/core/websocket_service.py
+++ b/src/hassette/core/websocket_service.py
@@ -230,7 +230,7 @@ class WebsocketService(Service):
         return self._connection_state == ConnectionState.CONNECTED
 
     async def wait_connected(self, *, timeout: float | None = None) -> bool:
-        """Wait until the Home Assistant WebSocket reaches CONNECTED.
+        """Wait until the Home Assistant WebSocket is connected and subscribed.
 
         Resource readiness only means this service is running and attempting to connect;
         callers that need HA data should wait on the connection state explicitly.

--- a/src/hassette/core/websocket_service.py
+++ b/src/hassette/core/websocket_service.py
@@ -128,6 +128,7 @@ class WebsocketService(Service):
         self._subscription_ids = set()
         self._connect_lock = asyncio.Lock()
         self._connected_event = asyncio.Event()
+        self._first_connection_attempt_done_event = asyncio.Event()
         self._connected_at = None
         self._connection_state: ConnectionState = ConnectionState.DISCONNECTED
         self._ever_connected: bool = False
@@ -241,6 +242,32 @@ class WebsocketService(Service):
         except TimeoutError:
             return False
         return self.is_connected
+
+    async def wait_initial_connection(self, *, timeout: float | None = None) -> bool:
+        """Wait for initial connection success, or the first failed connection attempt.
+
+        This lets startup state sync avoid racing ahead of the WebSocket connection attempt
+        without blocking optional-HA startup until the full retry budget is exhausted.
+        """
+        if self.is_connected and self._connected_event.is_set():
+            return True
+        if self._first_connection_attempt_done_event.is_set():
+            return False
+
+        connected_task = asyncio.create_task(self._connected_event.wait())
+        attempt_done_task = asyncio.create_task(self._first_connection_attempt_done_event.wait())
+        try:
+            done, _pending = await asyncio.wait(
+                {connected_task, attempt_done_task}, timeout=timeout, return_when=asyncio.FIRST_COMPLETED
+            )
+        finally:
+            for task in (connected_task, attempt_done_task):
+                if not task.done():
+                    task.cancel()
+
+        if not done:
+            return False
+        return self.is_connected and self._connected_event.is_set()
 
     def get_next_message_id(self) -> int:
         """Get the next message ID."""
@@ -388,6 +415,7 @@ class WebsocketService(Service):
         self._subscription_ids.add(await self.subscribe_events())
 
         self._connected_event.set()
+        self._first_connection_attempt_done_event.set()
 
         mark_ready(self, reason="WebSocket connected, authenticated, and subscribed")
         await self._emit_readiness_event()
@@ -450,8 +478,12 @@ class WebsocketService(Service):
         )
         async def _inner_connect() -> asyncio.Task:
             await self.partial_cleanup()
-            await self.connect_ws(session)
-            return await self.start_recv_and_subscribe()
+            try:
+                await self.connect_ws(session)
+                return await self.start_recv_and_subscribe()
+            except Exception:
+                self._first_connection_attempt_done_event.set()
+                raise
 
         return await _inner_connect()
 

--- a/src/hassette/test_utils/harness.py
+++ b/src/hassette/test_utils/harness.py
@@ -637,6 +637,7 @@ class HassetteHarness:
             self.hassette._websocket_service.has_ever_connected = True
             self.hassette._websocket_service.total_timeout_seconds = 1
             self.hassette._websocket_service.wait_connected = AsyncMock(return_value=True)
+            self.hassette._websocket_service.wait_initial_connection = AsyncMock(return_value=True)
 
         if not self.hassette._api:
             self.hassette._api = AsyncMock()
@@ -789,6 +790,7 @@ class HassetteHarness:
         self.hassette._websocket_service.has_ever_connected = True
         self.hassette._websocket_service.total_timeout_seconds = 1
         self.hassette._websocket_service.wait_connected = AsyncMock(return_value=True)
+        self.hassette._websocket_service.wait_initial_connection = AsyncMock(return_value=True)
 
     async def _start_api_mock(self) -> None:
         if not self.api_base_url:
@@ -812,6 +814,7 @@ class HassetteHarness:
         self.hassette._websocket_service.has_ever_connected = True
         self.hassette._websocket_service.total_timeout_seconds = 1
         self.hassette._websocket_service.wait_connected = AsyncMock(return_value=True)
+        self.hassette._websocket_service.wait_initial_connection = AsyncMock(return_value=True)
 
         self.hassette._api_service = self.hassette.add_child(
             ApiResource,

--- a/src/hassette/test_utils/harness.py
+++ b/src/hassette/test_utils/harness.py
@@ -631,13 +631,7 @@ class HassetteHarness:
 
         if not self.hassette._websocket_service:
             self.hassette._websocket_service = Mock()
-            self.hassette._websocket_service.ready_event = asyncio.Event()
-            self.hassette._websocket_service.ready_event.set()
-            self.hassette._websocket_service.is_connected = True
-            self.hassette._websocket_service.has_ever_connected = True
-            self.hassette._websocket_service.total_timeout_seconds = 1
-            self.hassette._websocket_service.wait_connected = AsyncMock(return_value=True)
-            self.hassette._websocket_service.wait_initial_connection = AsyncMock(return_value=True)
+            self._configure_ready_websocket_mock(self.hassette._websocket_service)
 
         if not self.hassette._api:
             self.hassette._api = AsyncMock()
@@ -648,6 +642,16 @@ class HassetteHarness:
 
         if not self.has_component("bus"):
             self.hassette.send_event = AsyncMock()
+
+    @staticmethod
+    def _configure_ready_websocket_mock(websocket_service: Mock) -> None:
+        websocket_service.ready_event = asyncio.Event()
+        websocket_service.ready_event.set()
+        websocket_service.is_connected = True
+        websocket_service.has_ever_connected = True
+        websocket_service.total_timeout_seconds = 1
+        websocket_service.wait_connected = AsyncMock(return_value=True)
+        websocket_service.wait_initial_connection = AsyncMock(return_value=True)
 
     def _capture_original_app_manifests(self) -> None:
         """Snapshot app manifests after startup so reset() can restore them between tests."""
@@ -786,11 +790,7 @@ class HassetteHarness:
         self.hassette._app_handler = self.hassette.add_child(AppHandler)
         self.hassette._websocket_service = Mock()
         self.hassette._websocket_service._status = ResourceStatus.RUNNING
-        self.hassette._websocket_service.is_connected = True
-        self.hassette._websocket_service.has_ever_connected = True
-        self.hassette._websocket_service.total_timeout_seconds = 1
-        self.hassette._websocket_service.wait_connected = AsyncMock(return_value=True)
-        self.hassette._websocket_service.wait_initial_connection = AsyncMock(return_value=True)
+        self._configure_ready_websocket_mock(self.hassette._websocket_service)
 
     async def _start_api_mock(self) -> None:
         if not self.api_base_url:
@@ -808,13 +808,7 @@ class HassetteHarness:
         self._exit_stack.push_async_callback(site.stop)
 
         self.hassette._websocket_service = Mock(spec=WebsocketService)
-        self.hassette._websocket_service.ready_event = asyncio.Event()
-        self.hassette._websocket_service.ready_event.set()
-        self.hassette._websocket_service.is_connected = True
-        self.hassette._websocket_service.has_ever_connected = True
-        self.hassette._websocket_service.total_timeout_seconds = 1
-        self.hassette._websocket_service.wait_connected = AsyncMock(return_value=True)
-        self.hassette._websocket_service.wait_initial_connection = AsyncMock(return_value=True)
+        self._configure_ready_websocket_mock(self.hassette._websocket_service)
 
         self.hassette._api_service = self.hassette.add_child(
             ApiResource,

--- a/src/hassette/test_utils/harness.py
+++ b/src/hassette/test_utils/harness.py
@@ -633,6 +633,10 @@ class HassetteHarness:
             self.hassette._websocket_service = Mock()
             self.hassette._websocket_service.ready_event = asyncio.Event()
             self.hassette._websocket_service.ready_event.set()
+            self.hassette._websocket_service.is_connected = True
+            self.hassette._websocket_service.has_ever_connected = True
+            self.hassette._websocket_service.total_timeout_seconds = 1
+            self.hassette._websocket_service.wait_connected = AsyncMock(return_value=True)
 
         if not self.hassette._api:
             self.hassette._api = AsyncMock()
@@ -781,6 +785,10 @@ class HassetteHarness:
         self.hassette._app_handler = self.hassette.add_child(AppHandler)
         self.hassette._websocket_service = Mock()
         self.hassette._websocket_service._status = ResourceStatus.RUNNING
+        self.hassette._websocket_service.is_connected = True
+        self.hassette._websocket_service.has_ever_connected = True
+        self.hassette._websocket_service.total_timeout_seconds = 1
+        self.hassette._websocket_service.wait_connected = AsyncMock(return_value=True)
 
     async def _start_api_mock(self) -> None:
         if not self.api_base_url:
@@ -800,6 +808,10 @@ class HassetteHarness:
         self.hassette._websocket_service = Mock(spec=WebsocketService)
         self.hassette._websocket_service.ready_event = asyncio.Event()
         self.hassette._websocket_service.ready_event.set()
+        self.hassette._websocket_service.is_connected = True
+        self.hassette._websocket_service.has_ever_connected = True
+        self.hassette._websocket_service.total_timeout_seconds = 1
+        self.hassette._websocket_service.wait_connected = AsyncMock(return_value=True)
 
         self.hassette._api_service = self.hassette.add_child(
             ApiResource,

--- a/tests/integration/test_dashboard_without_ha.py
+++ b/tests/integration/test_dashboard_without_ha.py
@@ -188,7 +188,9 @@ class TestInitialStateSyncBeforeApps:
             connection_attempted.set()
             await release_connection.wait()
             hassette.websocket_service.set_connection_state(ConnectionState.CONNECTED)
+            await hassette.websocket_service.send_connection_established_event()
             hassette.websocket_service._connected_event.set()  # pyright: ignore[reportPrivateUsage]  # coordinator-internal
+            hassette.websocket_service._first_connection_attempt_done_event.set()  # pyright: ignore[reportPrivateUsage]  # coordinator-internal
             await keep_ws_alive.wait()
 
         async def load_states() -> list[dict]:
@@ -222,6 +224,7 @@ class TestInitialStateSyncBeforeApps:
                 desc="state-reading app ready",
             )
             await asyncio.wait_for(load_cache_entered.wait(), timeout=1)
+            hassette.api.get_states_raw.assert_awaited_once()
 
             app = hassette.app_handler.registry.get("state_reader", 0)
             assert app is not None

--- a/tests/integration/test_dashboard_without_ha.py
+++ b/tests/integration/test_dashboard_without_ha.py
@@ -16,15 +16,29 @@ from collections.abc import AsyncIterator, Callable
 from pathlib import Path
 from unittest.mock import AsyncMock
 
+import pytest
 from httpx2 import ASGITransport, AsyncClient, Response
 
 from hassette import Hassette
-from hassette.test_utils import wait_for
+from hassette.test_utils import make_light_state_dict, wait_for
 from hassette.test_utils.helpers import cleanup_hassette_streams
+from hassette.types.enums import ConnectionState
 from hassette.web.app import create_fastapi_app
 
 WEBAPI_READY_TIMEOUT = 10.0
 HEALTH_ENDPOINT = "/api/health"
+STATE_READER_APP = """
+from hassette import App, AppConfig
+
+
+class StateReaderConfig(AppConfig):
+    test_entity: str = "light.office"
+
+
+class StateReaderApp(App[StateReaderConfig]):
+    async def on_initialize(self) -> None:
+        self.states.light[self.app_config.test_entity]
+""".strip()
 
 
 async def _get_health(hassette: Hassette) -> Response:
@@ -53,6 +67,7 @@ async def _running_hassette_without_ha(
     config = TestConfig(
         data_dir=tmp_path / "data",
         web_api={"run": True, "port": unused_tcp_port_factory()},
+        websocket={"total_timeout_seconds": 1},
         apps={
             "directory": TEST_APPS_PATH,
             "autodetect": False,
@@ -128,3 +143,93 @@ class TestDashboardWithoutHA:
             body = response.json()
             assert body["status"] == "starting"
             assert body["websocket_connected"] is False
+
+
+class TestInitialStateSyncBeforeApps:
+    async def test_app_bootstrap_waits_for_first_websocket_connection_and_state_sync(
+        self, tmp_path: Path, unused_tcp_port_factory: Callable[[], int]
+    ) -> None:
+        """Apps that read startup state must not initialize against the optional-HA empty cold cache."""
+        # lazy-import: a module-level import makes pytest try to collect TestConfig as a test class
+        from tests.conftest import TestConfig
+
+        app_dir = tmp_path / "apps"
+        app_dir.mkdir()
+        (app_dir / "state_reader.py").write_text(STATE_READER_APP, encoding="utf-8")
+
+        config = TestConfig(
+            data_dir=tmp_path / "data",
+            web_api={"run": True, "port": unused_tcp_port_factory()},
+            websocket={"total_timeout_seconds": 2},
+            apps={
+                "directory": app_dir,
+                "autodetect": False,
+                "apps": {
+                    "state_reader": {
+                        "filename": "state_reader.py",
+                        "class_name": "StateReaderApp",
+                        "config": {"instance_name": "state_reader", "test_entity": "light.office"},
+                    },
+                },
+            },
+        )
+
+        hassette = Hassette(config)
+        hassette.wire_services()
+
+        connection_attempted = asyncio.Event()
+        release_connection = asyncio.Event()
+        keep_ws_alive = asyncio.Event()
+        state_proxy_subscribed = asyncio.Event()
+        load_cache_entered = asyncio.Event()
+
+        async def delayed_serve() -> None:
+            hassette.websocket_service.set_connection_state(ConnectionState.CONNECTING)
+            connection_attempted.set()
+            await release_connection.wait()
+            hassette.websocket_service.set_connection_state(ConnectionState.CONNECTED)
+            hassette.websocket_service._connected_event.set()  # pyright: ignore[reportPrivateUsage]  # coordinator-internal
+            await keep_ws_alive.wait()
+
+        async def load_states() -> list[dict]:
+            load_cache_entered.set()
+            return [make_light_state_dict("light.office", "on")]
+
+        hassette.websocket_service.serve = delayed_serve  # pyright: ignore[reportAttributeAccessIssue]
+        hassette.api.get_states_raw = AsyncMock(side_effect=load_states)
+        original_subscribe_to_events = hassette.state_proxy.subscribe_to_events
+
+        async def tracked_subscribe_to_events() -> None:
+            await original_subscribe_to_events()
+            state_proxy_subscribed.set()
+
+        hassette.state_proxy.subscribe_to_events = tracked_subscribe_to_events  # pyright: ignore[reportAttributeAccessIssue]
+
+        run_task = asyncio.create_task(hassette.run_forever())
+        try:
+            await asyncio.wait_for(connection_attempted.wait(), timeout=1)
+            await asyncio.wait_for(state_proxy_subscribed.wait(), timeout=1)
+
+            with pytest.raises(TimeoutError):
+                await asyncio.wait_for(load_cache_entered.wait(), timeout=1)
+            assert hassette.app_handler.registry.get("state_reader", 0) is None
+
+            release_connection.set()
+
+            await wait_for(
+                lambda: ((app := hassette.app_handler.registry.get("state_reader", 0)) is not None and app.is_ready()),
+                timeout=WEBAPI_READY_TIMEOUT,
+                desc="state-reading app ready",
+            )
+            await asyncio.wait_for(load_cache_entered.wait(), timeout=1)
+
+            app = hassette.app_handler.registry.get("state_reader", 0)
+            assert app is not None
+            assert app.is_ready()
+        finally:
+            hassette.shutdown_event.set()
+            release_connection.set()
+            keep_ws_alive.set()
+            with contextlib.suppress(Exception):
+                await asyncio.wait_for(run_task, timeout=WEBAPI_READY_TIMEOUT)
+            await cleanup_hassette_streams(hassette)

--- a/tests/integration/test_state_proxy.py
+++ b/tests/integration/test_state_proxy.py
@@ -132,6 +132,37 @@ class TestStateProxyInit:
 
         assert proxy.get_state("light.nonexistent") is None
 
+    async def test_initial_sync_waits_for_first_websocket_connection(self, state_proxy: "StateProxy") -> None:
+        """StateProxy does not race app startup by loading an empty cache before first HA connection."""
+        entered_wait = asyncio.Event()
+        release_wait = asyncio.Event()
+
+        async def blocked_wait_connected(*, timeout: float | None = None) -> bool:
+            assert timeout == 1.0
+            entered_wait.set()
+            await release_wait.wait()
+            return True
+
+        websocket_service = state_proxy.hassette.websocket_service
+        websocket_service.is_connected = False
+        websocket_service.has_ever_connected = False
+        websocket_service.total_timeout_seconds = 1.0
+        websocket_service.wait_connected = AsyncMock(side_effect=blocked_wait_connected)
+
+        state_proxy.load_cache = AsyncMock()  # pyright: ignore[reportMethodAssign]
+        mark_not_ready(state_proxy, reason="test setup")
+
+        init_task = asyncio.create_task(state_proxy.on_initialize())
+        await asyncio.wait_for(entered_wait.wait(), timeout=1)
+
+        state_proxy.load_cache.assert_not_awaited()
+
+        release_wait.set()
+        await init_task
+
+        websocket_service.wait_connected.assert_awaited_once()
+        state_proxy.load_cache.assert_awaited_once()
+
 
 @pytest.fixture
 def state_proxy():

--- a/tests/integration/test_state_proxy.py
+++ b/tests/integration/test_state_proxy.py
@@ -137,7 +137,7 @@ class TestStateProxyInit:
         entered_wait = asyncio.Event()
         release_wait = asyncio.Event()
 
-        async def blocked_wait_connected(*, timeout: float | None = None) -> bool:
+        async def blocked_wait_initial_connection(*, timeout: float | None = None) -> bool:
             assert timeout == 1.0
             entered_wait.set()
             await release_wait.wait()
@@ -147,7 +147,7 @@ class TestStateProxyInit:
         websocket_service.is_connected = False
         websocket_service.has_ever_connected = False
         websocket_service.total_timeout_seconds = 1.0
-        websocket_service.wait_connected = AsyncMock(side_effect=blocked_wait_connected)
+        websocket_service.wait_initial_connection = AsyncMock(side_effect=blocked_wait_initial_connection)
 
         state_proxy.load_cache = AsyncMock()  # pyright: ignore[reportMethodAssign]
         mark_not_ready(state_proxy, reason="test setup")
@@ -160,7 +160,7 @@ class TestStateProxyInit:
         release_wait.set()
         await init_task
 
-        websocket_service.wait_connected.assert_awaited_once()
+        websocket_service.wait_initial_connection.assert_awaited_once()
         state_proxy.load_cache.assert_awaited_once()
 
 

--- a/tests/integration/test_state_proxy.py
+++ b/tests/integration/test_state_proxy.py
@@ -163,6 +163,36 @@ class TestStateProxyInit:
         websocket_service.wait_initial_connection.assert_awaited_once()
         state_proxy.load_cache.assert_awaited_once()
 
+    async def test_initial_connected_event_does_not_double_sync(self, state_proxy: "StateProxy") -> None:
+        """The startup sync path owns the first load even if the real connected event is dispatched."""
+        wait_entered = asyncio.Event()
+        release_wait = asyncio.Event()
+
+        async def blocked_wait_initial_connection(*, timeout: float | None = None) -> bool:
+            assert timeout == 1.0
+            wait_entered.set()
+            await release_wait.wait()
+            return True
+
+        websocket_service = state_proxy.hassette.websocket_service
+        websocket_service.total_timeout_seconds = 1.0
+        websocket_service.wait_initial_connection = AsyncMock(side_effect=blocked_wait_initial_connection)
+        state_proxy.load_cache = AsyncMock()  # pyright: ignore[reportMethodAssign]
+        state_proxy._initialized = False  # pyright: ignore[reportPrivateUsage]  # coordinator-internal
+        mark_not_ready(state_proxy, reason="test setup")
+
+        init_task = asyncio.create_task(state_proxy.on_initialize())
+        await asyncio.wait_for(wait_entered.wait(), timeout=1)
+
+        await state_proxy.on_reconnect()
+        await asyncio.sleep(0)
+        state_proxy.load_cache.assert_not_awaited()
+
+        release_wait.set()
+        await init_task
+
+        state_proxy.load_cache.assert_awaited_once()
+
 
 @pytest.fixture
 def state_proxy():
@@ -180,6 +210,7 @@ def state_proxy():
 
     proxy = StateProxy(mock_hassette, parent=mock_hassette)
     mark_ready(proxy, reason="Test setup")
+    proxy._initialized = True  # pyright: ignore[reportPrivateUsage]  # coordinator-internal
     return proxy
 
 

--- a/tests/unit/core/test_ws_connection_state.py
+++ b/tests/unit/core/test_ws_connection_state.py
@@ -54,6 +54,18 @@ class TestIsConnectedPropertyMirrorsState:
         assert websocket_service.is_connected is True
 
 
+class TestWaitConnected:
+    async def test_returns_true_when_already_connected(self, websocket_service: WebsocketService) -> None:
+        websocket_service._connection_state = ConnectionState.CONNECTING
+        websocket_service.set_connection_state(ConnectionState.CONNECTED)
+        websocket_service._connected_event.set()
+
+        assert await websocket_service.wait_connected(timeout=0.01) is True
+
+    async def test_returns_false_when_timeout_expires(self, websocket_service: WebsocketService) -> None:
+        assert await websocket_service.wait_connected(timeout=0.01) is False
+
+
 class TestValidTransitionTable:
     async def test_disconnected_to_connecting(self, websocket_service: WebsocketService) -> None:
         """DISCONNECTED → CONNECTING is valid."""

--- a/tests/unit/core/test_ws_connection_state.py
+++ b/tests/unit/core/test_ws_connection_state.py
@@ -66,6 +66,20 @@ class TestWaitConnected:
         assert await websocket_service.wait_connected(timeout=0.01) is False
 
 
+class TestWaitInitialConnection:
+    async def test_returns_true_when_connected(self, websocket_service: WebsocketService) -> None:
+        websocket_service._connection_state = ConnectionState.CONNECTING
+        websocket_service.set_connection_state(ConnectionState.CONNECTED)
+        websocket_service._connected_event.set()
+
+        assert await websocket_service.wait_initial_connection(timeout=0.01) is True
+
+    async def test_returns_false_after_first_failed_attempt(self, websocket_service: WebsocketService) -> None:
+        websocket_service._first_connection_attempt_done_event.set()
+
+        assert await websocket_service.wait_initial_connection(timeout=0.01) is False
+
+
 class TestValidTransitionTable:
     async def test_disconnected_to_connecting(self, websocket_service: WebsocketService) -> None:
         """DISCONNECTED → CONNECTING is valid."""


### PR DESCRIPTION
## Summary
- add a WebSocket connection wait primitive that only completes after the initial event subscription is established
- have StateProxy wait for the first WebSocket connection attempt before initial state sync, while preserving optional-HA degraded startup after timeout
- add unit, StateProxy, and full lifecycle regression tests for app bootstrap reading initial state

## Testing
- uv run pytest tests/unit/core/test_ws_connection_state.py tests/integration/test_state_proxy.py tests/integration/test_dashboard_without_ha.py -v
- prek -a