### PR TITLE
refactor: resolve ServiceWatcher services to a single match instead of a list

### DIFF
--- a/src/hassette/core/service_watcher.py
+++ b/src/hassette/core/service_watcher.py
@@ -22,7 +22,6 @@ from hassette.types.types import LOG_LEVEL_TYPE
 if typing.TYPE_CHECKING:
     from hassette import Hassette
 
-DEFAULT_READINESS_TIMEOUT = 30.0
 SERVICE_STATUS_PATH = "payload.data.status"
 
 
@@ -116,9 +115,16 @@ class ServiceWatcher(Resource):
     def service_key(name: str, role: object) -> str:
         return f"{name}:{role}"
 
-    def get_service(self, name: str, role: object) -> list[Service]:
-        """Return matching Service instances from hassette.children."""
-        return [c for c in self.hassette.children if isinstance(c, Service) and c.class_name == name and c.role == role]
+    def get_service(self, name: str, role: object) -> Service | None:
+        """Return the Service child matching name/role, or None if there is no match.
+
+        Hassette rejects duplicate child types at construction, so (class_name, role)
+        identifies at most one service.
+        """
+        return next(
+            (c for c in self.hassette.children if isinstance(c, Service) and c.class_name == name and c.role == role),
+            None,
+        )
 
     def get_budget(self, key: str, spec: RestartSpec) -> RestartBudget:
         """Return existing budget for key or create a new one from spec."""
@@ -128,12 +134,12 @@ class ServiceWatcher(Resource):
 
     def set_service_status(self, name: str, role: object, status: ResourceStatus, context: str | None = None) -> None:
         """Find the service by name/role and set its status, warning if not found."""
-        services = self.get_service(name, role)
-        if not services:
+        service = self.get_service(name, role)
+        if service is None:
             label = context if context is not None else status.name
             self.logger.warning("No %s found for '%s' after %s, skipping status set", role, name, label)
             return
-        services[0].status = status
+        service.status = status
 
     async def shutdown_safe_sleep(self, duration: float) -> bool:
         """Sleep for duration seconds, waking early if shutdown is requested.
@@ -298,17 +304,16 @@ class ServiceWatcher(Resource):
         if budget:
             budget.reset()
 
-        services = self.get_service(name, role)
-        if not services:
+        service = self.get_service(name, role)
+        if service is None:
             self.logger.warning("No %s found for '%s' after cooldown, skipping restart", role, name)
             return
 
         self.logger.info("%s '%s' cooldown complete, attempting restart", role, name)
-        for service in services:
-            try:
-                await restart(service)
-            except Exception as exc:
-                self.logger.error("%s '%s' restart after cooldown failed: %s", role, name, exc)
+        try:
+            await restart(service)
+        except Exception as exc:
+            self.logger.error("%s '%s' restart after cooldown failed: %s", role, name, exc)
 
     async def restart_service(self, event: HassetteServiceEvent) -> None:
         """Restart a failed service using per-service RestartSpec-driven behavior."""
@@ -319,12 +324,11 @@ class ServiceWatcher(Resource):
         key = self.service_key(name, role)
 
         # Resolve the service and its restart_spec
-        services = self.get_service(name, role)
-        if not services:
+        service = self.get_service(name, role)
+        if service is None:
             self.logger.warning("No %s found for '%s', skipping restart", role, name)
             return
 
-        service = services[0]
         spec = service.restart_spec
 
         # Step 1: Check fatal errors — immediate shutdown regardless of restart type
@@ -383,7 +387,7 @@ class ServiceWatcher(Resource):
         # Spawn the backoff + restart as a detached task so this handler returns
         # immediately and releases its dispatch semaphore slot.
         self.task_bucket.spawn(
-            self.execute_restart(name, role, key, spec, services, budget),
+            self.execute_restart(name, role, key, spec, service, budget),
             name=f"service_watcher:restart:{key}",
         )
 
@@ -393,7 +397,7 @@ class ServiceWatcher(Resource):
         role: object,
         key: str,
         spec: RestartSpec,
-        services: list[Service],
+        service: Service,
         budget: RestartBudget,
     ) -> None:
         """Execute backoff sleep and service restart (runs as a detached task)."""
@@ -421,22 +425,18 @@ class ServiceWatcher(Resource):
 
             self.logger.debug("%s '%s' is being restarted", role, name)
 
-            if len(services) > 1:
-                self.logger.warning("Multiple %s found for '%s', restarting all", role, name)
-
             # Step 7: Restart the service — catch and log exceptions, do NOT double-count budget.
-            # Clear in-restart guard in the finally AFTER the entire loop so concurrent FAILED
-            # events cannot enter restart_service() while restarts are still in progress.
-            for service in services:
-                try:
-                    await restart(service)
-                except Exception as exc:
-                    self.logger.error(
-                        "%s '%s' restart raised an exception (service left in FAILED state): %s",
-                        role,
-                        name,
-                        exc,
-                    )
+            # Clear the in-restart guard in the finally so concurrent FAILED events cannot enter
+            # restart_service() while the restart is still in progress.
+            try:
+                await restart(service)
+            except Exception as exc:
+                self.logger.error(
+                    "%s '%s' restart raised an exception (service left in FAILED state): %s",
+                    role,
+                    name,
+                    exc,
+                )
         finally:
             self._restarting.discard(key)
 
@@ -500,17 +500,15 @@ class ServiceWatcher(Resource):
         if key not in self._budgets and key not in self._restarting:
             return
 
-        # Find the service to verify it actually becomes ready (not just RUNNING)
-        service = next(
-            (c for c in self.hassette.children if c.class_name == name and c.role == role),
-            None,
-        )
+        # Find the service to verify it actually becomes ready (not just RUNNING).
+        # Only Services reach this point — budget and in-restart keys are only ever
+        # recorded for Services.
+        service = self.get_service(name, role)
         if service is None:
             return
 
         # Use per-service startup_timeout_seconds from restart_spec
-        spec = service.restart_spec if isinstance(service, Service) else None
-        readiness_timeout = spec.startup_timeout_seconds if spec is not None else DEFAULT_READINESS_TIMEOUT
+        readiness_timeout = service.restart_spec.startup_timeout_seconds
 
         # Spawn readiness check as a detached task so this handler returns
         # immediately and releases its dispatch semaphore slot.
@@ -521,7 +519,7 @@ class ServiceWatcher(Resource):
 
     async def await_service_readiness(
         self,
-        service: Resource,
+        service: Service,
         name: str,
         role: object,
         key: str,

--- a/src/hassette/core/service_watcher.py
+++ b/src/hassette/core/service_watcher.py
@@ -118,8 +118,12 @@ class ServiceWatcher(Resource):
     def get_service(self, name: str, role: object) -> Service | None:
         """Return the Service child matching name/role, or None if there is no match.
 
-        Hassette rejects duplicate child types at construction, so (class_name, role)
-        identifies at most one service.
+        Hassette rejects duplicate child *types* at construction (see the
+        `type_counts`/`duplicates` check in `Hassette.__init__`, core.py). Since
+        `class_name` is set to `type(self).__name__` and `role` is a fixed
+        `ClassVar` per subclass, at most one instance of a given type can ever
+        exist in `hassette.children`, so (class_name, role) identifies at most
+        one service.
         """
         return next(
             (c for c in self.hassette.children if isinstance(c, Service) and c.class_name == name and c.role == role),
@@ -501,8 +505,7 @@ class ServiceWatcher(Resource):
             return
 
         # Find the service to verify it actually becomes ready (not just RUNNING).
-        # Only Services reach this point — budget and in-restart keys are only ever
-        # recorded for Services.
+        # See get_service() for why (class_name, role) resolves to at most one match.
         service = self.get_service(name, role)
         if service is None:
             return

--- a/tests/unit/core/test_service_watcher_coverage.py
+++ b/tests/unit/core/test_service_watcher_coverage.py
@@ -278,10 +278,10 @@ class TestGetService:
         """A non-Service child sharing the name is not returned."""
         hassette = build_watcher_hassette()
         watcher = make_watcher(hassette)
-        plain = MagicMock()
-        plain.class_name = "DummyService"
-        plain.role = ResourceRole.SERVICE
-        hassette.children = [plain]
+        not_a_service = MagicMock()
+        not_a_service.class_name = "DummyService"
+        not_a_service.role = ResourceRole.SERVICE
+        hassette.children = [not_a_service]
 
         assert watcher.get_service("DummyService", ResourceRole.SERVICE) is None
 

--- a/tests/unit/core/test_service_watcher_coverage.py
+++ b/tests/unit/core/test_service_watcher_coverage.py
@@ -4,7 +4,7 @@ Complements test_service_watcher_exhausted.py (handle_exhaustion/cooldown_and_re
 status-setting) and tests/integration/test_service_watcher.py (restart_service branch
 coverage via a real bus-backed watcher). This file targets the remaining branches:
 listener registration, the BusService-recovery gate, on_service_running's early-return
-guards, cooldown abort/failure paths, and the multiple-services-found warning path.
+guards, cooldown abort/failure paths, and service lookup.
 """
 
 from unittest.mock import AsyncMock, MagicMock, Mock, patch
@@ -256,34 +256,34 @@ class TestCooldownAndRetry:
         await watcher.cooldown_and_retry("GoneService", "Service", "GoneService:Service", spec)
 
 
-class TestRestartServiceMultipleMatches:
-    async def test_restarts_all_matching_services_and_warns(self) -> None:
-        """When two services share class_name/role, restart_service restarts both and warns."""
+class TestGetService:
+    def test_returns_the_matching_service(self) -> None:
+        """get_service resolves a child by class_name/role."""
         hassette = build_watcher_hassette()
         watcher = make_watcher(hassette)
-        watcher.logger = Mock()
+        dummy = DummyService(hassette)
+        hassette.children = [dummy]
 
-        svc_a = DummyService(hassette)
-        svc_b = DummyService(hassette)
-        hassette.children = [svc_a, svc_b]
+        assert watcher.get_service(dummy.class_name, dummy.role) is dummy
 
-        spec = RestartSpec(restart_type=RestartType.TRANSIENT, backoff_base_seconds=0, budget_intensity=10)
-        svc_a.restart_spec = spec  # pyright: ignore[reportAttributeAccessIssue]
+    def test_returns_none_when_no_match(self) -> None:
+        """get_service returns None rather than an empty collection when nothing matches."""
+        hassette = build_watcher_hassette()
+        watcher = make_watcher(hassette)
+        hassette.children = [DummyService(hassette)]
 
-        event = make_service_failed_event(svc_a)
+        assert watcher.get_service("GoneService", ResourceRole.SERVICE) is None
 
-        # restart() is a module-level function (hassette.resources.operations), not a
-        # method — patch it at the call site (service_watcher.py) rather than reassigning
-        # instance attributes, since execute_restart() calls the free function directly.
-        with patch("hassette.core.service_watcher.restart", new_callable=AsyncMock) as mock_restart:
-            await watcher.restart_service(event)
-            key = watcher.service_key(svc_a.class_name, svc_a.role)
-            await wait_for(lambda: key not in watcher._restarting, desc="execute_restart completed")
+    def test_ignores_non_service_children(self) -> None:
+        """A non-Service child sharing the name is not returned."""
+        hassette = build_watcher_hassette()
+        watcher = make_watcher(hassette)
+        plain = MagicMock()
+        plain.class_name = "DummyService"
+        plain.role = ResourceRole.SERVICE
+        hassette.children = [plain]
 
-            mock_restart.assert_any_await(svc_a)
-            mock_restart.assert_any_await(svc_b)
-            assert mock_restart.await_count == 2
-        watcher.logger.warning.assert_called_once()
+        assert watcher.get_service("DummyService", ResourceRole.SERVICE) is None
 
 
 class TestRestartServiceNoServiceFound:

--- a/tests/unit/core/test_service_watcher_exhausted.py
+++ b/tests/unit/core/test_service_watcher_exhausted.py
@@ -4,7 +4,7 @@ Verifies:
 - handle_exhaustion sets EXHAUSTED_COOLING on the service instance for TRANSIENT services
 - handle_exhaustion sets EXHAUSTED_DEAD on the service instance for TEMPORARY services
 - cooldown_and_retry transitions EXHAUSTED_COOLING → EXHAUSTED_DEAD when cooldown cycle limit exceeded
-- Status assignment is skipped (with warning) when get_service returns empty list
+- Status assignment is skipped (with warning) when get_service returns None
 """
 
 from unittest.mock import MagicMock, patch
@@ -125,7 +125,7 @@ async def test_cooldown_exceeded_sets_exhausted_dead():
 
 
 async def test_exhausted_status_skipped_when_service_not_found():
-    """When get_service returns empty list, status set is skipped — no exception, event still emitted."""
+    """When get_service returns None, status set is skipped — no exception, event still emitted."""
     hassette = build_watcher_hassette()
     hassette.children = []
 


### PR DESCRIPTION
## Summary

`ServiceWatcher.get_service()` returned `list[Service]` from a linear scan over `hassette.children`, but every caller treated the result as at most one service — two unpacked `services[0]` and the third looped over a list that can only ever hold one element. Hassette rejects duplicate child types at construction (`core.py`), so `(class_name, role)` identifies at most one `Service` child.

This changes the return type to match that reality, which deletes the unreachable multi-match handling that hung off the old signature.

## What changed

- **`get_service()` now returns `Service | None`.** Callers guard with `is None` instead of unpacking a list they assume is length 1.
- **`execute_restart()` takes a single `Service`.** The `"Multiple %s found for '%s', restarting all"` loop and its warning are gone, along with the test that pinned that unreachable behavior.
- **`on_service_running()` now calls `get_service()`** instead of running its own inline scan over `hassette.children`. The inline version matched non-`Service` resources, so it needed a downstream `isinstance(service, Service)` check and a `DEFAULT_READINESS_TIMEOUT` fallback for the non-`Service` case. Both were unreachable — budget and in-restart keys are only ever recorded for `Service`s, and the guard above returns before the lookup otherwise. `DEFAULT_READINESS_TIMEOUT` is deleted; the timeout now comes straight from `service.restart_spec.startup_timeout_seconds`.
- **`await_service_readiness()` narrows its `service` parameter** from `Resource` to `Service`.

## On indexing the lookup

The issue floated an indexed lookup, registry, or cache. Deliberately not doing that: `hassette.children` is mutated after construction (tests append to it), lookups only happen on rare failure events, and the list holds ~20 items. An index would add staleness risk for no measurable gain. The ergonomics problem the issue describes was the `list[Service]` return type, not the scan itself.

## Testing

- `uv run nox -s dev` — 8451 passed, 1 skipped, 2 xfailed
- `prek -a` — all hooks pass
- `prek pyright -a --stage pre-push` — passes

The test that pinned the multi-match restart behavior is replaced by `TestGetService`, which covers the three real cases: a matching child is returned, a miss returns `None` rather than an empty collection, and a non-`Service` child sharing the name is not returned.

Closes #703