### PR TITLE
fix: key the state model cache on last_updated, not the context id

### DIFF
--- a/src/hassette/state_manager/state_manager.py
+++ b/src/hassette/state_manager/state_manager.py
@@ -88,13 +88,13 @@ class DomainStates(Mapping[str, StateT]):
         if cached is not None and last_updated is not None and cached.last_updated == last_updated:
             return cached.model
 
-        # no last_updated to go by, so compare the frozen states
+        # fast path didn't match — compare full content
         frozen_state = deepfreeze(state)
         if cached is not None and cached.frozen_state == frozen_state:
             return cached.model
 
         validated = STATE_REGISTRY.coerce_and_construct(self._model, state, entity_id)
-        self._cache[entity_id] = CacheValue(last_updated, frozen_state, validated)
+        self._cache[entity_id] = CacheValue(last_updated=last_updated, frozen_state=frozen_state, model=validated)
         return validated
 
     def to_dict(self) -> dict[str, StateT]:

--- a/src/hassette/state_manager/state_manager.py
+++ b/src/hassette/state_manager/state_manager.py
@@ -27,7 +27,7 @@ HOME_STATE = "home"
 
 
 class CacheValue(Generic[StateT], NamedTuple):
-    context_id: str | None
+    last_updated: str | None
     frozen_state: frozendict
     model: StateT
 
@@ -76,21 +76,25 @@ class DomainStates(Mapping[str, StateT]):
         self._cache: dict[str, CacheValue[StateT]] = {}
 
     def _validate_or_return_from_cache(self, entity_id: str, state: "HassStateDict") -> StateT:
-        context_id: str | None = state.get("context", {}).get("id")
+        last_updated: str | None = state.get("last_updated")
 
         cached = self._cache.get(entity_id)
 
-        # first check if the context ID matches
-        if cached is not None and context_id is not None and cached.context_id == context_id:  # pyright: ignore[reportUnnecessaryComparison]
+        # last_updated moves whenever the state or its attributes change, so it
+        # identifies the content. The context id does not: Home Assistant attaches
+        # one context to every state that results from the same cause, so a lamp
+        # ramping through a transition or an automation run reports several
+        # different states under a single id.
+        if cached is not None and last_updated is not None and cached.last_updated == last_updated:
             return cached.model
 
-        # if not then use deepfreeze and see if frozen states match
+        # no last_updated to go by, so compare the frozen states
         frozen_state = deepfreeze(state)
         if cached is not None and cached.frozen_state == frozen_state:
             return cached.model
 
         validated = STATE_REGISTRY.coerce_and_construct(self._model, state, entity_id)
-        self._cache[entity_id] = CacheValue(context_id, frozen_state, validated)
+        self._cache[entity_id] = CacheValue(last_updated, frozen_state, validated)
         return validated
 
     def to_dict(self) -> dict[str, StateT]:

--- a/src/hassette/state_manager/state_manager.pyi
+++ b/src/hassette/state_manager/state_manager.pyi
@@ -28,7 +28,7 @@ if typing.TYPE_CHECKING:
     from hassette.events import HassStateDict
 
 class CacheValue(Generic[StateT], NamedTuple):
-    context_id: str | None
+    last_updated: str | None
     frozen_state: frozendict
     model: StateT
 

--- a/tests/unit/test_state_manager.py
+++ b/tests/unit/test_state_manager.py
@@ -96,7 +96,7 @@ def domain_states() -> DomainStates[LightState]:
 
 
 class TestDomainStatesCacheValidation:
-    def test_context_id_match_returns_cached_object(self, domain_states: DomainStates[LightState]) -> None:
+    def test_last_updated_match_returns_cached_object(self, domain_states: DomainStates[LightState]) -> None:
         ds = domain_states
         ts = "2026-01-01T00:00:00+00:00"
         ctx = {"id": "fixed-context-id", "parent_id": None, "user_id": None}
@@ -126,25 +126,24 @@ class TestDomainStatesCacheValidation:
         assert spy.call_count == 1
 
     def test_frozen_state_match_returns_cached_object(self, domain_states: DomainStates[LightState]) -> None:
+        """Without last_updated to compare, identical states still hit the cache."""
         ds = domain_states
         ts = "2026-01-01T00:00:00+00:00"
 
-        state_1 = make_light_state_dict(
-            "light.bedroom",
-            "on",
-            brightness=150,
-            last_changed=ts,
-            last_updated=ts,
-            context={"id": None, "parent_id": None, "user_id": None},
-        )
-        state_2 = make_light_state_dict(
-            "light.bedroom",
-            "on",
-            brightness=150,
-            last_changed=ts,
-            last_updated=ts,
-            context={"id": None, "parent_id": None, "user_id": None},
-        )
+        def state_without_last_updated() -> dict:
+            state = make_light_state_dict(
+                "light.bedroom",
+                "on",
+                brightness=150,
+                last_changed=ts,
+                last_updated=ts,
+                context={"id": None, "parent_id": None, "user_id": None},
+            )
+            del state["last_updated"]
+            return state
+
+        state_1 = state_without_last_updated()
+        state_2 = state_without_last_updated()
 
         with patch.object(STATE_REGISTRY, "coerce_and_construct", wraps=STATE_REGISTRY.coerce_and_construct) as spy:
             first = ds._validate_or_return_from_cache("light.bedroom", state_1)
@@ -152,6 +151,40 @@ class TestDomainStatesCacheValidation:
 
         assert first is second
         assert spy.call_count == 1
+
+    def test_shared_context_id_does_not_mask_a_newer_state(self, domain_states: DomainStates[LightState]) -> None:
+        """Home Assistant attaches one context to every state a single cause produces.
+
+        A light driven through a transition reports its ramp and its settled value
+        under the context of the originating turn_on, so the context id must not be
+        treated as a content key -- doing so let the first state answer for all the
+        later ones, permanently.
+        """
+        ds = domain_states
+        ctx = {"id": "01ABCDEF", "parent_id": None, "user_id": None}
+
+        turned_on = make_light_state_dict(
+            "light.bedroom",
+            "on",
+            brightness=15,
+            last_changed="2026-01-01T00:00:00.434000+00:00",
+            last_updated="2026-01-01T00:00:00.434000+00:00",
+            context=ctx,
+        )
+        settled_off = make_light_state_dict(
+            "light.bedroom",
+            "off",
+            last_changed="2026-01-01T00:00:02.830000+00:00",
+            last_updated="2026-01-01T00:00:02.830000+00:00",
+            context=ctx,
+        )
+
+        first = ds._validate_or_return_from_cache("light.bedroom", turned_on)
+        second = ds._validate_or_return_from_cache("light.bedroom", settled_off)
+
+        assert first.value is True
+        assert second.value is False
+        assert ds._cache["light.bedroom"].model is second
 
     def test_changed_state_produces_new_object(self, domain_states: DomainStates[LightState]) -> None:
         ds = domain_states


### PR DESCRIPTION
Hi! Thanks for the project, I've been using it for a few months now. I encountered a problem with the caching, and me and my agent came up with the following solution:

## Problem

`DomainStates` memoises the validated state model per entity and uses the **context id** as its primary invalidation key ([`state_manager.py`](https://github.com/NodeJSmith/hassette/blob/main/src/hassette/state_manager/state_manager.py)):

```python
if cached is not None and context_id is not None and cached.context_id == context_id:
    return cached.model
```

A context id identifies the *cause* of a change, not its content. From the Home Assistant context documentation (<https://data.home-assistant.io/docs/context/>):

> Whenever anything (e.g. an automation or user interaction) triggers a new change, a new context is assigned. This context will be attached to **all events and states** that happen as result of the change.

So "one context, several states" is the documented contract. Two everyday patterns hit it:

- **A light with a transition.** The ramp and the settled value are written under the originating `light.turn_on` context. On my instance a lamp was switched on at 03:00:00 and went off at 03:00:02, and the logbook entry for the *off* state still reads `context_domain: light, context_service: turn_on` — it inherited the turn-on context.
- **An automation run.** Every action inherits the automation's context, so a `repeat` toggling an `input_boolean` ten times produces ten states under one id.

When that happens the first state is cached and answers for every later one, and the entry is only replaced once a state with a *different* context id arrives. For an entity that is not touched again, that is never. `last_updated` was not consulted, so a strictly newer state did not invalidate.

`StateProxy.load_cache()` does not help: it replaces `StateProxy.states` wholesale, but the fresh dict carries the same context id, so the short-circuit still fires. A watchdog of mine called `load_cache()` every five minutes and logged the divergence eight times in a row without fixing it; only a process restart helped.

## Fix

Key the fast path on `last_updated`, which moves whenever the state or its attributes change and therefore identifies the content:

```python
if cached is not None and last_updated is not None and cached.last_updated == last_updated:
    return cached.model
```

The context id is dropped rather than combined: if `last_updated` matches, the content is identical and the context adds nothing; if it differs, a context match must *not* return the cached model. The `deepfreeze` comparison stays as the fallback for states that carry no `last_updated`.

The cache stays just as effective — a repeated read of an unchanged state still returns the identical object and still calls `coerce_and_construct` only once.

## Tests

- `test_shared_context_id_does_not_mask_a_newer_state` — new regression test, fails on `main` (`assert True is False`) and passes with the fix.
- `test_context_id_match_returns_cached_object` → renamed to `test_last_updated_match_returns_cached_object`; the states in it are identical, so it passes either way, but the name now says what it checks.
- `test_frozen_state_match_returns_cached_object` — the two states carried the same `last_updated`, so after this change the new fast path would answer and the `deepfreeze` branch would no longer be exercised. The states now omit `last_updated` so the test keeps covering the fallback.

`tests/unit/test_state_manager.py` and `tests/unit/state_manager/` pass (51 tests); ruff check and format are clean. I did not run the full suite locally.

## How I hit this

A light control app of mine switched on a lamp in an empty room. Its rules are configured so that they may adjust that lamp but never switch it on, and the guard is `current > 0 or rule.can_turn_on` — the app believed the lamp had been at brightness 15 since 03:00 while HA had it off, so the "adjustment" became a `light.turn_on`. Same root cause on two other occasions with an `input_boolean` toggled by an automation.
