### PR TITLE
fix: add explicit configurable timeout to outbound REST requests

### DIFF
--- a/hassette.schema.json
+++ b/hassette.schema.json
@@ -111,6 +111,13 @@
             "label": "Verify SSL"
           }
         },
+        "rest_request_timeout_seconds": {
+          "default": 30.0,
+          "description": "Default total timeout in seconds for outbound REST requests to Home Assistant, applied per retry attempt.\nPassed to aiohttp as a :class:`aiohttp.ClientTimeout`. Override per call by passing a ``timeout=`` kwarg to\n:meth:`~hassette.core.api_resource.ApiResource.rest_request`.",
+          "exclusiveMinimum": 0,
+          "title": "Rest Request Timeout Seconds",
+          "type": "number"
+        },
         "token": {
           "anyOf": [
             {

--- a/src/hassette/config/config.py
+++ b/src/hassette/config/config.py
@@ -134,7 +134,7 @@ class HassetteConfig(ExcludeExtrasMixin, BaseSettings):
     """Whether to verify SSL certificates when connecting to Home Assistant. Useful to disable for self-signed
     certificates."""
 
-    rest_request_timeout_seconds: float = Field(default=30.0, gt=0)
+    rest_request_timeout_seconds: float = Field(default=30.0, gt=0, allow_inf_nan=False)
     """Default total timeout in seconds for outbound REST requests to Home Assistant, applied per retry attempt.
     Passed to aiohttp as a :class:`aiohttp.ClientTimeout`. Override per call by passing a ``timeout=`` kwarg to
     :meth:`~hassette.core.api_resource.ApiResource.rest_request`."""

--- a/src/hassette/config/config.py
+++ b/src/hassette/config/config.py
@@ -134,6 +134,11 @@ class HassetteConfig(ExcludeExtrasMixin, BaseSettings):
     """Whether to verify SSL certificates when connecting to Home Assistant. Useful to disable for self-signed
     certificates."""
 
+    rest_request_timeout_seconds: float = Field(default=30.0, gt=0)
+    """Default total timeout in seconds for outbound REST requests to Home Assistant, applied per retry attempt.
+    Passed to aiohttp as a :class:`aiohttp.ClientTimeout`. Override per call by passing a ``timeout=`` kwarg to
+    :meth:`~hassette.core.api_resource.ApiResource.rest_request`."""
+
     token: SecretStr | None = Field(
         default=None,
         validation_alias=AliasChoices("token", "hassette__token", "ha_token", "home_assistant_token"),

--- a/src/hassette/core/api_resource.py
+++ b/src/hassette/core/api_resource.py
@@ -148,6 +148,11 @@ class ApiResource(Resource):
             if params:
                 request_kwargs["params"] = params
 
+            if "timeout" not in kwargs:
+                request_kwargs["timeout"] = aiohttp.ClientTimeout(
+                    total=self.hassette.config.rest_request_timeout_seconds
+                )
+
             try:
                 response = await self._session.request(
                     method, url, ssl=self.hassette.config.verify_ssl, **request_kwargs, **kwargs

--- a/tests/integration/test_api.py
+++ b/tests/integration/test_api.py
@@ -1,7 +1,12 @@
 from typing import Any
+from unittest.mock import patch
+
+import aiohttp
+import pytest
 
 from hassette import STATE_REGISTRY
 from hassette.api import Api
+from hassette.core import api_resource as api_resource_module
 from hassette.models.entities.light import LightEntity
 from hassette.test_utils import SimpleTestServer
 from hassette.utils.request_utils import clean_kwargs
@@ -80,6 +85,57 @@ async def test_get_state_or_none_returns_none_for_missing_entity(
     result = await api_client.get_state_or_none("light.nonexistent")
 
     assert result is None, f"Expected None for missing entity, got {result!r}"
+
+
+async def test_rest_request_uses_configured_timeout(hassette_with_mock_api: tuple[Api, SimpleTestServer]):
+    """rest_request passes a ClientTimeout sourced from config when the caller doesn't override it."""
+    api_client, mock_server = hassette_with_mock_api
+
+    mock_server.expect("GET", "/api/thing", "", status=200)
+
+    session = api_client._api_service._session
+    assert session is not None
+
+    with patch.object(session, "request", wraps=session.request) as spy:
+        await api_client.rest_request("GET", "/api/thing")
+
+    timeout = spy.call_args.kwargs["timeout"]
+    assert isinstance(timeout, aiohttp.ClientTimeout)
+    assert timeout.total == api_client.hassette.config.rest_request_timeout_seconds
+
+
+async def test_rest_request_per_call_timeout_overrides_config(hassette_with_mock_api: tuple[Api, SimpleTestServer]):
+    """A caller-supplied timeout kwarg is passed through untouched instead of the config default."""
+    api_client, mock_server = hassette_with_mock_api
+
+    mock_server.expect("GET", "/api/thing", "", status=200)
+
+    session = api_client._api_service._session
+    assert session is not None
+    override = aiohttp.ClientTimeout(total=1.5)
+
+    with patch.object(session, "request", wraps=session.request) as spy:
+        await api_client.rest_request("GET", "/api/thing", timeout=override)
+
+    assert spy.call_args.kwargs["timeout"] is override
+
+
+async def test_rest_request_propagates_timeout_error(
+    hassette_with_mock_api: tuple[Api, SimpleTestServer], monkeypatch: pytest.MonkeyPatch
+):
+    """A request that times out at the aiohttp boundary surfaces as a ClientError, not a silent hang."""
+    api_client, _ = hassette_with_mock_api
+
+    session = api_client._api_service._session
+    assert session is not None
+    # Avoid exercising the real retry/backoff schedule in a fast unit-level check.
+    monkeypatch.setattr(api_resource_module, "MAX_RETRY_ATTEMPTS", 1)
+
+    with (
+        patch.object(session, "request", side_effect=aiohttp.ServerTimeoutError("boom")),
+        pytest.raises(aiohttp.ServerTimeoutError),
+    ):
+        await api_client.rest_request("GET", "/api/thing")
 
 
 async def test_get_entity_or_none_returns_none_for_missing_entity(

--- a/tests/integration/test_api.py
+++ b/tests/integration/test_api.py
@@ -96,12 +96,17 @@ async def test_rest_request_uses_configured_timeout(hassette_with_mock_api: tupl
     session = api_client._api_service._session
     assert session is not None
 
-    with patch.object(session, "request", wraps=session.request) as spy:
-        await api_client.rest_request("GET", "/api/thing")
+    original = api_client.hassette.config.rest_request_timeout_seconds
+    api_client.hassette.config.rest_request_timeout_seconds = 7.25
+    try:
+        with patch.object(session, "request", wraps=session.request) as spy:
+            await api_client.rest_request("GET", "/api/thing")
+    finally:
+        api_client.hassette.config.rest_request_timeout_seconds = original
 
     timeout = spy.call_args.kwargs["timeout"]
     assert isinstance(timeout, aiohttp.ClientTimeout)
-    assert timeout.total == api_client.hassette.config.rest_request_timeout_seconds
+    assert timeout.total == 7.25
 
 
 async def test_rest_request_per_call_timeout_overrides_config(hassette_with_mock_api: tuple[Api, SimpleTestServer]):

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -1,3 +1,4 @@
+import math
 import os
 import sys
 import textwrap
@@ -7,7 +8,7 @@ from pathlib import Path
 
 import dotenv
 import pytest
-from pydantic import SecretStr
+from pydantic import SecretStr, ValidationError
 
 from hassette import HassetteConfig, context
 from hassette.config.classes import HassetteTomlConfigSettingsSource
@@ -571,6 +572,22 @@ class TestErrorHandlerTimeoutSeconds:
         """lifecycle.error_handler_timeout_seconds rejects booleans."""
         with pytest.raises(Exception, match="timeout must be"):
             LogLevelTestConfig(lifecycle={"error_handler_timeout_seconds": True})
+
+
+class TestRestRequestTimeout:
+    """Tests for HassetteConfig.rest_request_timeout_seconds field."""
+
+    def test_rejects_infinity(self) -> None:
+        with pytest.raises(ValidationError):
+            LogLevelTestConfig(rest_request_timeout_seconds=math.inf)
+
+    def test_rejects_nan(self) -> None:
+        with pytest.raises(ValidationError):
+            LogLevelTestConfig(rest_request_timeout_seconds=math.nan)
+
+    def test_accepts_positive_float(self) -> None:
+        config = LogLevelTestConfig(rest_request_timeout_seconds=7.25)
+        assert config.rest_request_timeout_seconds == 7.25
 
 
 class TestDefaultCacheTtl:


### PR DESCRIPTION
## Summary

`ApiResource.rest_request` called `self._session.request(...)` without an explicit timeout, relying on aiohttp's built-in default. Combined with the retry decorator and exponential backoff, a degraded network connection to Home Assistant could amplify into long hangs with no way to configure a shorter bound.

## Changes

- Added `HassetteConfig.rest_request_timeout_seconds` (default `30.0`, must be `> 0`) as a new configurable setting.
- `ApiResource.rest_request` now applies this value as an `aiohttp.ClientTimeout(total=...)` unless the caller already passed an explicit `timeout=` kwarg, in which case the caller's value is used untouched.
- Regenerated `hassette.schema.json` to include the new config field.

## Testing

- Added three integration tests in `tests/integration/test_api.py`:
  - `test_rest_request_uses_configured_timeout` — verifies the configured timeout is passed to the underlying session request when the caller doesn't override it.
  - `test_rest_request_per_call_timeout_overrides_config` — verifies a caller-supplied `timeout=` kwarg passes through untouched.
  - `test_rest_request_propagates_timeout_error` — verifies a timeout at the aiohttp boundary surfaces as a `ClientError` rather than hanging silently.
- Full suite: `uv run nox -s dev` — 8488 passed, 1 skipped, 2 xfailed.
- Lint/type checks: `prek -a` and `prek pyright -a --stage pre-push` — all hooks passed.

Closes #1035