### PR TITLE
test: replace scheduler __new__ doubles with shared factory in reschedule tests

### DIFF
--- a/tests/unit/core/test_scheduler_service_reschedule.py
+++ b/tests/unit/core/test_scheduler_service_reschedule.py
@@ -15,6 +15,7 @@ Tests cover:
 - _enqueue_then_register: uses trigger protocol methods; no isinstance dispatch
 """
 
+import asyncio
 import inspect
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -224,6 +225,10 @@ class TestJitter:
         """pop_due_and_peek_next dequeues based on fire_at, not next_run.
 
         A job with fire_at > current_time must NOT be dequeued even when next_run <= current_time.
+
+        Uses __new__ to bypass _ScheduledJobQueue.__init__ (which requires full Resource
+        wiring) — this test exercises queue pop logic in isolation, not scheduler service
+        integration.
         """
         queue = _ScheduledJobQueue.__new__(_ScheduledJobQueue)
         queue._lock = FairAsyncRLock()

--- a/tests/unit/core/test_scheduler_service_reschedule.py
+++ b/tests/unit/core/test_scheduler_service_reschedule.py
@@ -15,7 +15,6 @@ Tests cover:
 - _enqueue_then_register: uses trigger protocol methods; no isinstance dispatch
 """
 
-import asyncio
 import inspect
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -226,21 +225,10 @@ class TestJitter:
 
         A job with fire_at > current_time must NOT be dequeued even when next_run <= current_time.
         """
-        svc = SchedulerService.__new__(SchedulerService)
-        svc.hassette = MagicMock()
-        svc.hassette.config.scheduler.behind_schedule_threshold_seconds = 60
-        svc.hassette.config.scheduler.min_delay_seconds = 0.1
-        svc.hassette.config.scheduler.max_delay_seconds = 300.0
-        svc.hassette.config.scheduler.default_delay_seconds = 10.0
-        svc._removal_callbacks = {}
-        svc._jobs_by_id = {}
-        svc.logger = MagicMock()
-        svc._wakeup_event = asyncio.Event()
-
-        svc._job_queue = _ScheduledJobQueue.__new__(_ScheduledJobQueue)
-        svc._job_queue._lock = FairAsyncRLock()
-        svc._job_queue._queue = HeapQueue()
-        svc._job_queue.logger = MagicMock()
+        queue = _ScheduledJobQueue.__new__(_ScheduledJobQueue)
+        queue._lock = FairAsyncRLock()
+        queue._queue = HeapQueue()
+        queue.logger = MagicMock()
 
         # next_run is in the past, but fire_at is in the future (jitter applied)
         base_time = date_utils.now()
@@ -250,11 +238,11 @@ class TestJitter:
         job.set_next_run(base_time.add(seconds=-10))  # next_run in past
         job.fire_at = future_fire  # fire_at in future
 
-        await svc._job_queue.add(job)
+        await queue.add(job)
 
         # Ask for due jobs at current time — job should NOT be dequeued (fire_at > now)
         current_time = date_utils.now()
-        due_jobs, next_run_time = await svc._job_queue.pop_due_and_peek_next(current_time)
+        due_jobs, next_run_time = await queue.pop_due_and_peek_next(current_time)
 
         assert len(due_jobs) == 0, f"Job should not fire yet (fire_at={job.fire_at} > now={current_time})"
         assert next_run_time == job.fire_at
@@ -326,16 +314,7 @@ class TestEnqueueThenRegisterUsesProtocol:
         Verifies that trigger_type in the ScheduledJobRegistration equals
         trigger.trigger_db_type() for an Every trigger (which returns "interval").
         """
-        svc = SchedulerService.__new__(SchedulerService)
-        svc.hassette = MagicMock()
-        svc._removal_callbacks = {}
-        svc._jobs_by_id = {}
-        svc.logger = MagicMock()
-        svc._wakeup_event = asyncio.Event()
-
-        svc._job_queue = MagicMock()
-        svc._job_queue.add = AsyncMock(return_value=None)
-        svc._job_queue.remove_job = AsyncMock(return_value=True)
+        svc = make_scheduler_service()
 
         captured_registrations = []
 
@@ -343,7 +322,6 @@ class TestEnqueueThenRegisterUsesProtocol:
             captured_registrations.append(reg)
             return 42  # fake db_id
 
-        svc._executor = MagicMock()
         svc._executor.register_job = _fake_register_job
 
         trigger = Every(hours=1)
@@ -536,20 +514,11 @@ class TestAddJobDbFailure:
         and fail app startup rather than degrading silently. The job is NOT
         enqueued when registration fails.
         """
-        svc = SchedulerService.__new__(SchedulerService)
-        svc.hassette = MagicMock()
-        svc._removal_callbacks = {}
-        svc._jobs_by_id = {}
-        svc.logger = MagicMock()
-        svc._wakeup_event = asyncio.Event()
-
-        svc._job_queue = MagicMock()
-        svc._job_queue.add = AsyncMock(return_value=None)
+        svc = make_scheduler_service()
 
         async def _failing_register_job(_reg):
             raise RuntimeError("DB unavailable")
 
-        svc._executor = MagicMock()
         svc._executor.register_job = _failing_register_job
 
         trigger = Every(hours=1)


### PR DESCRIPTION
## Summary

`test_scheduler_service_reschedule.py` had a few tests that bypassed `SchedulerService.__init__` via `SchedulerService.__new__(SchedulerService)` and then hand-assembled the instance's internals (`hassette`, `_removal_callbacks`, `logger`, `_wakeup_event`, `_job_queue`, `_executor`) field by field. Most of the file already used the shared `make_scheduler_service()` factory from `conftest.py`; these were leftover doubles that predated that factory's introduction.

This PR converts the remaining `SchedulerService.__new__` sites to use `make_scheduler_service()`, matching the rest of the file. One `_ScheduledJobQueue.__new__` construction remains — it's a genuine unit test of the queue class itself (not `SchedulerService`), so it's an appropriate boundary-level double rather than a `SchedulerService` shortcut, and is left as-is.

## Testing

- `uv run pytest tests/unit/core/test_scheduler_service_reschedule.py -v` — 29 passed
- `uv run nox -s dev` — 8485 passed, 1 skipped, 2 xfailed
- `prek -a` — all hooks pass (frontend hooks required `npm install` in this worktree first, per the worktree setup convention)
- `prek pyright -a --stage pre-push` — passed

Closes #1072