### PR TITLE
fix: run demo container as non-root to prevent root-owned files

### DIFF
--- a/scripts/capture_screenshots.py
+++ b/scripts/capture_screenshots.py
@@ -67,8 +67,9 @@ def _clean_stale_demo_db(repo_root: Path) -> None:
             try:
                 db_file.unlink()
             except PermissionError:
+                # Pre-existing root-owned files from before the non-root container fix
                 print(
-                    f"WARNING: cannot delete root-owned {db_file.name} (will be overwritten by the new demo run)",
+                    f"WARNING: cannot delete root-owned {db_file.name} — run: sudo rm -rf .demo-data",
                     file=sys.stderr,
                     flush=True,
                 )

--- a/scripts/capture_screenshots.py
+++ b/scripts/capture_screenshots.py
@@ -69,7 +69,7 @@ def _clean_stale_demo_db(repo_root: Path) -> None:
             except PermissionError:
                 # Pre-existing root-owned files from before the non-root container fix
                 print(
-                    f"WARNING: cannot delete root-owned {db_file.name} — run: sudo rm -rf .demo-data",
+                    f"WARNING: cannot delete root-owned {db_file.name} — run: sudo rm -rf {repo_root / '.demo-data'}",
                     file=sys.stderr,
                     flush=True,
                 )

--- a/scripts/demo_stack.py
+++ b/scripts/demo_stack.py
@@ -109,12 +109,17 @@ class DemoStack:
             self._tmp_dir = None
             raise
 
+        # Pre-create so Docker doesn't auto-create it as root on first bind-mount
+        (self._repo_root / ".demo-data").mkdir(exist_ok=True)
+
         env = {
             **os.environ,
             "HA_CONFIG_PATH": self._tmp_dir,
             "DEMO_HA_PORT": str(self._ha_port),
             "DEMO_HASSETTE_PORT": str(self._hassette_port),
             "DEMO_VITE_PORT": str(self._vite_port),
+            "HOST_UID": str(os.getuid()),
+            "HOST_GID": str(os.getgid()),
         }
 
         try:

--- a/scripts/docker/Dockerfile.hassette-dev
+++ b/scripts/docker/Dockerfile.hassette-dev
@@ -4,7 +4,7 @@ COPY --from=ghcr.io/astral-sh/uv:0.11.26 /uv /bin/uv
 
 ARG UID=1000
 ARG GID=1000
-RUN groupadd --gid "$GID" hassette \
+RUN (getent group "$GID" >/dev/null 2>&1 || groupadd --gid "$GID" hassette) \
     && useradd --uid "$UID" --gid "$GID" --create-home hassette \
     && mkdir -p /opt/venv \
     && chown hassette:hassette /opt/venv

--- a/scripts/docker/Dockerfile.hassette-dev
+++ b/scripts/docker/Dockerfile.hassette-dev
@@ -1,6 +1,15 @@
 FROM python:3.14.6-slim
 RUN apt-get update && apt-get install -y --no-install-recommends curl && rm -rf /var/lib/apt/lists/*
 COPY --from=ghcr.io/astral-sh/uv:0.11.26 /uv /bin/uv
+
+ARG UID=1000
+ARG GID=1000
+RUN groupadd --gid "$GID" hassette \
+    && useradd --uid "$UID" --gid "$GID" --create-home hassette \
+    && mkdir -p /opt/venv \
+    && chown hassette:hassette /opt/venv
+
 ENV UV_PROJECT_ENVIRONMENT=/opt/venv
+USER hassette
 WORKDIR /app
 CMD ["sh", "-c", "uv sync --locked && exec uv run python -m hassette --config-file examples/hassette.toml run"]

--- a/scripts/docker/ha-demo.yml
+++ b/scripts/docker/ha-demo.yml
@@ -19,6 +19,9 @@ services:
     build:
       context: ../..
       dockerfile: scripts/docker/Dockerfile.hassette-dev
+      args:
+        UID: "${HOST_UID:-1000}"
+        GID: "${HOST_GID:-1000}"
     container_name: "hassette-demo-hassette"
     ports:
       - "127.0.0.1:${DEMO_HASSETTE_PORT:-18126}:8126"


### PR DESCRIPTION
### Demo container runs as non-root

- `Dockerfile.hassette-dev` now creates a `hassette` user with parameterized `UID`/`GID` build args and switches to it before `CMD`, matching the pattern already used in the production Dockerfile. Docker's default is to run as root, which is fine in an ephemeral CI container but leaves `.demo-data/` files on the host owned by root — those files then block `git worktree remove` (and plain `rm -rf`) from cleaning up, since the invoking user lacks permission to delete them.
- `ha-demo.yml` wires `HOST_UID`/`HOST_GID` through as build args (defaulting to `1000` when unset), so the container's user ID matches whichever host user built the image.
- `DemoStack.__enter__` (`scripts/demo_stack.py`) now sets `HOST_UID`/`HOST_GID` from `os.getuid()`/`os.getgid()` in the compose environment, and pre-creates `.demo-data/` on the host *before* Docker Compose starts — otherwise Docker auto-creates the bind-mount target as root on first use, defeating the point of running the container as a non-root user.
- `capture_screenshots.py`'s stale-DB cleanup `PermissionError` handler now tells the user exactly how to recover (`sudo rm -rf .demo-data`) instead of just warning and continuing — this is a one-time transition message for anyone with pre-existing root-owned files from before this fix; new runs won't hit it.

Closes #1505
