### PR TITLE
fix: eliminate CI-flaky tests from suppressed timeouts and races

### DIFF
--- a/src/hassette/test_utils/config.py
+++ b/src/hassette/test_utils/config.py
@@ -32,6 +32,11 @@ numbered file to migrations_sql/."""
 # at test teardown. Generous relative to test workloads so it never masks a real hang.
 TEST_SYNC_EXECUTOR_SHUTDOWN_TIMEOUT_SECONDS = 5.0
 
+# Matches the production default (WebSocketConfig.total_timeout_seconds). Tests use this
+# instead of a tight override to avoid the config-driven real-clock timeout race
+# documented in CLAUDE.md.
+TEST_TOTAL_TIMEOUT_SECONDS = 30
+
 # Cached (hermetic_subclass, init_kwargs_ref) pair — avoids creating a new class per
 # make_test_config call, which would accumulate permanently in __subclasses__()
 # and Pydantic's internal model cache.

--- a/src/hassette/test_utils/mock_hassette.py
+++ b/src/hassette/test_utils/mock_hassette.py
@@ -189,8 +189,10 @@ def make_ws_hassette_stub(*, strict_lifecycle: bool = False, sealed: bool = True
     Both test files share an identical config shape — this wrapper eliminates duplication.
 
     The ``websocket.*`` overrides use low retry/timeout values (sub-millisecond for backoff,
-    low-single-digit seconds for connection timeouts) so tests complete quickly. The
-    non-websocket overrides set DEBUG logging and fast lifecycle timeouts.
+    low-single-digit seconds for per-phase timeouts) so tests complete quickly.
+    ``total_timeout_seconds`` is kept at the production default (30) to avoid the
+    config-driven real-clock timeout race documented in CLAUDE.md. The non-websocket
+    overrides set DEBUG logging and fast lifecycle timeouts.
 
     Args:
         strict_lifecycle: Passed through to ``make_mock_hassette()`` as a config override.
@@ -210,7 +212,7 @@ def make_ws_hassette_stub(*, strict_lifecycle: bool = False, sealed: bool = True
         websocket={
             "response_timeout_seconds": 1,
             "connection_timeout_seconds": 1,
-            "total_timeout_seconds": 2,
+            "total_timeout_seconds": 30,
             "heartbeat_interval_seconds": 5,
             "authentication_timeout_seconds": 5,
             "connect_retry_max_attempts": 3,

--- a/src/hassette/test_utils/mock_hassette.py
+++ b/src/hassette/test_utils/mock_hassette.py
@@ -13,7 +13,7 @@ from pathlib import Path
 from typing import Any
 from unittest.mock import AsyncMock, Mock, seal
 
-from hassette.test_utils.config import TEST_WS_URL, make_test_config
+from hassette.test_utils.config import TEST_TOTAL_TIMEOUT_SECONDS, TEST_WS_URL, make_test_config
 
 
 def make_mock_hassette(
@@ -190,9 +190,9 @@ def make_ws_hassette_stub(*, strict_lifecycle: bool = False, sealed: bool = True
 
     The ``websocket.*`` overrides use low retry/timeout values (sub-millisecond for backoff,
     low-single-digit seconds for per-phase timeouts) so tests complete quickly.
-    ``total_timeout_seconds`` is kept at the production default (30) to avoid the
-    config-driven real-clock timeout race documented in CLAUDE.md. The non-websocket
-    overrides set DEBUG logging and fast lifecycle timeouts.
+    ``total_timeout_seconds`` uses ``TEST_TOTAL_TIMEOUT_SECONDS`` (the production default)
+    to avoid the config-driven real-clock timeout race documented in CLAUDE.md. The
+    non-websocket overrides set DEBUG logging and fast lifecycle timeouts.
 
     Args:
         strict_lifecycle: Passed through to ``make_mock_hassette()`` as a config override.
@@ -212,7 +212,7 @@ def make_ws_hassette_stub(*, strict_lifecycle: bool = False, sealed: bool = True
         websocket={
             "response_timeout_seconds": 1,
             "connection_timeout_seconds": 1,
-            "total_timeout_seconds": 30,
+            "total_timeout_seconds": TEST_TOTAL_TIMEOUT_SECONDS,
             "heartbeat_interval_seconds": 5,
             "authentication_timeout_seconds": 5,
             "connect_retry_max_attempts": 3,

--- a/src/hassette/test_utils/ws_mocks.py
+++ b/src/hassette/test_utils/ws_mocks.py
@@ -15,6 +15,7 @@ from unittest.mock import AsyncMock, Mock
 from aiohttp import ClientWebSocketResponse
 
 from hassette.resources.lifecycle import mark_ready
+from hassette.test_utils.config import TEST_TOTAL_TIMEOUT_SECONDS
 from hassette.types.enums import ConnectionState
 
 if TYPE_CHECKING:
@@ -69,7 +70,7 @@ def configure_ready_websocket_mock(websocket_service: Mock, *, generation: int =
     websocket_service.is_connected = True
     websocket_service.has_ever_connected = True
     websocket_service.get_connected_generation = Mock(return_value=generation)
-    websocket_service.total_timeout_seconds = 30
+    websocket_service.total_timeout_seconds = TEST_TOTAL_TIMEOUT_SECONDS
     websocket_service.wait_connected = AsyncMock(return_value=True)
     websocket_service.wait_connected_generation = AsyncMock(return_value=generation)
     websocket_service.wait_initial_connection = AsyncMock(return_value=True)

--- a/src/hassette/test_utils/ws_mocks.py
+++ b/src/hassette/test_utils/ws_mocks.py
@@ -69,7 +69,7 @@ def configure_ready_websocket_mock(websocket_service: Mock, *, generation: int =
     websocket_service.is_connected = True
     websocket_service.has_ever_connected = True
     websocket_service.get_connected_generation = Mock(return_value=generation)
-    websocket_service.total_timeout_seconds = 1
+    websocket_service.total_timeout_seconds = 30
     websocket_service.wait_connected = AsyncMock(return_value=True)
     websocket_service.wait_connected_generation = AsyncMock(return_value=generation)
     websocket_service.wait_initial_connection = AsyncMock(return_value=True)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -69,7 +69,8 @@ def build_websocket_config() -> WebSocketConfig:
     return WebSocketConfig(
         connection_timeout_seconds=1,
         authentication_timeout_seconds=1,
-        total_timeout_seconds=2,
+        # Matches production default; see CLAUDE.md "Config-driven real-clock timeouts".
+        total_timeout_seconds=30,
         response_timeout_seconds=1,
         heartbeat_interval_seconds=5,
     )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -69,7 +69,7 @@ def build_websocket_config() -> WebSocketConfig:
     return WebSocketConfig(
         connection_timeout_seconds=1,
         authentication_timeout_seconds=1,
-        # Matches production default; see CLAUDE.md "Config-driven real-clock timeouts".
+        # Keep in sync with TEST_TOTAL_TIMEOUT_SECONDS in hassette.test_utils.config.
         total_timeout_seconds=30,
         response_timeout_seconds=1,
         heartbeat_interval_seconds=5,

--- a/tests/integration/bus/test_bus.py
+++ b/tests/integration/bus/test_bus.py
@@ -1,7 +1,6 @@
 # pyright: reportInvalidTypeArguments=none, reportArgumentType=none
 
 import asyncio
-import contextlib
 import inspect
 from types import SimpleNamespace
 from typing import TYPE_CHECKING
@@ -340,8 +339,7 @@ async def assert_glob_matching(
             create_state_change_event(entity_id=entity, old_value="off", new_value="on", new_attrs=attrs),
         )
 
-    with contextlib.suppress(asyncio.TimeoutError):
-        await asyncio.wait_for(events_processed.wait(), timeout=0.2)
+    await asyncio.wait_for(events_processed.wait(), timeout=5.0)
 
     actual = set(received_entity_ids)
     assert actual == expected, f"Expected handler to receive {expected}, got {actual}"
@@ -401,8 +399,7 @@ async def test_can_subscribe_to_all_state_change_events(hassette_with_bus: "Hass
     await hassette.send_event(create_state_change_event(entity_id="light.living_room", old_value="off", new_value="on"))
     await hassette.send_event(create_state_change_event(entity_id="switch.garage", old_value="off", new_value="on"))
 
-    with contextlib.suppress(asyncio.TimeoutError):
-        await asyncio.wait_for(events_processed.wait(), timeout=0.2)
+    await asyncio.wait_for(events_processed.wait(), timeout=5.0)
 
     actual = set(received_entity_ids)
 

--- a/tests/integration/telemetry/test_blocking_io_executor_offload.py
+++ b/tests/integration/telemetry/test_blocking_io_executor_offload.py
@@ -272,8 +272,11 @@ class TestExecutorOffloadProducesNoBlocking:
             # regression here.
             orig_lag = mock_hassette.config.blocking_io.lag_threshold_seconds
             orig_interval = mock_hassette.config.blocking_io.watchdog_interval_seconds
-            mock_hassette.config.blocking_io.lag_threshold_seconds = 0.05
-            mock_hassette.config.blocking_io.watchdog_interval_seconds = 0.01
+            # CI scheduling jitter produces 58-71ms loop lag even with no blocking I/O;
+            # 50ms tripped false positives. 150ms tolerates jitter while still detecting
+            # real stalls (multi-hundred-ms).
+            mock_hassette.config.blocking_io.lag_threshold_seconds = 0.15
+            mock_hassette.config.blocking_io.watchdog_interval_seconds = 0.03
 
             stall_events: list[object] = []
             watchdog = LoopWatchdog(

--- a/tests/integration/test_dashboard_without_ha.py
+++ b/tests/integration/test_dashboard_without_ha.py
@@ -21,6 +21,7 @@ from httpx2 import ASGITransport, AsyncClient, Response
 
 from hassette import Hassette
 from hassette.test_utils import make_light_state_dict, wait_for
+from hassette.test_utils.config import TEST_TOTAL_TIMEOUT_SECONDS
 from hassette.test_utils.helpers import cleanup_hassette_streams
 from hassette.types.enums import ConnectionState
 from hassette.web.app import create_fastapi_app
@@ -67,7 +68,7 @@ async def _running_hassette_without_ha(
     config = TestConfig(
         data_dir=tmp_path / "data",
         web_api={"run": True, "port": unused_tcp_port_factory()},
-        websocket={"total_timeout_seconds": 30},
+        websocket={"total_timeout_seconds": TEST_TOTAL_TIMEOUT_SECONDS},
         apps={
             "directory": TEST_APPS_PATH,
             "autodetect": False,
@@ -178,7 +179,7 @@ class TestInitialStateSyncBeforeApps:
             # release_connection.set() is called) or StateProxy._bootstrap_initial_sync gives up on
             # the connection before that release fires — this raced and flaked under CI scheduling
             # jitter at 2s. See CLAUDE.md's "Config-driven real-clock timeouts" pattern.
-            websocket={"total_timeout_seconds": 30},
+            websocket={"total_timeout_seconds": TEST_TOTAL_TIMEOUT_SECONDS},
             apps={
                 "directory": app_dir,
                 "autodetect": False,

--- a/tests/integration/test_dashboard_without_ha.py
+++ b/tests/integration/test_dashboard_without_ha.py
@@ -67,7 +67,7 @@ async def _running_hassette_without_ha(
     config = TestConfig(
         data_dir=tmp_path / "data",
         web_api={"run": True, "port": unused_tcp_port_factory()},
-        websocket={"total_timeout_seconds": 1},
+        websocket={"total_timeout_seconds": 30},
         apps={
             "directory": TEST_APPS_PATH,
             "autodetect": False,
@@ -228,8 +228,8 @@ class TestInitialStateSyncBeforeApps:
 
         run_task = asyncio.create_task(hassette.run_forever())
         try:
-            await asyncio.wait_for(connection_attempted.wait(), timeout=1)
-            await asyncio.wait_for(state_proxy_subscribed.wait(), timeout=1)
+            await asyncio.wait_for(connection_attempted.wait(), timeout=5)
+            await asyncio.wait_for(state_proxy_subscribed.wait(), timeout=5)
 
             with pytest.raises(TimeoutError):
                 await asyncio.wait_for(load_cache_entered.wait(), timeout=1)
@@ -242,7 +242,7 @@ class TestInitialStateSyncBeforeApps:
                 timeout=WEBAPI_READY_TIMEOUT,
                 desc="state-reading app ready",
             )
-            await asyncio.wait_for(load_cache_entered.wait(), timeout=1)
+            await asyncio.wait_for(load_cache_entered.wait(), timeout=5)
             hassette.api.get_states_raw.assert_awaited_once()
 
             app = hassette.app_handler.registry.get("state_reader", 0)

--- a/tests/integration/test_file_watcher.py
+++ b/tests/integration/test_file_watcher.py
@@ -1,9 +1,9 @@
 import asyncio
-import contextlib
 import typing
 from typing import Any
 
 import anyio
+import pytest
 
 from hassette.events.hassette import Event
 from hassette.types import Topic
@@ -38,11 +38,14 @@ async def test_event_emitted_on_file_change(hassette_with_file_watcher: "Hassett
     assert updated_files, "No watchable files found to touch in test_event_emitted_on_file_change"
 
     # Event emission can be racy, so retry briefly.
-    for _ in range(2):
-        with contextlib.suppress(asyncio.TimeoutError):
-            with anyio.fail_after(1):
+    for attempt in range(2):
+        try:
+            with anyio.fail_after(2):
                 await file_event_received.wait()
                 assert file_event_received.is_set(), (
                     f"Expected file_event_received to be set, got {file_event_received.is_set()}"
                 )
                 return
+        except TimeoutError:
+            if attempt == 1:
+                pytest.fail("file_event_received was never set after 2 attempts")

--- a/tests/integration/test_state_proxy.py
+++ b/tests/integration/test_state_proxy.py
@@ -10,6 +10,7 @@ from hassette.events.metadata import stamp_websocket_generation
 from hassette.exceptions import ResourceNotReadyError
 from hassette.resources.lifecycle import mark_ready
 from hassette.test_utils import make_full_state_change_event, make_light_state_dict, make_mock_hassette
+from hassette.test_utils.config import TEST_TOTAL_TIMEOUT_SECONDS
 from hassette.test_utils.ws_mocks import configure_ready_websocket_mock
 
 # Generous bound for deterministic gate/task waits below — long enough to absorb slow CI,
@@ -168,7 +169,7 @@ async def test_duplicate_startup_and_connected_signals_coalesce_one_initial_sync
     release_snapshot = asyncio.Event()
 
     async def blocked_wait_initial_connection(*, timeout: float | None = None) -> bool:
-        assert timeout == 30
+        assert timeout == TEST_TOTAL_TIMEOUT_SECONDS
         wait_entered.set()
         await release_wait.wait()
         return True

--- a/tests/integration/test_state_proxy.py
+++ b/tests/integration/test_state_proxy.py
@@ -168,7 +168,7 @@ async def test_duplicate_startup_and_connected_signals_coalesce_one_initial_sync
     release_snapshot = asyncio.Event()
 
     async def blocked_wait_initial_connection(*, timeout: float | None = None) -> bool:
-        assert timeout == 1
+        assert timeout == 30
         wait_entered.set()
         await release_wait.wait()
         return True


### PR DESCRIPTION
### Suppressed-timeout anti-pattern (bus glob tests, file watcher)

`contextlib.suppress(asyncio.TimeoutError)` around a wait, with no follow-up check, silently
swallows a real timeout and lets the test fall through to whatever partial state existed at that
moment. Under CI load the wait was genuinely too short (200ms in `test_bus.py`), so the assertion
below failed on incomplete data instead of the timeout failing loudly with a clear message.

- `tests/integration/bus/test_bus.py`: removed the suppress, widened the glob-matching wait from
  200ms to 5s. A real timeout now raises instead of being swallowed.
- `tests/integration/test_file_watcher.py`: replaced the same suppress-then-fall-through pattern
  with an explicit `pytest.fail` on the final retry, so a persistent failure is loud instead of
  silently passing through an empty retry loop.

### Watchdog lag threshold too tight for CI (`test_blocking_io_executor_offload.py`)

`lag_threshold_seconds=0.05` tripped false positives from ordinary CI scheduling jitter — observed
lag of 58-71ms with no actual blocking I/O in play. Widened to 150ms (comment explains the
observed jitter range) and adjusted `watchdog_interval_seconds` from 10ms to 30ms proportionally,
so the watchdog still catches real multi-hundred-ms stalls.

### Config-driven real-clock timeout races (partial #1503)

Several tests override `websocket.total_timeout_seconds` to a small value (1-2s) for speed, while
holding a real-time delay elsewhere in the same test to prove something hasn't happened yet. The
two clocks race independently; CI's noisier scheduling is what eventually exposes the collision
(see CLAUDE.md's "Config-driven real-clock timeouts" regression pattern, written after this exact
failure mode hit `test_dashboard_without_ha.py` in PR #1500).

- Added `TEST_TOTAL_TIMEOUT_SECONDS = 30` to `src/hassette/test_utils/config.py` — matches
  `WebSocketConfig.total_timeout_seconds`'s production default, so tests get a realistic
  real-world margin instead of an arbitrary tight number.
- Replaced hardcoded `1`/`2` overrides with the shared constant in `mock_hassette.py`,
  `ws_mocks.py`, `tests/conftest.py`, `test_dashboard_without_ha.py`, and `test_state_proxy.py`.
- Widened the "must happen quickly" `wait_for` calls in `test_dashboard_without_ha.py` from 1s to
  5s to keep headroom over the new 30s config value.

This covers the sites this branch touched, not the full audit scope in #1503 (unit-test sites
like `test_wait_for.py`, `test_execution_timeout.py`, etc. are still open) — partially addresses
#1503, does not close it.
