### PR TITLE
feat: automate external contributor attribution and GitHub Release sync

### DIFF
--- a/.claude/commands/changelog-review.md
+++ b/.claude/commands/changelog-review.md
@@ -28,6 +28,20 @@ For each commit that produced a changelog entry, fetch its PR body via `gh pr vi
 - Breaking change migration details
 - Whether the change is internal-only
 
+## Step 3.5: Check for external contributors
+
+Run `uv run python scripts/release_contributors.py <prev-tag> <base-commit>` (using the same range from Step 3).
+
+If external contributors are found, surface them as a finding:
+
+> **External contributors detected — ensure attribution in the changelog:**
+>
+> <script output>
+
+When rewriting entries in Step 4, add "thanks @username!" (or "thanks Name!" if no GitHub username is available) to the relevant changelog bullet. See v0.24.0's `@mlsteele` attribution for the format.
+
+If no external contributors are found, continue silently.
+
 ## Step 4: Rewrite
 
 Rewrite the release section to match the v0.24.0 style:

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -109,6 +109,58 @@ jobs:
                       sleep $((attempt * 3))
                   done
 
+    # After a release is created, replace the auto-generated GitHub Release notes
+    # with the curated section from CHANGELOG.md (which we edit on the release-please
+    # branch before merging). The auto-generated notes are release-please's raw PR
+    # list; the curated version groups by topic, removes internal entries, and adds
+    # contributor attribution.
+    sync-release-notes:
+        needs: release-please
+        if: >-
+            always()
+            && (
+              (github.event_name == 'push' && needs.release-please.outputs.release_created == 'true')
+              || github.event_name == 'workflow_dispatch'
+            )
+        runs-on: ubuntu-latest
+        timeout-minutes: 5
+        steps:
+            - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+              with:
+                  ref: ${{ needs.release-please.outputs.tag_name || inputs.tag_name }}
+                  persist-credentials: false
+
+            # github.token (not the app token) is sufficient here: we only need
+            # contents:write to edit the release body, and unlike sync-lockfile's
+            # git push, this doesn't need to re-trigger downstream workflows.
+            - name: Extract and sync release notes
+              env:
+                  GH_TOKEN: ${{ github.token }}
+                  TAG_NAME: ${{ needs.release-please.outputs.tag_name || inputs.tag_name }}
+              run: |
+                  set -euo pipefail
+
+                  version="${TAG_NAME#v}"
+
+                  # Extract the section for this version from CHANGELOG.md.
+                  # Captures everything between "## [<version>]" and the next "## [" heading.
+                  notes=$(awk -v ver="$version" '
+                    /^## \[/ {
+                      if (found) exit
+                      if (index($0, "## [" ver "]")) found=1
+                      next
+                    }
+                    found { print }
+                  ' CHANGELOG.md)
+
+                  if [ -z "$notes" ]; then
+                      echo "::warning::No CHANGELOG.md section found for version ${version} — skipping release notes sync"
+                      exit 0
+                  fi
+
+                  echo "Syncing $(echo "$notes" | wc -l) lines of curated notes to GitHub Release ${TAG_NAME}"
+                  gh release edit "$TAG_NAME" --notes "$notes"
+
     build-pypi:
         needs: release-please
         if: >-

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -159,7 +159,10 @@ jobs:
                   fi
 
                   echo "Syncing $(echo "$notes" | wc -l) lines of curated notes to GitHub Release ${TAG_NAME}"
-                  gh release edit "$TAG_NAME" --notes "$notes"
+                  notes_file=$(mktemp)
+                  printf '%s\n' "$notes" > "$notes_file"
+                  gh release edit "$TAG_NAME" --notes-file "$notes_file"
+                  rm -f "$notes_file"
 
     build-pypi:
         needs: release-please

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -16,6 +16,9 @@ Operational scripts for building, running, and demoing hassette.
 - **`hassette_demo.py`** — thin wrapper around `DemoStack` for interactive visual
   QA: starts the compose stack, prints URLs, blocks until signaled; also
   `mise run demo`. See CLAUDE.md → "Demo Stack & Doc Screenshots".
+- **`release_contributors.py`** — find external contributors between two git
+  tags. Filters bots and repo owner, resolves GitHub usernames from noreply
+  emails. Used by the `changelog-review` command during release prep.
 - **`docker_start.sh`** — Docker container entrypoint.
 - **`docker/`** — Docker Compose configs for demo/test environments
   (`ha-demo.yml` defines the HA + hassette + Vite demo stack;

--- a/scripts/release_contributors.py
+++ b/scripts/release_contributors.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3
+"""Find external contributors between two git tags.
+
+Usage:
+    uv run python scripts/release_contributors.py v0.50.0 v0.51.0
+    uv run python scripts/release_contributors.py v0.50.0 HEAD
+    uv run python scripts/release_contributors.py              # auto: second-latest tag..latest tag
+
+Scans git log for authors who are not the repo owner or bots, and prints
+each contributor with their associated PRs.
+"""
+
+import argparse
+import re
+import subprocess
+import sys
+
+OWNER_EMAILS = frozenset(
+    {
+        "8505845+NodeJSmith@users.noreply.github.com",
+    }
+)
+
+OWNER_NAMES = frozenset(
+    {
+        "Jessica Smith",
+    }
+)
+
+BOT_PATTERNS = re.compile(r"\[bot\]|dependabot|renovate", re.IGNORECASE)
+
+
+def git(*args: str) -> str:
+    result = subprocess.run(
+        ["git", *args],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return result.stdout.strip()
+
+
+def get_latest_tags(count: int = 2) -> list[str]:
+    output = git("tag", "--sort=-v:refname", "--list", "v*")
+    return output.splitlines()[:count]
+
+
+def get_commits(from_ref: str, to_ref: str) -> list[dict[str, str]]:
+    sep = "§§"
+    log_format = f"%an{sep}%ae{sep}%s"
+    output = git("log", f"--format={log_format}", f"{from_ref}..{to_ref}")
+    if not output:
+        return []
+
+    commits = []
+    for line in output.splitlines():
+        parts = line.split(sep, 2)
+        if len(parts) != 3:
+            continue
+        commits.append({"name": parts[0], "email": parts[1], "subject": parts[2]})
+    return commits
+
+
+def is_external(name: str, email: str) -> bool:
+    if name in OWNER_NAMES or email in OWNER_EMAILS:
+        return False
+    if BOT_PATTERNS.search(name) or BOT_PATTERNS.search(email):
+        return False
+    return True
+
+
+def parse_github_username(email: str) -> str | None:
+    m = re.match(r"(?:\d+\+)?(.+)@users\.noreply\.github\.com", email)
+    return m.group(1) if m else None
+
+
+def find_external_contributors(from_ref: str, to_ref: str) -> dict[str, list[dict[str, str]]]:
+    commits = get_commits(from_ref, to_ref)
+    contributors: dict[str, list[dict[str, str]]] = {}
+
+    for commit in commits:
+        if not is_external(commit["name"], commit["email"]):
+            continue
+
+        name = commit["name"]
+        entry = {"subject": commit["subject"], "email": commit["email"]}
+
+        if name not in contributors:
+            contributors[name] = []
+        contributors[name].append(entry)
+
+    return contributors
+
+
+def print_contributors(
+    contributors: dict[str, list[dict[str, str]]],
+    from_ref: str,
+    to_ref: str,
+) -> None:
+    if not contributors:
+        print(f"No external contributors found in {from_ref}..{to_ref}")
+        return
+
+    print(f"External contributors in {from_ref}..{to_ref}:\n")
+    for name, entries in sorted(contributors.items()):
+        username = None
+        for entry in entries:
+            username = parse_github_username(entry["email"])
+            if username:
+                break
+
+        display = f"@{username}" if username else name
+        print(f"  {display}")
+        for entry in entries:
+            print(f"    - {entry['subject']}")
+        print()
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Find external contributors between git tags.")
+    parser.add_argument("from_ref", nargs="?", help="Start ref (default: second-latest tag)")
+    parser.add_argument("to_ref", nargs="?", default="HEAD", help="End ref (default: HEAD)")
+    args = parser.parse_args()
+
+    if args.from_ref is None:
+        tags = get_latest_tags(2)
+        if len(tags) < 1:
+            print("No tags found. Provide explicit refs.", file=sys.stderr)
+            return 1
+        if len(tags) < 2:
+            args.from_ref = tags[0]
+            print(f"Only one tag found, scanning {args.from_ref}..HEAD\n")
+        else:
+            args.from_ref = tags[1]
+            args.to_ref = tags[0]
+            print(f"Auto-detected range: {args.from_ref}..{args.to_ref}\n")
+
+    contributors = find_external_contributors(args.from_ref, args.to_ref)
+    print_contributors(contributors, args.from_ref, args.to_ref)
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Automates two manual steps from the release prep workflow that were identified during v0.51.0 release (#1508):

1. **Contributor detection** — `scripts/release_contributors.py` scans git log between tags, filters bots and repo owner, and resolves GitHub usernames from noreply emails. Integrated into the `changelog-review` command (Step 3.5) so unattributed external contributors surface as findings before the release PR is merged.

2. **GitHub Release sync** — new `sync-release-notes` job in the release-please workflow extracts the curated section from `CHANGELOG.md` and replaces the auto-generated release notes via `gh release edit`. Runs on both release creation and `workflow_dispatch` (for manual recovery).

Also backfilled 30 existing GitHub Releases (v0.3.1 through v0.50.0) with their curated CHANGELOG.md content — those were previously showing the raw release-please format.

## Changes

- `scripts/release_contributors.py` — new script
- `scripts/README.md` — added entry
- `.claude/commands/changelog-review.md` — added Step 3.5
- `.github/workflows/release-please.yml` — added `sync-release-notes` job

Closes #1508