### PR TITLE
perf(ui): scope AppDetailPage store selectors to its own app

### DIFF
--- a/frontend/src/pages/app-detail.rerender.test.tsx
+++ b/frontend/src/pages/app-detail.rerender.test.tsx
@@ -1,0 +1,119 @@
+import { act } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { WsExecutionCompletedPayload } from "../api/ws-types";
+import { appStatusKey, useAppStore } from "../state/store";
+import { createManifest } from "../test/factories";
+import { createWouterMock } from "../test/mock-wouter";
+import { renderWithAppState } from "../test/render-helpers";
+import { AppDetailPage } from "./app-detail";
+import { setupApi } from "./app-detail.test-helpers";
+
+const mockNavigate = vi.fn();
+
+vi.mock("wouter", () =>
+  createWouterMock({
+    useLocation: () => ["/apps/test_app", mockNavigate],
+    useSearch: () => "",
+  }),
+);
+
+// Render counter for the page body. `OverviewTab` is not memoized, so it renders exactly once per
+// AppDetailPage render — that makes it the seam for asserting the page stayed put.
+const counter = vi.hoisted(() => ({ renders: 0 }));
+
+vi.mock("../components/app-detail/overview-tab", () => ({
+  OverviewTab: ({ appStatus }: { appStatus?: string }) => {
+    counter.renders += 1;
+    return <div data-testid="overview-tab">{appStatus}</div>;
+  },
+}));
+
+// Stub child components not under test. Shared stub factories live in app-detail.test-helpers —
+// imported dynamically (not as a static top-level import) because these vi.mock factories run
+// while this file's own real "./app-detail" import is still resolving, and a static import here
+// would be in the TDZ at that point.
+vi.mock("../components/shared/error-banner", async () =>
+  (await import("./app-detail.test-helpers")).createErrorBannerStub(),
+);
+vi.mock("../components/app-detail/handlers-tab", async () =>
+  (await import("./app-detail.test-helpers")).createHandlersTabStub(),
+);
+vi.mock("../components/app-detail/code-tab", async () =>
+  (await import("./app-detail.test-helpers")).createCodeTabStub(),
+);
+vi.mock("../components/app-detail/config-tab", async () =>
+  (await import("./app-detail.test-helpers")).createConfigTabStub(),
+);
+vi.mock("../components/shared/log-table", async () => (await import("./app-detail.test-helpers")).createLogTableStub());
+vi.mock("../components/shared/spinner", async () => (await import("./app-detail.test-helpers")).createSpinnerStub());
+
+vi.mock("../hooks/use-correct-url", () => ({ useCorrectUrl: () => vi.fn() }));
+
+function makeExecution(appKey: string, kind: "handler" | "job"): WsExecutionCompletedPayload {
+  return { kind, app_key: appKey, instance_index: 0, status: "ok", duration_ms: 5 };
+}
+
+/** Renders the overview tab and waits for the initial load to settle. */
+async function renderSettled() {
+  setupApi(createManifest({ app_key: "test_app" }));
+  const view = renderWithAppState(<AppDetailPage params={{ key: "test_app" }} />, {
+    storeOverrides: { uptimeSeconds: 120 },
+  });
+  await view.findByTestId("overview-tab");
+  return view;
+}
+
+describe("AppDetailPage store subscriptions", () => {
+  beforeEach(() => {
+    counter.renders = 0;
+    vi.clearAllMocks();
+  });
+
+  it("does not re-render when an unrelated app's status changes", async () => {
+    await renderSettled();
+    const before = counter.renders;
+
+    act(() => {
+      useAppStore.getState().updateAppStatus(appStatusKey("other_app", 0), { status: "failed", index: 0 });
+    });
+
+    expect(counter.renders).toBe(before);
+  });
+
+  it("re-renders when its own app's status changes", async () => {
+    const { findByTestId } = await renderSettled();
+    const before = counter.renders;
+
+    act(() => {
+      useAppStore.getState().updateAppStatus(appStatusKey("test_app", 0), { status: "failed", index: 0 });
+    });
+
+    expect(counter.renders).toBeGreaterThan(before);
+    expect((await findByTestId("overview-tab")).textContent).toBe("failed");
+  });
+
+  it("does not re-render on an unrelated app's execution completions", async () => {
+    await renderSettled();
+    const before = counter.renders;
+
+    act(() => {
+      useAppStore
+        .getState()
+        .setExecutionCompleted([makeExecution("other_app", "handler"), makeExecution("other_app", "job")]);
+    });
+
+    expect(counter.renders).toBe(before);
+  });
+
+  it("re-renders on its own app's execution completions", async () => {
+    await renderSettled();
+    const before = counter.renders;
+
+    act(() => {
+      useAppStore.getState().setExecutionCompleted([makeExecution("test_app", "handler")]);
+    });
+
+    expect(counter.renders).toBeGreaterThan(before);
+  });
+});

--- a/frontend/src/pages/app-detail.rerender.test.tsx
+++ b/frontend/src/pages/app-detail.rerender.test.tsx
@@ -106,12 +106,12 @@ describe("AppDetailPage store subscriptions", () => {
     expect(counter.renders).toBe(before);
   });
 
-  it("re-renders on its own app's execution completions", async () => {
+  it.each(["handler", "job"] as const)("re-renders on its own app's %s execution completion", async (kind) => {
     await renderSettled();
     const before = counter.renders;
 
     act(() => {
-      useAppStore.getState().setExecutionCompleted([makeExecution("test_app", "handler")]);
+      useAppStore.getState().setExecutionCompleted([makeExecution("test_app", kind)]);
     });
 
     expect(counter.renders).toBeGreaterThan(before);

--- a/frontend/src/pages/app-detail.tsx
+++ b/frontend/src/pages/app-detail.tsx
@@ -95,6 +95,11 @@ function TabPanel({ id, children, className }: { id: TabId; children: ReactNode;
  * to `undefined`, which is `Object.is`-equal to the previous `undefined`, so the store never
  * notifies. The record itself is a fresh object per batch, so consecutive own-app completions do
  * each register as a change.
+ *
+ * One case still costs a render: the batch immediately after this app's own completion selects
+ * back to `undefined`, which is *not* `Object.is`-equal to the previous matched record, so one
+ * extra render fires even if that next batch has nothing to do with this app. Bounded to exactly
+ * one render per own completion — steady-state unrelated activity stays undefined-to-undefined.
  */
 function findExecution(
   events: WsExecutionCompletedPayload[] | null,
@@ -149,8 +154,11 @@ export function AppDetailPage({ params }: Props) {
     { placeholderData: keepPreviousData },
   );
 
-  useQueryInvalidator(handlerExecution, (e) => e !== undefined, queryKeys.appListeners.prefix(appKey));
-  useQueryInvalidator(jobExecution, (e) => e !== undefined, queryKeys.appJobs.prefix(appKey));
+  // Sibling call sites filter the raw fleet-wide batch with `events?.some(...)`; findExecution
+  // above already reduced this to a single matched-or-undefined record, so the filter here only
+  // needs to check definedness.
+  useQueryInvalidator(handlerExecution, (exec) => exec !== undefined, queryKeys.appListeners.prefix(appKey));
+  useQueryInvalidator(jobExecution, (exec) => exec !== undefined, queryKeys.appJobs.prefix(appKey));
 
   const displayListeners = listenersData ?? [];
   const displayJobs = jobsData ?? [];

--- a/frontend/src/pages/app-detail.tsx
+++ b/frontend/src/pages/app-detail.tsx
@@ -6,6 +6,7 @@ import { Link, useLocation } from "wouter";
 import { cn } from "@/lib/utils";
 
 import { getAppJobs, getAppListeners } from "../api/endpoints";
+import type { WsExecutionCompletedPayload } from "../api/ws-types";
 import { AppDetailHeader } from "../components/app-detail/app-detail-header";
 import { AppLogsPanel } from "../components/app-detail/app-logs-panel";
 import { CodeTab } from "../components/app-detail/code-tab";
@@ -86,6 +87,23 @@ function TabPanel({ id, children, className }: { id: TabId; children: ReactNode;
   );
 }
 
+/**
+ * Pick this app's first execution completion of `kind` out of the latest WS batch.
+ *
+ * Selecting the matching record rather than the whole `executionCompleted` batch is what keeps
+ * this page off the fleet-wide render path: a batch carrying only other apps' executions selects
+ * to `undefined`, which is `Object.is`-equal to the previous `undefined`, so the store never
+ * notifies. The record itself is a fresh object per batch, so consecutive own-app completions do
+ * each register as a change.
+ */
+function findExecution(
+  events: WsExecutionCompletedPayload[] | null,
+  appKey: string,
+  kind: "handler" | "job",
+): WsExecutionCompletedPayload | undefined {
+  return events?.find((e) => e.kind === kind && e.app_key === appKey);
+}
+
 function handleTabKeyDown(e: ReactKeyboardEvent) {
   if (e.key !== "ArrowRight" && e.key !== "ArrowLeft") return;
   e.preventDefault();
@@ -99,8 +117,8 @@ function handleTabKeyDown(e: ReactKeyboardEvent) {
 export function AppDetailPage({ params }: Props) {
   const appKey = params.key;
   const activeTab: TabId = params.tab ?? "overview";
-  const appStatus = useAppStore((s) => s.appStatus);
-  const executionCompleted = useAppStore((s) => s.executionCompleted);
+  const handlerExecution = useAppStore((s) => findExecution(s.executionCompleted, appKey, "handler"));
+  const jobExecution = useAppStore((s) => findExecution(s.executionCompleted, appKey, "job"));
   const { data: manifest, isPending: manifestLoading, error: manifestError } = useManifest(appKey);
   const [, navigate] = useLocation();
   const queryParams = useQueryParams();
@@ -131,16 +149,8 @@ export function AppDetailPage({ params }: Props) {
     { placeholderData: keepPreviousData },
   );
 
-  useQueryInvalidator(
-    executionCompleted,
-    (events) => events?.some((e) => e.kind === "handler" && e.app_key === appKey) ?? false,
-    queryKeys.appListeners.prefix(appKey),
-  );
-  useQueryInvalidator(
-    executionCompleted,
-    (events) => events?.some((e) => e.kind === "job" && e.app_key === appKey) ?? false,
-    queryKeys.appJobs.prefix(appKey),
-  );
+  useQueryInvalidator(handlerExecution, (e) => e !== undefined, queryKeys.appListeners.prefix(appKey));
+  useQueryInvalidator(jobExecution, (e) => e !== undefined, queryKeys.appJobs.prefix(appKey));
 
   const displayListeners = listenersData ?? [];
   const displayJobs = jobsData ?? [];
@@ -153,16 +163,15 @@ export function AppDetailPage({ params }: Props) {
   const currentInstance = !showParentOverview
     ? manifest?.instances?.find((i) => i.index === resolvedInstanceIndex)
     : undefined;
-  const wsStatus = appStatus[appStatusKey(appKey, resolvedInstanceIndex)]?.status;
-  const instanceStatus = wsStatus ?? currentInstance?.status ?? manifest?.status ?? "unknown";
-  let liveStatus: string;
-  if (!showParentOverview) {
-    liveStatus = instanceStatus;
-  } else if (manifest) {
-    liveStatus = appLiveStatus(appStatus, manifest);
-  } else {
-    liveStatus = "unknown";
-  }
+  // Resolving the status inside the selector — instead of subscribing to the whole `appStatus`
+  // map — means this page only re-renders when its own app's status actually changes. The
+  // selector must keep returning a primitive for that to hold; a fresh object would compare
+  // unequal on every store write.
+  const liveStatus = useAppStore((s) => {
+    if (showParentOverview) return manifest ? appLiveStatus(s.appStatus, manifest) : "unknown";
+    const wsStatus = s.appStatus[appStatusKey(appKey, resolvedInstanceIndex)]?.status;
+    return wsStatus ?? currentInstance?.status ?? manifest?.status ?? "unknown";
+  });
 
   const hasData = !manifestLoading && listenersData !== undefined && jobsData !== undefined;
   const initialLoading = !hasData && (listenersLoading || jobsLoading || manifestLoading);


### PR DESCRIPTION
## Summary

`AppDetailPage` subscribed to two whole-fleet store fields, so any other app's activity re-rendered the page:

- `useAppStore((s) => s.appStatus)` — the per-app-and-instance status map for *every* app in the install. `updateAppStatus` replaces the whole map object on every single key write, so one app's WS `app_status_changed` invalidated the selector for all subscribers.
- `useAppStore((s) => s.executionCompleted)` — every execution completion fleet-wide, as a fresh array per WS batch.

Both selectors now narrow **inside** the field rather than subscribing to it wholesale:

- `liveStatus` is resolved inside the selector and returns a primitive status string, so the store only notifies when this app's own status actually changes.
- `executionCompleted` is selected down to this app's first matching `handler` / `job` record via a small `findExecution` helper. A batch carrying only other apps' executions selects to `undefined`, which is `Object.is`-equal to the previous `undefined`, so no notification fires. The record is a fresh object per batch, so consecutive own-app completions still register.

The two `useQueryInvalidator` calls simplify accordingly — the "does this batch concern me?" test moved into the selector, so the predicate is just `(e) => e !== undefined`.

This keeps the one-selector-per-field convention from spec 020: no multi-field object selectors were introduced.

## Testing

New `frontend/src/pages/app-detail.rerender.test.tsx` uses a render-counting stub for the (unmemoized) `OverviewTab` as the seam, asserting all four directions:

- unrelated app's status change → no re-render
- own app's status change → re-renders, and shows the new status
- unrelated app's execution completions → no re-render
- own app's execution completions → re-renders

Verified locally:

- `npm run test -- --run` — 1487 tests passed across 101 files
- `uv run nox -s dev` — 8784 passed, 1 skipped, 2 xfailed
- `prek -a` and `prek pyright -a --stage pre-push` — both clean

No visual change — this is a subscription-granularity fix only, so the PR carries the `no-visual-change` label rather than screenshots.

Closes #1465
