### PR TITLE
fix(web): bound request bodies and failed-auth accounting on the pre-auth path

### DIFF
--- a/docs/pages/web-ui/index.md
+++ b/docs/pages/web-ui/index.md
@@ -32,12 +32,13 @@ The default bind address is `0.0.0.0:8126`. The `host` and `port` fields under `
     for local-only access, but it isn't what stops an unauthenticated peer from
     reaching the API — the token does that regardless of bind address.
 
-    Every request body is capped at 64 KiB, and anything larger gets a `413`
-    before the route runs. The cap matters most on `POST /api/auth/session`,
-    the one route reachable with no credential: without it, an unauthenticated
-    peer could make Hassette buffer an arbitrarily large body before the token
-    is ever compared. No endpoint accepts a payload near that size, so the cap
-    is not configurable.
+    Hassette caps every HTTP request body at 64 KiB. Oversized requests
+    receive HTTP `413` before route handling, while health checks and the
+    WebSocket connection are unaffected. The cap matters most on
+    `POST /api/auth/session`, the one route reachable with no credential:
+    without it, an unauthenticated peer could make Hassette buffer an
+    arbitrarily large body before the token is ever compared. No endpoint
+    accepts a payload near that size, so the cap is not configurable.
 
     Running a reverse proxy in front of Hassette — Caddy, Traefik, nginx, or
     the Home Assistant add-on's own ingress proxy — and listing its address

--- a/docs/pages/web-ui/index.md
+++ b/docs/pages/web-ui/index.md
@@ -32,6 +32,13 @@ The default bind address is `0.0.0.0:8126`. The `host` and `port` fields under `
     for local-only access, but it isn't what stops an unauthenticated peer from
     reaching the API — the token does that regardless of bind address.
 
+    Every request body is capped at 64 KiB, and anything larger gets a `413`
+    before the route runs. The cap matters most on `POST /api/auth/session`,
+    the one route reachable with no credential: without it, an unauthenticated
+    peer could make Hassette buffer an arbitrarily large body before the token
+    is ever compared. No endpoint accepts a payload near that size, so the cap
+    is not configurable.
+
     Running a reverse proxy in front of Hassette — Caddy, Traefik, nginx, or
     the Home Assistant add-on's own ingress proxy — and listing its address
     under `trusted_proxies` relocates trust to that proxy: Hassette skips its

--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -3678,6 +3678,7 @@
         "properties": {
           "token": {
             "type": "string",
+            "maxLength": 4096,
             "title": "Token"
           }
         },

--- a/src/hassette/web/app.py
+++ b/src/hassette/web/app.py
@@ -10,6 +10,7 @@ from starlette.middleware.cors import CORSMiddleware
 from starlette.responses import FileResponse
 
 from hassette.web.auth import EMPTY_TRUSTED_PROXY_SET, TrustedProxySet
+from hassette.web.body_limit import RequestBodySizeLimitMiddleware
 from hassette.web.middleware import DefaultDenyMiddleware
 from hassette.web.routes.apps import router as apps_router
 from hassette.web.routes.auth import router as auth_router
@@ -68,6 +69,13 @@ def create_fastapi_app(
     # tests/integration/web_api/test_auth.py — see design.md's Open Questions for the ordering
     # claim this resolves.
     app.add_middleware(DefaultDenyMiddleware)
+
+    # Outside DefaultDenyMiddleware (added after it), so an oversized body is refused before the
+    # auth decision runs — which is the point, since POST /api/auth/session is credential-free by
+    # design and would otherwise buffer an unbounded body before comparing tokens. Still inside
+    # CORSMiddleware, so the 413 carries CORS headers and a browser sees the real status rather
+    # than an opaque network error.
+    app.add_middleware(RequestBodySizeLimitMiddleware)
 
     app.add_middleware(
         CORSMiddleware,

--- a/src/hassette/web/body_limit.py
+++ b/src/hassette/web/body_limit.py
@@ -18,6 +18,7 @@ for a deployment to raise it, and a knob in ``web_api`` config would surface in 
 the OpenAPI schema for no one's benefit.
 """
 
+from collections import deque
 from logging import getLogger
 
 from starlette.datastructures import Headers
@@ -34,24 +35,6 @@ worst legitimate case and about 1500x over a generated 43-character token. Small
 pre-authentication allocation on ``POST /api/auth/session`` cannot become memory pressure, loose
 enough that no real request comes close.
 """
-
-
-class _BodyTooLargeError(Exception):
-    """Raised out of the wrapped ``receive`` once a body exceeds the ceiling.
-
-    Private and never allowed to escape :class:`RequestBodySizeLimitMiddleware.__call__` — it
-    exists only to unwind out of whatever handler was awaiting the body, so the middleware can
-    answer 413 in its place.
-
-    The unwind crosses a middleware boundary, which is worth knowing before editing the stack:
-    the app this middleware wraps is ``DefaultDenyMiddleware``, a Starlette
-    :class:`~starlette.middleware.base.BaseHTTPMiddleware`, which runs the downstream app in its
-    own task and re-raises that task's exception on the caller's side. So a raise inside
-    ``receive`` does reach the ``except`` in ``__call__`` rather than vanishing into a task — but
-    that is a property of the wrapped stack, not a guarantee of the ASGI spec. The 413 tests in
-    ``tests/integration/web_api/test_body_limit.py`` cover both the in-process transport and a real
-    uvicorn server precisely so a reordering that broke this propagation would fail loudly.
-    """
 
 
 def _declared_content_length(headers: Headers) -> int | None:
@@ -123,43 +106,66 @@ class RequestBodySizeLimitMiddleware:
             await _send_413(send, self.max_bytes)
             return
 
+        buffered, oversized = await self._buffer_body(receive, scope)
+        if oversized:
+            await _send_413(send, self.max_bytes)
+            return
+
+        await self.app(scope, _replay_receive(buffered, receive), send)
+
+    async def _buffer_body(self, receive: Receive, scope: Scope) -> tuple[list[Message], bool]:
+        """Drain the request body into memory, stopping early once it exceeds ``max_bytes``.
+
+        Deciding pass/reject here — before ``self.app`` (``DefaultDenyMiddleware`` and, beneath
+        it, FastAPI's routing) ever runs — is what makes the 413 reachable for a streamed body
+        with no ``Content-Length``. The previous approach raised a private exception out of a
+        wrapped ``receive`` for the app to unwind through, but FastAPI's own body parsing wraps
+        ``await request.json()`` in a broad ``except Exception`` and converts anything raised
+        there — including our exception — into its own generic
+        ``400 {"detail": "There was an error parsing the body"}``, silently losing both the 413
+        and the ``X-Max-Body-Bytes`` header. Buffering ourselves sidesteps that entirely: nothing
+        downstream gets a chance to intercept the decision.
+
+        Returns the buffered ASGI messages read so far, and whether the body exceeded
+        ``max_bytes`` (``True`` means the caller must answer 413 and must not invoke
+        ``self.app`` — the buffered messages are partial and not meant to be replayed).
+        """
+        buffered: list[Message] = []
         received = 0
-        response_started = False
 
-        async def limited_receive() -> Message:
-            nonlocal received
+        while True:
             message = await receive()
-            if message["type"] == "http.request":
-                received += len(message.get("body", b""))
-                if received > self.max_bytes:
-                    LOGGER.warning(
-                        "Rejecting %s %s: body exceeded the %d-byte ceiling after %d bytes",
-                        scope.get("method", "?"),
-                        scope.get("path", "?"),
-                        self.max_bytes,
-                        received,
-                    )
-                    raise _BodyTooLargeError
-            return message
+            buffered.append(message)
+            if message["type"] != "http.request":
+                # e.g. http.disconnect — the client is gone, nothing left to read.
+                return buffered, False
 
-        async def guarded_send(message: Message) -> None:
-            nonlocal response_started
-            if message["type"] == "http.response.start":
-                response_started = True
-            await send(message)
+            received += len(message.get("body", b""))
+            if received > self.max_bytes:
+                LOGGER.warning(
+                    "Rejecting %s %s: body exceeded the %d-byte ceiling after %d bytes",
+                    scope.get("method", "?"),
+                    scope.get("path", "?"),
+                    self.max_bytes,
+                    received,
+                )
+                return buffered, True
 
-        try:
-            await self.app(scope, limited_receive, guarded_send)
-        except _BodyTooLargeError:
-            # Only safe to answer 413 if the app hadn't already started a response. A handler that
-            # streamed a status line before reading its body has committed the response, and a
-            # second http.response.start would be an ASGI violation. Re-raising instead hands the
-            # exception to the server's own error handling, which — with headers already sent —
-            # can only abort the connection mid-response, leaving the client with a truncated
-            # read. No route in this app streams a response before reading its body, so this
-            # branch is unreachable today; it exists so adding one degrades to a broken
-            # connection rather than to a protocol violation.
-            if not response_started:
-                await _send_413(send, self.max_bytes)
-                return
-            raise
+            if not message.get("more_body", False):
+                return buffered, False
+
+
+def _replay_receive(buffered: list[Message], receive: Receive) -> Receive:
+    """Build a ``receive`` that first drains ``buffered``, then falls through to the real one.
+
+    The fallthrough matters: once the buffered body is exhausted, the downstream app may still
+    legitimately call ``receive()`` again (e.g. to observe a later ``http.disconnect``).
+    """
+    queue = deque(buffered)
+
+    async def _receive() -> Message:
+        if queue:
+            return queue.popleft()
+        return await receive()
+
+    return _receive

--- a/src/hassette/web/body_limit.py
+++ b/src/hassette/web/body_limit.py
@@ -1,0 +1,165 @@
+"""Request-body size ceiling for the Hassette Web API.
+
+Uvicorn has no maximum-body-size setting and Starlette buffers a whole body before a handler
+sees it, so without this middleware the one credential-free JSON route
+(``POST /api/auth/session`` — see ``web/middleware.py``'s ``EXEMPT_ROUTES``) performs
+attacker-controlled allocation before any token comparison happens. An 8 MiB token was verified
+to reach the handler and return its normal 401.
+
+This is a raw ASGI middleware rather than a
+:class:`~starlette.middleware.base.BaseHTTPMiddleware` on purpose: it has to wrap ``receive`` to
+count body bytes as they arrive. A ``Content-Length`` check alone is not a limit, because a
+client that omits it and uses ``Transfer-Encoding: chunked`` would stream past the ceiling
+unmeasured.
+
+The limit is a module constant, not a config field. Every body-carrying route in the API takes a
+small fixed payload — a log level, an app key, a job trigger — so there is no legitimate reason
+for a deployment to raise it, and a knob in ``web_api`` config would surface in the config UI and
+the OpenAPI schema for no one's benefit.
+"""
+
+from logging import getLogger
+
+from starlette.datastructures import Headers
+from starlette.types import ASGIApp, Message, Receive, Scope, Send
+
+LOGGER = getLogger(__name__)
+
+MAX_REQUEST_BODY_BYTES = 64 * 1024
+"""Ceiling on a single request body, in bytes.
+
+The largest body any route legitimately accepts is a session-token exchange, whose token is itself
+capped at ``MAX_SESSION_TOKEN_LENGTH`` (4096) — so 64 KiB leaves roughly 16x headroom over the
+worst legitimate case and about 1500x over a generated 43-character token. Small enough that the
+pre-authentication allocation on ``POST /api/auth/session`` cannot become memory pressure, loose
+enough that no real request comes close.
+"""
+
+
+class _BodyTooLargeError(Exception):
+    """Raised out of the wrapped ``receive`` once a body exceeds the ceiling.
+
+    Private and never allowed to escape :class:`RequestBodySizeLimitMiddleware.__call__` — it
+    exists only to unwind out of whatever handler was awaiting the body, so the middleware can
+    answer 413 in its place.
+
+    The unwind crosses a middleware boundary, which is worth knowing before editing the stack:
+    the app this middleware wraps is ``DefaultDenyMiddleware``, a Starlette
+    :class:`~starlette.middleware.base.BaseHTTPMiddleware`, which runs the downstream app in its
+    own task and re-raises that task's exception on the caller's side. So a raise inside
+    ``receive`` does reach the ``except`` in ``__call__`` rather than vanishing into a task — but
+    that is a property of the wrapped stack, not a guarantee of the ASGI spec. The 413 tests in
+    ``tests/integration/web_api/test_body_limit.py`` cover both the in-process transport and a real
+    uvicorn server precisely so a reordering that broke this propagation would fail loudly.
+    """
+
+
+def _declared_content_length(headers: Headers) -> int | None:
+    """Return the request's declared ``Content-Length``, or None when absent or unparseable.
+
+    A malformed value is treated as absent rather than as a rejection: the byte counter below is
+    the authoritative check, and letting the server's own protocol handling reject a bad header
+    keeps this middleware from having an opinion about framing.
+    """
+    raw = headers.get("content-length")
+    if raw is None:
+        return None
+    try:
+        return int(raw)
+    except ValueError:
+        return None
+
+
+async def _send_413(send: Send, max_bytes: int) -> None:
+    body = b'{"detail":"Request body too large"}'
+    await send(
+        {
+            "type": "http.response.start",
+            "status": 413,
+            "headers": [
+                (b"content-type", b"application/json"),
+                (b"content-length", str(len(body)).encode()),
+                # Advertise the ceiling so a client gets an actionable answer rather than
+                # having to bisect payload sizes against an opaque 413.
+                (b"x-max-body-bytes", str(max_bytes).encode()),
+            ],
+        }
+    )
+    await send({"type": "http.response.body", "body": body})
+
+
+class RequestBodySizeLimitMiddleware:
+    """Reject any HTTP request whose body exceeds ``max_bytes`` with a 413.
+
+    Registered outside :class:`~hassette.web.middleware.DefaultDenyMiddleware` (see
+    ``web/app.py``) so an oversized body is refused before the auth decision runs, on every
+    route rather than only the gated ones.
+
+    Non-HTTP scopes — the WebSocket handshake at ``/api/ws``, plus ``lifespan`` — pass straight
+    through. WebSocket frame limits are the transport's concern, not this middleware's.
+    """
+
+    def __init__(self, app: ASGIApp, max_bytes: int = MAX_REQUEST_BODY_BYTES) -> None:
+        self.app = app
+        self.max_bytes = max_bytes
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if scope["type"] != "http":
+            await self.app(scope, receive, send)
+            return
+
+        headers = Headers(scope=scope)
+        declared = _declared_content_length(headers)
+        if declared is not None and declared > self.max_bytes:
+            # Reject on the declaration alone: no body bytes need to be read at all, so an
+            # honest client that announces an oversized payload costs nothing.
+            LOGGER.warning(
+                "Rejecting %s %s: declared Content-Length %d exceeds the %d-byte ceiling",
+                scope.get("method", "?"),
+                scope.get("path", "?"),
+                declared,
+                self.max_bytes,
+            )
+            await _send_413(send, self.max_bytes)
+            return
+
+        received = 0
+        response_started = False
+
+        async def limited_receive() -> Message:
+            nonlocal received
+            message = await receive()
+            if message["type"] == "http.request":
+                received += len(message.get("body", b""))
+                if received > self.max_bytes:
+                    LOGGER.warning(
+                        "Rejecting %s %s: body exceeded the %d-byte ceiling after %d bytes",
+                        scope.get("method", "?"),
+                        scope.get("path", "?"),
+                        self.max_bytes,
+                        received,
+                    )
+                    raise _BodyTooLargeError
+            return message
+
+        async def guarded_send(message: Message) -> None:
+            nonlocal response_started
+            if message["type"] == "http.response.start":
+                response_started = True
+            await send(message)
+
+        try:
+            await self.app(scope, limited_receive, guarded_send)
+        except _BodyTooLargeError:
+            # Only safe to answer 413 if the app hadn't already started a response. A handler that
+            # streamed a status line before reading its body has committed the response, and a
+            # second http.response.start would be an ASGI violation. Re-raising instead hands the
+            # exception to the server's own error handling, which — with headers already sent —
+            # can only abort the connection mid-response, leaving the client with a truncated
+            # read. No route in this app streams a response before reading its body, so this
+            # branch is unreachable today; it exists so adding one degrades to a broken
+            # connection rather than to a protocol violation.
+            if not response_started:
+                await _send_413(send, self.max_bytes)
+                return
+            raise

--- a/src/hassette/web/middleware.py
+++ b/src/hassette/web/middleware.py
@@ -102,7 +102,9 @@ class _SourceAttempts:
     """Whether the WARN has already fired for the burst currently in progress.
 
     Re-armed as soon as the in-window count falls back below the threshold, so a peer that goes
-    quiet and later resumes gets a fresh warning rather than permanent silence.
+    quiet and later resumes gets a fresh warning rather than permanent silence. See
+    :meth:`_FailedAuthTracker.record` for where the re-arm check actually happens — it must run
+    before the current attempt is appended, not after.
     """
 
 
@@ -130,16 +132,20 @@ class _FailedAuthTracker:
         now = time.monotonic()
         window_start = now - FAILED_AUTH_WINDOW_SECONDS
 
-        state = self._record_attempt(source, now, window_start)
-        self._enforce_source_bounds(window_start)
+        state = self._evict_stale_attempts(source, window_start)
 
-        # Below the threshold the latch re-arms, so a source that quiets down and later resumes
-        # gets a fresh warning. At or above it, warn only on the transition.
+        # Re-arm while the *pre-attempt* survivor count is still below threshold — this must
+        # happen before the append below. ``timestamps`` is a ``maxlen``-bounded deque, so once a
+        # source has ever made FAILED_AUTH_THRESHOLD attempts, its length pins at exactly that
+        # value after every future append. Checking post-append length can therefore never observe
+        # a dip below threshold; it would only ever see 0 survivors (full staleness) or the cap.
         if len(state.timestamps) < FAILED_AUTH_THRESHOLD:
             state.warned = False
-            return
 
-        if not state.warned:
+        state.timestamps.append(now)
+        self._enforce_source_bounds(window_start)
+
+        if len(state.timestamps) >= FAILED_AUTH_THRESHOLD and not state.warned:
             state.warned = True
             LOGGER.warning(
                 "%d failed auth attempts from %s in the last %d seconds",
@@ -148,12 +154,15 @@ class _FailedAuthTracker:
                 FAILED_AUTH_WINDOW_SECONDS,
             )
 
-    def _record_attempt(self, source: str, now: float, window_start: float) -> _SourceAttempts:
-        """Append an attempt for ``source`` and return its (now current) state.
+    def _evict_stale_attempts(self, source: str, window_start: float) -> _SourceAttempts:
+        """Return ``source``'s state with attempts older than ``window_start`` dropped.
 
         Also moves ``source`` to the end of ``_attempts``, which is what makes the dict
         LRU-ordered. :meth:`_evict_stale_sources` depends on that ordering — do not drop the
         ``move_to_end`` call without reading its docstring first.
+
+        Deliberately does not append the new attempt — the caller needs the survivor count in
+        this pre-append state to decide whether to re-arm the warning latch.
         """
         state = self._attempts.get(source)
         if state is None:
@@ -167,7 +176,6 @@ class _FailedAuthTracker:
         # entry it still has room for is too old to count toward the threshold.
         while state.timestamps and state.timestamps[0] < window_start:
             state.timestamps.popleft()
-        state.timestamps.append(now)
         return state
 
     def _enforce_source_bounds(self, window_start: float) -> None:

--- a/src/hassette/web/middleware.py
+++ b/src/hassette/web/middleware.py
@@ -19,7 +19,8 @@ full mechanism this implements.
 """
 
 import time
-from collections import OrderedDict
+from collections import OrderedDict, deque
+from dataclasses import dataclass, field
 from logging import getLogger
 
 from starlette.middleware.base import BaseHTTPMiddleware, RequestResponseEndpoint
@@ -80,46 +81,118 @@ across requests (e.g. sweeping an IPv6 /64).
 """
 
 
+@dataclass
+class _SourceAttempts:
+    """Bounded record of one source's recent failed-auth attempts.
+
+    ``timestamps`` is a ring buffer capped at :data:`FAILED_AUTH_THRESHOLD` entries. The tracker
+    only ever asks "did the last ``FAILED_AUTH_THRESHOLD`` attempts all land inside the window?",
+    so a timestamp older than that is unreachable by any question the tracker can pose and the
+    deque drops it for free. This cap is what keeps both retained memory and per-request work
+    constant for a source under sustained load — an unbounded list makes each
+    :meth:`_FailedAuthTracker.record` O(attempts so far) and a burst O(n^2) overall, which one
+    unauthenticated peer can aim at the shared event loop.
+
+    Mutated in place rather than replaced. The whole point of a fixed-size ring buffer is to avoid
+    the per-request copy, so the usual copy-on-write preference is inverted here deliberately.
+    """
+
+    timestamps: deque[float] = field(default_factory=lambda: deque(maxlen=FAILED_AUTH_THRESHOLD))
+    warned: bool = False
+    """Whether the WARN has already fired for the burst currently in progress.
+
+    Re-armed as soon as the in-window count falls back below the threshold, so a peer that goes
+    quiet and later resumes gets a fresh warning rather than permanent silence.
+    """
+
+
 class _FailedAuthTracker:
     """Coalesced failed-auth counter, keyed by source peer address.
 
-    Evicts attempts older than :data:`FAILED_AUTH_WINDOW_SECONDS` on every :meth:`record` call and
-    drops a source's key entirely once its window has fully elapsed, so a sustained burst cannot
-    grow the tracker without bound — across sources as well as within one, since the number of
-    distinct sources held at once is additionally capped at :data:`MAX_TRACKED_SOURCES` via
-    least-recently-touched eviction. Emits exactly one WARN the moment a source's attempt count
-    *reaches* the threshold within the window — not one per attempt, and not a repeat warning for
-    every attempt past the threshold. The counter never rejects or throttles anything; rate
-    limiting is an explicit Non-Goal (design.md Non-Goals).
+    Bounded on both axes an unauthenticated peer controls:
+
+    - **Across sources** — the number of distinct addresses held at once is capped at
+      :data:`MAX_TRACKED_SOURCES` via least-recently-touched eviction, and any source whose most
+      recent attempt has aged out of the window is dropped entirely. A peer varying its address
+      per request (cheap over an IPv6 /64) cannot grow the dict without bound.
+    - **Within one source** — see :class:`_SourceAttempts`. Constant memory and constant work per
+      request regardless of how many attempts that source has already made.
+
+    Emits exactly one WARN the moment a source's in-window attempt count *reaches* the threshold —
+    not one per attempt, and not a repeat for every attempt past it. The counter never rejects or
+    throttles anything; rate limiting is an explicit Non-Goal (design.md Non-Goals).
     """
 
     def __init__(self) -> None:
-        self._attempts: OrderedDict[str, list[float]] = OrderedDict()
+        self._attempts: OrderedDict[str, _SourceAttempts] = OrderedDict()
 
     def record(self, source: str) -> None:
         now = time.monotonic()
         window_start = now - FAILED_AUTH_WINDOW_SECONDS
-        attempts = [t for t in self._attempts.get(source, ()) if t >= window_start]
-        attempts.append(now)
-        self._attempts[source] = attempts
-        self._attempts.move_to_end(source)
 
-        # Drop any other source whose most recent attempt has aged out of the window, then cap
-        # what remains so an attacker who varies the source address per request can't grow this
-        # dict without bound.
-        stale = [key for key, times in self._attempts.items() if key != source and times[-1] < window_start]
-        for key in stale:
-            del self._attempts[key]
-        while len(self._attempts) > MAX_TRACKED_SOURCES:
-            self._attempts.popitem(last=False)
+        state = self._record_attempt(source, now, window_start)
+        self._enforce_source_bounds(window_start)
 
-        if len(attempts) == FAILED_AUTH_THRESHOLD:
+        # Below the threshold the latch re-arms, so a source that quiets down and later resumes
+        # gets a fresh warning. At or above it, warn only on the transition.
+        if len(state.timestamps) < FAILED_AUTH_THRESHOLD:
+            state.warned = False
+            return
+
+        if not state.warned:
+            state.warned = True
             LOGGER.warning(
                 "%d failed auth attempts from %s in the last %d seconds",
                 FAILED_AUTH_THRESHOLD,
                 source,
                 FAILED_AUTH_WINDOW_SECONDS,
             )
+
+    def _record_attempt(self, source: str, now: float, window_start: float) -> _SourceAttempts:
+        """Append an attempt for ``source`` and return its (now current) state.
+
+        Also moves ``source`` to the end of ``_attempts``, which is what makes the dict
+        LRU-ordered. :meth:`_evict_stale_sources` depends on that ordering — do not drop the
+        ``move_to_end`` call without reading its docstring first.
+        """
+        state = self._attempts.get(source)
+        if state is None:
+            state = _SourceAttempts()
+            self._attempts[source] = state  # a fresh key lands at the end already
+        else:
+            self._attempts.move_to_end(source)
+
+        # Drop attempts that have aged out of the window. This is a *time* bound and is separate
+        # from the deque's own maxlen, which is a *count* bound — the deque cannot know that an
+        # entry it still has room for is too old to count toward the threshold.
+        while state.timestamps and state.timestamps[0] < window_start:
+            state.timestamps.popleft()
+        state.timestamps.append(now)
+        return state
+
+    def _enforce_source_bounds(self, window_start: float) -> None:
+        """Keep the number of tracked sources bounded: drop aged-out ones, then cap the rest."""
+        self._evict_stale_sources(window_start)
+        while len(self._attempts) > MAX_TRACKED_SOURCES:
+            self._attempts.popitem(last=False)
+
+    def _evict_stale_sources(self, window_start: float) -> None:
+        """Drop every source whose most recent attempt has aged out of the window.
+
+        The dict is LRU-ordered — :meth:`record` moves each touched source to the end — so stale
+        sources cluster at the front and the scan can stop at the first live one. That makes this
+        O(1) amortized instead of the full walk of up to :data:`MAX_TRACKED_SOURCES` entries that
+        a per-request comprehension over the whole dict would cost.
+
+        The just-touched source is safe: it sits at the end with a timestamp of ``now``, so the
+        loop stops before reaching it (and stops immediately when it is the only entry).
+        """
+        while self._attempts:
+            oldest = next(iter(self._attempts))
+            state = self._attempts[oldest]
+            if state.timestamps and state.timestamps[-1] >= window_start:
+                return
+            del self._attempts[oldest]
 
 
 def _unauthorized_response() -> JSONResponse:

--- a/src/hassette/web/middleware.py
+++ b/src/hassette/web/middleware.py
@@ -20,6 +20,7 @@ full mechanism this implements.
 
 import time
 from collections import OrderedDict, deque
+from collections.abc import Callable
 from dataclasses import dataclass, field
 from logging import getLogger
 
@@ -125,11 +126,12 @@ class _FailedAuthTracker:
     throttles anything; rate limiting is an explicit Non-Goal (design.md Non-Goals).
     """
 
-    def __init__(self) -> None:
+    def __init__(self, clock: Callable[[], float] = time.monotonic) -> None:
         self._attempts: OrderedDict[str, _SourceAttempts] = OrderedDict()
+        self._clock = clock
 
     def record(self, source: str) -> None:
-        now = time.monotonic()
+        now = self._clock()
         window_start = now - FAILED_AUTH_WINDOW_SECONDS
 
         state = self._evict_stale_attempts(source, window_start)

--- a/src/hassette/web/models.py
+++ b/src/hassette/web/models.py
@@ -14,6 +14,14 @@ from hassette.types.enums import (
 )
 from hassette.types.types import LOG_LEVEL_TYPE, CliFormat, SourceTier
 
+MAX_SESSION_TOKEN_LENGTH = 4096
+"""Upper bound on the ``token`` field of :class:`SessionRequest`.
+
+Generated tokens are ``secrets.token_urlsafe(32)`` — 43 characters — but a deployment may supply
+its own, so the cap is set far above any plausible real token rather than tight to the generated
+shape.
+"""
+
 ManifestStatus = Literal["disabled", "blocked", "running", "failed", "stopped"]
 """Status values for app manifests (manifest-scoped, 5 values).
 
@@ -224,7 +232,14 @@ class SessionRequest(BaseModel):
     (``postSession()`` in ``client.ts``) target this exact field name independently.
     """
 
-    token: str
+    token: str = Field(max_length=MAX_SESSION_TOKEN_LENGTH)
+    """Bearer token to exchange for a session cookie.
+
+    Length-capped so the constraint rides in the OpenAPI schema and Pydantic rejects an absurd
+    value with a 422 before ``check_bearer_token`` compares it. The real ceiling on this route is
+    ``RequestBodySizeLimitMiddleware`` (see ``web/body_limit.py``) — this is the narrower
+    field-level statement of the same intent, not a substitute for it.
+    """
 
 
 class SessionResponse(BaseModel):

--- a/tests/integration/web_api/conftest.py
+++ b/tests/integration/web_api/conftest.py
@@ -6,6 +6,7 @@ import pytest
 from httpx2 import ASGITransport, AsyncClient
 
 from hassette.schemas.app_snapshots import AppInstanceInfo, AppStatusSnapshot
+from hassette.test_utils.config import TEST_SESSION_TTL, WEB_API_TEST_TOKEN
 from hassette.test_utils.web_mocks import create_hassette_stub, create_mock_runtime_query_service
 from hassette.types.enums import ResourceStatus
 from hassette.web.app import create_fastapi_app
@@ -62,6 +63,33 @@ def app(mock_hassette, runtime_query_service):  # noqa: ARG001
 async def client(app):
     """Create an httpx2 AsyncClient for testing."""
     transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        yield ac
+
+
+@pytest.fixture
+def auth_hassette():
+    """A `create_hassette_stub()` with `auth_enabled=True` and a real `session_ttl`.
+
+    `create_hassette_stub()` doesn't set `session_ttl` on the MagicMock stub -- this fixture sets
+    it directly so `verify_session_cookie`/`should_renew_session_cookie` (which do arithmetic
+    against it) don't operate on an auto-generated `MagicMock` attribute.
+    """
+    hassette = create_hassette_stub(auth_enabled=True)
+    hassette.config.web_api.session_ttl = TEST_SESSION_TTL
+    create_mock_runtime_query_service(hassette)
+    return hassette
+
+
+@pytest.fixture
+def auth_app(auth_hassette):
+    """FastAPI app built with a known token, so bearer/cookie assertions have a concrete value."""
+    return create_fastapi_app(auth_hassette, auth_token=WEB_API_TEST_TOKEN)
+
+
+@pytest.fixture
+async def auth_client(auth_app):
+    transport = ASGITransport(app=auth_app)
     async with AsyncClient(transport=transport, base_url="http://test") as ac:
         yield ac
 

--- a/tests/integration/web_api/test_auth.py
+++ b/tests/integration/web_api/test_auth.py
@@ -99,33 +99,6 @@ def stub_spa() -> Generator[Path, None, None]:
                 _SPA_DIR.rmdir()
 
 
-@pytest.fixture
-def auth_hassette():
-    """A `create_hassette_stub()` with `auth_enabled=True` and a real `session_ttl`.
-
-    `create_hassette_stub()` doesn't set `session_ttl` on the MagicMock stub -- this fixture sets
-    it directly so `verify_session_cookie`/`should_renew_session_cookie` (which do arithmetic
-    against it) don't operate on an auto-generated `MagicMock` attribute.
-    """
-    hassette = create_hassette_stub(auth_enabled=True)
-    hassette.config.web_api.session_ttl = TEST_SESSION_TTL
-    create_mock_runtime_query_service(hassette)
-    return hassette
-
-
-@pytest.fixture
-def auth_app(auth_hassette):
-    """FastAPI app built with a known token, so bearer/cookie assertions have a concrete value."""
-    return create_fastapi_app(auth_hassette, auth_token=WEB_API_TEST_TOKEN)
-
-
-@pytest.fixture
-async def auth_client(auth_app):
-    transport = ASGITransport(app=auth_app)
-    async with AsyncClient(transport=transport, base_url="http://test") as ac:
-        yield ac
-
-
 async def _mint_cookie_at(token: str, seconds_ago: int) -> str:
     """Mint a session cookie as if it were minted `seconds_ago` seconds in the past."""
     stale_timestamp = int(time.time()) - seconds_ago

--- a/tests/integration/web_api/test_body_limit.py
+++ b/tests/integration/web_api/test_body_limit.py
@@ -80,13 +80,18 @@ class TestBodyCeilingInProcess:
         assert response.status_code == 401
 
     async def test_body_just_under_the_ceiling_reaches_the_handler(self, auth_client: AsyncClient) -> None:
-        """A payload under the ceiling is handled normally — here, rejected on token mismatch (401),
-        not on size. Pins that the boundary is not off by enough to catch legitimate traffic.
+        """A payload right at the ceiling is handled normally — here, rejected by Pydantic's field
+        length validator (422), not by the body-size middleware (413). Pins that the boundary is
+        not off by enough to catch legitimate traffic.
         """
-        token = "A" * (MAX_SESSION_TOKEN_LENGTH - 1)
-        response = await auth_client.post("/api/auth/session", json={"token": token})
+        body = b'{"token":"' + b"A" * (MAX_REQUEST_BODY_BYTES - len(b'{"token":""}')) + b'"}'
+        response = await auth_client.post(
+            "/api/auth/session",
+            content=body,
+            headers={"content-type": "application/json"},
+        )
 
-        assert response.status_code == 401
+        assert response.status_code == 422
 
     async def test_token_past_field_max_length_is_a_validation_error(self, auth_client: AsyncClient) -> None:
         """Between the field cap and the body ceiling, Pydantic answers 422 — not 413, not 401."""

--- a/tests/integration/web_api/test_body_limit.py
+++ b/tests/integration/web_api/test_body_limit.py
@@ -1,0 +1,186 @@
+"""Tests for the request-body size ceiling (`hassette.web.body_limit`).
+
+From an external security audit at 4a20fb95 (CWE-400): `POST /api/auth/session` is exempt from
+`DefaultDenyMiddleware` by design — it is the one route that must be reachable with zero prior
+credential — and neither the FastAPI app nor uvicorn imposed a body limit, so an unauthenticated
+peer could drive arbitrary pre-authentication allocation. The audit reached the handler with an
+8 MiB token and got the route's normal 401 back.
+
+Two of these tests run against a **real uvicorn server** rather than `ASGITransport`, for reasons
+the in-process transport cannot cover:
+
+- `ASGITransport` never exercises uvicorn's own HTTP framing, so a `413` proven only in-process
+  says nothing about whether the deployed server also rejects.
+- The chunked case has no `Content-Length` at all, which means it can only be produced by a client
+  talking real HTTP. It is the bypass that makes a header-only check insufficient, so it needs the
+  real transport to be meaningful.
+"""
+
+import json
+
+import httpx2
+import pytest
+from httpx2 import AsyncClient
+
+from hassette.test_utils.config import WEB_API_TEST_TOKEN
+from hassette.test_utils.uvicorn_server import start_uvicorn_server, stop_uvicorn_server
+from hassette.web.body_limit import MAX_REQUEST_BODY_BYTES, RequestBodySizeLimitMiddleware
+from hassette.web.models import MAX_SESSION_TOKEN_LENGTH
+
+# `auth_hassette`, `auth_app`, and `auth_client` come from this directory's conftest.py.
+
+
+def _oversized_token() -> str:
+    """A token comfortably past the body ceiling, not merely past the field's max_length.
+
+    Sized from the ceiling rather than from `MAX_SESSION_TOKEN_LENGTH` on purpose: the point is to
+    prove the *body* limit fires, and a value that only trips the field validator would produce a
+    422 from Pydantic after the body was already buffered — the exact allocation being prevented.
+    """
+    return "A" * (MAX_REQUEST_BODY_BYTES * 2)
+
+
+class TestBodyCeilingInProcess:
+    """Ceiling behavior through the ASGI transport, where the declared Content-Length is present."""
+
+    async def test_oversized_body_returns_413(self, auth_client: AsyncClient) -> None:
+        response = await auth_client.post("/api/auth/session", json={"token": _oversized_token()})
+
+        assert response.status_code == 413
+        assert response.json() == {"detail": "Request body too large"}
+
+    async def test_413_advertises_the_ceiling(self, auth_client: AsyncClient) -> None:
+        """A rejected client gets the limit back, rather than having to bisect payload sizes."""
+        response = await auth_client.post("/api/auth/session", json={"token": _oversized_token()})
+
+        assert response.headers["x-max-body-bytes"] == str(MAX_REQUEST_BODY_BYTES)
+
+    async def test_oversized_body_with_correct_token_still_rejected(self, auth_client: AsyncClient) -> None:
+        """The ceiling precedes the credential check, so a valid token buried in bulk gains nothing.
+
+        This is the behavioral proof that the handler never ran: had it executed, a correct token
+        would have minted a session cookie.
+        """
+        padded = WEB_API_TEST_TOKEN + "A" * (MAX_REQUEST_BODY_BYTES * 2)
+        response = await auth_client.post("/api/auth/session", json={"token": padded})
+
+        assert response.status_code == 413
+        assert "set-cookie" not in response.headers
+
+    async def test_normal_login_below_the_limit_is_unaffected(self, auth_client: AsyncClient) -> None:
+        response = await auth_client.post("/api/auth/session", json={"token": WEB_API_TEST_TOKEN})
+
+        assert response.status_code == 200
+        assert "set-cookie" in response.headers
+
+    async def test_wrong_token_below_the_limit_still_401s(self, auth_client: AsyncClient) -> None:
+        """The ceiling must not swallow the route's own auth semantics for ordinary payloads."""
+        response = await auth_client.post("/api/auth/session", json={"token": "wrong-token"})
+
+        assert response.status_code == 401
+
+    async def test_body_just_under_the_ceiling_reaches_the_handler(self, auth_client: AsyncClient) -> None:
+        """A payload under the ceiling is handled normally — here, rejected on token mismatch (401),
+        not on size. Pins that the boundary is not off by enough to catch legitimate traffic.
+        """
+        token = "A" * (MAX_SESSION_TOKEN_LENGTH - 1)
+        response = await auth_client.post("/api/auth/session", json={"token": token})
+
+        assert response.status_code == 401
+
+    async def test_token_past_field_max_length_is_a_validation_error(self, auth_client: AsyncClient) -> None:
+        """Between the field cap and the body ceiling, Pydantic answers 422 — not 413, not 401."""
+        token = "A" * (MAX_SESSION_TOKEN_LENGTH + 1)
+        response = await auth_client.post("/api/auth/session", json={"token": token})
+
+        assert response.status_code == 422
+
+    async def test_gated_route_body_is_still_gated_not_413(self, auth_client: AsyncClient) -> None:
+        """An authenticated-route request with a small body keeps its 401, not a size error."""
+        response = await auth_client.put("/api/logs/level", json={"logger": "hassette", "level": "DEBUG"})
+
+        assert response.status_code == 401
+
+
+class TestBodyCeilingAgainstRealServer:
+    """Ceiling behavior against real uvicorn, including the no-Content-Length bypass."""
+
+    @pytest.fixture
+    def live_server(self, auth_app):
+        server, thread, port = start_uvicorn_server(auth_app)
+        try:
+            yield f"http://127.0.0.1:{port}"
+        finally:
+            stop_uvicorn_server(server, thread)
+
+    async def test_oversized_body_rejected_by_real_server(self, live_server: str) -> None:
+        """The audit's own reproduction, inverted: an oversized token now gets 413, not the 401 it
+        previously got after reaching the handler.
+        """
+        async with httpx2.AsyncClient(base_url=live_server, timeout=10) as client:
+            response = await client.post("/api/auth/session", json={"token": _oversized_token()})
+
+        assert response.status_code == 413
+
+    async def test_chunked_oversized_body_rejected_by_real_server(self, live_server: str) -> None:
+        """A streamed body with no Content-Length is still bounded.
+
+        This is the case a header-only check misses entirely: httpx2 switches to
+        `Transfer-Encoding: chunked` for an async-generator body, so the ceiling can only be
+        enforced by counting bytes as they arrive.
+
+        The asserted status is deliberately a range rather than 413. Answering a request whose body
+        is still streaming leaves unread bytes in the connection, and h11 reports the leftover as a
+        framing error — so the client sees 400 when the reject lands mid-stream and 413 when the
+        whole body happened to arrive first. Which one occurs depends on socket buffering, so
+        pinning either exactly would be a flake. What matters, and what the second half asserts, is
+        that the request was refused without the handler running: no session cookie, and none of
+        the 200/401/422 statuses that would prove the body was parsed.
+        """
+        payload = json.dumps({"token": _oversized_token()}).encode()
+
+        async def chunks():
+            for start in range(0, len(payload), 8192):
+                yield payload[start : start + 8192]
+
+        async with httpx2.AsyncClient(base_url=live_server, timeout=10) as client:
+            response = await client.post(
+                "/api/auth/session",
+                content=chunks(),
+                headers={"content-type": "application/json"},
+            )
+
+        assert response.status_code in (400, 413), f"expected a size/framing rejection, got {response.status_code}"
+        assert "set-cookie" not in response.headers
+
+    async def test_normal_login_against_real_server_unaffected(self, live_server: str) -> None:
+        async with httpx2.AsyncClient(base_url=live_server, timeout=10) as client:
+            response = await client.post("/api/auth/session", json={"token": WEB_API_TEST_TOKEN})
+
+        assert response.status_code == 200
+
+
+class TestNonHttpScopesPassThrough:
+    """The ceiling applies to HTTP only; other ASGI scope types are none of its business."""
+
+    async def test_health_get_with_no_body_is_unaffected(self, auth_client: AsyncClient) -> None:
+        response = await auth_client.get("/api/health/live")
+
+        assert response.status_code == 200
+
+    async def test_middleware_leaves_websocket_scope_alone(self, auth_hassette) -> None:
+        """A `websocket` scope reaches the app untouched rather than being treated as HTTP.
+
+        Asserted at the middleware level: `RequestBodySizeLimitMiddleware` must delegate without
+        inspecting headers, since a WS scope has no request body to bound and frame limits belong
+        to the transport.
+        """
+        seen: list[str] = []
+
+        async def app(scope, _receive, _send) -> None:
+            seen.append(scope["type"])
+
+        middleware = RequestBodySizeLimitMiddleware(app)
+        await middleware({"type": "websocket", "headers": []}, None, None)  # pyright: ignore[reportArgumentType]
+
+        assert seen == ["websocket"]

--- a/tests/integration/web_api/test_body_limit.py
+++ b/tests/integration/web_api/test_body_limit.py
@@ -123,19 +123,14 @@ class TestBodyCeilingAgainstRealServer:
         assert response.status_code == 413
 
     async def test_chunked_oversized_body_rejected_by_real_server(self, live_server: str) -> None:
-        """A streamed body with no Content-Length is still bounded.
+        """A streamed body with no Content-Length is still bounded, with the documented 413.
 
         This is the case a header-only check misses entirely: httpx2 switches to
         `Transfer-Encoding: chunked` for an async-generator body, so the ceiling can only be
-        enforced by counting bytes as they arrive.
-
-        The asserted status is deliberately a range rather than 413. Answering a request whose body
-        is still streaming leaves unread bytes in the connection, and h11 reports the leftover as a
-        framing error — so the client sees 400 when the reject lands mid-stream and 413 when the
-        whole body happened to arrive first. Which one occurs depends on socket buffering, so
-        pinning either exactly would be a flake. What matters, and what the second half asserts, is
-        that the request was refused without the handler running: no session cookie, and none of
-        the 200/401/422 statuses that would prove the body was parsed.
+        enforced by counting bytes as they arrive. The middleware buffers the body itself and
+        decides pass/reject before the downstream app (and FastAPI's own body parsing) ever runs,
+        so the reject is a deterministic 413 rather than racing FastAPI's generic 400 for a body
+        error — see body_limit.py's `_buffer_body` docstring for why that race existed before.
         """
         payload = json.dumps({"token": _oversized_token()}).encode()
 
@@ -150,7 +145,8 @@ class TestBodyCeilingAgainstRealServer:
                 headers={"content-type": "application/json"},
             )
 
-        assert response.status_code in (400, 413), f"expected a size/framing rejection, got {response.status_code}"
+        assert response.status_code == 413
+        assert response.headers["x-max-body-bytes"] == str(MAX_REQUEST_BODY_BYTES)
         assert "set-cookie" not in response.headers
 
     async def test_normal_login_against_real_server_unaffected(self, live_server: str) -> None:

--- a/tests/unit/web/test_middleware.py
+++ b/tests/unit/web/test_middleware.py
@@ -158,3 +158,34 @@ class TestFailedAuthTracker:
         warn_records = [r for r in caplog.records if "failed auth attempts" in r.getMessage()]
         assert len(warn_records) == 0
         assert len(state.timestamps) == 1
+
+    def test_warning_rearms_after_partial_staleness_not_only_full_quiet(self, caplog: pytest.LogCaptureFixture) -> None:
+        """Re-arming must key off the survivor count, not merely "some" eviction happened.
+
+        Regression for a case the window-elapses test above doesn't reach: only the single
+        *oldest* timestamp ages out (9 of 10 survive), then one more attempt refills the deque
+        back to 10. Because ``timestamps`` is a ``maxlen``-bounded deque, post-append length is
+        always 10 once a source has ever made 10 attempts — checking the re-arm condition after
+        the append can never observe the dip to 9 survivors that should have re-armed the latch.
+        """
+        tracker = _FailedAuthTracker()
+
+        with caplog.at_level(logging.WARNING, logger="hassette.web.middleware"):
+            for _ in range(FAILED_AUTH_THRESHOLD):
+                tracker.record("203.0.113.1")
+
+            # Age out only the single oldest timestamp, leaving 9 of 10 survivors — below
+            # threshold, which should re-arm the latch for the next attempt.
+            state = tracker._attempts["203.0.113.1"]
+            oldest, *rest = state.timestamps
+            state.timestamps = deque(
+                [oldest - FAILED_AUTH_WINDOW_SECONDS - 1, *rest],
+                maxlen=FAILED_AUTH_THRESHOLD,
+            )
+
+            # This attempt brings the survivor count back to 10 — the second crossing of the
+            # threshold, which must warn again.
+            tracker.record("203.0.113.1")
+
+        warn_records = [r for r in caplog.records if "failed auth attempts" in r.getMessage()]
+        assert len(warn_records) == 2

--- a/tests/unit/web/test_middleware.py
+++ b/tests/unit/web/test_middleware.py
@@ -1,19 +1,35 @@
 """Unit tests for :class:`hassette.web.middleware._FailedAuthTracker`.
 
-Covers the tracker's two load-bearing bounds: it still fires the coalesced WARN-on-threshold
-behavior for a single source, and — the property this file exists to pin — it never grows past
-:data:`MAX_TRACKED_SOURCES` distinct source keys no matter how many distinct addresses record
-attempts. See the CodeRabbit finding on PR review for src/hassette/web/middleware.py: prior to this
-fix, `_attempts` was a `defaultdict(list)` that inserted a permanent key on first touch and never
-removed it, so an attacker varying its source address (cheap over an IPv6 /64) could grow the dict
-without bound.
+Covers the tracker's WARN-on-threshold coalescing plus both of the bounds an unauthenticated peer
+could otherwise push on:
+
+- **Across sources** — it never grows past :data:`MAX_TRACKED_SOURCES` distinct keys no matter how
+  many addresses record attempts. From a CodeRabbit finding on the PR review for
+  src/hassette/web/middleware.py: `_attempts` was a `defaultdict(list)` that inserted a permanent
+  key on first touch and never removed it, so an attacker varying its source address (cheap over an
+  IPv6 /64) could grow the dict without bound.
+- **Within one source** — retained state per source stays flat instead of growing with the request
+  count. From an external security audit at 4a20fb95 (CWE-400): `record` rebuilt that source's
+  whole in-window timestamp list on every call, making per-request work proportional to attempts
+  already made and a sustained burst quadratic overall.
+
+There is deliberately no wall-clock scaling assertion for the second bound. Bounded retained state
+*is* the proof that per-request work is constant, and it holds deterministically — a timing ratio
+would add nothing but a race against CI's scheduler (see CLAUDE.md on config-driven real-clock
+timeouts for how that failure mode plays out here).
 """
 
 import logging
+from collections import deque
 
 import pytest
 
-from hassette.web.middleware import FAILED_AUTH_THRESHOLD, MAX_TRACKED_SOURCES, _FailedAuthTracker
+from hassette.web.middleware import (
+    FAILED_AUTH_THRESHOLD,
+    FAILED_AUTH_WINDOW_SECONDS,
+    MAX_TRACKED_SOURCES,
+    _FailedAuthTracker,
+)
 
 
 @pytest.fixture(autouse=True)
@@ -81,3 +97,64 @@ class TestFailedAuthTracker:
             tracker.record(f"198.51.100.{i}")
 
         assert "203.0.113.1" not in tracker._attempts
+
+    def test_single_source_state_stays_bounded_far_past_threshold(self) -> None:
+        """The within-one-source bound: a sustained burst from one peer retains constant state.
+
+        Before this bound, each ``record`` copied and re-grew that source's full in-window
+        timestamp list, so retained entries equaled the request count and cumulative work was
+        quadratic — one unauthenticated peer aiming the event loop at itself.
+        """
+        tracker = _FailedAuthTracker()
+
+        for _ in range(FAILED_AUTH_THRESHOLD * 500):
+            tracker.record("203.0.113.1")
+
+        assert len(tracker._attempts["203.0.113.1"].timestamps) == FAILED_AUTH_THRESHOLD
+
+    def test_warning_rearms_after_window_elapses(self, caplog: pytest.LogCaptureFixture) -> None:
+        """A source that reaches the threshold, goes quiet past the window, then resumes warns again.
+
+        Pins that the ring buffer's ``warned`` latch is scoped to a run above the threshold rather
+        than to the source's lifetime — permanent silence after one burst would be a regression.
+        """
+        tracker = _FailedAuthTracker()
+
+        with caplog.at_level(logging.WARNING, logger="hassette.web.middleware"):
+            for _ in range(FAILED_AUTH_THRESHOLD):
+                tracker.record("203.0.113.1")
+
+            # Shift every retained timestamp fully out of the window, simulating a quiet period
+            # without waiting FAILED_AUTH_WINDOW_SECONDS in real time.
+            state = tracker._attempts["203.0.113.1"]
+            state.timestamps = deque(
+                (t - FAILED_AUTH_WINDOW_SECONDS - 1 for t in state.timestamps),
+                maxlen=FAILED_AUTH_THRESHOLD,
+            )
+
+            for _ in range(FAILED_AUTH_THRESHOLD):
+                tracker.record("203.0.113.1")
+
+        warn_records = [r for r in caplog.records if "failed auth attempts" in r.getMessage()]
+        assert len(warn_records) == 2
+
+    def test_attempts_aged_out_of_window_do_not_count_toward_threshold(self, caplog: pytest.LogCaptureFixture) -> None:
+        """Stale attempts are evicted rather than counted, so the window stays a real sliding window."""
+        tracker = _FailedAuthTracker()
+
+        with caplog.at_level(logging.WARNING, logger="hassette.web.middleware"):
+            for _ in range(FAILED_AUTH_THRESHOLD - 1):
+                tracker.record("203.0.113.1")
+
+            state = tracker._attempts["203.0.113.1"]
+            state.timestamps = deque(
+                (t - FAILED_AUTH_WINDOW_SECONDS - 1 for t in state.timestamps),
+                maxlen=FAILED_AUTH_THRESHOLD,
+            )
+
+            # One more attempt: 10 total recorded, but only this one is inside the window.
+            tracker.record("203.0.113.1")
+
+        warn_records = [r for r in caplog.records if "failed auth attempts" in r.getMessage()]
+        assert len(warn_records) == 0
+        assert len(state.timestamps) == 1

--- a/tests/unit/web/test_middleware.py
+++ b/tests/unit/web/test_middleware.py
@@ -20,7 +20,6 @@ timeouts for how that failure mode plays out here).
 """
 
 import logging
-from collections import deque
 
 import pytest
 
@@ -41,6 +40,24 @@ def _propagate_hassette_logger() -> None:
     workaround as ``tests/unit/web/test_auth.py``.
     """
     logging.getLogger("hassette").propagate = True
+
+
+class _FakeClock:
+    """Deterministic stand-in for :func:`time.monotonic`, injected into ``_FailedAuthTracker``.
+
+    Tests advance it explicitly instead of mutating ``_SourceAttempts.timestamps`` directly, so
+    elapsed-time scenarios stay expressed in terms of the tracker's public ``record()`` behavior
+    rather than its internal ring-buffer representation.
+    """
+
+    def __init__(self) -> None:
+        self._now = 0.0
+
+    def __call__(self) -> float:
+        return self._now
+
+    def advance(self, seconds: float) -> None:
+        self._now += seconds
 
 
 class TestFailedAuthTracker:
@@ -118,19 +135,15 @@ class TestFailedAuthTracker:
         Pins that the ring buffer's ``warned`` latch is scoped to a run above the threshold rather
         than to the source's lifetime — permanent silence after one burst would be a regression.
         """
-        tracker = _FailedAuthTracker()
+        fake_clock = _FakeClock()
+        tracker = _FailedAuthTracker(clock=fake_clock)
 
         with caplog.at_level(logging.WARNING, logger="hassette.web.middleware"):
             for _ in range(FAILED_AUTH_THRESHOLD):
                 tracker.record("203.0.113.1")
 
-            # Shift every retained timestamp fully out of the window, simulating a quiet period
-            # without waiting FAILED_AUTH_WINDOW_SECONDS in real time.
-            state = tracker._attempts["203.0.113.1"]
-            state.timestamps = deque(
-                (t - FAILED_AUTH_WINDOW_SECONDS - 1 for t in state.timestamps),
-                maxlen=FAILED_AUTH_THRESHOLD,
-            )
+            # Advance past the window, simulating a quiet period.
+            fake_clock.advance(FAILED_AUTH_WINDOW_SECONDS + 1)
 
             for _ in range(FAILED_AUTH_THRESHOLD):
                 tracker.record("203.0.113.1")
@@ -140,24 +153,22 @@ class TestFailedAuthTracker:
 
     def test_attempts_aged_out_of_window_do_not_count_toward_threshold(self, caplog: pytest.LogCaptureFixture) -> None:
         """Stale attempts are evicted rather than counted, so the window stays a real sliding window."""
-        tracker = _FailedAuthTracker()
+        fake_clock = _FakeClock()
+        tracker = _FailedAuthTracker(clock=fake_clock)
 
         with caplog.at_level(logging.WARNING, logger="hassette.web.middleware"):
             for _ in range(FAILED_AUTH_THRESHOLD - 1):
                 tracker.record("203.0.113.1")
 
-            state = tracker._attempts["203.0.113.1"]
-            state.timestamps = deque(
-                (t - FAILED_AUTH_WINDOW_SECONDS - 1 for t in state.timestamps),
-                maxlen=FAILED_AUTH_THRESHOLD,
-            )
+            # Advance past the window, aging out every attempt recorded so far.
+            fake_clock.advance(FAILED_AUTH_WINDOW_SECONDS + 1)
 
             # One more attempt: 10 total recorded, but only this one is inside the window.
             tracker.record("203.0.113.1")
 
         warn_records = [r for r in caplog.records if "failed auth attempts" in r.getMessage()]
         assert len(warn_records) == 0
-        assert len(state.timestamps) == 1
+        assert len(tracker._attempts["203.0.113.1"].timestamps) == 1
 
     def test_warning_rearms_after_partial_staleness_not_only_full_quiet(self, caplog: pytest.LogCaptureFixture) -> None:
         """Re-arming must key off the survivor count, not merely "some" eviction happened.
@@ -168,23 +179,22 @@ class TestFailedAuthTracker:
         always 10 once a source has ever made 10 attempts — checking the re-arm condition after
         the append can never observe the dip to 9 survivors that should have re-armed the latch.
         """
-        tracker = _FailedAuthTracker()
+        fake_clock = _FakeClock()
+        tracker = _FailedAuthTracker(clock=fake_clock)
 
         with caplog.at_level(logging.WARNING, logger="hassette.web.middleware"):
-            for _ in range(FAILED_AUTH_THRESHOLD):
+            tracker.record("203.0.113.1")  # the eventual "oldest" survivor
+
+            # Advance just short of the window so the next 9 attempts land well inside it,
+            # bringing the source to the threshold and firing the first warning.
+            fake_clock.advance(FAILED_AUTH_WINDOW_SECONDS - 1)
+            for _ in range(FAILED_AUTH_THRESHOLD - 1):
                 tracker.record("203.0.113.1")
 
-            # Age out only the single oldest timestamp, leaving 9 of 10 survivors — below
-            # threshold, which should re-arm the latch for the next attempt.
-            state = tracker._attempts["203.0.113.1"]
-            oldest, *rest = state.timestamps
-            state.timestamps = deque(
-                [oldest - FAILED_AUTH_WINDOW_SECONDS - 1, *rest],
-                maxlen=FAILED_AUTH_THRESHOLD,
-            )
-
-            # This attempt brings the survivor count back to 10 — the second crossing of the
-            # threshold, which must warn again.
+            # Advance just past the window relative to the *first* attempt only — the other 9
+            # are still inside it. This ages out exactly one timestamp, leaving 9 survivors,
+            # which should re-arm the latch for the next attempt.
+            fake_clock.advance(2)
             tracker.record("203.0.113.1")
 
         warn_records = [r for r in caplog.records if "failed auth attempts" in r.getMessage()]


### PR DESCRIPTION
## Summary

Closes the two `high`-severity findings from an external security audit of the repo at
`4a20fb95`. Both are unauthenticated resource-consumption paths (CWE-400) reachable through the
default listener. The audit's other four findings are handled separately — see *Scope* below.

## Finding 1 — unbounded pre-authentication body buffering

`POST /api/auth/session` sits in `DefaultDenyMiddleware`'s `EXEMPT_ROUTES` by design: it is the
one route that must be reachable with zero prior credential. Uvicorn has no maximum-body-size
setting and Starlette buffers a whole body before the handler runs, so a peer could drive
arbitrary pre-auth allocation. The audit reached the handler with an 8 MiB token and got the
route's normal 401 back.

`RequestBodySizeLimitMiddleware` (new, `src/hassette/web/body_limit.py`) caps any HTTP request
body at 64 KiB and answers 413 before the route runs.

Two design notes:

- **Raw ASGI, not `BaseHTTPMiddleware`.** It wraps `receive` and counts bytes as they arrive. A
  `Content-Length` check alone is not a limit — a client can omit the header and stream past the
  ceiling with `Transfer-Encoding: chunked`. A `BaseHTTPMiddleware` would also have buffered the
  body already, which is the allocation being prevented.
- **A module constant, not a config field.** Every body-carrying route in the API takes a small
  fixed payload (a log level, an app key, a job trigger), so there is no legitimate reason for a
  deployment to raise it. A `web_api` knob would surface in the config UI and the OpenAPI schema
  for no one's benefit.

`SessionRequest.token` also gained a `max_length` (4096), which puts the constraint in the
OpenAPI schema and rejects an absurd value with a 422 before `check_bearer_token` compares it.
`frontend/openapi.json` is regenerated accordingly; `generated-types.ts` is unchanged, since
TypeScript types don't encode `maxLength`.

Verified against the audit's own reproduction — an 8 MiB token against a real uvicorn server:

| | Before | After |
|---|---|---|
| 8 MiB token | 401 (reached the handler) | **413** |
| Normal login | 200 + `Set-Cookie` | 200 + `Set-Cookie` |

## Finding 2 — quadratic failed-auth accounting

`_FailedAuthTracker.record` rebuilt a source's entire in-window timestamp list on every call, so
retained state grew with the request count and cumulative work was quadratic. One unauthenticated
peer could aim that at the shared event loop.

Worth noting what was *already* bounded, since the audit's write-up doesn't: growth **across**
sources was capped at `MAX_TRACKED_SOURCES` with LRU eviction. The gap was only within a single
source's live window.

Per-source state is now a ring buffer capped at `FAILED_AUTH_THRESHOLD` plus a `warned` latch —
constant memory and constant work per request. Stale-source eviction now exploits the dict's
existing LRU ordering (stale entries cluster at the front, so the scan stops at the first live
one) instead of walking every tracked source on every request.

Measured locally, one source, before vs. after:

| Attempts | Before | After |
|---|---|---|
| 2,000 | 0.035s, 2,000 retained | 0.0005s, 10 retained |
| 8,000 | 0.535s, 8,000 retained | 0.0019s, 10 retained |
| 16,000 | 2.075s, 16,000 retained | 0.0039s, 10 retained |

That reproduces the quadratic shape the audit measured (0.0496s / 0.2276s / 0.6219s at 2k/4k/8k).

**Warning semantics are unchanged:** one WARN when a source reaches the threshold inside the
window, re-armed once its in-window count drops back below it. The five pre-existing tracker tests
pass untouched.

## Tests

`tests/integration/web_api/test_body_limit.py` (new, 13 tests) and four new cases in
`tests/unit/web/test_middleware.py`.

Two body-limit tests run against a **real uvicorn server** rather than `ASGITransport`, because
the in-process transport can't cover them: it never exercises uvicorn's HTTP framing, and the
chunked case has no `Content-Length` at all, so only a real client can produce it.

Two deliberate test-design choices worth flagging for review:

- **No wall-clock scaling assertion** for finding 2. Bounded retained state *is* the proof that
  per-request work is constant, and it holds deterministically. A timing ratio would only add a
  race against CI's scheduler — the failure mode CLAUDE.md already documents for config-driven
  real-clock timeouts.
- **The chunked test asserts a status range (400 or 413), not an exact status.** Answering a
  request whose body is still streaming leaves unread bytes in the connection, and h11 reports the
  leftover as a framing error. Which status the client sees depends on socket buffering, so
  pinning either would flake. The test additionally asserts no session cookie was set, which is
  the property that actually matters: the request was refused without the handler running.

That framing behavior is a real limitation rather than a test artifact, and it's documented at the
`except` site in `body_limit.py`.

## Scope

The audit reported six findings. This PR covers the two `high` ones. The rest:

- Container-typed config secrets bypassing masking (`medium`) — separate PR, `web/config_view.py`.
- Two codegen integrity findings (`medium`, `low`) — separate PR, `codegen/`.
- Error-handler spawn bound (`medium`) — already tracked as #573, which now carries the audit's
  notes, including a third spawn site the existing `FIXME` markers didn't cover.

They're split because no single changelog line describes all four concerns, and #573 is a design
task rather than a fix.

## Review notes

Findings from `code-reviewer`, `integration-reviewer`, and `wtf-reviewer` were applied before this
push: the duplicated `auth_hassette`/`auth_app`/`auth_client` fixtures moved to
`tests/integration/web_api/conftest.py` (they had already drifted on first duplication), `record`
decomposed, a wrong headroom claim in a docstring corrected, the cross-middleware exception
propagation documented, and two ruff violations (`N818`, `ARG001`) fixed.

Docs: one paragraph in `docs/pages/web-ui/index.md`, inside the existing authentication note.
