### PR TITLE
fix(web): mask secrets held inside config lists, tuples, and mappings

### DIFF
--- a/src/hassette/web/config_view.py
+++ b/src/hassette/web/config_view.py
@@ -159,6 +159,14 @@ def _mask_node(node: dict[str, Any], value: Any) -> Any:
     if _is_secret_node(node):
         return MASK_SENTINEL if value is not None and value != "" else value
 
+    # A tuple is what prefixItems exists to describe, so it is masked like a list and handed
+    # back as a tuple. Neither endpoint produces one today -- TOML parsing and
+    # model_dump(mode="json") both yield lists -- but passing one through unmasked would be a
+    # silent leak rather than a visible failure.
+    if isinstance(value, tuple):
+        masked_items = _mask_node(node, list(value))
+        return tuple(masked_items) if isinstance(masked_items, list) else masked_items
+
     # A plain scalar has nothing to descend into, whatever the schema says about it.
     if not isinstance(value, dict | list):
         return value

--- a/src/hassette/web/config_view.py
+++ b/src/hassette/web/config_view.py
@@ -22,6 +22,7 @@ Note: the OpenAPI freshness check does not cover ``ui`` annotation content (it r
 ``ui``-shape drift.
 """
 
+import re
 from collections.abc import Iterator
 from logging import getLogger
 from typing import TYPE_CHECKING, Any
@@ -82,20 +83,38 @@ def _shape_candidates(node: dict[str, Any]) -> Iterator[dict[str, Any]]:
 def _mask_object(shape: dict[str, Any], value: dict[str, Any]) -> dict[str, Any] | None:
     """Mask a mapping value against an object-shaped schema node, or None if it is not one.
 
-    ``properties`` names specific keys; ``additionalProperties`` describes everything else. A
-    model with ``extra="allow"`` carries both, so named keys are resolved first and the rest
-    fall back — rather than picking one key and ignoring the other.
+    Three keys can describe a mapping's values, in descending specificity: ``properties``
+    names exact keys, ``patternProperties`` matches keys by regex (which is what Pydantic
+    emits for a mapping whose key type carries a pattern constraint), and
+    ``additionalProperties`` covers everything left. A model with ``extra="allow"`` can carry
+    more than one, so each key is resolved against the most specific match rather than
+    picking a single schema key and ignoring the others.
     """
     named_props = shape.get("properties")
+    pattern_props = shape.get("patternProperties")
     extra_props = shape.get("additionalProperties")
-    if not isinstance(named_props, dict) and not isinstance(extra_props, dict):
+    if not any(isinstance(candidate, dict) for candidate in (named_props, pattern_props, extra_props)):
         return None
     named_props = named_props if isinstance(named_props, dict) else {}
+    pattern_props = pattern_props if isinstance(pattern_props, dict) else {}
 
     masked: dict[str, Any] = {}
     for key, item in value.items():
         if key in named_props:
             masked[key] = _mask_node(named_props[key], item)
+            continue
+
+        # JSON Schema applies every patternProperties entry whose regex matches (unanchored),
+        # so all matches are folded in rather than stopping at the first.
+        matched_pattern = False
+        item_masked = item
+        for pattern, sub_node in pattern_props.items():
+            if isinstance(sub_node, dict) and re.search(pattern, key):
+                item_masked = _mask_node(sub_node, item_masked)
+                matched_pattern = True
+
+        if matched_pattern:
+            masked[key] = item_masked
         elif isinstance(extra_props, dict):
             masked[key] = _mask_node(extra_props, item)
         else:
@@ -140,20 +159,23 @@ def _mask_node(node: dict[str, Any], value: Any) -> Any:
     if _is_secret_node(node):
         return MASK_SENTINEL if value is not None and value != "" else value
 
-    for shape in _shape_candidates(node):
-        if isinstance(value, dict):
-            masked_object = _mask_object(shape, value)
-            if masked_object is not None:
-                return masked_object
-        elif isinstance(value, list):
-            masked_array = _mask_array(shape, value)
-            if masked_array is not None:
-                return masked_array
+    # A plain scalar has nothing to descend into, whatever the schema says about it.
+    if not isinstance(value, dict | list):
+        return value
 
-    # No candidate shape described this value: either it is a plain scalar, or the schema says
-    # nothing about its structure. Either way there is nothing to descend into, so it passes
-    # through unchanged — masking is type-driven and never guesses.
-    return value
+    # Every candidate shape is applied in turn rather than stopping at the first that matches.
+    # A union can offer several branches that all describe an object, and picking one means a
+    # branch that is not chosen never masks: for a discriminated union, a variant's secret key
+    # is simply absent from the other variant's properties and passes straight through. Folding
+    # is safe because masking only ever replaces a value with the sentinel or recurses -- it
+    # never restores plaintext, and re-masking the sentinel is a no-op -- so applying a branch
+    # that does not describe this value cannot mask anything extra.
+    masked = value
+    for shape in _shape_candidates(node):
+        result = _mask_object(shape, masked) if isinstance(masked, dict) else _mask_array(shape, masked)
+        if result is not None:
+            masked = result
+    return masked
 
 
 def mask_values(schema_props: dict[str, Any], values: dict[str, Any]) -> dict[str, Any]:

--- a/src/hassette/web/config_view.py
+++ b/src/hassette/web/config_view.py
@@ -22,6 +22,7 @@ Note: the OpenAPI freshness check does not cover ``ui`` annotation content (it r
 ``ui``-shape drift.
 """
 
+from collections.abc import Iterator
 from logging import getLogger
 from typing import TYPE_CHECKING, Any
 
@@ -55,47 +56,123 @@ def _is_secret_node(node: dict[str, Any]) -> bool:
     return False
 
 
-def _object_properties(node: dict[str, Any]) -> dict[str, Any] | None:
-    """Return the ``properties`` dict of an object-typed schema node, or None.
+def _shape_candidates(node: dict[str, Any]) -> Iterator[dict[str, Any]]:
+    """Yield ``node`` itself, then any ``anyOf``/``oneOf``/``allOf`` branch.
 
-    Handles a required nested model (``{type: object, properties: {...}}``) directly,
-    and an optional nested model (``SomeGroup | None``) which Pydantic emits as
-    ``anyOf: [{type: object, properties: {...}}, {type: null}]`` — without the anyOf
-    branch, secrets inside an optional nested group would pass through unmasked.
+    An optional field wraps its real shape in a union — ``SomeGroup | None`` becomes
+    ``anyOf: [{type: object, properties: {...}}, {type: null}]`` and
+    ``tuple[SecretStr, SecretStr] | None`` becomes ``anyOf: [{type: array, prefixItems:
+    [...]}, {type: null}]``. Object and container shapes therefore have to be looked for in
+    the branches as well as on the node, or secrets nested inside an optional group or
+    container pass through unmasked.
+
+    ``anyOf`` is what optional fields actually emit today. ``oneOf`` is what a discriminated
+    union would emit, which the module docstring already flags as a shape to expect. ``allOf``
+    is not emitted by the current Pydantic — a ``$ref`` with sibling keywords is inlined
+    rather than wrapped — but older versions did wrap, and looking in one extra place can only
+    ever mask more, never less, so it stays as fail-safe insurance on a security boundary.
     """
-    if node.get("type") == "object" and "properties" in node:
-        return node["properties"]
-    for branch in node.get("anyOf", []):
-        if isinstance(branch, dict) and branch.get("type") == "object" and "properties" in branch:
-            return branch["properties"]
-    return None
+    yield node
+    for keyword in ("anyOf", "oneOf", "allOf"):
+        for branch in node.get(keyword, []):
+            if isinstance(branch, dict):
+                yield branch
+
+
+def _mask_object(shape: dict[str, Any], value: dict[str, Any]) -> dict[str, Any] | None:
+    """Mask a mapping value against an object-shaped schema node, or None if it is not one.
+
+    ``properties`` names specific keys; ``additionalProperties`` describes everything else. A
+    model with ``extra="allow"`` carries both, so named keys are resolved first and the rest
+    fall back — rather than picking one key and ignoring the other.
+    """
+    named_props = shape.get("properties")
+    extra_props = shape.get("additionalProperties")
+    if not isinstance(named_props, dict) and not isinstance(extra_props, dict):
+        return None
+    named_props = named_props if isinstance(named_props, dict) else {}
+
+    masked: dict[str, Any] = {}
+    for key, item in value.items():
+        if key in named_props:
+            masked[key] = _mask_node(named_props[key], item)
+        elif isinstance(extra_props, dict):
+            masked[key] = _mask_node(extra_props, item)
+        else:
+            masked[key] = item
+    return masked
+
+
+def _mask_array(shape: dict[str, Any], value: list[Any]) -> list[Any] | None:
+    """Mask a list value against an array-shaped schema node, or None if it is not one.
+
+    ``prefixItems`` is positional and describes a fixed-length tuple; ``items`` is homogeneous
+    and describes the rest. A tuple emits only the former and a list only the latter, so both
+    are handled, with positional slots taking precedence.
+    """
+    prefix_items = shape.get("prefixItems")
+    item_schema = shape.get("items")
+    if not isinstance(prefix_items, list) and not isinstance(item_schema, dict):
+        return None
+    prefix_items = prefix_items if isinstance(prefix_items, list) else []
+
+    masked: list[Any] = []
+    for index, item in enumerate(value):
+        if index < len(prefix_items) and isinstance(prefix_items[index], dict):
+            masked.append(_mask_node(prefix_items[index], item))
+        elif isinstance(item_schema, dict):
+            masked.append(_mask_node(item_schema, item))
+        else:
+            masked.append(item)
+    return masked
+
+
+def _mask_node(node: dict[str, Any], value: Any) -> Any:
+    """Return ``value`` masked according to the schema node describing it.
+
+    The walk is schema-and-value recursive rather than property recursive: an object's
+    ``properties``/``additionalProperties`` and a container's ``prefixItems``/``items`` are
+    all descended, and each descent lands back here — so an object inside a list, or a list
+    inside a mapping, is reached the same way a top-level field is.
+
+    Returns new dicts and lists; never mutates ``value``.
+    """
+    if _is_secret_node(node):
+        return MASK_SENTINEL if value is not None and value != "" else value
+
+    for shape in _shape_candidates(node):
+        if isinstance(value, dict):
+            masked_object = _mask_object(shape, value)
+            if masked_object is not None:
+                return masked_object
+        elif isinstance(value, list):
+            masked_array = _mask_array(shape, value)
+            if masked_array is not None:
+                return masked_array
+
+    # No candidate shape described this value: either it is a plain scalar, or the schema says
+    # nothing about its structure. Either way there is nothing to descend into, so it passes
+    # through unchanged — masking is type-driven and never guesses.
+    return value
 
 
 def mask_values(schema_props: dict[str, Any], values: dict[str, Any]) -> dict[str, Any]:
     """Return a copy of ``values`` with secret fields replaced by ``MASK_SENTINEL``.
 
-    Walks ``schema_props`` (the ``properties`` dict of a deref'd schema node).
-    For each property:
-    - If the node is a secret (``writeOnly``/``format: password``), replaces the value
-      with ``MASK_SENTINEL`` when present and non-empty, leaves it ``None``/absent otherwise.
-    - If the node is a nested object with its own ``properties`` (required or optional via
-      ``anyOf``), recurses so secrets at any depth are masked.
+    Walks ``schema_props`` (the ``properties`` dict of a deref'd schema node) and masks each
+    value against its own node. A secret (``writeOnly``/``format: password``) is replaced
+    with ``MASK_SENTINEL`` when present and non-empty, and left ``None``/empty/absent
+    otherwise. Nested objects and list/tuple/mapping containers are descended, so a secret
+    is reached at any depth and through any combination of the two.
+
+    Keys absent from ``schema_props``, and plain non-secret values, are passed through
+    untouched — masking is type-driven, so an ordinary list or mapping stays readable.
 
     Does not mutate the input dict; returns a new dict.
     """
-    result = dict(values)
-    for key, node in schema_props.items():
-        if key not in result:
-            continue
-        if _is_secret_node(node):
-            current = result[key]
-            if current is not None and current != "":
-                result[key] = MASK_SENTINEL
-            continue
-        nested_props = _object_properties(node)
-        if nested_props is not None and isinstance(result.get(key), dict):
-            result[key] = mask_values(nested_props, result[key])
-    return result
+    return {
+        key: _mask_node(schema_props[key], value) if key in schema_props else value for key, value in values.items()
+    }
 
 
 def _materialize(obj: Any, seen: frozenset[int] | None = None) -> Any:

--- a/tests/integration/web_api/test_api_app_config.py
+++ b/tests/integration/web_api/test_api_app_config.py
@@ -271,6 +271,29 @@ class AppWithBasicConfig:
     app_config_cls = BasicAppConfig
 
 
+class SecretHolder(BaseModel):
+    """Nested sub-model carrying a secret, used as a list element."""
+
+    label: str = "unnamed"
+    token: SecretStr
+
+
+class ContainerSecretConfig(BaseModel):
+    """Stub app config holding secrets inside containers rather than as scalar fields.
+
+    An app author's third-party credentials commonly land in a list or mapping rather than
+    a single field. Each of these maps to a different JSON-schema key.
+    """
+
+    api_keys: list[SecretStr] = []
+    creds: dict[str, SecretStr] = {}
+    holders: list[SecretHolder] = []
+
+
+class AppWithContainerSecrets:
+    app_config_cls = ContainerSecretConfig
+
+
 class TestAppConfigTypeDrivenMasking:
     """Tests for type-driven masking on the app config endpoint.
 
@@ -324,6 +347,82 @@ class TestAppConfigTypeDrivenMasking:
         response = await client.get("/api/apps/my_app/config")
 
         assert "super-secret-value-12345" not in response.text
+
+
+class TestAppConfigContainerMasking:
+    """Secrets held inside containers are masked in the response, not just in ``mask_values``.
+
+    A unit test proves the masking function; these prove the bytes that leave the endpoint.
+    ``config_toml`` is rendered from the already-masked values, so asserting on the full
+    response body covers the JSON and TOML surfaces together.
+    """
+
+    async def test_list_of_secrets_masked_in_response(self, client, mock_hassette) -> None:
+        """api_keys: list[SecretStr] is masked element-wise."""
+        manifest = make_manifest_mock(
+            app_key="my_app",
+            app_config={"api_keys": ["first-plaintext", "second-plaintext"]},
+        )
+        mock_hassette._app_handler.registry.get_manifest.return_value = manifest
+        mock_hassette._app_handler.registry.get.return_value = AppWithContainerSecrets()
+
+        response = await client.get("/api/apps/my_app/config")
+
+        assert response.status_code == 200
+        assert response.json()["app_config"]["api_keys"] == [MASK_SENTINEL, MASK_SENTINEL]
+
+    async def test_dict_of_secrets_masked_in_response(self, client, mock_hassette) -> None:
+        """creds: dict[str, SecretStr] is masked by value, keys preserved."""
+        manifest = make_manifest_mock(
+            app_key="my_app",
+            app_config={"creds": {"prod": "prod-plaintext", "dev": "dev-plaintext"}},
+        )
+        mock_hassette._app_handler.registry.get_manifest.return_value = manifest
+        mock_hassette._app_handler.registry.get.return_value = AppWithContainerSecrets()
+
+        response = await client.get("/api/apps/my_app/config")
+
+        assert response.status_code == 200
+        assert response.json()["app_config"]["creds"] == {"prod": MASK_SENTINEL, "dev": MASK_SENTINEL}
+
+    async def test_secret_in_listed_model_masked_in_response(self, client, mock_hassette) -> None:
+        """A secret on a model nested under a list is masked; its plain sibling is not."""
+        manifest = make_manifest_mock(
+            app_key="my_app",
+            app_config={"holders": [{"label": "broker", "token": "broker-plaintext"}]},
+        )
+        mock_hassette._app_handler.registry.get_manifest.return_value = manifest
+        mock_hassette._app_handler.registry.get.return_value = AppWithContainerSecrets()
+
+        response = await client.get("/api/apps/my_app/config")
+
+        assert response.status_code == 200
+        holder = response.json()["app_config"]["holders"][0]
+        assert holder["token"] == MASK_SENTINEL
+        assert holder["label"] == "broker"
+
+    async def test_container_plaintext_never_appears_in_response_body(self, client, mock_hassette) -> None:
+        """No container-held plaintext survives anywhere in the body, TOML rendering included."""
+        manifest = make_manifest_mock(
+            app_key="my_app",
+            app_config={
+                "api_keys": ["listed-secret-12345"],
+                "creds": {"prod": "mapped-secret-67890"},
+                "holders": [{"label": "broker", "token": "nested-secret-abcde"}],
+            },
+        )
+        mock_hassette._app_handler.registry.get_manifest.return_value = manifest
+        mock_hassette._app_handler.registry.get.return_value = AppWithContainerSecrets()
+
+        response = await client.get("/api/apps/my_app/config")
+
+        assert "listed-secret-12345" not in response.text
+        assert "mapped-secret-67890" not in response.text
+        assert "nested-secret-abcde" not in response.text
+        # The TOML surface is rendered from the same masked values, so it is covered above --
+        # parse it anyway to prove the masked value is what actually reaches the rendering.
+        parsed = tomllib.loads(response.json()["config_toml"])
+        assert parsed["hassette"]["apps"]["my_app"]["config"]["api_keys"] == [MASK_SENTINEL]
 
 
 class TestSchemaDeref:

--- a/tests/unit/web/test_config_view.py
+++ b/tests/unit/web/test_config_view.py
@@ -56,6 +56,38 @@ class _OptionalGroupConfig(BaseModel):
     inner_opt: _InnerConfig | None = None
 
 
+class _ContainerSecretConfig(BaseModel):
+    """Throwaway model: secrets held directly inside list/tuple/dict containers.
+
+    Pydantic emits a different schema key for each: ``items`` for a homogeneous list,
+    ``prefixItems`` for a fixed-length tuple, and ``additionalProperties`` for a mapping.
+    The optional tuple additionally wraps its array shape in ``anyOf``.
+    """
+
+    key_list: list[SecretStr]
+    key_pair: tuple[SecretStr, SecretStr] | None = None
+    key_map: dict[str, SecretStr]
+
+
+class _NestedContainerConfig(BaseModel):
+    """Throwaway model: containers whose elements are objects or further containers.
+
+    ``inners`` puts an object node under ``items``, so masking has to cross from a
+    container back into a property walk. ``grouped_keys`` stacks two container levels.
+    """
+
+    inners: list[_InnerConfig]
+    grouped_keys: dict[str, list[SecretStr]]
+
+
+class _PlainContainerConfig(BaseModel):
+    """Throwaway model: containers of plain values, which must stay visible."""
+
+    names: list[str]
+    labels: dict[str, str]
+    real_secret: SecretStr
+
+
 class TestTypeDrivenMasking:
     """Masking is driven by the schema's writeOnly/format:password markers, not field names."""
 
@@ -168,6 +200,124 @@ class TestNestedMasking:
         values = {"name": "test", "inner_opt": None}
         result = build_config_view(schema, values)
         assert result["config_values"]["inner_opt"] is None
+
+
+class TestContainerMasking:
+    """Masking recurses through list/tuple/dict containers, not just object properties.
+
+    Each case below covers a distinct schema key. A walk that only reads ``properties``
+    hands the secret out in plaintext on the app-config endpoints, where values come from
+    raw TOML and never passed through a ``SecretStr`` field for Pydantic to mask natively.
+    """
+
+    def test_list_of_secrets_masked(self) -> None:
+        """Secrets under ``items`` (list[SecretStr]) are masked element-wise."""
+        schema = _ContainerSecretConfig.model_json_schema()
+        values = {"key_list": ["one", "two"], "key_map": {}}
+        result = build_config_view(schema, values)
+        assert result["config_values"]["key_list"] == [MASK_SENTINEL, MASK_SENTINEL]
+
+    def test_optional_tuple_of_secrets_masked(self) -> None:
+        """Secrets under ``prefixItems`` nested in ``anyOf`` are masked positionally.
+
+        The field is optional, so Pydantic wraps the array shape in a union — container
+        detection has to look inside union branches, not just at the top-level node.
+        """
+        schema = _ContainerSecretConfig.model_json_schema()
+        values = {"key_list": [], "key_pair": ["left", "right"], "key_map": {}}
+        result = build_config_view(schema, values)
+        assert result["config_values"]["key_pair"] == [MASK_SENTINEL, MASK_SENTINEL]
+
+    def test_dict_of_secrets_masked(self) -> None:
+        """Secrets under ``additionalProperties`` (dict[str, SecretStr]) are masked by value."""
+        schema = _ContainerSecretConfig.model_json_schema()
+        values = {"key_list": [], "key_map": {"prod": "live-key", "dev": "test-key"}}
+        result = build_config_view(schema, values)
+        assert result["config_values"]["key_map"] == {"prod": MASK_SENTINEL, "dev": MASK_SENTINEL}
+
+    def test_dict_keys_are_preserved(self) -> None:
+        """Mapping keys stay visible — only the values are secret."""
+        schema = _ContainerSecretConfig.model_json_schema()
+        values = {"key_list": [], "key_map": {"prod": "live-key", "dev": "test-key"}}
+        result = build_config_view(schema, values)
+        assert set(result["config_values"]["key_map"]) == {"prod", "dev"}
+
+    def test_list_of_nested_models_masked(self) -> None:
+        """A secret inside an object under ``items`` is masked; its siblings stay visible.
+
+        This is the case a scalar-container-only fix would still miss: the element schema
+        is an object with its own ``properties``, so the walk has to cross from container
+        back into a property walk.
+        """
+        schema = _NestedContainerConfig.model_json_schema()
+        values = {
+            "inners": [
+                {"nested_secret": "first", "nested_name": "a"},
+                {"nested_secret": "second", "nested_name": "b"},
+            ],
+            "grouped_keys": {},
+        }
+        result = build_config_view(schema, values)
+        assert [i["nested_secret"] for i in result["config_values"]["inners"]] == [MASK_SENTINEL, MASK_SENTINEL]
+        assert [i["nested_name"] for i in result["config_values"]["inners"]] == ["a", "b"]
+
+    def test_two_container_levels_masked(self) -> None:
+        """dict[str, list[SecretStr]] — ``additionalProperties`` wrapping ``items``."""
+        schema = _NestedContainerConfig.model_json_schema()
+        values = {"inners": [], "grouped_keys": {"prod": ["a", "b"], "dev": ["c"]}}
+        result = build_config_view(schema, values)
+        assert result["config_values"]["grouped_keys"] == {
+            "prod": [MASK_SENTINEL, MASK_SENTINEL],
+            "dev": [MASK_SENTINEL],
+        }
+
+    def test_plain_containers_left_visible(self) -> None:
+        """list[str] and dict[str, str] stay readable — masking is type-driven, not blanket.
+
+        A regression to blanket-masking containers would break the config UI for every
+        ordinary list or mapping setting.
+        """
+        schema = _PlainContainerConfig.model_json_schema()
+        values = {
+            "names": ["alpha", "beta"],
+            "labels": {"env": "prod"},
+            "real_secret": "hunter2",
+        }
+        result = build_config_view(schema, values)
+        assert result["config_values"]["names"] == ["alpha", "beta"]
+        assert result["config_values"]["labels"] == {"env": "prod"}
+        assert result["config_values"]["real_secret"] == MASK_SENTINEL
+
+    def test_empty_and_null_inside_containers_left_untouched(self) -> None:
+        """The scalar rule carries into containers: '' and None are not masked."""
+        schema = _ContainerSecretConfig.model_json_schema()
+        values = {"key_list": ["", "set", None], "key_map": {"blank": "", "unset": None, "set": "x"}}
+        result = build_config_view(schema, values)
+        assert result["config_values"]["key_list"] == ["", MASK_SENTINEL, None]
+        assert result["config_values"]["key_map"] == {"blank": "", "unset": None, "set": MASK_SENTINEL}
+
+    def test_container_input_not_mutated(self) -> None:
+        """Masking a container returns new containers; the caller's nested data is untouched."""
+        schema = _NestedContainerConfig.model_json_schema()
+        values = {
+            "inners": [{"nested_secret": "deep", "nested_name": "a"}],
+            "grouped_keys": {"prod": ["live-key"]},
+        }
+        build_config_view(schema, values)
+        assert values["inners"][0]["nested_secret"] == "deep"
+        assert values["grouped_keys"]["prod"] == ["live-key"]
+
+    def test_masking_containers_is_idempotent(self) -> None:
+        """Masking already-masked container values is a no-op.
+
+        The global config path feeds in values Pydantic already masked, so the mask has to
+        survive a second pass unchanged.
+        """
+        schema = _ContainerSecretConfig.model_json_schema()
+        values = {"key_list": [MASK_SENTINEL], "key_map": {"prod": MASK_SENTINEL}}
+        result = build_config_view(schema, values)
+        assert result["config_values"]["key_list"] == [MASK_SENTINEL]
+        assert result["config_values"]["key_map"] == {"prod": MASK_SENTINEL}
 
 
 class TestUnsetSecrets:

--- a/tests/unit/web/test_config_view.py
+++ b/tests/unit/web/test_config_view.py
@@ -1,8 +1,9 @@
 """Unit tests for the shared config view builder (schema deref + type-driven masking)."""
 
 import json
+from typing import Annotated, Literal
 
-from pydantic import BaseModel, SecretStr
+from pydantic import BaseModel, Field, SecretStr, StringConstraints
 
 from hassette.web.config_view import MASK_SENTINEL, build_config_view, deref_schema, mask_all_values, mask_values
 
@@ -86,6 +87,45 @@ class _PlainContainerConfig(BaseModel):
     names: list[str]
     labels: dict[str, str]
     real_secret: SecretStr
+
+
+_PatternKey = Annotated[str, StringConstraints(pattern="^svc_")]
+
+
+class _PatternMapConfig(BaseModel):
+    """Throwaway model: a mapping whose key type carries a pattern constraint.
+
+    Pydantic then emits the value schema under ``patternProperties`` keyed by the regex,
+    not under ``additionalProperties`` — a fourth container key, distinct from the three
+    that plain containers use.
+    """
+
+    creds: dict[_PatternKey, SecretStr] = {}
+
+
+class _PlainVariant(BaseModel):
+    """Discriminated-union variant carrying no secret."""
+
+    kind: Literal["plain"] = "plain"
+    label: str = "x"
+
+
+class _SecretVariant(BaseModel):
+    """Discriminated-union variant carrying a secret."""
+
+    kind: Literal["secret"] = "secret"
+    token: SecretStr
+
+
+class _DiscriminatedListConfig(BaseModel):
+    """Throwaway model: a list whose element is a discriminated union.
+
+    Pydantic emits ``oneOf`` with one object branch per variant. Masking against only the
+    first matching branch leaves a later variant's secret in plaintext, because the secret's
+    key is simply absent from the earlier branch's ``properties``.
+    """
+
+    entries: list[Annotated[_PlainVariant | _SecretVariant, Field(discriminator="kind")]] = []
 
 
 class TestTypeDrivenMasking:
@@ -318,6 +358,49 @@ class TestContainerMasking:
         result = build_config_view(schema, values)
         assert result["config_values"]["key_list"] == [MASK_SENTINEL]
         assert result["config_values"]["key_map"] == {"prod": MASK_SENTINEL}
+
+
+class TestPatternAndUnionMasking:
+    """Two further container shapes that a first-match walk hands out in plaintext.
+
+    Both were found by review after the initial container fix, and neither appears in the
+    audit write-up. They share a root cause with it: the walk has to consider every schema
+    key that can describe a value, and every union branch that can apply to it.
+    """
+
+    def test_pattern_properties_secrets_masked(self) -> None:
+        """A secret under ``patternProperties`` is masked for a key matching the regex."""
+        schema = _PatternMapConfig.model_json_schema()
+        values = {"creds": {"svc_prod": "prod-plaintext"}}
+        result = build_config_view(schema, values)
+        assert result["config_values"]["creds"] == {"svc_prod": MASK_SENTINEL}
+
+    def test_pattern_properties_non_matching_key_left_visible(self) -> None:
+        """A key the pattern does not describe is not masked — still type-driven, not blanket."""
+        schema = _PatternMapConfig.model_json_schema()
+        values = {"creds": {"other": "not-a-secret-by-schema"}}
+        result = build_config_view(schema, values)
+        assert result["config_values"]["creds"] == {"other": "not-a-secret-by-schema"}
+
+    def test_secret_in_later_union_branch_masked(self) -> None:
+        """A secret on the second ``oneOf`` branch is masked, not just the first branch's fields.
+
+        The element is a discriminated union. Returning after the first object branch that
+        matches leaves ``token`` untouched, because ``token`` is absent from the plain
+        variant's ``properties`` and therefore passes straight through.
+        """
+        schema = _DiscriminatedListConfig.model_json_schema()
+        values = {"entries": [{"kind": "secret", "token": "union-plaintext"}]}
+        result = build_config_view(schema, values)
+        assert result["config_values"]["entries"][0]["token"] == MASK_SENTINEL
+
+    def test_other_union_branch_plain_field_stays_visible(self) -> None:
+        """Considering every branch must not blanket-mask a variant's plain fields."""
+        schema = _DiscriminatedListConfig.model_json_schema()
+        values = {"entries": [{"kind": "plain", "label": "visible"}]}
+        result = build_config_view(schema, values)
+        assert result["config_values"]["entries"][0]["label"] == "visible"
+        assert result["config_values"]["entries"][0]["kind"] == "plain"
 
 
 class TestUnsetSecrets:

--- a/tests/unit/web/test_config_view.py
+++ b/tests/unit/web/test_config_view.py
@@ -268,6 +268,20 @@ class TestContainerMasking:
         result = build_config_view(schema, values)
         assert result["config_values"]["key_pair"] == [MASK_SENTINEL, MASK_SENTINEL]
 
+    def test_runtime_tuple_masked_positionally(self) -> None:
+        """A runtime tuple is masked like the list form, and stays a tuple.
+
+        The endpoints only ever hand this function lists — TOML parsing and
+        ``model_dump(mode="json")`` both produce lists — so this is not reachable through
+        either route today. It is covered because ``prefixItems`` exists specifically to
+        describe tuples: accepting one and returning it unmasked would be a silent leak the
+        moment a caller passed ``model_dump(mode="python")`` output.
+        """
+        schema = _ContainerSecretConfig.model_json_schema()
+        values = {"key_list": [], "key_pair": ("left", "right"), "key_map": {}}
+        result = build_config_view(schema, values)
+        assert result["config_values"]["key_pair"] == (MASK_SENTINEL, MASK_SENTINEL)
+
     def test_dict_of_secrets_masked(self) -> None:
         """Secrets under ``additionalProperties`` (dict[str, SecretStr]) are masked by value."""
         schema = _ContainerSecretConfig.model_json_schema()


### PR DESCRIPTION
### Security fix

Third fix in a series responding to an external security audit — audit finding 3, CWE-200
(sensitive information exposure), medium severity. Follows #1531 and #1532.

`mask_values()` in `src/hassette/web/config_view.py` walked only a schema node's
`properties`, never `items`, `prefixItems`, or `additionalProperties`. Any `AppConfig` field
that held a secret inside a container — `api_keys: list[SecretStr]`, `creds: dict[str,
SecretStr]`, an optional `tuple[SecretStr, SecretStr] | None`, or a `SecretStr` nested inside
a list of sub-models — had that value returned in plaintext by `GET /api/config` and
`GET /api/apps/{app_key}/config`, in both the JSON body and the rendered TOML.

This is not privilege escalation — the caller already holds the Hassette admin token. What
crosses the boundary is a *different* secret: the app author's own third-party credential (a
cloud API key, a broker password), exposed to someone who was only ever granted Hassette
access.

The fix replaces the property-only walk with a schema-node/value co-walk. `_mask_node`
dispatches on the runtime value's shape (dict vs. list) against schema-derived candidates
from `_shape_candidates`, which now also looks inside `anyOf`/`oneOf`/`allOf` branches —
an optional field wraps its real shape in a union, so without checking those branches, a
secret inside an optional container would pass through unmasked the same way the audit
finding described for optional objects. `_mask_object` and `_mask_array` handle
`properties`/`additionalProperties` and `prefixItems`/`items` respectively. `_object_properties`
is subsumed by the co-walk and deleted.

Masking stays strictly type-driven: ordinary `list[str]` and `dict[str, str]` values are
still returned readable, which the config UI relies on. Tests pin that explicitly so a future
change can't accidentally over-mask.

Shapes now covered that the audit write-up didn't call out: `list[NestedModel]` where the
nested model has a `SecretStr` field, and `dict[str, list[SecretStr]]`.

Supersedes part of #708 (already closed as not-planned) — the remaining piece, an on-demand
reveal toggle for masked secrets in the web UI, is tracked separately as #1533.

### Testing

- `edb82bf3` adds the failing tests first (RED — 6 of 10 new tests failed against the
  pre-fix code), `94095736` is the fix (GREEN).
- 4 of the new integration tests were confirmed to genuinely exercise the bug by temporarily
  reverting only `config_view.py` and re-running them.
- Full unit+integration suite on the rebased base: 8931 passed, 1 skipped, 2 xfailed.
- `ruff check`, `prek -a`, `prek pyright -a --stage pre-push`, and
  `tools/check_schemas_fresh.py` all exit 0.
- No Pydantic model or route signature changed, so no schema/type regeneration was needed.
- code-reviewer and integration-reviewer: PASS, 0 findings. wtf-reviewer raised 5 findings,
  all fixed before this PR.

Note: GitHub Actions is currently experiencing an outage on this repo, so CI may show zero
runs — expected, not a signal to act on.
