### PR TITLE
fix(codegen): render Home Assistant strings as literals instead of raw source

### DIFF
--- a/codegen/src/hassette_codegen/generators/_env.py
+++ b/codegen/src/hassette_codegen/generators/_env.py
@@ -5,14 +5,21 @@ from pathlib import Path
 
 import jinja2
 
+from hassette_codegen.rendering import py_literal
+
 _TEMPLATE_DIR = Path(__file__).resolve().parent.parent / "templates"
 
 
 @lru_cache(maxsize=1)
 def get_jinja_env() -> jinja2.Environment:
-    return jinja2.Environment(
+    env = jinja2.Environment(
         loader=jinja2.FileSystemLoader(str(_TEMPLATE_DIR)),
         keep_trailing_newline=True,
         trim_blocks=True,
         lstrip_blocks=True,
     )
+    # Templates emit Python, so upstream-derived values must never be hand-quoted — see
+    # hassette_codegen.rendering. Autoescape stays off deliberately: HTML escaping is the wrong
+    # escaping for this output and would corrupt generated source.
+    env.filters["py_literal"] = py_literal
+    return env

--- a/codegen/src/hassette_codegen/generators/constants.py
+++ b/codegen/src/hassette_codegen/generators/constants.py
@@ -1,6 +1,7 @@
 """Generate sensor constants file from extracted data."""
 
 from hassette_codegen.extractors.constants import ExtractedConstantSet
+from hassette_codegen.rendering import py_literal
 
 
 def generate_sensor_constants(constant_sets: list[ExtractedConstantSet]) -> str:
@@ -10,7 +11,7 @@ def generate_sensor_constants(constant_sets: list[ExtractedConstantSet]) -> str:
     for cs in constant_sets:
         lines.append(f"{cs.name} = Literal[")
         for val in cs.values:
-            lines.append(f'    "{val}",')
+            lines.append(f"    {py_literal(val)},")
         lines.append("]")
         lines.append("")
 

--- a/codegen/src/hassette_codegen/generators/entities.py
+++ b/codegen/src/hassette_codegen/generators/entities.py
@@ -19,6 +19,7 @@ from hassette_codegen.domain_data import ExtractedDomain, domain_to_title
 from hassette_codegen.extractors.features import ExtractedEnum
 from hassette_codegen.generators._env import get_jinja_env
 from hassette_codegen.generators.states import rename_collisions
+from hassette_codegen.rendering import escape_docstring_text, require_identifier
 from hassette_codegen.type_mapping import map_selector_to_type
 
 DOCSTRING_INDENT = " " * 8
@@ -74,11 +75,18 @@ def generate_entity_wrapper(domain: ExtractedDomain) -> str | None:
         enum_name_lookup[original.lower()] = renamed
 
     for service in domain.services:
+        # Service and field names come straight from the domain's services.yaml keys, which are
+        # arbitrary text — unlike enum members and properties, which the extractors read out of
+        # parsed Python and are identifiers by construction. Nothing downstream can escape an
+        # identifier position, so reject here; the pipeline drops this domain's entity wrapper.
+        require_identifier(service.method_name, kind=f"{domain.name} service method name")
+
         params: list[ServiceParam] = []
         for field in service.fields:
             param_name = field.name
             if domain.override and param_name in domain.override.service_param_renames:
                 param_name = domain.override.service_param_renames[param_name]
+            require_identifier(param_name, kind=f"{domain.name}.{service.name} parameter name")
 
             type_from_override = False
             if domain.override and field.name in domain.override.param_type_overrides:
@@ -129,7 +137,9 @@ def generate_entity_wrapper(domain: ExtractedDomain) -> str | None:
             )
 
         sorted_params = sorted(params, key=lambda p: (not p.required, p.name))
-        summary = service.description or f"Call the {domain.name}.{service.name} service."
+        # A whitespace-only description is as good as absent — it collapses to nothing during
+        # wrapping, and an empty summary produces a docstring with no text to carry.
+        summary = (service.description or "").strip() or f"Call the {domain.name}.{service.name} service."
         services_for_template.append(
             ServiceForTemplate(
                 name=service.name,
@@ -163,17 +173,25 @@ def build_method_docstring(summary: str, params: list[ServiceParam]) -> str:
     a resolved field description appear in ``Args``. Text is rewrapped to the project line length
     and given a trailing period when it lacks terminal punctuation. No ``Returns`` section is
     emitted — the ``-> None`` / ``-> Coroutine`` annotation already states the return.
+
+    Because the result lands in the template at raw statement position, upstream text is escaped
+    before it is wrapped — escaping afterwards would let the added characters push past the line
+    width, and not escaping at all lets a ``\"\"\"`` in a service description close the docstring
+    and land in executable position.
     """
+    # textwrap.fill drops initial_indent entirely when the text collapses to nothing, which would
+    # leave the opening delimiter off and turn the closing one into a string that swallows the rest
+    # of the class. Fall back to an empty docstring rather than a half-open one.
     lines = textwrap.fill(
-        _with_period(summary),
+        _with_period(escape_docstring_text(summary)),
         width=LINE_LENGTH,
         initial_indent=f'{DOCSTRING_INDENT}"""',
         subsequent_indent=DOCSTRING_INDENT,
         break_long_words=False,
         break_on_hyphens=False,
-    ).splitlines()
+    ).splitlines() or [f'{DOCSTRING_INDENT}"""']
 
-    documented = [p for p in params if p.description]
+    documented = [p for p in params if (p.description or "").strip()]
     if documented:
         lines.append("")
         lines.append(f"{DOCSTRING_INDENT}Args:")
@@ -181,7 +199,7 @@ def build_method_docstring(summary: str, params: list[ServiceParam]) -> str:
             # Google hanging indent: the ``name:`` label sits at +4, continuation lines at +8.
             lines.append(
                 textwrap.fill(
-                    _with_period(param.description or ""),
+                    _with_period(escape_docstring_text(param.description or "")),
                     width=LINE_LENGTH,
                     initial_indent=f"{DOCSTRING_INDENT}    {param.name}: ",
                     subsequent_indent=f"{DOCSTRING_INDENT}        ",

--- a/codegen/src/hassette_codegen/generators/states.py
+++ b/codegen/src/hassette_codegen/generators/states.py
@@ -13,7 +13,13 @@ _ATTRIBUTE_SUFFIX_RE = re.compile(r"(?:Entity)?(?P<attr_type>State|Capability)At
 
 
 def generate_state_model(domain: ExtractedDomain) -> str:
-    """Render a state model .py file for a domain."""
+    """Render a state model .py file for a domain.
+
+    Unlike ``generate_entity_wrapper``, this does not validate the identifiers it emits. Enum
+    member names and property names both come from ``ast.Name`` targets the extractors read out of
+    Home Assistant's parsed Python, so they are identifiers by construction; only services.yaml
+    keys are free text. Member *values* still go through ``py_literal`` in the template.
+    """
     env = get_jinja_env()
     template = env.get_template("state_model.py.j2")
 

--- a/codegen/src/hassette_codegen/manifest.py
+++ b/codegen/src/hassette_codegen/manifest.py
@@ -5,6 +5,16 @@ from pathlib import Path
 MANIFEST_FILENAME = ".generated-manifest"
 
 
+def manifest_exists(repo_root: Path) -> bool:
+    """Whether ownership information has ever been recorded.
+
+    An absent manifest and an empty one mean different things: the first is a checkout that has
+    never run the generator, the second is a generator that currently owns nothing. Callers that
+    gate on ownership need to tell them apart, which ``load_manifest`` alone cannot.
+    """
+    return (repo_root / MANIFEST_FILENAME).exists()
+
+
 def load_manifest(repo_root: Path) -> set[Path]:
     """Read the manifest and return owned file paths (relative to repo root)."""
     manifest_path = repo_root / MANIFEST_FILENAME

--- a/codegen/src/hassette_codegen/pipeline.py
+++ b/codegen/src/hassette_codegen/pipeline.py
@@ -20,7 +20,14 @@ from hassette_codegen.ha_source import (
     check_ruff_available,
     discover_domains,
 )
-from hassette_codegen.manifest import detect_orphans, load_manifest, merge_manifest, save_manifest
+from hassette_codegen.manifest import (
+    detect_orphans,
+    is_owned,
+    load_manifest,
+    manifest_exists,
+    merge_manifest,
+    save_manifest,
+)
 from hassette_codegen.output import atomic_write, check_drift
 from hassette_codegen.overrides import (
     DomainOverride,
@@ -29,6 +36,13 @@ from hassette_codegen.overrides import (
     load_overrides,
     validate_overrides,
 )
+from hassette_codegen.rendering import UnsafeGeneratedValueError, require_identifier
+
+# Hand-written files in the generated packages. A Home Assistant component directory with one of
+# these names would otherwise be written straight over them. This list is not redundant with the
+# ownership gate in _may_overwrite: on a checkout that has never run the generator there is no
+# manifest to consult, and this is what protects these files in that window.
+RESERVED_BASENAMES = frozenset({"base", "catalog", "__init__"})
 
 
 def run_pipeline(
@@ -42,10 +56,12 @@ def run_pipeline(
     check_python_version(ha_source.path)
     check_ruff_available()
 
-    all_domains = discover_domains(ha_source.path)
+    all_domains = _reject_unsafe_domain_names(discover_domains(ha_source.path))
     overrides = load_overrides()
 
-    manual_domains = _discover_manual_domains(ha_source.path, overrides, {d.name for d in all_domains})
+    manual_domains = _reject_unsafe_domain_names(
+        _discover_manual_domains(ha_source.path, overrides, {d.name for d in all_domains})
+    )
     all_domains.extend(manual_domains)
     print(f"Discovered {len(all_domains)} entity domains ({len(manual_domains)} manual)", file=sys.stderr)
 
@@ -60,6 +76,7 @@ def run_pipeline(
     validate_overrides(overrides, {d.name for d in all_domains})
 
     previous_manifest = load_manifest(repo_root)
+    manifest_tracked = manifest_exists(repo_root)
     generated_files: set[Path] = set()
     skipped_domains: list[str] = []
     any_drift = False
@@ -85,6 +102,9 @@ def run_pipeline(
                 any_drift = True
             generated_files.add(rel_state)
         else:
+            if not _may_overwrite(state_path, rel_state, previous_manifest, tracked=manifest_tracked):
+                skipped_domains.append(domain_info.name)
+                continue
             if atomic_write(state_path, state_content):
                 generated_files.add(rel_state)
             else:
@@ -92,7 +112,14 @@ def run_pipeline(
                 skipped_domains.append(domain_info.name)
                 continue
 
-        entity_content = generate_entity_wrapper(extracted)
+        try:
+            entity_content = generate_entity_wrapper(extracted)
+        except UnsafeGeneratedValueError as exc:
+            # The state model above is unaffected and stays generated — only the service wrappers
+            # depend on the rejected name.
+            print(f"WARNING: Skipped {domain_info.name} entity wrapper: {exc}", file=sys.stderr)
+            continue
+
         if entity_content is not None:
             entity_path = entities_dir / f"{domain_info.name}.py"
             rel_entity = entity_path.relative_to(repo_root)
@@ -102,6 +129,11 @@ def run_pipeline(
                     any_drift = True
                 generated_files.add(rel_entity)
             else:
+                # Unlike the state model above, the domain is not added to skipped_domains: its
+                # state model did generate. The refusal is reported by the warning, matching how
+                # an entity wrapper that fails ruff validation is already handled.
+                if not _may_overwrite(entity_path, rel_entity, previous_manifest, tracked=manifest_tracked):
+                    continue
                 if atomic_write(entity_path, entity_content):
                     generated_files.add(rel_entity)
                 else:
@@ -164,6 +196,49 @@ def run_pipeline(
         return 1
 
     return 0
+
+
+def _reject_unsafe_domain_names(domains: list[DiscoveredDomain]) -> list[DiscoveredDomain]:
+    """Drop domains whose name cannot safely become a module.
+
+    A domain name is a Home Assistant component directory name taken verbatim, and it becomes
+    both an output filename (``models/states/{name}.py``) and an import path
+    (``from hassette.models.states.{name} import ...``). A name that is not an identifier breaks
+    the import; a name matching a hand-written module overwrites it silently.
+    """
+    safe: list[DiscoveredDomain] = []
+    for domain in domains:
+        if domain.name in RESERVED_BASENAMES:
+            print(f"WARNING: Skipping domain '{domain.name}': reserved for hand-written files", file=sys.stderr)
+            continue
+        try:
+            require_identifier(domain.name, kind="domain name")
+        except UnsafeGeneratedValueError as exc:
+            print(f"WARNING: Skipping domain '{domain.name}': {exc}", file=sys.stderr)
+            continue
+        safe.append(domain)
+    return safe
+
+
+def _may_overwrite(out_path: Path, rel_path: Path, previous_manifest: set[Path], *, tracked: bool) -> bool:
+    """Whether an existing file may be replaced by generated content.
+
+    First-time generation is always allowed — the target does not exist yet. On a checkout that
+    has never run the generator (``tracked`` false) there is no ownership information to consult,
+    so the gate falls through rather than refusing every file; this is the case
+    ``RESERVED_BASENAMES`` exists to cover, since it is the one moment the ownership check cannot
+    protect the hand-written modules. A manifest that exists but lists nothing is a different
+    thing — the generator owns nothing, so it may overwrite nothing.
+
+    The manifest passed here must be the *previous* one, which still lists domains a ``--domain``
+    run did not process — reading a partially rebuilt manifest would refuse to regenerate files
+    the current run legitimately owns.
+    """
+    if not out_path.exists() or not tracked or is_owned(rel_path, previous_manifest):
+        return True
+
+    print(f"WARNING: Refusing to overwrite {rel_path}: exists and is not generator-owned", file=sys.stderr)
+    return False
 
 
 def _extract_domain(

--- a/codegen/src/hassette_codegen/pipeline.py
+++ b/codegen/src/hassette_codegen/pipeline.py
@@ -2,6 +2,7 @@
 
 import sys
 from pathlib import Path
+from typing import NamedTuple
 
 from hassette_codegen.domain_data import ExtractedDomain
 from hassette_codegen.extractors.base_class import determine_base_class
@@ -42,7 +43,22 @@ from hassette_codegen.rendering import UnsafeGeneratedValueError, require_identi
 # these names would otherwise be written straight over them. This list is not redundant with the
 # ownership gate in _may_overwrite: on a checkout that has never run the generator there is no
 # manifest to consult, and this is what protects these files in that window.
-RESERVED_BASENAMES = frozenset({"base", "catalog", "__init__"})
+#
+# Only basenames that are not themselves Home Assistant domains belong here. The hand-written
+# modules that do share a domain name (calendar, zone, person, and the rest) are covered by the
+# ownership gate instead — reserving those would permanently block ever generating that domain.
+RESERVED_BASENAMES = frozenset({"base", "catalog", "input", "simple", "__init__"})
+
+
+class Rejection(NamedTuple):
+    """Output the pipeline refused to produce because a name from upstream was not safe to use.
+
+    ``domain`` stays a bare domain name so it can be matched against ``--domain``; ``what`` names
+    the output that was refused, for the operator reading why the run failed.
+    """
+
+    domain: str
+    what: str
 
 
 def run_pipeline(
@@ -52,21 +68,25 @@ def run_pipeline(
     check_mode: bool = False,
     domain_filter: set[str] | None = None,
 ) -> int:
-    """Run the full generation pipeline. Returns exit code (0=ok, 1=drift/skip)."""
+    """Run the full generation pipeline. Returns exit code (0=ok, 1=drift/skip/rejection)."""
     check_python_version(ha_source.path)
     check_ruff_available()
 
-    all_domains = _reject_unsafe_domain_names(discover_domains(ha_source.path))
+    all_domains, rejections = _reject_unsafe_domain_names(discover_domains(ha_source.path))
     overrides = load_overrides()
 
-    manual_domains = _reject_unsafe_domain_names(
+    manual_domains, manual_rejections = _reject_unsafe_domain_names(
         _discover_manual_domains(ha_source.path, overrides, {d.name for d in all_domains})
     )
     all_domains.extend(manual_domains)
+    rejections.extend(manual_rejections)
     print(f"Discovered {len(all_domains)} entity domains ({len(manual_domains)} manual)", file=sys.stderr)
 
     if domain_filter:
         domains = [d for d in all_domains if d.name in domain_filter]
+        # A rejection outside the requested filter is not this run's concern, and letting it fail
+        # --check would make every filtered run answer for the whole of upstream.
+        rejections = [r for r in rejections if r.domain in domain_filter]
         if not domains:
             print(f"WARNING: No domains matched filter: {domain_filter}", file=sys.stderr)
             return 1
@@ -78,6 +98,10 @@ def run_pipeline(
     previous_manifest = load_manifest(repo_root)
     manifest_tracked = manifest_exists(repo_root)
     generated_files: set[Path] = set()
+    # Two ways a domain can come up short, kept apart because they mean different things to the
+    # operator: a skip is "the generator tried and could not finish this domain", a rejection is
+    # "a name from upstream was not safe to put in generated source, so nothing was attempted".
+    # Both fail --check; only skips reduce the generated count in the summary.
     skipped_domains: list[str] = []
     any_drift = False
 
@@ -116,8 +140,11 @@ def run_pipeline(
             entity_content = generate_entity_wrapper(extracted)
         except UnsafeGeneratedValueError as exc:
             # The state model above is unaffected and stays generated — only the service wrappers
-            # depend on the rejected name.
-            print(f"WARNING: Skipped {domain_info.name} entity wrapper: {exc}", file=sys.stderr)
+            # depend on the rejected name, so the domain is not added to skipped_domains. It is
+            # still recorded as a rejection: the committed wrapper was never checked against
+            # upstream, and --check must not report the tree as current on that basis.
+            print(f"WARNING: Rejected {domain_info.name} entity wrapper: {exc}", file=sys.stderr)
+            rejections.append(Rejection(domain_info.name, "entity wrapper"))
             continue
 
         if entity_content is not None:
@@ -148,10 +175,12 @@ def run_pipeline(
         if check_mode:
             if not check_drift(const_path, const_content, "sensor constants"):
                 any_drift = True
-        else:
-            atomic_write(const_path, const_content)
-
-        generated_files.add(rel_const)
+            generated_files.add(rel_const)
+        elif atomic_write(const_path, const_content):
+            # Ownership is only claimed for output this run actually produced. atomic_write
+            # reports its own failure, and leaving the path out of the manifest surfaces the
+            # retained older copy as an orphan on the next full run.
+            generated_files.add(rel_const)
 
     for pkg_dir in (states_dir, entities_dir):
         init_content = generate_init_py(pkg_dir)
@@ -161,10 +190,9 @@ def run_pipeline(
         if check_mode:
             if not check_drift(init_path, init_content, f"{pkg_dir.name} __init__.py"):
                 any_drift = True
-        else:
-            atomic_write(init_path, init_content)
-
-        generated_files.add(rel_init)
+            generated_files.add(rel_init)
+        elif atomic_write(init_path, init_content):
+            generated_files.add(rel_init)
 
     if not check_mode:
         if domain_filter:
@@ -182,6 +210,10 @@ def run_pipeline(
     generated_count = len(domains) - len(skipped_domains)
     print(
         f"Summary: {generated_count} domains generated, {len(skipped_domains)} skipped"
+        # Rejections are their own count: a rejected domain never entered `domains`, and a
+        # rejected entity wrapper left its domain's state model generated, so neither is
+        # visible in the two numbers above.
+        + (f", {len(rejections)} rejected" if rejections else "")
         + (
             f", {len(detect_orphans(previous_manifest, generated_files))} orphans"
             if not check_mode and not domain_filter
@@ -190,34 +222,43 @@ def run_pipeline(
         file=sys.stderr,
     )
 
-    if check_mode and (any_drift or skipped_domains):
+    if check_mode and (any_drift or skipped_domains or rejections):
         if skipped_domains:
             print(f"Skipped domains: {', '.join(skipped_domains)}", file=sys.stderr)
+        if rejections:
+            print(f"Rejected: {', '.join(f'{r.domain} ({r.what})' for r in rejections)}", file=sys.stderr)
         return 1
 
     return 0
 
 
-def _reject_unsafe_domain_names(domains: list[DiscoveredDomain]) -> list[DiscoveredDomain]:
-    """Drop domains whose name cannot safely become a module.
+def _reject_unsafe_domain_names(domains: list[DiscoveredDomain]) -> tuple[list[DiscoveredDomain], list[Rejection]]:
+    """Split domains into those safe to generate and the rejections for those dropped.
 
     A domain name is a Home Assistant component directory name taken verbatim, and it becomes
     both an output filename (``models/states/{name}.py``) and an import path
     (``from hassette.models.states.{name} import ...``). A name that is not an identifier breaks
     the import; a name matching a hand-written module overwrites it silently.
+
+    The rejections are returned rather than only warned about because ``--check`` has to fail on
+    them. A dropped domain leaves whatever is committed for it unexamined, which is the same
+    "this tree was not verified against upstream" outcome as an extraction failure.
     """
     safe: list[DiscoveredDomain] = []
+    rejected: list[Rejection] = []
     for domain in domains:
         if domain.name in RESERVED_BASENAMES:
-            print(f"WARNING: Skipping domain '{domain.name}': reserved for hand-written files", file=sys.stderr)
+            print(f"WARNING: Rejected domain '{domain.name}': reserved for hand-written files", file=sys.stderr)
+            rejected.append(Rejection(domain.name, "domain name"))
             continue
         try:
             require_identifier(domain.name, kind="domain name")
         except UnsafeGeneratedValueError as exc:
-            print(f"WARNING: Skipping domain '{domain.name}': {exc}", file=sys.stderr)
+            print(f"WARNING: Rejected domain '{domain.name}': {exc}", file=sys.stderr)
+            rejected.append(Rejection(domain.name, "domain name"))
             continue
         safe.append(domain)
-    return safe
+    return safe, rejected
 
 
 def _may_overwrite(out_path: Path, rel_path: Path, previous_manifest: set[Path], *, tracked: bool) -> bool:

--- a/codegen/src/hassette_codegen/rendering.py
+++ b/codegen/src/hassette_codegen/rendering.py
@@ -1,0 +1,74 @@
+"""Render upstream-derived values into generated Python source.
+
+Every string codegen pulls out of the Home Assistant checkout — service names, enum member
+values, sensor constants, docstring prose — is eventually interpolated into generated source.
+Doing that with an f-string or a bare Jinja placeholder lets a quote character change the
+*structure* of the output rather than its content, and `ruff` plus `py_compile` only validate
+that the result is still syntactically valid Python. An input that stays valid while meaning
+something else passes every existing gate.
+
+These helpers are the one place that turns an upstream value into source text. Use them instead
+of hand-quoting; ``py_literal`` is also registered as a Jinja filter for the templates.
+"""
+
+import json
+import keyword
+
+
+class UnsafeGeneratedValueError(ValueError):
+    """An upstream-derived value cannot be safely rendered into generated source."""
+
+
+def py_literal(value: object) -> str:
+    """Render ``value`` as a Python literal.
+
+    Strings go through ``json.dumps``, following the ``tojson`` filter already used for the
+    datetime field validator in ``state_model.py.j2``: JSON string syntax is a subset of Python's,
+    it escapes quotes and backslashes, and it always emits double quotes — which is what
+    ``ruff format`` settles on anyway, so unformatted output stays readable and diff-free.
+    ``ensure_ascii=False`` keeps non-ASCII characters intact rather than expanding them to escapes.
+
+    ``int`` (and therefore ``bool``) is the only other type codegen emits. Anything else would
+    render as an unparseable ``<object at 0x...>``, so refuse it rather than emit broken source.
+    """
+    if isinstance(value, str):
+        return json.dumps(value, ensure_ascii=False)
+    if isinstance(value, int):
+        return repr(value)
+    raise UnsafeGeneratedValueError(f"cannot render {type(value).__name__} as a Python literal: {value!r}")
+
+
+def escape_docstring_text(text: str) -> str:
+    """Neutralize characters that would break out of a triple-quoted docstring.
+
+    ``build_method_docstring`` assembles docstring lines that a template inserts as raw source,
+    so the text has to be safe before it is wrapped. A ``\"\"\"`` in the text would close the
+    docstring and put the remainder in executable position; a trailing backslash would escape
+    the closing delimiter; a NUL is the one character Python refuses to read in source at all,
+    which would leave the whole module uncompilable.
+
+    Order matters twice over: backslashes are doubled first so the ones this function introduces
+    are not doubled in turn, and the NUL escape is written last for the same reason.
+
+    Whitespace is deliberately untouched. Callers collapse runs of whitespace before wrapping,
+    so an embedded newline is already a space by the time it reaches the docstring. (Python
+    normalizes a lone carriage return in source to a newline, so the text is not preserved
+    byte-for-byte, but nothing structural depends on it.)
+
+    One precondition stays with the caller: a single trailing quote is left alone, so the closing
+    delimiter must not sit directly against the text or it would read as a fourth quote.
+    ``build_method_docstring`` puts it on its own line.
+    """
+    return text.replace("\\", "\\\\").replace('"""', '\\"\\"\\"').replace("\x00", "\\x00")
+
+
+def require_identifier(value: str, *, kind: str) -> str:
+    """Return ``value`` if it is usable as a Python identifier, else raise.
+
+    Identifier positions — method names, parameter names, module paths — accept no escaping, so
+    the only safe handling is to reject the value and skip whatever depends on it. Keywords pass
+    ``str.isidentifier()`` but are not usable as names, hence the second check.
+    """
+    if not value.isidentifier() or keyword.iskeyword(value):
+        raise UnsafeGeneratedValueError(f"{kind} {value!r} is not a usable Python identifier")
+    return value

--- a/codegen/src/hassette_codegen/templates/entity_wrapper.py.j2
+++ b/codegen/src/hassette_codegen/templates/entity_wrapper.py.j2
@@ -40,7 +40,7 @@ class {{ domain_title }}Entity(BaseEntity[{{ domain_title }}State, str]):
 {{ service.doc }}
         return self.api.call_service(
             domain=self.domain,
-            service="{{ service.name }}",
+            service={{ service.name | py_literal }},
             target={"entity_id": self.entity_id},
 {% for param in service.params %}
             {{ param.name }}={{ param.name }},
@@ -52,7 +52,7 @@ class {{ domain_title }}Entity(BaseEntity[{{ domain_title }}State, str]):
 {{ service.doc }}
         return self.api.call_service(
             domain=self.domain,
-            service="{{ service.name }}",
+            service={{ service.name | py_literal }},
             target={"entity_id": self.entity_id},
         )
 {% endif %}
@@ -78,7 +78,7 @@ class {{ domain_title }}EntitySyncFacade(BaseEntitySyncFacade[{{ domain_title }}
 {{ service.doc }}
         self.entity.api.sync.call_service(
             domain=self.entity.domain,
-            service="{{ service.name }}",
+            service={{ service.name | py_literal }},
             target={"entity_id": self.entity.entity_id},
 {% for param in service.params %}
             {{ param.name }}={{ param.name }},
@@ -89,7 +89,7 @@ class {{ domain_title }}EntitySyncFacade(BaseEntitySyncFacade[{{ domain_title }}
 {{ service.doc }}
         self.entity.api.sync.call_service(
             domain=self.entity.domain,
-            service="{{ service.name }}",
+            service={{ service.name | py_literal }},
             target={"entity_id": self.entity.entity_id},
         )
 {% endif %}

--- a/codegen/src/hassette_codegen/templates/state_model.py.j2
+++ b/codegen/src/hassette_codegen/templates/state_model.py.j2
@@ -22,7 +22,7 @@ from .base import AttributesBase, {{ base_class }}
 
 class {{ enum.name }}(StrEnum):
 {% for member_name, member_value in enum.members %}
-    {{ member_name }} = "{{ member_value }}"
+    {{ member_name }} = {{ member_value | py_literal }}
 {% endfor %}
 {% endfor %}
 {% for enum in features %}
@@ -30,7 +30,7 @@ class {{ enum.name }}(StrEnum):
 
 class {{ enum.name }}(IntFlag):
 {% for member_name, member_value in enum.members %}
-    {{ member_name }} = {{ member_value }}
+    {{ member_name }} = {{ member_value | py_literal }}
 {% endfor %}
 {% endfor %}
 
@@ -65,6 +65,6 @@ class {{ domain_title }}State({{ base_class }}):
     See: https://www.home-assistant.io/integrations/{{ domain }}/
     """
 
-    domain: Literal["{{ domain }}"]
+    domain: Literal[{{ domain | py_literal }}]
 
     attributes: {{ domain_title }}Attributes

--- a/codegen/tests/test_constants_and_exports.py
+++ b/codegen/tests/test_constants_and_exports.py
@@ -1,5 +1,6 @@
 """Unit tests for constants extraction and __init__.py generation."""
 
+import ast
 import os
 import py_compile
 import sys
@@ -10,7 +11,7 @@ import pytest
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
 
-from hassette_codegen.extractors.constants import extract_sensor_constants
+from hassette_codegen.extractors.constants import ExtractedConstantSet, extract_sensor_constants
 from hassette_codegen.generators.constants import generate_sensor_constants
 from hassette_codegen.generators.exports import generate_init_py
 
@@ -75,3 +76,35 @@ class TestExportsGenerator:
             f.write(output)
             f.flush()
             py_compile.compile(f.name, doraise=True)
+
+
+class TestConstantsEscaping:
+    """Sensor constant values come from HA's StrEnum members and land inside a ``Literal[...]``.
+
+    Hand-quoting made a value containing a quote split into two literals — valid syntax, wrong
+    content — so the assertions count literals rather than compare strings.
+    """
+
+    @staticmethod
+    def _literals(output: str) -> list[str]:
+        module = ast.parse(output)
+        return [
+            node.value for node in ast.walk(module) if isinstance(node, ast.Constant) and isinstance(node.value, str)
+        ]
+
+    def test_quote_in_value_stays_one_literal(self) -> None:
+        hostile = 'closes", "and reopens'
+        output = generate_sensor_constants([ExtractedConstantSet(name="DEVICE_CLASS", values=[hostile])])
+
+        assert self._literals(output) == [hostile]
+
+    def test_backslash_in_value_is_not_read_as_an_escape(self) -> None:
+        output = generate_sensor_constants([ExtractedConstantSet(name="DEVICE_CLASS", values=["C:\\new"])])
+
+        assert self._literals(output) == ["C:\\new"]
+
+    def test_hostile_values_still_compile(self) -> None:
+        values = ['a", "b', "trailing \\", 'quote " here', "newline\nhere"]
+        output = generate_sensor_constants([ExtractedConstantSet(name="DEVICE_CLASS", values=values)])
+
+        assert self._literals(output) == values

--- a/codegen/tests/test_docstring_builder.py
+++ b/codegen/tests/test_docstring_builder.py
@@ -4,6 +4,7 @@ These cover the description-threading path directly, independent of a live HA co
 (the integration tests in test_services.py skip when HA_CORE_PATH is absent).
 """
 
+import ast
 import json
 import sys
 from pathlib import Path
@@ -124,3 +125,75 @@ class TestExtractDescriptions:
 
     def test_missing_strings_json_returns_empty_maps(self, tmp_path: Path) -> None:
         assert _extract_descriptions(tmp_path / "nonexistent") == ({}, {})
+
+
+class TestDocstringEscaping:
+    """A service description is Home Assistant's text inserted at raw statement position.
+
+    Nothing between services.yaml and the generated file quotes it, so the escaping has to happen
+    here. Each test parses the result and asserts the method body still contains only what the
+    generator put there.
+    """
+
+    @staticmethod
+    def _parse_method(doc: str) -> ast.FunctionDef:
+        """Wrap a built docstring at its native indentation and return the enclosing method."""
+        module = ast.parse(f"class C:\n    def m(self) -> None:\n{doc}\n        pass\n")
+        cls = module.body[0]
+        assert isinstance(cls, ast.ClassDef)
+        assert len(module.body) == 1, "text escaped the class body into module scope"
+        assert len(cls.body) == 1, "text escaped the method body into class scope"
+
+        method = cls.body[0]
+        assert isinstance(method, ast.FunctionDef)
+        return method
+
+    @staticmethod
+    def _docstring(method: ast.FunctionDef) -> str:
+        """The docstring's text, less the indentation its own closing-delimiter line carries."""
+        return (ast.get_docstring(method, clean=False) or "").strip()
+
+    def test_triple_quote_in_summary_cannot_reach_executable_position(self) -> None:
+        method = self._parse_method(build_method_docstring('Close the cover."""\nimport os\n"""', []))
+
+        # Docstring plus the `pass` the wrapper adds — an injected `import os` would make it three.
+        assert len(method.body) == 2
+        assert '"""' in self._docstring(method)
+
+    def test_triple_quote_in_param_description_cannot_reach_executable_position(self) -> None:
+        params = [ServiceParam(name="position", python_type="int", required=True, description='x"""\nimport os\n"""')]
+        method = self._parse_method(build_method_docstring("Move the cover.", params))
+
+        assert len(method.body) == 2
+        assert '"""' in self._docstring(method)
+
+    def test_trailing_backslash_does_not_escape_the_closing_delimiter(self) -> None:
+        method = self._parse_method(build_method_docstring("Ends with a backslash \\", []))
+
+        assert len(method.body) == 2
+        assert self._docstring(method).endswith("backslash \\.")
+
+    def test_windows_path_is_not_read_as_escape_sequences(self) -> None:
+        method = self._parse_method(build_method_docstring("Path is C:\\new\\table.", []))
+
+        assert self._docstring(method) == "Path is C:\\new\\table."
+
+    def test_nul_byte_leaves_the_module_compilable(self) -> None:
+        # Python refuses to read source containing a literal NUL at all.
+        method = self._parse_method(build_method_docstring("Has a \x00 byte.", []))
+
+        assert self._docstring(method) == "Has a \x00 byte."
+
+    def test_whitespace_only_summary_still_opens_the_docstring(self) -> None:
+        # textwrap.fill drops initial_indent when the text collapses to nothing, which used to
+        # emit a lone closing delimiter that swallowed everything after it.
+        method = self._parse_method(build_method_docstring("   ", []))
+
+        assert len(method.body) == 2
+        assert self._docstring(method) == ""
+
+    def test_whitespace_only_param_description_is_not_documented(self) -> None:
+        params = [ServiceParam(name="position", python_type="int", required=True, description="  ")]
+        doc = build_method_docstring("Move the cover.", params)
+
+        assert "Args:" not in doc

--- a/codegen/tests/test_entity_generator.py
+++ b/codegen/tests/test_entity_generator.py
@@ -690,7 +690,9 @@ class TestEntityWrapperEscaping:
     """
 
     @staticmethod
-    def _domain(service_name: str = "turn_on", method_name: str = "turn_on", field_name: str = "percentage"):
+    def _domain(
+        service_name: str = "turn_on", method_name: str = "turn_on", field_name: str = "percentage"
+    ) -> ExtractedDomain:
         return ExtractedDomain(
             name="fan",
             base_class="BoolBaseState",

--- a/codegen/tests/test_entity_generator.py
+++ b/codegen/tests/test_entity_generator.py
@@ -7,6 +7,8 @@ import sys
 import tempfile
 from pathlib import Path
 
+import pytest
+
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
 
 from hassette_codegen.domain_data import ExtractedDomain
@@ -14,6 +16,7 @@ from hassette_codegen.extractors.features import ExtractedEnum
 from hassette_codegen.extractors.services import ExtractedService, ServiceField
 from hassette_codegen.generators.entities import generate_entity_wrapper
 from hassette_codegen.overrides import DomainOverride
+from hassette_codegen.rendering import UnsafeGeneratedValueError
 
 
 class TestEntityWrapperGenerator:
@@ -677,3 +680,82 @@ class TestStrEnumMatching:
             f.write(output)
             f.flush()
             py_compile.compile(f.name, doraise=True)
+
+
+class TestEntityWrapperEscaping:
+    """Service and field names come from services.yaml keys — arbitrary text, four render sites each.
+
+    ``entity_wrapper.py.j2`` emits four service blocks (async and sync facade, with and without
+    params), so every assertion here checks all occurrences rather than the first.
+    """
+
+    @staticmethod
+    def _domain(service_name: str = "turn_on", method_name: str = "turn_on", field_name: str = "percentage"):
+        return ExtractedDomain(
+            name="fan",
+            base_class="BoolBaseState",
+            services=[
+                ExtractedService(
+                    name=service_name,
+                    method_name=method_name,
+                    fields=[ServiceField(name=field_name, selector_type="number", selector_data={})],
+                ),
+                ExtractedService(name=service_name, method_name=f"{method_name}_bare", fields=[]),
+            ],
+        )
+
+    def test_quote_in_service_name_stays_one_literal_at_every_site(self) -> None:
+        hostile = 'turn_on", target={"entity_id": "light.evil'
+        output = generate_entity_wrapper(self._domain(service_name=hostile))
+        assert output is not None
+
+        module = ast.parse(output)
+        rendered = [
+            kw.value.value
+            for node in ast.walk(module)
+            if isinstance(node, ast.Call)
+            for kw in node.keywords
+            if kw.arg == "service" and isinstance(kw.value, ast.Constant)
+        ]
+        # Four service blocks in the template, two services here — every one intact.
+        assert rendered == [hostile] * 4
+
+    def test_non_identifier_method_name_is_rejected(self) -> None:
+        with pytest.raises(UnsafeGeneratedValueError):
+            generate_entity_wrapper(self._domain(method_name="turn on"))
+
+    def test_keyword_method_name_is_rejected(self) -> None:
+        with pytest.raises(UnsafeGeneratedValueError):
+            generate_entity_wrapper(self._domain(method_name="class"))
+
+    def test_non_identifier_param_name_is_rejected(self) -> None:
+        with pytest.raises(UnsafeGeneratedValueError):
+            generate_entity_wrapper(self._domain(field_name="percentage: int = 1, evil"))
+
+    def test_param_rename_is_validated_after_the_override_applies(self) -> None:
+        # An override that maps a bad name to a good one must be honoured, not rejected first.
+        domain = self._domain(field_name="for")
+        domain.override = DomainOverride(domain="fan", service_param_renames={"for": "for_"})
+        output = generate_entity_wrapper(domain)
+
+        assert output is not None
+        assert "for_:" in output
+
+    def test_whitespace_only_descriptions_do_not_swallow_sibling_methods(self) -> None:
+        # A services.yaml description of "   " is truthy, so it used to reach the docstring builder
+        # and collapse to nothing there — producing valid Python that silently lost a method.
+        domain = ExtractedDomain(
+            name="light",
+            base_class="BoolBaseState",
+            services=[
+                ExtractedService(name="first", method_name="first", fields=[], description="   "),
+                ExtractedService(name="second", method_name="second", fields=[], description="   "),
+                ExtractedService(name="third", method_name="third", fields=[], description="Turn on."),
+            ],
+        )
+        output = generate_entity_wrapper(domain)
+        assert output is not None
+
+        module = ast.parse(output)
+        facade = next(n for n in module.body if isinstance(n, ast.ClassDef) and n.name.endswith("SyncFacade"))
+        assert [n.name for n in facade.body if isinstance(n, ast.FunctionDef)] == ["first", "second", "third"]

--- a/codegen/tests/test_entity_generator.py
+++ b/codegen/tests/test_entity_generator.py
@@ -758,4 +758,18 @@ class TestEntityWrapperEscaping:
 
         module = ast.parse(output)
         facade = next(n for n in module.body if isinstance(n, ast.ClassDef) and n.name.endswith("SyncFacade"))
-        assert [n.name for n in facade.body if isinstance(n, ast.FunctionDef)] == ["first", "second", "third"]
+        methods = [n for n in facade.body if isinstance(n, ast.FunctionDef)]
+        assert [n.name for n in methods] == ["first", "second", "third"]
+
+        # The half-open docstring did not just drop `second`: it left `first` calling the service
+        # that belonged to `second`, because the closing delimiter landed mid-method. Asserting the
+        # method names alone would miss that.
+        for method in methods:
+            called = [
+                kw.value.value
+                for node in ast.walk(method)
+                if isinstance(node, ast.Call)
+                for kw in node.keywords
+                if kw.arg == "service" and isinstance(kw.value, ast.Constant)
+            ]
+            assert called == [method.name]

--- a/codegen/tests/test_pipeline_guards.py
+++ b/codegen/tests/test_pipeline_guards.py
@@ -16,9 +16,16 @@ import pytest
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
 
+from hassette_codegen import pipeline
 from hassette_codegen.ha_source import DiscoveredDomain, HASource
 from hassette_codegen.manifest import load_manifest, save_manifest
-from hassette_codegen.pipeline import _may_overwrite, _reject_unsafe_domain_names, run_pipeline
+from hassette_codegen.pipeline import (
+    RESERVED_BASENAMES,
+    Rejection,
+    _may_overwrite,
+    _reject_unsafe_domain_names,
+    run_pipeline,
+)
 
 # The smallest component that discover_domains() will pick up: the marker constant it greps for,
 # plus a class inheriting from a known entity base, plus one _attr_ field to extract.
@@ -33,11 +40,19 @@ class DemoEntity(Entity):
 
 HAND_WRITTEN = '"""Hand-written, not generated."""\n\nSENTINEL = "do not overwrite"\n'
 
+# A services.yaml key becomes a method name verbatim, so a key that is not an identifier is what
+# makes generate_entity_wrapper refuse the whole wrapper.
+UNSAFE_SERVICE_YAML = "turn on:\n  fields: {}\n"
+
 STATES = Path("src/hassette/models/states")
 
 
-def make_ha_core(root: Path, domain_names: list[str]) -> HASource:
-    """Build the minimal HA core layout the pipeline walks."""
+def make_ha_core(root: Path, domain_names: list[str], services: dict[str, str] | None = None) -> HASource:
+    """Build the minimal HA core layout the pipeline walks.
+
+    ``services`` maps a domain name to the body of its ``services.yaml``, for the domains that
+    need service wrappers generated.
+    """
     (root / "homeassistant").mkdir(parents=True)
     (root / "homeassistant" / "const.py").write_text("REQUIRED_PYTHON_VER = (3, 11, 0)\n", encoding="utf-8")
 
@@ -47,6 +62,8 @@ def make_ha_core(root: Path, domain_names: list[str]) -> HASource:
         component = components / name
         component.mkdir()
         (component / "__init__.py").write_text(COMPONENT_SOURCE, encoding="utf-8")
+        if services and name in services:
+            (component / "services.yaml").write_text(services[name], encoding="utf-8")
 
     return HASource(path=root, version="test")
 
@@ -57,15 +74,27 @@ def make_domains(*names: str) -> list[DiscoveredDomain]:
 
 class TestRejectUnsafeDomainNames:
     def test_keeps_ordinary_domains(self) -> None:
-        assert [d.name for d in _reject_unsafe_domain_names(make_domains("fan", "light"))] == ["fan", "light"]
+        safe, rejected = _reject_unsafe_domain_names(make_domains("fan", "light"))
 
-    @pytest.mark.parametrize("name", ["base", "catalog", "__init__"])
+        assert [d.name for d in safe] == ["fan", "light"]
+        assert rejected == []
+
+    @pytest.mark.parametrize("name", ["base", "catalog", "input", "simple", "__init__"])
     def test_drops_names_reserved_for_hand_written_modules(self, name: str) -> None:
-        assert _reject_unsafe_domain_names(make_domains(name, "fan")) == make_domains("fan")
+        expected = (make_domains("fan"), [Rejection(name, "domain name")])
+        assert _reject_unsafe_domain_names(make_domains(name, "fan")) == expected
 
     @pytest.mark.parametrize("name", ["not a domain", "fan-2", "2fan", "fan.evil", "class"])
     def test_drops_names_that_are_not_importable_modules(self, name: str) -> None:
-        assert _reject_unsafe_domain_names(make_domains(name, "fan")) == make_domains("fan")
+        expected = (make_domains("fan"), [Rejection(name, "domain name")])
+        assert _reject_unsafe_domain_names(make_domains(name, "fan")) == expected
+
+    def test_reserves_every_hand_written_module_that_is_not_a_domain(self) -> None:
+        # These four have no Home Assistant component of the same name, so nothing but this list
+        # keeps a future one from landing on them before a manifest exists.
+        hand_written = {"base", "catalog", "input", "simple"}
+
+        assert hand_written <= RESERVED_BASENAMES
 
     def test_explains_each_rejection(self, capsys: pytest.CaptureFixture[str]) -> None:
         _reject_unsafe_domain_names(make_domains("base", "fan-2"))
@@ -155,3 +184,74 @@ class TestPipelineWriteGuards:
         run_pipeline(ha_source, repo_root, check_mode=False)
 
         assert (repo_root / STATES / "newdomain.py").exists()
+
+    def test_a_failed_write_does_not_claim_manifest_ownership(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # The manifest is what _may_overwrite consults on the next run, so recording a path whose
+        # write failed would hand the generator ownership of a file it never produced.
+        ha_source = make_ha_core(tmp_path / "core", ["fan"])
+        repo_root = tmp_path / "repo"
+        real_atomic_write = pipeline.atomic_write
+
+        def fail_package_inits(out_path: Path, content: str) -> bool:
+            return False if out_path.name == "__init__.py" else real_atomic_write(out_path, content)
+
+        monkeypatch.setattr(pipeline, "atomic_write", fail_package_inits)
+        run_pipeline(ha_source, repo_root, check_mode=False)
+
+        manifest = load_manifest(repo_root)
+        assert Path(STATES / "fan.py") in manifest, "the run produced nothing — guard proves nothing"
+        assert not [path for path in manifest if path.name == "__init__.py"]
+
+
+class TestCheckModeReportsRejections:
+    """--check answers "is the committed tree current against upstream?".
+
+    A domain the pipeline refuses to touch leaves whatever is committed for it unexamined, so
+    check mode has to fail on it. Every test here generates first so the tree is genuinely current
+    — the exit code then turns on the rejection alone, not on drift.
+    """
+
+    def test_a_clean_tree_passes(self, tmp_path: Path) -> None:
+        # The control: without a rejection the same setup exits 0, so the failures below are not
+        # just "check mode always fails on a freshly generated tree".
+        ha_source = make_ha_core(tmp_path / "core", ["fan"])
+        repo_root = tmp_path / "repo"
+        run_pipeline(ha_source, repo_root, check_mode=False)
+
+        assert run_pipeline(ha_source, repo_root, check_mode=True) == 0
+
+    def test_fails_when_a_domain_name_is_rejected(self, tmp_path: Path) -> None:
+        ha_source = make_ha_core(tmp_path / "core", ["base", "fan"])
+        repo_root = tmp_path / "repo"
+        run_pipeline(ha_source, repo_root, check_mode=False)
+
+        assert run_pipeline(ha_source, repo_root, check_mode=True) == 1
+
+    def test_names_the_rejected_domain(self, tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+        ha_source = make_ha_core(tmp_path / "core", ["base", "fan"])
+        repo_root = tmp_path / "repo"
+        run_pipeline(ha_source, repo_root, check_mode=False)
+        capsys.readouterr()  # drop the write run's output so only the check run is asserted on
+
+        run_pipeline(ha_source, repo_root, check_mode=True)
+
+        assert "Rejected: base (domain name)" in capsys.readouterr().err
+
+    def test_fails_when_an_entity_wrapper_is_rejected(self, tmp_path: Path) -> None:
+        ha_source = make_ha_core(tmp_path / "core", ["fan"], services={"fan": UNSAFE_SERVICE_YAML})
+        repo_root = tmp_path / "repo"
+        run_pipeline(ha_source, repo_root, check_mode=False)
+
+        # The state model generated fine; only the wrapper was refused, and that alone must fail.
+        assert (repo_root / STATES / "fan.py").exists()
+        assert run_pipeline(ha_source, repo_root, check_mode=True) == 1
+
+    def test_ignores_a_rejection_outside_the_requested_filter(self, tmp_path: Path) -> None:
+        # --domain fan asks about fan. An unrelated bad name upstream is not that run's answer.
+        ha_source = make_ha_core(tmp_path / "core", ["base", "fan"])
+        repo_root = tmp_path / "repo"
+        run_pipeline(ha_source, repo_root, check_mode=False)
+
+        assert run_pipeline(ha_source, repo_root, check_mode=True, domain_filter={"fan"}) == 0

--- a/codegen/tests/test_pipeline_guards.py
+++ b/codegen/tests/test_pipeline_guards.py
@@ -1,0 +1,157 @@
+"""Tests for the pipeline's guards on where generated output is allowed to land.
+
+A domain name is a Home Assistant component directory name used verbatim as an output basename,
+so a component called ``base`` would write straight over the hand-written
+``models/states/base.py``. These cover the two gates that stop it: the reserved-name check at
+discovery, and the manifest-ownership check before each write.
+
+Every end-to-end test generates a second, ordinary domain in the same run. Without that control
+a test proving "the file was not overwritten" would also pass if the pipeline never ran at all.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
+
+from hassette_codegen.ha_source import DiscoveredDomain, HASource
+from hassette_codegen.manifest import load_manifest, save_manifest
+from hassette_codegen.pipeline import _may_overwrite, _reject_unsafe_domain_names, run_pipeline
+
+# The smallest component that discover_domains() will pick up: the marker constant it greps for,
+# plus a class inheriting from a known entity base, plus one _attr_ field to extract.
+COMPONENT_SOURCE = '''"""A synthetic Home Assistant component."""
+
+CACHED_PROPERTIES_WITH_ATTR_ = {"percentage"}
+
+
+class DemoEntity(Entity):
+    _attr_percentage: int | None = None
+'''
+
+HAND_WRITTEN = '"""Hand-written, not generated."""\n\nSENTINEL = "do not overwrite"\n'
+
+STATES = Path("src/hassette/models/states")
+
+
+def make_ha_core(root: Path, domain_names: list[str]) -> HASource:
+    """Build the minimal HA core layout the pipeline walks."""
+    (root / "homeassistant").mkdir(parents=True)
+    (root / "homeassistant" / "const.py").write_text("REQUIRED_PYTHON_VER = (3, 11, 0)\n", encoding="utf-8")
+
+    components = root / "homeassistant" / "components"
+    components.mkdir()
+    for name in domain_names:
+        component = components / name
+        component.mkdir()
+        (component / "__init__.py").write_text(COMPONENT_SOURCE, encoding="utf-8")
+
+    return HASource(path=root, version="test")
+
+
+def make_domains(*names: str) -> list[DiscoveredDomain]:
+    return [DiscoveredDomain(name=name, path=Path(name), has_services_yaml=False, has_const_py=False) for name in names]
+
+
+class TestRejectUnsafeDomainNames:
+    def test_keeps_ordinary_domains(self) -> None:
+        assert [d.name for d in _reject_unsafe_domain_names(make_domains("fan", "light"))] == ["fan", "light"]
+
+    @pytest.mark.parametrize("name", ["base", "catalog", "__init__"])
+    def test_drops_names_reserved_for_hand_written_modules(self, name: str) -> None:
+        assert _reject_unsafe_domain_names(make_domains(name, "fan")) == make_domains("fan")
+
+    @pytest.mark.parametrize("name", ["not a domain", "fan-2", "2fan", "fan.evil", "class"])
+    def test_drops_names_that_are_not_importable_modules(self, name: str) -> None:
+        assert _reject_unsafe_domain_names(make_domains(name, "fan")) == make_domains("fan")
+
+    def test_explains_each_rejection(self, capsys: pytest.CaptureFixture[str]) -> None:
+        _reject_unsafe_domain_names(make_domains("base", "fan-2"))
+        err = capsys.readouterr().err
+
+        assert "reserved for hand-written files" in err
+        assert "not a usable Python identifier" in err
+
+
+class TestMayOverwrite:
+    def test_allows_a_file_that_does_not_exist_yet(self, tmp_path: Path) -> None:
+        assert _may_overwrite(tmp_path / "new.py", Path("new.py"), {Path("other.py")}, tracked=True) is True
+
+    def test_allows_a_file_the_generator_owns(self, tmp_path: Path) -> None:
+        target = tmp_path / "owned.py"
+        target.write_text("stale", encoding="utf-8")
+
+        assert _may_overwrite(target, Path("owned.py"), {Path("owned.py")}, tracked=True) is True
+
+    def test_refuses_an_existing_file_the_generator_does_not_own(self, tmp_path: Path) -> None:
+        target = tmp_path / "hand_written.py"
+        target.write_text(HAND_WRITTEN, encoding="utf-8")
+
+        assert _may_overwrite(target, Path("hand_written.py"), {Path("other.py")}, tracked=True) is False
+
+    def test_falls_through_when_the_generator_has_never_run(self, tmp_path: Path) -> None:
+        # No manifest file at all means no ownership information to consult; refusing everything
+        # would make the first run a no-op.
+        target = tmp_path / "existing.py"
+        target.write_text("content", encoding="utf-8")
+
+        assert _may_overwrite(target, Path("existing.py"), set(), tracked=False) is True
+
+    def test_an_empty_manifest_owns_nothing_rather_than_everything(self, tmp_path: Path) -> None:
+        # A manifest that exists but lists nothing is a recorded state, not missing information.
+        target = tmp_path / "existing.py"
+        target.write_text(HAND_WRITTEN, encoding="utf-8")
+
+        assert _may_overwrite(target, Path("existing.py"), set(), tracked=True) is False
+
+
+class TestPipelineWriteGuards:
+    def test_reserved_domain_name_leaves_the_hand_written_file_untouched(self, tmp_path: Path) -> None:
+        ha_source = make_ha_core(tmp_path / "core", ["base", "fan"])
+        repo_root = tmp_path / "repo"
+        hand_written = repo_root / STATES / "base.py"
+        hand_written.parent.mkdir(parents=True)
+        hand_written.write_text(HAND_WRITTEN, encoding="utf-8")
+
+        run_pipeline(ha_source, repo_root, check_mode=False)
+
+        assert hand_written.read_text(encoding="utf-8") == HAND_WRITTEN
+        assert (repo_root / STATES / "fan.py").exists(), "the run produced nothing — guard proves nothing"
+        assert Path(STATES / "base.py") not in load_manifest(repo_root)
+
+    def test_unowned_collision_leaves_the_existing_file_untouched(self, tmp_path: Path) -> None:
+        ha_source = make_ha_core(tmp_path / "core", ["mydomain", "fan"])
+        repo_root = tmp_path / "repo"
+        collision = repo_root / STATES / "mydomain.py"
+        collision.parent.mkdir(parents=True)
+        collision.write_text(HAND_WRITTEN, encoding="utf-8")
+        save_manifest(repo_root, {Path(STATES / "somethingelse.py")})
+
+        run_pipeline(ha_source, repo_root, check_mode=False)
+
+        assert collision.read_text(encoding="utf-8") == HAND_WRITTEN
+        assert (repo_root / STATES / "fan.py").exists(), "the run produced nothing — guard proves nothing"
+
+    def test_owned_file_is_still_regenerated(self, tmp_path: Path) -> None:
+        ha_source = make_ha_core(tmp_path / "core", ["fan"])
+        repo_root = tmp_path / "repo"
+        owned = repo_root / STATES / "fan.py"
+        owned.parent.mkdir(parents=True)
+        owned.write_text("# stale\n", encoding="utf-8")
+        save_manifest(repo_root, {Path(STATES / "fan.py")})
+
+        run_pipeline(ha_source, repo_root, check_mode=False)
+
+        assert "class FanState" in owned.read_text(encoding="utf-8")
+
+    def test_new_domain_generates_even_though_the_manifest_predates_it(self, tmp_path: Path) -> None:
+        ha_source = make_ha_core(tmp_path / "core", ["newdomain"])
+        repo_root = tmp_path / "repo"
+        repo_root.mkdir()
+        save_manifest(repo_root, {Path(STATES / "fan.py")})
+
+        run_pipeline(ha_source, repo_root, check_mode=False)
+
+        assert (repo_root / STATES / "newdomain.py").exists()

--- a/codegen/tests/test_rendering.py
+++ b/codegen/tests/test_rendering.py
@@ -1,0 +1,107 @@
+"""Unit tests for rendering upstream-derived values into generated source.
+
+The failure mode these guard against is "valid syntax, wrong structure" — an input that changes
+how many literals or statements the generated module contains while still compiling. String
+equality does not catch that, so the assertions here parse the rendered text and check its shape.
+"""
+
+import ast
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
+
+from hassette_codegen.rendering import (
+    UnsafeGeneratedValueError,
+    escape_docstring_text,
+    py_literal,
+    require_identifier,
+)
+
+# Each of these breaks at least one of the hand-quoting sites the generators used to have.
+HOSTILE_STRINGS = [
+    'has "double" quotes',
+    "has 'single' quotes",
+    'closes the list", "and opens another',
+    "trailing backslash \\",
+    "back\\slash",
+    'triple """ quote',
+    "new\nline",
+    "carriage\rreturn",
+    "tab\there",
+    "nul\x00byte",
+    "non-ascii é ☃",
+    '"""\nimport os\n"""',
+]
+
+
+class TestPyLiteral:
+    @pytest.mark.parametrize("value", HOSTILE_STRINGS)
+    def test_string_renders_as_exactly_one_literal(self, value: str) -> None:
+        node = ast.parse(py_literal(value), mode="eval").body
+        assert isinstance(node, ast.Constant)
+        assert node.value == value
+
+    @pytest.mark.parametrize("value", HOSTILE_STRINGS)
+    def test_string_does_not_smuggle_extra_statements(self, value: str) -> None:
+        module = ast.parse(f"X = {py_literal(value)}")
+        assert len(module.body) == 1
+
+    def test_prefers_double_quotes(self) -> None:
+        # Matches what ruff format settles on, so unformatted generated output reads the same.
+        assert py_literal("plain") == '"plain"'
+
+    @pytest.mark.parametrize(("value", "expected"), [(0, "0"), (4, "4"), (-1, "-1"), (True, "True")])
+    def test_int_renders_verbatim(self, value: int, expected: str) -> None:
+        assert py_literal(value) == expected
+
+    @pytest.mark.parametrize("value", [None, 1.5, ["a"], {"a": 1}, object()])
+    def test_rejects_types_codegen_never_emits(self, value: object) -> None:
+        with pytest.raises(UnsafeGeneratedValueError):
+            py_literal(value)
+
+
+# Python's tokenizer normalizes a lone carriage return in source to a newline, so those inputs
+# survive structurally but not byte-for-byte. Covered separately below.
+DOCSTRING_ROUND_TRIP_STRINGS = [text for text in HOSTILE_STRINGS if "\r" not in text]
+
+
+class TestEscapeDocstringText:
+    @pytest.mark.parametrize("text", DOCSTRING_ROUND_TRIP_STRINGS)
+    def test_escaped_text_survives_a_docstring_round_trip(self, text: str) -> None:
+        source = f'def f():\n    """{escape_docstring_text(text)}"""\n'
+        module = ast.parse(source)
+
+        assert len(module.body) == 1, "text escaped the docstring into executable position"
+        assert ast.get_docstring(module.body[0], clean=False) == text  # pyright: ignore[reportArgumentType]
+
+    def test_backslashes_are_escaped_before_the_quotes_they_introduce(self) -> None:
+        # Escaping quotes first would leave the added backslashes to be doubled by the second pass.
+        assert escape_docstring_text('"""') == '\\"\\"\\"'
+
+    def test_carriage_return_stays_inside_the_docstring(self) -> None:
+        # Python normalizes it to a newline rather than preserving it, but nothing escapes.
+        escaped = escape_docstring_text("carriage\rreturn")
+        module = ast.parse(f'def f():\n    """{escaped}"""\n')
+
+        assert len(module.body) == 1
+        assert ast.get_docstring(module.body[0], clean=False) == "carriage\nreturn"  # pyright: ignore[reportArgumentType]
+
+
+class TestRequireIdentifier:
+    @pytest.mark.parametrize("name", ["turn_on", "_private", "café", "match", "type"])
+    def test_accepts_usable_names(self, name: str) -> None:
+        assert require_identifier(name, kind="test") == name
+
+    @pytest.mark.parametrize("name", ["", "turn on", "turn-on", "2fast", "foo.bar", "foo()", "os.system('x')"])
+    def test_rejects_non_identifiers(self, name: str) -> None:
+        with pytest.raises(UnsafeGeneratedValueError):
+            require_identifier(name, kind="test")
+
+    @pytest.mark.parametrize("name", ["class", "import", "None", "lambda"])
+    def test_rejects_keywords(self, name: str) -> None:
+        # Keywords pass str.isidentifier() but are not usable as names.
+        with pytest.raises(UnsafeGeneratedValueError):
+            require_identifier(name, kind="test")

--- a/codegen/tests/test_state_generator.py
+++ b/codegen/tests/test_state_generator.py
@@ -1,5 +1,6 @@
 """Unit tests for the state model generator."""
 
+import ast
 import py_compile
 import sys
 import tempfile
@@ -219,3 +220,48 @@ class TestNormalizeEnumPrefixes:
         assert "class WaterHeaterEntityStateAttribute(StrEnum):" in output
         assert "WaterHeaterCapabilityAttribute" not in output
         assert "WaterHeaterStateAttribute" not in output
+
+
+class TestStateModelEscaping:
+    """StrEnum member values and the domain name are HA-derived and land in literal positions."""
+
+    @staticmethod
+    def _enum_member_values(output: str, enum_name: str) -> list[object]:
+        module = ast.parse(output)
+        cls = next(n for n in module.body if isinstance(n, ast.ClassDef) and n.name == enum_name)
+        assigns = [n for n in cls.body if isinstance(n, ast.Assign)]
+        for assign in assigns:
+            # A member whose value parsed as anything but a literal means the input became code.
+            assert isinstance(assign.value, ast.Constant), ast.dump(assign.value)
+        return [assign.value.value for assign in assigns]  # pyright: ignore[reportAttributeAccessIssue]
+
+    def test_strenum_member_value_stays_one_literal(self) -> None:
+        hostile = 'off"\n    INJECTED = "yes'
+        domain = ExtractedDomain(
+            name="fan",
+            base_class="StringBaseState",
+            strenums=[ExtractedEnum(name="FanMode", members=[("OFF", hostile)], kind="StrEnum")],
+        )
+
+        assert self._enum_member_values(generate_state_model(domain), "FanMode") == [hostile]
+
+    def test_intflag_member_value_is_not_an_arbitrary_expression(self) -> None:
+        # The extractor only yields ints today, so this pins the unquoted template position rather
+        # than a reachable input: a string here used to render as bare source.
+        domain = ExtractedDomain(
+            name="fan",
+            base_class="StringBaseState",
+            features=[ExtractedEnum(name="FanEntityFeature", members=[("EVIL", "__import__('os')")])],
+        )
+
+        assert self._enum_member_values(generate_state_model(domain), "FanEntityFeature") == ["__import__('os')"]
+
+    def test_domain_renders_as_one_literal(self) -> None:
+        domain = ExtractedDomain(name="fan", base_class="StringBaseState")
+        module = ast.parse(generate_state_model(domain))
+        cls = next(n for n in module.body if isinstance(n, ast.ClassDef) and n.name == "FanState")
+        annotation = next(n for n in cls.body if isinstance(n, ast.AnnAssign)).annotation
+
+        assert isinstance(annotation, ast.Subscript)
+        assert isinstance(annotation.slice, ast.Constant)
+        assert annotation.slice.value == "fan"

--- a/design/audits/2026-08-06-security-scan/audit.md
+++ b/design/audits/2026-08-06-security-scan/audit.md
@@ -1,0 +1,126 @@
+# Security scan follow-ups (2026-08-06)
+
+An external security scan of the tree at `4a20fb95` (the merge commit for #1531) reported six
+findings: 2 high, 3 medium, 1 low, all at high confidence. Each was verified against the code
+before any work started. None were false positives, but three write-ups were imprecise about
+severity or location, and two missed a variant of the defect they described. Those corrections are
+recorded below, because the original report will outlive this note and should not be trusted
+uncritically on those points.
+
+## Disposition
+
+| # | Finding | Severity | Resolution |
+|---|---------|----------|------------|
+| 1 | Pre-login route buffers request bodies with no size ceiling | high | #1532 |
+| 2 | Failed-login accounting can overwhelm the shared event loop | high | #1532 |
+| 3 | Container-shaped app secrets bypass configuration masking | medium | #1534 |
+| 4 | Generated Python can inherit executable structure from upstream strings | medium | this PR |
+| 5 | Recovery callbacks can bypass event-dispatch concurrency limits | medium | open — issue #573 |
+| 6 | Generated module names can replace hand-written package files | low | this PR |
+
+Findings 1 and 2 shipped together because both are unauthenticated resource consumption on the same
+pre-auth path. The rest were split so each PR title describes one coherent change, per
+`.claude/rules/changelog-quality.md`.
+
+## Where the report was wrong
+
+**Finding 2's severity is overstated.** The per-source attempt list was genuinely rebuilt on every
+call, but cross-source growth was already bounded — `MAX_TRACKED_SOURCES = 1024` with
+least-recently-touched eviction, plus expiry of stale sources. The unbounded part was one list
+inside a live window. For a self-hosted single-user tool that is medium, not high. The fix was cheap
+enough that the severity argument did not change what was done.
+
+**Finding 3 leaks two shapes the report does not mention.** It described "arrays, tuples, or
+mappings" of secrets. `list[NestedModel]` where the model has a `SecretStr` field also leaked, as
+did `dict[str, list[SecretStr]]`. An implementation handling only flat scalar containers would have
+passed the report's own description and still leaked. The masker has to recurse through container
+nodes into object nodes and back out again.
+
+**Finding 4 points at the wrong worst site.** The report cited `generators/constants.py` and the two
+templates. Those were real, but the sharpest instance was one it never named:
+`build_method_docstring()` in `generators/entities.py`, which wraps Home Assistant's own
+`services.yaml` description in `"""…"""` and hands the result to the template as raw source lines. A
+description containing `"""` closed the docstring and landed the remainder in executable position.
+
+**Finding 5 is partly remediated already.** `invoke_error_handler` does enforce
+`error_handler_timeout_seconds`, so the report's "finite timeouts" ask was already satisfied. The
+missing piece is the concurrency bound, which is what #573 tracks. The code carries `FIXME(#573)` at
+the spawn sites.
+
+## Facts worth not re-deriving
+
+### The JSON Schema shapes Pydantic emits for container secrets
+
+Established by probing `deref_schema` + `mask_values` against real models rather than by reading
+code. This is why `config_view.py`'s masker co-walks schema nodes with values instead of walking
+`properties` alone.
+
+```
+list[SecretStr]:
+  {"type": "array", "items": {"type": "string", "format": "password", "writeOnly": true}}
+
+tuple[SecretStr, SecretStr] | None:
+  {"anyOf": [{"type": "array", "maxItems": 2, "minItems": 2,
+              "prefixItems": [{...password...}, {...password...}]},
+             {"type": "null"}]}
+
+dict[str, SecretStr]:
+  {"type": "object", "additionalProperties": {...password...}}
+
+list[NestedModel]:
+  {"type": "array", "items": {"type": "object", "properties": {...}}}
+
+dict[str, list[SecretStr]]:
+  {"type": "object", "additionalProperties": {"type": "array", "items": {...password...}}}
+```
+
+Two details drive the design. An optional container is wrapped in `anyOf`, so container detection
+has to look inside union branches. And `prefixItems` is positional while `items` is homogeneous —
+different keys, different semantics.
+
+### Where the finding-3 exposure actually was
+
+Not the global config endpoint. `HassetteConfig`'s typed fields are serialized by Pydantic, which
+masks `SecretStr` in JSON mode before the masker ever runs. The leak was in app config, because
+`app_config` is typed `dict[str, Any]` holding raw TOML that never passed through a `SecretStr`
+field. What crossed the boundary was an app author's third-party credential — a cloud API key, a
+broker password — handed to a caller who was only ever granted Hassette access.
+
+### Every unsafe interpolation in `entity_wrapper.py.j2` appears four times
+
+The template renders four service blocks: async and sync-facade variants, each with and without
+params. A fix applied to one block looks correct and silently misses three quarters of the surface.
+
+### `is_owned()` already existed
+
+`codegen/manifest.py` defined and tested the exact ownership predicate finding 6 needed, and nothing
+in production ever called it. Most of that fix was wiring up a function that was already there.
+
+## Scope decisions taken deliberately
+
+**The AST allowlist for finding 4 was skipped.** The report proposed validating generated modules
+structurally before atomic replacement. That is a large amount of machinery for a threat gated
+behind an already-compromised upstream checkout. Centralizing literal and identifier rendering
+(`codegen/rendering.py`) gets nearly all of the value at a fraction of the cost. This was a choice,
+not an oversight.
+
+**Findings 4 and 6 are not live vulnerabilities in a deployed instance.** Both require an attacker
+who already controls the Home Assistant checkout that codegen reads, which is a developer-machine or
+release-pipeline compromise. They were fixed anyway because finding 4 is simultaneously a plain
+correctness bug: any HA constant or service description containing a quote produced broken or wrong
+output, with no attacker involved.
+
+**Masking stays type-driven, never name-driven.** Reading schema markers rather than field names is
+a standing constraint stated in `config_view.py`'s module docstring, and the reason the earlier
+regex deny-list was removed. #708's "incomplete deny-list" bullets describe that older design and
+no longer apply.
+
+## Still open
+
+- **#573** — per-listener rate limiting for error-handler task spawns (finding 5). Roughly half a
+  day, independent of everything above.
+- **#1533** — on-demand reveal for masked config secrets in the web UI. This is the surviving half
+  of #708, which was closed once #1534 landed. It is not a security fix: masking is server-side, so
+  a reveal toggle needs a backend endpoint that serves unmasked third-party credentials to any
+  Hassette-token holder. That is a security decision in its own right, which is why the issue gates
+  the UI behind it rather than assuming it.


### PR DESCRIPTION
## Summary

Closes the last two findings from the 2026-08-06 security scan, both in the standalone `codegen/`
package. Follows #1531, #1532, and #1534, which covered findings 1–3.

Values extracted from the Home Assistant checkout were interpolated into generated Python by hand:
f-string quoting in the generators, bare `"{{ x }}"` in the Jinja templates, and — the sharpest
case — service docstrings inserted at raw statement position. A quote or a `"""` in upstream text
changes the *structure* of the generated module rather than its content, which is precisely what
`ruff check` and `py_compile` in `atomic_write` do not catch: the output is still valid Python.

This is a latent correctness bug as much as a supply-chain one. Any HA constant or `services.yaml`
description containing a quote produces broken or wrong generated output today, with no attacker
involved.

## Finding 4 — external strings rendered as source text (CWE-94, medium)

All rendering now goes through a new `codegen/src/hassette_codegen/rendering.py`:

| Helper | Applies to |
|---|---|
| `py_literal` (also a Jinja filter) | sensor constants, StrEnum and IntFlag member values, service names, the domain literal |
| `escape_docstring_text` | service and parameter descriptions, which the template inserts verbatim |
| `require_identifier` | service method and parameter names |

`py_literal` follows the `tojson` precedent already present in `state_model.py.j2` rather than
introducing a second escaping style. `entity_wrapper.py.j2` renders four service blocks (async and
sync facade, each with and without params), so every one of these sites appears four times — all
four are covered.

Identifier positions get validation rather than escaping, because nothing can escape an identifier
position. A rejected name is reported and the affected domain's entity wrapper is skipped, matching
how `pipeline.py` already handles extraction failures. Only service method and parameter names need
this: they come from `services.yaml` keys, which are free text. Enum member names and property names
come from `ast.Name` targets in parsed Python and are identifiers by construction; `python_type`
comes from codegen's own closed type mapping. Both facts are now recorded in
`generate_state_model`'s docstring so the asymmetry doesn't read as an oversight.

### Two related defects found while fixing this

A whitespace-only service description survives the `service.description or <fallback>` check
(`"   "` is truthy), then collapses to nothing inside `build_method_docstring` — and
`textwrap.fill` silently drops `initial_indent` when the text is empty. The method got a closing
`"""` with no opening one.

Two such services in the same domain is where it turns bad. Given services `bad1` and `bad2` with
whitespace-only descriptions and a normal `good`:

```python
    def bad1(self) -> None:
        """                                  # lone delimiter — opens a string
        self.entity.api.sync.call_service(
            service="bad1",                  # bad1's own body, now inside that string
        )
    def bad2(self) -> None:                  # still inside the string
        """                                  # bad2's lone delimiter — closes it
        self.entity.api.sync.call_service(
            service="bad2",                  # still indented under def bad1
        )
```

`bad2` is never defined. `bad1` is, but its body is now a string literal followed by
`call_service(service="bad2")` — so calling `bad1()` invokes the wrong service. Confirmed against
the parsed AST:

```
methods defined: ['bad1', 'good']
bad1 statement 1 is a string? True
bad1 statement 2 calls service= ['bad2']
```

This compiles, so `ruff check` and `py_compile` in `atomic_write` both accept it — the same
valid-syntax-wrong-structure shape as finding 4 itself, which is why it is fixed here rather than
filed separately. Whitespace-only descriptions are now treated as absent, and the builder can no
longer emit a half-open docstring even if one reaches it. `escape_docstring_text` also neutralizes
NUL, the one character Python refuses to read in source at all.

## Finding 6 — generated names replacing hand-written files (CWE-73, low)

A component directory name becomes an output basename verbatim, so a component called `base` or
`catalog` would overwrite the hand-written modules of those names. Discovery now rejects reserved
and non-identifier domain names, and each write consults the previous manifest through `is_owned` —
a predicate that already existed in `manifest.py`, was already tested, and had never been called in
production.

The reserved-name list is not redundant with the ownership gate. A checkout that has never run the
generator has no manifest to consult, and that window is what the list covers. A manifest that
exists but lists nothing is a different state — the generator owns nothing, so it may overwrite
nothing — which is why `manifest_exists()` was added rather than testing the loaded set for
emptiness.

## Deliberate scope decision

**The audit's proposed AST allowlist before atomic replacement is skipped.** It is a large amount of
machinery for a threat gated behind an already-compromised upstream checkout; centralizing literal
and identifier rendering gets nearly all of the value at a fraction of the cost. Recorded here so a
reviewer doesn't reopen it.

Neither finding is a live vulnerability in a deployed Hassette instance — both require an attacker
who already controls the Home Assistant checkout codegen reads from, which is a developer-machine or
release-pipeline compromise.

## Verification

- `codegen` suite: **254 passed** (was 153)
- `prek -a` exit 0; `prek pyright -a --stage pre-push` exit 0
- `hassette-codegen generate --ha-core-path ~/source/core --check` against real HA 2026.7.1 (matching `ha-version.txt`): **exit 0, zero drift, 0 skipped** across all 34 domains. The escaping change is a no-op on real input, which matters more than any single escaping test.
- Reverting the rendering changes fails **9** of the new tests. Assertions parse the output with `ast` and count literals and statements rather than comparing strings, because the failure mode is valid-syntax-wrong-structure and string equality misses it.

No changes outside `codegen/`, which `src/hassette` never imports.

## Design record

`design/audits/2026-08-06-security-scan/audit.md` carries forward what outlives the implementation
briefs on `chore/security-audit-briefs` (now retired, not merged): the six findings and where each
landed, the points where the scan report itself was wrong or incomplete, the probe-derived JSON
Schema shapes behind `config_view`'s masker, and the scope decisions above. Findings 5 (#573) and
the config reveal toggle (#1533) remain open and are noted there.
