### PR TITLE
refactor: consolidate duplicate version-lookup implementations into utils

### DIFF
--- a/src/hassette/cli/__init__.py
+++ b/src/hassette/cli/__init__.py
@@ -1,6 +1,5 @@
 """Hassette CLI — cyclopts App setup and subcommand registration."""
 
-from importlib.metadata import PackageNotFoundError, version
 from pathlib import Path
 from typing import Annotated, Literal
 
@@ -16,19 +15,13 @@ from hassette.cli.commands.run import cmd_run
 from hassette.cli.commands.status import cmd_dashboard, cmd_status, cmd_telemetry
 from hassette.cli.context import CLIContext
 from hassette.config.config import HassetteConfig
-
-# Version string
-
-try:
-    _version = version("hassette")
-except PackageNotFoundError:
-    _version = "unknown"
+from hassette.utils import get_version
 
 # Root App
 
 app = App(
     name="hassette",
-    version=_version,
+    version=get_version(),
     version_flags=["--version", "-v"],
     help="Hassette — async-first Home Assistant automation framework.",
 )

--- a/src/hassette/config/helpers.py
+++ b/src/hassette/config/helpers.py
@@ -2,7 +2,6 @@ import os
 import sys
 from collections.abc import Callable, Sequence
 from contextlib import suppress
-from importlib.metadata import version
 from logging import getLogger
 from pathlib import Path
 from typing import cast, get_args
@@ -13,11 +12,11 @@ from packaging.version import Version
 from hassette import context
 from hassette.exceptions import HassetteNotInitializedError
 from hassette.types.types import LOG_LEVEL_TYPE
+from hassette.utils import get_version
 
 LOG_LEVEL_VALUES = get_args(LOG_LEVEL_TYPE)
 
-PACKAGE_KEY = "hassette"
-VERSION = Version(version(PACKAGE_KEY))
+VERSION = Version(get_version())
 
 LOGGER = getLogger(__name__)
 

--- a/src/hassette/config/helpers.py
+++ b/src/hassette/config/helpers.py
@@ -7,16 +7,15 @@ from pathlib import Path
 from typing import cast, get_args
 
 import platformdirs
-from packaging.version import Version
 
 from hassette import context
 from hassette.exceptions import HassetteNotInitializedError
 from hassette.types.types import LOG_LEVEL_TYPE
-from hassette.utils import get_version
+from hassette.utils import get_parsed_version
 
 LOG_LEVEL_VALUES = get_args(LOG_LEVEL_TYPE)
 
-VERSION = Version(get_version())
+VERSION = get_parsed_version()
 
 LOGGER = getLogger(__name__)
 

--- a/src/hassette/schemas/domain_models.py
+++ b/src/hassette/schemas/domain_models.py
@@ -22,18 +22,11 @@ models via ``hassette.web.mappers``. Core services must NOT import from
 ``hassette.web``.
 """
 
-import importlib.metadata
 from typing import Any, Literal
 
 from pydantic import BaseModel, Field
 
-
-def _get_hassette_version() -> str:
-    """Return the installed hassette package version, or 'unknown' if unavailable."""
-    try:
-        return importlib.metadata.version("hassette")
-    except importlib.metadata.PackageNotFoundError:
-        return "unknown"
+from hassette.utils import get_version
 
 
 class BootIssue(BaseModel):
@@ -91,7 +84,7 @@ class SystemStatus(BaseModel):
     services: list[ServiceInfo] = Field(default_factory=list)
     """Structured info for all tracked services."""
 
-    version: str = Field(default_factory=_get_hassette_version)
+    version: str = Field(default_factory=get_version)
     """Installed hassette package version."""
 
     boot_issues: list[BootIssue] = Field(default_factory=list)

--- a/src/hassette/utils/__init__.py
+++ b/src/hassette/utils/__init__.py
@@ -1,12 +1,13 @@
 from .date_utils import assume_tz, convert_datetime_str_to_tz, convert_utc_timestamp_to_tz
 from .exception_utils import get_traceback_string
 from .service_utils import topological_levels, topological_sort, validate_dependency_graph, wait_for_ready
-from .version_utils import get_version
+from .version_utils import get_parsed_version, get_version
 
 __all__ = [
     "assume_tz",
     "convert_datetime_str_to_tz",
     "convert_utc_timestamp_to_tz",
+    "get_parsed_version",
     "get_traceback_string",
     "get_version",
     "topological_levels",

--- a/src/hassette/utils/__init__.py
+++ b/src/hassette/utils/__init__.py
@@ -1,12 +1,14 @@
 from .date_utils import assume_tz, convert_datetime_str_to_tz, convert_utc_timestamp_to_tz
 from .exception_utils import get_traceback_string
 from .service_utils import topological_levels, topological_sort, validate_dependency_graph, wait_for_ready
+from .version_utils import get_version
 
 __all__ = [
     "assume_tz",
     "convert_datetime_str_to_tz",
     "convert_utc_timestamp_to_tz",
     "get_traceback_string",
+    "get_version",
     "topological_levels",
     "topological_sort",
     "validate_dependency_graph",

--- a/src/hassette/utils/version_utils.py
+++ b/src/hassette/utils/version_utils.py
@@ -1,9 +1,24 @@
 from importlib.metadata import PackageNotFoundError, version
 
+from packaging.version import Version
+
+UNKNOWN_VERSION = "unknown"
+FALLBACK_VERSION = "0.0.0"
+
 
 def get_version() -> str:
     """Return the installed hassette package version, or 'unknown' if unavailable."""
     try:
         return version("hassette")
     except PackageNotFoundError:
-        return "unknown"
+        return UNKNOWN_VERSION
+
+
+def get_parsed_version() -> Version:
+    """Return the installed hassette package version as a `Version`.
+
+    Falls back to `FALLBACK_VERSION` when package metadata is unavailable, since
+    `UNKNOWN_VERSION` is not a valid PEP 440 version string.
+    """
+    version_str = get_version()
+    return Version(version_str if version_str != UNKNOWN_VERSION else FALLBACK_VERSION)

--- a/src/hassette/utils/version_utils.py
+++ b/src/hassette/utils/version_utils.py
@@ -1,0 +1,9 @@
+from importlib.metadata import PackageNotFoundError, version
+
+
+def get_version() -> str:
+    """Return the installed hassette package version, or 'unknown' if unavailable."""
+    try:
+        return version("hassette")
+    except PackageNotFoundError:
+        return "unknown"

--- a/tests/unit/utils/test_version_utils.py
+++ b/tests/unit/utils/test_version_utils.py
@@ -1,0 +1,30 @@
+"""Tests for hassette.utils.version_utils."""
+
+from importlib.metadata import PackageNotFoundError
+
+import pytest
+from packaging.version import Version
+
+from hassette.utils.version_utils import FALLBACK_VERSION, UNKNOWN_VERSION, get_parsed_version, get_version
+
+
+def test_get_version_returns_installed_version() -> None:
+    assert get_version() != UNKNOWN_VERSION
+
+
+def test_get_version_returns_unknown_when_package_metadata_missing(monkeypatch: pytest.MonkeyPatch) -> None:
+    def raise_not_found(_name: str) -> str:
+        raise PackageNotFoundError
+
+    monkeypatch.setattr("hassette.utils.version_utils.version", raise_not_found)
+    assert get_version() == UNKNOWN_VERSION
+
+
+def test_get_parsed_version_falls_back_when_package_metadata_unavailable(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("hassette.utils.version_utils.get_version", lambda: UNKNOWN_VERSION)
+    assert get_parsed_version() == Version(FALLBACK_VERSION)
+
+
+def test_get_parsed_version_parses_real_version_string(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("hassette.utils.version_utils.get_version", lambda: "1.2.3")
+    assert get_parsed_version() == Version("1.2.3")


### PR DESCRIPTION
## Summary

Three independent implementations of "get the installed hassette version" existed across the codebase, each with slightly different import patterns and error handling:

- `cli/__init__.py` — inline try/except around `importlib.metadata.version()`
- `config/helpers.py` — bare `version()` call (no fallback, would raise if package not found)
- `schemas/domain_models.py` — private `_get_hassette_version()` function with try/except

This PR consolidates all three into a single `get_version()` function in `utils/version_utils.py` with the defensive `PackageNotFoundError` fallback. Each call site now imports from `hassette.utils`. `config/helpers.py` wraps the result with `packaging.version.Version()` at the call site for its `VERSION.major` usage.

## Changes

- **New:** `src/hassette/utils/version_utils.py` — single `get_version() -> str` implementation
- **Updated:** `src/hassette/utils/__init__.py` — re-exports `get_version`
- **Simplified:** `cli/__init__.py`, `config/helpers.py`, `schemas/domain_models.py` — replaced inline version lookups with the shared utility

## Testing

- Full dev suite: 8949 passed, 1 skipped, 2 xfailed
- All lint checks (ruff, pyright, flake8-async, typos): passed
- Pre-push hooks (schema freshness, CLI drift): passed

Closes #1482