### PR TITLE
chore: clean code sweep — dedupe test scaffolding, single-source demo config

### DIFF
--- a/.claude/skills/ha-version-bump/SKILL.md
+++ b/.claude/skills/ha-version-bump/SKILL.md
@@ -40,15 +40,20 @@ Phase 2). Ask whether to continue or wait for a closer look.
 echo "<LATEST from Phase 1, substituted literally>" > codegen/ha-version.txt
 ```
 
-Find every other place an HA image tag is pinned, then check each hit against `$PINNED`
-to see which are actually stale. Don't rely on a fixed list of files — HA image tags are
-minor-version only (`2026.7`, not `2026.7.1`) and new ones get added over time:
+`scripts/docker/ha-demo.yml` and `tests/system/docker-compose.yml` both derive their HA
+image tag from `${HA_VERSION}`, interpolated by docker-compose from `scripts/docker/.env`
+(`tests/system/.env` is a symlink to the same file) — so there is exactly one place left
+to bump, not a fixed or grep-discovered list of compose files:
 
 ```bash
-grep -rn "homeassistant/home-assistant:" . | grep -v node_modules | grep -v /.git/
+grep -n "^HA_VERSION=" scripts/docker/.env
 ```
 
-Update each hit to the new minor version. This skill is the sole owner of these tags —
+Update that one line to the new minor version (HA image tags are minor-version only —
+`2026.7`, not `2026.7.1`). If a future `grep -rn "homeassistant/home-assistant:" .` finds a
+literal (non-`${HA_VERSION}`) tag anywhere outside `design/` (a new compose file added
+without wiring it to `scripts/docker/.env`), treat that as its own bug to fix, not just a
+value to bump. This skill is the sole owner of the `HA_VERSION` value —
 `renovate.json` explicitly disables Renovate for `homeassistant/home-assistant`
 (`packageRules` — `"enabled": false`) precisely so there's no second, weekly bump racing
 this monthly one. If `renovate.json` no longer has that rule, or the rule is present but

--- a/.gitignore
+++ b/.gitignore
@@ -134,6 +134,11 @@ celerybeat.pid
 # Environments
 .env
 .env.*
+# Fixture-only demo/system-test values (HA image tag, demo tokens), not secrets --
+# see scripts/docker/.env for the full explanation. tests/system/.env is a symlink
+# to it, kept in sync automatically.
+!scripts/docker/.env
+!tests/system/.env
 .venv
 env/
 venv/

--- a/.mise/tasks/demo-verify
+++ b/.mise/tasks/demo-verify
@@ -13,9 +13,15 @@ HASSETTE_URL="http://localhost:$HASSETTE_PORT"
 # Expected app instance count — derived from hassette.toml config sections
 EXPECTED_APPS=7
 
-# Must match HASSETTE__WEB_API__AUTH_TOKEN in scripts/docker/ha-demo.yml and
-# DEMO_AUTH_TOKEN in scripts/capture_screenshots.py
-AUTH_HEADER="Authorization: Bearer demo-token"
+# Single source of truth: scripts/docker/.env, also read by ha-demo.yml (via
+# docker-compose's auto env-file loading) and capture_screenshots.py (via python-dotenv).
+DEMO_ENV_FILE="$REPO_ROOT/scripts/docker/.env"
+DEMO_AUTH_TOKEN="$(grep -m1 '^DEMO_AUTH_TOKEN=' "$DEMO_ENV_FILE" | cut -d= -f2-)"
+if [[ -z "$DEMO_AUTH_TOKEN" ]]; then
+    echo "FAIL: DEMO_AUTH_TOKEN not found in $DEMO_ENV_FILE"
+    exit 1
+fi
+AUTH_HEADER="Authorization: Bearer $DEMO_AUTH_TOKEN"
 
 cleanup() {
     if [[ -n "${DEMO_PID:-}" ]]; then

--- a/codegen/pyproject.toml
+++ b/codegen/pyproject.toml
@@ -23,6 +23,7 @@ where = ["src"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
+pythonpath = ["src"]
 
 [tool.ruff]
 line-length = 120

--- a/codegen/tests/conftest.py
+++ b/codegen/tests/conftest.py
@@ -1,0 +1,15 @@
+"""Shared fixtures and constants for codegen tests.
+
+``src`` is added to the import path via the ``pythonpath`` pytest option in
+``codegen/pyproject.toml``, so ``hassette_codegen`` is importable without any
+per-file path manipulation.
+"""
+
+import os
+from pathlib import Path
+
+HA_CORE = Path(os.environ.get("HA_CORE_PATH", "~/source/core")).expanduser()
+"""Local checkout of Home Assistant core, used by tests that extract data from HA source."""
+
+HAS_HA_CORE = HA_CORE.exists()
+"""Whether HA_CORE points at a real checkout — tests that need it skip when this is False."""

--- a/codegen/tests/test_cli.py
+++ b/codegen/tests/test_cli.py
@@ -1,10 +1,7 @@
 """Unit tests for the CLI argument parsing and dispatch."""
 
-import sys
 from pathlib import Path
 from unittest.mock import patch
-
-sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
 
 from hassette_codegen.__main__ import _build_parser, main
 

--- a/codegen/tests/test_constants_and_exports.py
+++ b/codegen/tests/test_constants_and_exports.py
@@ -1,15 +1,11 @@
 """Unit tests for constants extraction and __init__.py generation."""
 
 import ast
-import os
 import py_compile
-import sys
 import tempfile
 from pathlib import Path
 
 import pytest
-
-sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
 
 from hassette_codegen.extractors.constants import (
     ExtractedConstantSet,
@@ -20,8 +16,9 @@ from hassette_codegen.generators.constants import generate_sensor_constants
 from hassette_codegen.generators.exports import generate_init_py
 from hassette_codegen.pipeline import _check_predicate_freshness
 
-_HA_CORE = Path(os.environ.get("HA_CORE_PATH", "~/source/core")).expanduser()
-_HAS_HA_CORE = _HA_CORE.exists()
+from .conftest import HA_CORE as _HA_CORE
+from .conftest import HAS_HA_CORE as _HAS_HA_CORE
+
 _STATES_DIR = Path(__file__).resolve().parent.parent.parent / "src" / "hassette" / "models" / "states"
 
 

--- a/codegen/tests/test_desync_docstring.py
+++ b/codegen/tests/test_desync_docstring.py
@@ -6,12 +6,7 @@ ast_utils.py AND a case here — the drift gate only detects changes to generate
 output, not phrasings the regex misses.
 """
 
-import sys
-from pathlib import Path
-
 import pytest
-
-sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
 
 from hassette_codegen.sync_facade.ast_utils import desync_docstring
 

--- a/codegen/tests/test_docstring_builder.py
+++ b/codegen/tests/test_docstring_builder.py
@@ -6,10 +6,7 @@ These cover the description-threading path directly, independent of a live HA co
 
 import ast
 import json
-import sys
 from pathlib import Path
-
-sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
 
 from hassette_codegen.extractors.services import _extract_descriptions, _resolve_key_ref
 from hassette_codegen.generators.entities import LINE_LENGTH, ServiceParam, build_method_docstring

--- a/codegen/tests/test_entity_generator.py
+++ b/codegen/tests/test_entity_generator.py
@@ -3,13 +3,9 @@
 import ast
 import py_compile
 import re
-import sys
 import tempfile
-from pathlib import Path
 
 import pytest
-
-sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
 
 from hassette_codegen.domain_data import ExtractedDomain
 from hassette_codegen.extractors.features import ExtractedEnum

--- a/codegen/tests/test_extractors.py
+++ b/codegen/tests/test_extractors.py
@@ -1,20 +1,17 @@
 """Unit tests for AST extractors — features, properties, and base class."""
 
-import os
-import sys
 from pathlib import Path
 
 import pytest
-
-sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
 
 from hassette_codegen.extractors.base_class import determine_base_class
 from hassette_codegen.extractors.constants import _extract_enum_ref_set, extract_numeric_state_expected_source
 from hassette_codegen.extractors.features import extract_features
 from hassette_codegen.extractors.properties import extract_properties
 
-_HA_CORE = Path(os.environ.get("HA_CORE_PATH", "~/source/core")).expanduser()
-_HAS_HA_CORE = _HA_CORE.exists()
+from .conftest import HA_CORE as _HA_CORE
+from .conftest import HAS_HA_CORE as _HAS_HA_CORE
+
 _COMPONENTS = _HA_CORE / "homeassistant" / "components"
 
 

--- a/codegen/tests/test_ha_source.py
+++ b/codegen/tests/test_ha_source.py
@@ -1,12 +1,9 @@
 """Unit tests for hassette_codegen.ha_source — HA source resolution and domain discovery."""
 
-import os
 import sys
 from pathlib import Path
 
 import pytest
-
-sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
 
 from hassette_codegen.ha_source import (
     _parse_required_python_ver,
@@ -14,8 +11,8 @@ from hassette_codegen.ha_source import (
     discover_domains,
 )
 
-_HA_CORE = Path(os.environ.get("HA_CORE_PATH", "~/source/core")).expanduser()
-_HAS_HA_CORE = _HA_CORE.exists()
+from .conftest import HA_CORE as _HA_CORE
+from .conftest import HAS_HA_CORE as _HAS_HA_CORE
 
 
 class TestParsePythonVer:

--- a/codegen/tests/test_integration.py
+++ b/codegen/tests/test_integration.py
@@ -1,15 +1,10 @@
 """Integration tests — full pipeline against real HA core domains."""
 
-import os
 import py_compile
-import sys
 import tempfile
 import time
-from pathlib import Path
 
 import pytest
-
-sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
 
 from hassette_codegen.domain_data import ExtractedDomain
 from hassette_codegen.extractors.base_class import determine_base_class
@@ -23,8 +18,9 @@ from hassette_codegen.generators.states import generate_state_model
 from hassette_codegen.ha_source import discover_domains
 from hassette_codegen.overrides import get_override, load_overrides
 
-_HA_CORE = Path(os.environ.get("HA_CORE_PATH", "~/source/core")).expanduser()
-_HAS_HA_CORE = _HA_CORE.exists()
+from .conftest import HA_CORE as _HA_CORE
+from .conftest import HAS_HA_CORE as _HAS_HA_CORE
+
 _COMPONENTS = _HA_CORE / "homeassistant" / "components"
 
 

--- a/codegen/tests/test_manifest.py
+++ b/codegen/tests/test_manifest.py
@@ -1,9 +1,6 @@
 """Unit tests for manifest-based file ownership tracking."""
 
-import sys
 from pathlib import Path
-
-sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
 
 from hassette_codegen.manifest import detect_orphans, is_owned, load_manifest, save_manifest
 

--- a/codegen/tests/test_output.py
+++ b/codegen/tests/test_output.py
@@ -1,9 +1,6 @@
 """Unit tests for hassette_codegen.output — shared ruff/validation/drift utilities."""
 
-import sys
 from pathlib import Path
-
-sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
 
 from hassette_codegen.output import atomic_write, check_drift, format_via_ruff
 

--- a/codegen/tests/test_overrides.py
+++ b/codegen/tests/test_overrides.py
@@ -1,11 +1,8 @@
 """Unit tests for the TOML override system."""
 
-import sys
 from pathlib import Path
 
 import pytest
-
-sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
 
 from hassette_codegen.extractors.properties import ExtractedProperty
 from hassette_codegen.overrides import (

--- a/codegen/tests/test_pipeline_guards.py
+++ b/codegen/tests/test_pipeline_guards.py
@@ -9,12 +9,9 @@ Every end-to-end test generates a second, ordinary domain in the same run. Witho
 a test proving "the file was not overwritten" would also pass if the pipeline never ran at all.
 """
 
-import sys
 from pathlib import Path
 
 import pytest
-
-sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
 
 from hassette_codegen import pipeline
 from hassette_codegen.ha_source import DiscoveredDomain, HASource

--- a/codegen/tests/test_rendering.py
+++ b/codegen/tests/test_rendering.py
@@ -6,12 +6,8 @@ equality does not catch that, so the assertions here parse the rendered text and
 """
 
 import ast
-import sys
-from pathlib import Path
 
 import pytest
-
-sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
 
 from hassette_codegen.rendering import (
     UnsafeGeneratedValueError,

--- a/codegen/tests/test_services.py
+++ b/codegen/tests/test_services.py
@@ -1,18 +1,13 @@
 """Unit tests for service extraction and type mapping."""
 
-import os
-import sys
-from pathlib import Path
-
 import pytest
-
-sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
 
 from hassette_codegen.extractors.services import extract_services
 from hassette_codegen.type_mapping import map_selector_to_type
 
-_HA_CORE = Path(os.environ.get("HA_CORE_PATH", "~/source/core")).expanduser()
-_HAS_HA_CORE = _HA_CORE.exists()
+from .conftest import HA_CORE as _HA_CORE
+from .conftest import HAS_HA_CORE as _HAS_HA_CORE
+
 _COMPONENTS = _HA_CORE / "homeassistant" / "components"
 
 

--- a/codegen/tests/test_state_generator.py
+++ b/codegen/tests/test_state_generator.py
@@ -2,11 +2,7 @@
 
 import ast
 import py_compile
-import sys
 import tempfile
-from pathlib import Path
-
-sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
 
 from hassette_codegen.domain_data import ExtractedDomain
 from hassette_codegen.extractors.features import ExtractedEnum

--- a/design/specs/091-web-api-auth/known-issues.md
+++ b/design/specs/091-web-api-auth/known-issues.md
@@ -103,7 +103,7 @@ Acceptance criteria:
 
 ## KI-003: The demo auth token `"demo-token"` is hardcoded independently in three files with no single source of truth
 
-Status: filed (#1523)
+Status: resolved (#1523)
 Run: 54
 Source: clean-code
 Reason not fixed now: out-of-scope
@@ -186,7 +186,7 @@ Acceptance criteria:
 
 ## KI-005: Repeated trusted-peer/renewal request-building sequence in `test_auth.py` is not extracted to a helper
 
-Status: filed (#1524)
+Status: resolved (#1524)
 Run: 54
 Source: clean-code
 Reason not fixed now: out-of-scope

--- a/scripts/capture_screenshots.py
+++ b/scripts/capture_screenshots.py
@@ -47,6 +47,7 @@ from pathlib import Path
 
 import yaml
 from demo_stack import DemoStack
+from dotenv import dotenv_values
 
 ERROR_DATA_TIMEOUT_SECONDS = 90
 ERROR_DATA_POLL_INTERVAL_SECONDS = 2
@@ -55,8 +56,14 @@ SCREENSHOT_CAPTURE_TIMEOUT_SECONDS = 600
 DEFAULT_SESSION_MAX_AGE_SECONDS = 3600  # WebApiConfig.session_ttl's own default, used only if a
 # Set-Cookie response is somehow missing Max-Age
 
-# Must match HASSETTE__WEB_API__AUTH_TOKEN in scripts/docker/ha-demo.yml
-DEMO_AUTH_TOKEN = "demo-token"
+# Single source of truth: scripts/docker/.env, also read by ha-demo.yml (via docker-compose's
+# auto env-file loading) and .mise/tasks/demo-verify (via grep).
+_DEMO_ENV_PATH = Path(__file__).resolve().parent / "docker" / ".env"
+_DEMO_ENV = dotenv_values(_DEMO_ENV_PATH)
+DEMO_AUTH_TOKEN = _DEMO_ENV.get("DEMO_AUTH_TOKEN")
+if not DEMO_AUTH_TOKEN:
+    print(f"ERROR: DEMO_AUTH_TOKEN not found in {_DEMO_ENV_PATH}", file=sys.stderr, flush=True)
+    sys.exit(1)
 
 EXPECTED_COOKIE_COUNT = 1
 """Set-Cookie from POST /api/auth/session mints exactly one cookie (the session cookie)."""
@@ -154,8 +161,7 @@ def _mint_auth_storage_state(hassette_port: int) -> dict[str, object]:
             set_cookie = resp.headers.get("Set-Cookie")
     except (urllib.error.HTTPError, urllib.error.URLError, OSError, TimeoutError) as exc:
         print(
-            f"ERROR: POST /api/auth/session failed ({exc}) -- DEMO_AUTH_TOKEN in "
-            "capture_screenshots.py must match HASSETTE__WEB_API__AUTH_TOKEN in ha-demo.yml",
+            f"ERROR: POST /api/auth/session failed ({exc}) -- check DEMO_AUTH_TOKEN in {_DEMO_ENV_PATH}",
             file=sys.stderr,
             flush=True,
         )

--- a/scripts/demo_stack.py
+++ b/scripts/demo_stack.py
@@ -24,6 +24,8 @@ import tempfile
 from pathlib import Path
 from types import FrameType, TracebackType
 
+from dotenv import dotenv_values
+
 COMPOSE_PROJECT_NAME = "hassette-demo"
 COMPOSE_UP_TIMEOUT_SECONDS = 120
 COMPOSE_DOWN_TIMEOUT_SECONDS = 30
@@ -121,6 +123,28 @@ class DemoStack:
             "HOST_UID": str(os.getuid()),
             "HOST_GID": str(os.getgid()),
         }
+        # Pin the fixture credentials even if the invoking shell exports its own
+        # HA_ACCESS_TOKEN/DEMO_AUTH_TOKEN -- Docker Compose's interpolation precedence favors
+        # the process env over the .env file (docs.docker.com/compose/how-tos/environment-
+        # variables/variable-interpolation), so an inherited value would otherwise silently
+        # override the token baked into tests/fixtures/demo-ha-config/.storage/auth, while
+        # capture_screenshots.py and demo-verify (which read scripts/docker/.env directly)
+        # would keep using the fixture value -- a mismatch between what the containers
+        # authenticate with and what the scripts send. Fails loudly (like conftest.py's
+        # HA_TOKEN) rather than silently falling back to an inherited/absent value, which
+        # would just be a quieter instance of the same bug this pinning fixes.
+        # Keep in sync with tests/system/conftest.py's ha_container fixture (same pinning,
+        # scoped to HA_ACCESS_TOKEN only since that compose stack has no hassette service).
+        # Parsed fresh per DemoStack() instantiation rather than cached at module level like
+        # conftest.py's HA_TOKEN -- this class has no import-time hook to do that caching in.
+        fixture_env_path = self._repo_root / "scripts" / "docker" / ".env"
+        fixture_env = dotenv_values(fixture_env_path)
+        for key in ("HA_ACCESS_TOKEN", "DEMO_AUTH_TOKEN"):
+            value = fixture_env.get(key)
+            if not value:
+                self._teardown()
+                raise RuntimeError(f"{key} not found in {fixture_env_path}")
+            env[key] = value
 
         try:
             result = subprocess.run(

--- a/scripts/docker/.env
+++ b/scripts/docker/.env
@@ -11,6 +11,8 @@
 #     compose file's own directory, not the invoking shell's cwd)
 #   - scripts/capture_screenshots.py (reads DEMO_AUTH_TOKEN via python-dotenv)
 #   - .mise/tasks/demo-verify (reads DEMO_AUTH_TOKEN via grep)
+#   - tests/system/conftest.py (reads HA_ACCESS_TOKEN via python-dotenv, from the
+#     tests/system/.env symlink)
 
 # Minor-only HA image tag (Home Assistant images are tagged YYYY.M, not
 # YYYY.M.PATCH). .claude/skills/ha-version-bump/SKILL.md is the sole owner of

--- a/scripts/docker/.env
+++ b/scripts/docker/.env
@@ -1,0 +1,27 @@
+# Single source of truth for the demo/system-test HA image tag and shared
+# credentials. Every value here is fixture-only demo/dev material (not a real
+# secret) -- see the comments below -- so this file is committed despite the
+# blanket .env ignore rule in .gitignore (explicit negation there).
+#
+# Consumed by:
+#   - scripts/docker/ha-demo.yml (docker-compose auto-loads this file since it
+#     sits next to the compose file)
+#   - tests/system/docker-compose.yml (tests/system/.env symlinks here, for
+#     the same auto-load reason, since docker-compose loads .env from the
+#     compose file's own directory, not the invoking shell's cwd)
+#   - scripts/capture_screenshots.py (reads DEMO_AUTH_TOKEN via python-dotenv)
+#   - .mise/tasks/demo-verify (reads DEMO_AUTH_TOKEN via grep)
+
+# Minor-only HA image tag (Home Assistant images are tagged YYYY.M, not
+# YYYY.M.PATCH). .claude/skills/ha-version-bump/SKILL.md is the sole owner of
+# this value and keeps it in lockstep with codegen/ha-version.txt's full
+# patch pin on each monthly bump.
+HA_VERSION=2026.8
+
+# Long-lived HA access token baked into
+# tests/fixtures/demo-ha-config/.storage/auth (signed with an all-zeros
+# fixture key -- not a real secret).
+HA_ACCESS_TOKEN=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiIwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMyIsImlhdCI6MTczNTY4OTYwMCwiZXhwIjoyMDUxMDQ5NjAwfQ.q-p85dOe-MMnKQhSNh_LEWnWJGK-GA3xdmqb4LKvkU0
+
+# hassette's own local demo/dev web API auth token.
+DEMO_AUTH_TOKEN=demo-token

--- a/scripts/docker/ha-demo.yml
+++ b/scripts/docker/ha-demo.yml
@@ -1,15 +1,15 @@
 services:
   homeassistant:
-    image: homeassistant/home-assistant:2026.8
+    image: homeassistant/home-assistant:${HA_VERSION}
     container_name: "hassette-demo-ha"
     ports:
       - "127.0.0.1:${DEMO_HA_PORT:-18123}:8123"
     volumes:
       - "${HA_CONFIG_PATH:-../../tests/fixtures/demo-ha-config}:/config"
     restart: "no"
-    # JWT must match HA_TOKEN in scripts/hassette_demo.py and tests/fixtures/demo-ha-config/.storage/auth
+    # HA_ACCESS_TOKEN (scripts/docker/.env) must match tests/fixtures/demo-ha-config/.storage/auth
     healthcheck:
-      test: ["CMD", "curl", "-sf", "http://localhost:8123/api/", "-H", "Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiIwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMyIsImlhdCI6MTczNTY4OTYwMCwiZXhwIjoyMDUxMDQ5NjAwfQ.q-p85dOe-MMnKQhSNh_LEWnWJGK-GA3xdmqb4LKvkU0"]
+      test: ["CMD", "curl", "-sf", "http://localhost:8123/api/", "-H", "Authorization: Bearer ${HA_ACCESS_TOKEN}"]
       interval: 5s
       timeout: 5s
       retries: 12
@@ -30,10 +30,10 @@ services:
       - "../../.demo-data:/app/.demo-data"
     environment:
       HASSETTE__BASE_URL: "http://homeassistant:8123"
-      # JWT must match HA_TOKEN in scripts/hassette_demo.py and tests/fixtures/demo-ha-config/.storage/auth
-      HASSETTE__TOKEN: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiIwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMyIsImlhdCI6MTczNTY4OTYwMCwiZXhwIjoyMDUxMDQ5NjAwfQ.q-p85dOe-MMnKQhSNh_LEWnWJGK-GA3xdmqb4LKvkU0"
-      # Must match DEMO_AUTH_TOKEN in scripts/capture_screenshots.py
-      HASSETTE__WEB_API__AUTH_TOKEN: "demo-token"
+      # HA_ACCESS_TOKEN (scripts/docker/.env) must match tests/fixtures/demo-ha-config/.storage/auth
+      HASSETTE__TOKEN: "${HA_ACCESS_TOKEN}"
+      # DEMO_AUTH_TOKEN (scripts/docker/.env), also read by capture_screenshots.py and demo-verify
+      HASSETTE__WEB_API__AUTH_TOKEN: "${DEMO_AUTH_TOKEN}"
       HASSETTE__WEB_API__PORT: "8126"
       HASSETTE__APPS__DIRECTORY: "/app/examples"
       HASSETTE__DATA_DIR: "/app/.demo-data"

--- a/src/hassette/core/app_lifecycle_service.py
+++ b/src/hassette/core/app_lifecycle_service.py
@@ -383,7 +383,7 @@ class AppLifecycleService(Resource):
         self,
         *,
         original_apps_config: dict[str, "AppManifest"],
-        curr_apps_config: dict[str, "AppManifest"],
+        current_apps_config: dict[str, "AppManifest"],
         changed_file_paths: frozenset[Path] | None,
     ) -> None:
         pending = self._pending_reconciliation
@@ -406,7 +406,7 @@ class AppLifecycleService(Resource):
 
         self._pending_reconciliation = PendingReconciliation(
             original_apps_config=merged_original,
-            current_apps_config=curr_apps_config,
+            current_apps_config=current_apps_config,
             changed_paths=merged_paths,
         )
 
@@ -642,7 +642,7 @@ class AppLifecycleService(Resource):
         async with self._change_event_lock:
             self.logger.debug("Handling app change event for files: %s", changed_file_paths)
 
-            original_apps_config, curr_apps_config = await self.refresh_config()
+            original_apps_config, current_apps_config = await self.refresh_config()
             await self.resolve_only_apps()
 
             if self.bootstrap_coordinator.is_released() and self._pending_reconciliation is not None:
@@ -660,7 +660,7 @@ class AppLifecycleService(Resource):
                         changed_file_paths |= pending_paths
 
             changes = self.change_detector.detect_changes(
-                original_apps_config, curr_apps_config, changed_file_paths, only_apps=self.registry.only_apps
+                original_apps_config, current_apps_config, changed_file_paths, only_apps=self.registry.only_apps
             )
 
             changes = self._fold_unblocked_apps_into_changes(changes)
@@ -673,7 +673,7 @@ class AppLifecycleService(Resource):
                 self.logger.debug("Deferring app reconciliation until bootstrap release opens")
                 self._record_pre_release_reconciliation(
                     original_apps_config=original_apps_config,
-                    curr_apps_config=curr_apps_config,
+                    current_apps_config=current_apps_config,
                     changed_file_paths=changed_file_paths,
                 )
                 return
@@ -700,9 +700,9 @@ class AppLifecycleService(Resource):
 
         self.set_apps_configs(self.hassette.config.apps.manifests)
         await self.persist_manifests()
-        curr_apps_config = {k: deepcopy(v) for k, v in self.registry.manifests.items() if v.enabled}
+        current_apps_config = {k: deepcopy(v) for k, v in self.registry.manifests.items() if v.enabled}
 
-        return original_apps_config, curr_apps_config
+        return original_apps_config, current_apps_config
 
     async def _replay_pre_release_reconciliation_if_needed(self) -> None:
         # Shares _pending_reconciliation state with handle_change_event(), which serializes on
@@ -712,14 +712,14 @@ class AppLifecycleService(Resource):
             if self._pending_reconciliation is None:
                 return
 
-            original_apps_config, curr_apps_config, changed_file_paths = self._take_pre_release_reconciliation()
-            if original_apps_config is None or curr_apps_config is None:
+            original_apps_config, current_apps_config, changed_file_paths = self._take_pre_release_reconciliation()
+            if original_apps_config is None or current_apps_config is None:
                 return
             self.logger.debug("Replaying deferred app reconciliation after bootstrap release opens")
             await self.resolve_only_apps()
 
             changes = self.change_detector.detect_changes(
-                original_apps_config, curr_apps_config, changed_file_paths, only_apps=self.registry.only_apps
+                original_apps_config, current_apps_config, changed_file_paths, only_apps=self.registry.only_apps
             )
 
             changes = self._fold_unblocked_apps_into_changes(changes)

--- a/src/hassette/core/app_lifecycle_service.py
+++ b/src/hassette/core/app_lifecycle_service.py
@@ -3,6 +3,7 @@
 import asyncio
 import typing
 from copy import deepcopy
+from dataclasses import dataclass
 from enum import StrEnum
 from pathlib import Path
 from timeit import default_timer as timer
@@ -59,6 +60,21 @@ class AppAdmissionMode(StrEnum):
     REJECT_IF_UNRELEASED = "reject_if_unreleased"
 
 
+@dataclass
+class PendingReconciliation:
+    """A deferred app-config reconciliation, queued while bootstrap release hasn't opened yet.
+
+    Presence of an instance (vs. ``None``) on ``AppLifecycleService._pending_reconciliation``
+    is the "is one queued?" signal — see ``_record_pre_release_reconciliation`` and
+    ``_take_pre_release_reconciliation``, which are the only code that constructs, merges, or
+    clears this record.
+    """
+
+    original_apps_config: dict[str, "AppManifest"]
+    current_apps_config: dict[str, "AppManifest"]
+    changed_paths: frozenset[Path] | None
+
+
 class AppLifecycleService(Resource):
     """Manages app lifecycle orchestration, change detection, and event emission.
 
@@ -95,15 +111,12 @@ class AppLifecycleService(Resource):
         self.registry = registry
         self.factory = AppFactory(hassette, self.registry)
         self.change_detector = AppChangeDetector()
-        self._pending_pre_release_reconciliation = False
-        self._pending_pre_release_original_apps_config: dict[str, AppManifest] | None = None
-        self._pending_pre_release_current_apps_config: dict[str, AppManifest] | None = None
-        self._pending_pre_release_changed_paths: frozenset[Path] | None = None
+        self._pending_reconciliation: PendingReconciliation | None = None
         # Bus dispatch spawns a fresh task per handler invocation rather than awaiting handlers
         # sequentially (see BusService._dispatch), so two file-watcher events arriving close
         # together can produce two concurrently-running handle_change_event() coroutines. Each
-        # does real awaited I/O (refresh_config(), resolve_only_apps()) before touching the
-        # shared _pending_pre_release_* fields, and refresh_config() mutates self.registry.manifests
+        # does real awaited I/O (refresh_config(), resolve_only_apps()) before touching
+        # ``_pending_reconciliation``, and refresh_config() mutates self.registry.manifests
         # in place — so overlapping calls can race on the "what was the world like before this
         # change" snapshot. This lock serializes handle_change_event so only one reconciliation
         # pass runs at a time, matching the "single reconciliation in flight" model the rest of
@@ -373,31 +386,38 @@ class AppLifecycleService(Resource):
         curr_apps_config: dict[str, "AppManifest"],
         changed_file_paths: frozenset[Path] | None,
     ) -> None:
-        had_pending_reconciliation = self._pending_pre_release_reconciliation
-        if not had_pending_reconciliation:
-            self._pending_pre_release_original_apps_config = original_apps_config
-        self._pending_pre_release_reconciliation = True
-        self._pending_pre_release_current_apps_config = curr_apps_config
-        if changed_file_paths is None:
-            self._pending_pre_release_changed_paths = None
-        elif not had_pending_reconciliation:
-            self._pending_pre_release_changed_paths = changed_file_paths
-        elif self._pending_pre_release_changed_paths is None:
-            self._pending_pre_release_changed_paths = None
+        pending = self._pending_reconciliation
+
+        if pending is None:
+            # First deferred change since the queue was last taken: this call's own baseline
+            # and paths become the queue's baseline and paths.
+            merged_original = original_apps_config
+            merged_paths = changed_file_paths
+        elif changed_file_paths is None or pending.changed_paths is None:
+            # Either this call or a previous one couldn't scope its paths, so the merged scope
+            # degrades to "unknown" (None means "assume everything may have changed").
+            merged_original = pending.original_apps_config
+            merged_paths = None
         else:
-            self._pending_pre_release_changed_paths |= changed_file_paths
+            # Keep the original pre-existing baseline (the "before" snapshot from the first
+            # deferred change), union the newly-touched paths onto the ones already queued.
+            merged_original = pending.original_apps_config
+            merged_paths = pending.changed_paths | changed_file_paths
+
+        self._pending_reconciliation = PendingReconciliation(
+            original_apps_config=merged_original,
+            current_apps_config=curr_apps_config,
+            changed_paths=merged_paths,
+        )
 
     def _take_pre_release_reconciliation(
         self,
     ) -> tuple[dict[str, "AppManifest"] | None, dict[str, "AppManifest"] | None, frozenset[Path] | None]:
-        original_apps_config = self._pending_pre_release_original_apps_config
-        curr_apps_config = self._pending_pre_release_current_apps_config
-        changed_file_paths = self._pending_pre_release_changed_paths
-        self._pending_pre_release_reconciliation = False
-        self._pending_pre_release_original_apps_config = None
-        self._pending_pre_release_current_apps_config = None
-        self._pending_pre_release_changed_paths = None
-        return original_apps_config, curr_apps_config, changed_file_paths
+        pending = self._pending_reconciliation
+        self._pending_reconciliation = None
+        if pending is None:
+            return None, None, None
+        return pending.original_apps_config, pending.current_apps_config, pending.changed_paths
 
     async def bootstrap_apps(self, *, admission_mode: AppAdmissionMode) -> None:
         """Initialize all configured and enabled apps, called at AppHandler startup.
@@ -616,7 +636,7 @@ class AppLifecycleService(Resource):
         Called as a Bus event handler with DI-injected ``changed_file_paths``. Serialized by
         ``self._change_event_lock`` — this listener runs in the bus's ``parallel`` execution
         mode (framework tier), so two file-watcher events dispatched close together would
-        otherwise run this method concurrently and race on ``_pending_pre_release_*`` and on
+        otherwise run this method concurrently and race on ``_pending_reconciliation`` and on
         ``refresh_config()``'s in-place mutation of ``self.registry.manifests``.
         """
         async with self._change_event_lock:
@@ -625,7 +645,7 @@ class AppLifecycleService(Resource):
             original_apps_config, curr_apps_config = await self.refresh_config()
             await self.resolve_only_apps()
 
-            if self.bootstrap_coordinator.is_released() and self._pending_pre_release_reconciliation:
+            if self.bootstrap_coordinator.is_released() and self._pending_reconciliation is not None:
                 # A pre-release change is still queued. Fold it into this diff's baseline so the
                 # comparison spans everything since before release, then clear the queue — otherwise
                 # bootstrap's later replay would apply that stale snapshot on top of a config it no
@@ -685,11 +705,11 @@ class AppLifecycleService(Resource):
         return original_apps_config, curr_apps_config
 
     async def _replay_pre_release_reconciliation_if_needed(self) -> None:
-        # Shares _pending_pre_release_* state with handle_change_event(), which serializes on
+        # Shares _pending_reconciliation state with handle_change_event(), which serializes on
         # this same lock — without it, a file-watcher event arriving as bootstrap replays could
         # race the take/clear of that state.
         async with self._change_event_lock:
-            if not self._pending_pre_release_reconciliation:
+            if self._pending_reconciliation is None:
                 return
 
             original_apps_config, curr_apps_config, changed_file_paths = self._take_pre_release_reconciliation()

--- a/src/hassette/test_utils/__init__.py
+++ b/src/hassette/test_utils/__init__.py
@@ -80,6 +80,7 @@ from .web_mocks import create_hassette_stub as create_hassette_stub
 from .web_mocks import create_mock_runtime_query_service as create_mock_runtime_query_service
 from .web_mocks import create_test_fastapi_app as create_test_fastapi_app
 from .ws_mocks import build_fake_ws as build_fake_ws
+from .ws_mocks import make_task_bucket_spawn_stub as make_task_bucket_spawn_stub
 from .ws_mocks import mark_websocket_service_connected as mark_websocket_service_connected
 
 __all__ = [

--- a/src/hassette/test_utils/__init__.py
+++ b/src/hassette/test_utils/__init__.py
@@ -68,6 +68,8 @@ from .helpers import write_test_app_with_decorator as write_test_app_with_decora
 from .mock_hassette import make_mock_hassette as make_mock_hassette
 from .mock_hassette import make_ws_hassette_stub as make_ws_hassette_stub
 from .recording_api import RecordingApi
+from .sql_helpers import insert_execution_row as insert_execution_row
+from .sql_helpers import sqlite_conn as sqlite_conn
 from .test_server import SimpleTestServer as SimpleTestServer
 from .uvicorn_server import get_free_port as get_free_port
 from .uvicorn_server import start_uvicorn_server as start_uvicorn_server

--- a/src/hassette/test_utils/config.py
+++ b/src/hassette/test_utils/config.py
@@ -46,6 +46,15 @@ TEST_SYNC_EXECUTOR_SHUTDOWN_TIMEOUT_SECONDS = 5.0
 # documented in CLAUDE.md.
 TEST_TOTAL_TIMEOUT_SECONDS = 30
 
+# Early-drop retry tuning shared by tests/integration/test_websocket_service.py and
+# tests/unit/core/test_ws_connection_state.py. Small backoff values keep the retry loop fast
+# and deterministic in CI. Tests that need a different value for the specific behavior under
+# test (e.g. proving retry-budget exhaustion) pass a literal instead of reusing these.
+TEST_EARLY_DROP_MAX_RETRIES = 5
+TEST_EARLY_DROP_STABLE_WINDOW_SECONDS = 30.0
+TEST_EARLY_DROP_BACKOFF_INITIAL_SECONDS = 0.001
+TEST_EARLY_DROP_BACKOFF_MAX_SECONDS = 0.01
+
 # Cached (hermetic_subclass, init_kwargs_ref) pair — avoids creating a new class per
 # make_test_config call, which would accumulate permanently in __subclasses__()
 # and Pydantic's internal model cache.

--- a/src/hassette/test_utils/sql_helpers.py
+++ b/src/hassette/test_utils/sql_helpers.py
@@ -1,0 +1,66 @@
+"""Shared sqlite/aiosqlite helpers for migration, schema, and telemetry tests.
+
+Replaces the ``conn = sqlite3.connect(db_path); try: ...; finally: conn.close()``
+boilerplate repeated across migration/schema test files, and the hand-typed
+``INSERT INTO executions (...)`` column list repeated across migration, schema,
+and telemetry repository tests.
+"""
+
+import sqlite3
+from collections.abc import Generator
+from contextlib import contextmanager
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    import aiosqlite
+
+
+@contextmanager
+def sqlite_conn(db_path: Path, *, foreign_keys: bool = False) -> Generator[sqlite3.Connection, None, None]:
+    """Open a sync sqlite3 connection to ``db_path``, closing it on exit.
+
+    Replaces the ``conn = sqlite3.connect(db_path); try: ...; finally: conn.close()``
+    pattern repeated across migration/schema test files. Pass ``foreign_keys=True``
+    to run ``PRAGMA foreign_keys = ON`` immediately after connecting — several tests
+    need FK enforcement active before inserting rows that exercise FK CHECK behavior.
+    """
+    conn = sqlite3.connect(db_path)
+    try:
+        if foreign_keys:
+            conn.execute("PRAGMA foreign_keys = ON")
+        yield conn
+    finally:
+        conn.close()
+
+
+def insert_execution_row(
+    conn: "sqlite3.Connection | aiosqlite.Connection",
+    *,
+    kind: str = "handler",
+    listener_id: int | None = None,
+    job_id: int | None = None,
+    session_id: int = 1,
+    execution_start_ts: float = 1.0,
+    duration_ms: float = 5.0,
+    status: str = "success",
+) -> Any:
+    """Insert a row into the ``executions`` table for tests.
+
+    ``source_tier`` is intentionally left out of the column list: the real schema
+    defaults it to ``'app'`` (see ``001.sql``), and every pre-existing call site that
+    specified it explicitly always passed that same default value, so omitting it and
+    relying on the default is behaviorally identical — including for the ``telemetry_db``
+    fixture (``tests/unit/core/conftest.py``), which is built from the full migrated
+    schema via ``run_migrations()`` and so defaults ``source_tier`` the same way.
+
+    Works with both a sync ``sqlite3.Connection`` (migration/schema tests — call
+    plainly) and an async ``aiosqlite.Connection`` (the ``telemetry_db`` fixture —
+    ``await`` the call). This just forwards to ``conn.execute()``, so which behavior
+    you get follows whatever ``conn`` itself is.
+    """
+    return conn.execute(
+        "INSERT INTO executions (kind, listener_id, job_id, session_id, execution_start_ts, duration_ms, status) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?)",
+        (kind, listener_id, job_id, session_id, execution_start_ts, duration_ms, status),
+    )

--- a/src/hassette/test_utils/ws_mocks.py
+++ b/src/hassette/test_utils/ws_mocks.py
@@ -8,6 +8,7 @@ separately.
 
 import asyncio
 import time
+import typing
 from types import SimpleNamespace
 from typing import TYPE_CHECKING, Any, cast
 from unittest.mock import AsyncMock, Mock
@@ -86,3 +87,23 @@ def mark_websocket_service_connected(websocket_service: "WebsocketService", *, r
     websocket_service._connection_state = ConnectionState.CONNECTED
     websocket_service._ever_connected = True
     _configure_websocket_external_readiness_primitives(websocket_service)
+
+
+def make_task_bucket_spawn_stub() -> tuple[list[typing.Coroutine], Mock]:
+    """Build a ``task_bucket.spawn`` stub that records coroutines without running them.
+
+    Returns the list that gets populated with each spawned coroutine (callers close()
+    them after the test to suppress ResourceWarning) and the ``Mock`` to assign as
+    ``websocket_service.task_bucket.spawn``.
+    """
+    spawned_coros: list[typing.Coroutine] = []
+
+    def _spawn_side_effect(coro, *, name=None):  # noqa: ARG001
+        spawned_coros.append(coro)
+
+        async def _noop():
+            pass
+
+        return asyncio.create_task(_noop())
+
+    return spawned_coros, Mock(side_effect=_spawn_side_effect)

--- a/src/hassette/test_utils/ws_mocks.py
+++ b/src/hassette/test_utils/ws_mocks.py
@@ -94,16 +94,14 @@ def make_task_bucket_spawn_stub() -> tuple[list[Coroutine], Mock]:
 
     Returns the list that gets populated with each spawned coroutine (callers close()
     them after the test to suppress ResourceWarning) and the ``Mock`` to assign as
-    ``websocket_service.task_bucket.spawn``.
+    ``websocket_service.task_bucket.spawn``. The stub returns a plain ``Mock`` in place of
+    the real ``asyncio.Task`` -- callers only ``.cancel()`` or ``.add_done_callback()`` it,
+    never await its completion, so no real task needs to be scheduled.
     """
     spawned_coros: list[Coroutine] = []
 
     def _spawn_side_effect(coro, *, name=None):  # noqa: ARG001
         spawned_coros.append(coro)
-
-        async def _noop():
-            pass
-
-        return asyncio.create_task(_noop())
+        return Mock()
 
     return spawned_coros, Mock(side_effect=_spawn_side_effect)

--- a/src/hassette/test_utils/ws_mocks.py
+++ b/src/hassette/test_utils/ws_mocks.py
@@ -8,7 +8,7 @@ separately.
 
 import asyncio
 import time
-import typing
+from collections.abc import Coroutine
 from types import SimpleNamespace
 from typing import TYPE_CHECKING, Any, cast
 from unittest.mock import AsyncMock, Mock
@@ -89,14 +89,14 @@ def mark_websocket_service_connected(websocket_service: "WebsocketService", *, r
     _configure_websocket_external_readiness_primitives(websocket_service)
 
 
-def make_task_bucket_spawn_stub() -> tuple[list[typing.Coroutine], Mock]:
+def make_task_bucket_spawn_stub() -> tuple[list[Coroutine], Mock]:
     """Build a ``task_bucket.spawn`` stub that records coroutines without running them.
 
     Returns the list that gets populated with each spawned coroutine (callers close()
     them after the test to suppress ResourceWarning) and the ``Mock`` to assign as
     ``websocket_service.task_bucket.spawn``.
     """
-    spawned_coros: list[typing.Coroutine] = []
+    spawned_coros: list[Coroutine] = []
 
     def _spawn_side_effect(coro, *, name=None):  # noqa: ARG001
         spawned_coros.append(coro)

--- a/tests/integration/bus/test_bus_error_handler.py
+++ b/tests/integration/bus/test_bus_error_handler.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING
 from hassette.bus.error_context import BusErrorContext
 from hassette.events.base import Event
 from hassette.test_utils import create_call_service_event, wait_for
+from hassette.test_utils.helpers import settle
 
 if TYPE_CHECKING:
     from hassette.test_utils.harness import HassetteHarness
@@ -70,8 +71,7 @@ async def test_per_listener_error_handler_wins(hassette_with_bus: "HassetteHarne
 
     await asyncio.wait_for(per_listener_ran.wait(), timeout=2.0)
 
-    # negative-assertion: no event-driven alternative
-    await asyncio.sleep(0.05)
+    await settle()
 
     assert len(per_listener_calls) == 1, f"Expected 1 per-listener call, got {len(per_listener_calls)}"
     assert len(app_level_calls) == 0, "App-level handler should not be called when per-listener wins"

--- a/tests/integration/bus/test_bus_immediate.py
+++ b/tests/integration/bus/test_bus_immediate.py
@@ -13,7 +13,7 @@ from whenever import ZonedDateTime
 from hassette.events import RawStateChangeEvent
 from hassette.test_utils import make_state_dict, wait_for
 from hassette.test_utils.harness import HassetteHarness
-from hassette.test_utils.helpers import create_state_change_event
+from hassette.test_utils.helpers import create_state_change_event, settle
 
 if TYPE_CHECKING:
     from hassette import Hassette
@@ -322,8 +322,7 @@ async def test_immediate_duration_starts_timer_for_remaining(
         name="immediate_duration_starts_timer_remaining",
     )
 
-    # negative-assertion: no event-driven alternative
-    await asyncio.sleep(0.05)
+    await settle()
     assert len(received) == 0, "Should not have fired immediately — only 3s elapsed of 5s"
 
     # Should fire after remaining ~2s (plus margin)
@@ -386,8 +385,7 @@ async def test_immediate_duration_negative_elapsed_clamped(
         name="immediate_duration_negative_elapsed_clamped",
     )
 
-    # negative-assertion: no event-driven alternative
-    await asyncio.sleep(0.05)
+    await settle()
     assert len(received) == 0, "Negative elapsed should be clamped to 0, not fire immediately"
 
 
@@ -418,8 +416,7 @@ async def test_immediate_duration_attribute_change_always_zero(
         name="immediate_duration_attr_change_always_zero",
     )
 
-    # negative-assertion: no event-driven alternative
-    await asyncio.sleep(0.05)
+    await settle()
     assert len(received) == 0, (
         "on_attribute_change with immediate+duration should always start from zero, not fire immediately"
     )

--- a/tests/integration/telemetry/helpers.py
+++ b/tests/integration/telemetry/helpers.py
@@ -1,6 +1,10 @@
 """Insert helpers for telemetry integration tests."""
 
 import time
+from collections.abc import Awaitable, Callable, Sequence
+from typing import Any
+
+import pytest
 
 from hassette.core.database_service import DatabaseService
 from hassette.test_utils.config import TEST_SOURCE_LOCATION
@@ -97,6 +101,54 @@ async def insert_invocation(
     await db_svc.db.commit()
     assert cursor.lastrowid is not None
     return cursor.lastrowid
+
+
+async def assert_last_error_row_coherence(
+    insert_row: Callable[..., Awaitable[int]],
+    query_fn: Callable[[], Awaitable[Sequence[Any]]],
+    error_rows: Sequence[dict[str, Any]],
+    *,
+    trailing_success_ts: float | None = None,
+) -> None:
+    """Assert that ``last_error_*`` fields on the row returned by ``query_fn`` all come from
+    the most recently inserted error row, not a mix of columns from different error rows.
+
+    This is the "row coherence" shape shared by ``get_job_summary()`` and
+    ``get_listener_summary()``: both use a ``ROW_NUMBER() OVER (PARTITION BY ... ORDER BY
+    execution_start_ts DESC)`` CTE to pick one error row per entity, and the risk this guards
+    against is that CTE picking columns from different rows instead of one coherent row.
+
+    Args:
+        insert_row: Async callable already bound to the entity (job/listener), db, and
+            session — e.g. ``lambda **kw: insert_execution(db_svc, job_id, session_id, **kw)``.
+            Called once per entry in ``error_rows`` with ``status="error"`` plus that entry's
+            kwargs, then once more for ``trailing_success_ts`` (with ``status="success"``) if given.
+        query_fn: Zero-arg async callable already bound to the query, scope (global or
+            per-instance), and any ``since`` filter — e.g.
+            ``lambda: query_service.get_job_summary(since=since_ts)``.
+        error_rows: Error rows to insert, ordered oldest to newest. Each dict must set at least
+            ``error_type``, ``error_message``, ``error_traceback``, and ``execution_start_ts``.
+            The last entry is the one the assertions expect to win.
+        trailing_success_ts: If given, insert a success row at this timestamp after all error
+            rows — proves a later success doesn't clear or overwrite the last_error_* columns.
+    """
+    for kw in error_rows:
+        await insert_row(status="error", **kw)
+    if trailing_success_ts is not None:
+        await insert_row(status="success", execution_start_ts=trailing_success_ts)
+
+    results = await query_fn()
+    assert len(results) == 1
+    row = results[0]
+    newest = error_rows[-1]
+    assert row.last_error_type == newest["error_type"]
+    assert row.last_error_message == newest["error_message"]
+    assert row.last_error_traceback == newest["error_traceback"]
+    # JobSummary exposes last_error_ts; ListenerSummary doesn't declare the field at all —
+    # check it whenever the returned row actually has it, rather than asking every caller
+    # to remember which query type does.
+    if hasattr(row, "last_error_ts"):
+        assert row.last_error_ts == pytest.approx(newest["execution_start_ts"])
 
 
 async def insert_execution(

--- a/tests/integration/telemetry/test_global_jobs_and_service_info.py
+++ b/tests/integration/telemetry/test_global_jobs_and_service_info.py
@@ -29,6 +29,7 @@ from hassette.web.mappers import system_status_response_from
 from hassette.web.models import ServiceInfoResponse
 
 from .helpers import (
+    assert_last_error_row_coherence,
     insert_execution,
     insert_job,
 )
@@ -193,35 +194,25 @@ class TestGetJobSummaryGlobal:
         base_ts = 1_000_000.0
 
         j1 = await insert_job(db_svc, app_key="coh_app", job_name="coherent_job")
-        await insert_execution(
-            db_svc,
-            j1,
-            session_id,
-            status="error",
-            error_type="OldError",
-            error_message="old message",
-            error_traceback="old traceback",
-            execution_start_ts=base_ts + 1.0,
-        )
-        await insert_execution(
-            db_svc,
-            j1,
-            session_id,
-            status="error",
-            error_type="NewError",
-            error_message="new message",
-            error_traceback="new traceback",
-            execution_start_ts=base_ts + 10.0,
-        )
 
-        results = await query_service.get_job_summary()
-        assert len(results) == 1
-        row = results[0]
-        # All three error columns must come from the same (most recent) row
-        assert row.last_error_type == "NewError"
-        assert row.last_error_message == "new message"
-        assert row.last_error_traceback == "new traceback"
-        assert row.last_error_ts == pytest.approx(base_ts + 10.0)
+        await assert_last_error_row_coherence(
+            lambda **kw: insert_execution(db_svc, j1, session_id, **kw),
+            lambda: query_service.get_job_summary(),
+            [
+                {
+                    "error_type": "OldError",
+                    "error_message": "old message",
+                    "error_traceback": "old traceback",
+                    "execution_start_ts": base_ts + 1.0,
+                },
+                {
+                    "error_type": "NewError",
+                    "error_message": "new message",
+                    "error_traceback": "new traceback",
+                    "execution_start_ts": base_ts + 10.0,
+                },
+            ],
+        )
 
     async def test_since_filter_scopes_error_cte(
         self,
@@ -234,33 +225,25 @@ class TestGetJobSummaryGlobal:
         since_ts = base_ts + 50.0
 
         j1 = await insert_job(db_svc, app_key="my_app", job_name="windowed_job")
-        await insert_execution(
-            db_svc,
-            j1,
-            session_id,
-            status="error",
-            error_type="OldError",
-            error_message="before window",
-            error_traceback="old tb",
-            execution_start_ts=base_ts + 1.0,
-        )
-        await insert_execution(
-            db_svc,
-            j1,
-            session_id,
-            status="error",
-            error_type="NewError",
-            error_message="inside window",
-            error_traceback="new tb",
-            execution_start_ts=base_ts + 100.0,
-        )
 
-        results = await query_service.get_job_summary(since=since_ts)
-        assert len(results) == 1
-        row = results[0]
-        assert row.last_error_type == "NewError"
-        assert row.last_error_message == "inside window"
-        assert row.last_error_traceback == "new tb"
+        await assert_last_error_row_coherence(
+            lambda **kw: insert_execution(db_svc, j1, session_id, **kw),
+            lambda: query_service.get_job_summary(since=since_ts),
+            [
+                {
+                    "error_type": "OldError",
+                    "error_message": "before window",
+                    "error_traceback": "old tb",
+                    "execution_start_ts": base_ts + 1.0,
+                },
+                {
+                    "error_type": "NewError",
+                    "error_message": "inside window",
+                    "error_traceback": "new tb",
+                    "execution_start_ts": base_ts + 100.0,
+                },
+            ],
+        )
 
 
 @pytest.fixture

--- a/tests/integration/telemetry/test_health_aggregates_and_global_listeners.py
+++ b/tests/integration/telemetry/test_health_aggregates_and_global_listeners.py
@@ -17,6 +17,7 @@ from hassette.schemas.listener_models import ListenerSummary
 
 from .helpers import (
     BASE_TS,
+    assert_last_error_row_coherence,
     insert_execution,
     insert_invocation,
     insert_job,
@@ -314,35 +315,24 @@ class TestGetListenerSummaryGlobal:
 
         listener_id = await insert_listener(db_svc, app_key="coh_app", handler_method="on_event")
 
-        await insert_invocation(
-            db_svc,
-            listener_id,
-            session_id,
-            status="error",
-            error_type="OldError",
-            error_message="old message",
-            error_traceback="old traceback",
-            execution_start_ts=BASE_TS + 1.0,
+        await assert_last_error_row_coherence(
+            lambda **kw: insert_invocation(db_svc, listener_id, session_id, **kw),
+            lambda: query_service.get_listener_summary(),
+            [
+                {
+                    "error_type": "OldError",
+                    "error_message": "old message",
+                    "error_traceback": "old traceback",
+                    "execution_start_ts": BASE_TS + 1.0,
+                },
+                {
+                    "error_type": "NewError",
+                    "error_message": "new message",
+                    "error_traceback": "new traceback",
+                    "execution_start_ts": BASE_TS + 10.0,
+                },
+            ],
         )
-        await insert_invocation(
-            db_svc,
-            listener_id,
-            session_id,
-            status="error",
-            error_type="NewError",
-            error_message="new message",
-            error_traceback="new traceback",
-            execution_start_ts=BASE_TS + 10.0,
-        )
-
-        results = await query_service.get_listener_summary()
-        assert len(results) == 1
-        row = results[0]
-
-        # All columns must come from the same (most recent) row
-        assert row.last_error_type == "NewError"
-        assert row.last_error_message == "new message"
-        assert row.last_error_traceback == "new traceback"
 
     async def test_source_tier_app_excludes_framework(
         self,
@@ -427,27 +417,22 @@ class TestGetListenerSummaryGlobal:
         since_ts = BASE_TS + 50.0
 
         listener_id = await insert_listener(db_svc, app_key="my_app", handler_method="on_event")
-        await insert_invocation(
-            db_svc,
-            listener_id,
-            session_id,
-            status="error",
-            error_type="OldError",
-            error_message="before window",
-            execution_start_ts=BASE_TS + 1.0,
-        )
-        await insert_invocation(
-            db_svc,
-            listener_id,
-            session_id,
-            status="error",
-            error_type="NewError",
-            error_message="inside window",
-            execution_start_ts=BASE_TS + 100.0,
-        )
 
-        results = await query_service.get_listener_summary(since=since_ts)
-        assert len(results) == 1
-        row = results[0]
-        assert row.last_error_type == "NewError"
-        assert row.last_error_message == "inside window"
+        await assert_last_error_row_coherence(
+            lambda **kw: insert_invocation(db_svc, listener_id, session_id, **kw),
+            lambda: query_service.get_listener_summary(since=since_ts),
+            [
+                {
+                    "error_type": "OldError",
+                    "error_message": "before window",
+                    "error_traceback": None,
+                    "execution_start_ts": BASE_TS + 1.0,
+                },
+                {
+                    "error_type": "NewError",
+                    "error_message": "inside window",
+                    "error_traceback": None,
+                    "execution_start_ts": BASE_TS + 100.0,
+                },
+            ],
+        )

--- a/tests/integration/telemetry/test_job_queries.py
+++ b/tests/integration/telemetry/test_job_queries.py
@@ -6,7 +6,7 @@ from hassette.core.database_service import DatabaseService
 from hassette.core.telemetry.query_service import TelemetryQueryService
 from hassette.schemas.job_models import JobSummary
 
-from .helpers import BASE_TS, insert_execution, insert_job
+from .helpers import BASE_TS, assert_last_error_row_coherence, insert_execution, insert_job
 
 
 class TestGetJobSummary:
@@ -244,42 +244,26 @@ class TestJobSummaryLastErrorRowCoherence:
         job_id = await insert_job(db_svc, job_name="multi_err_job")
 
         base_ts = BASE_TS
-        await insert_execution(
-            db_svc,
-            job_id,
-            session_id,
-            status="error",
-            error_type="OldError",
-            error_message="old message",
-            error_traceback="old traceback",
-            execution_start_ts=base_ts + 1.0,
-        )
-        await insert_execution(
-            db_svc,
-            job_id,
-            session_id,
-            status="error",
-            error_type="NewError",
-            error_message="new message",
-            error_traceback="new traceback",
-            execution_start_ts=base_ts + 10.0,
-        )
-        # Success after errors — should not affect error fields
-        await insert_execution(
-            db_svc,
-            job_id,
-            session_id,
-            status="success",
-            execution_start_ts=base_ts + 20.0,
-        )
 
-        rows = await query_service.get_job_summary("test_app", 0)
-        assert len(rows) == 1
-        row = rows[0]
-        assert row.last_error_type == "NewError"
-        assert row.last_error_message == "new message"
-        assert row.last_error_traceback == "new traceback"
-        assert row.last_error_ts == pytest.approx(base_ts + 10.0)
+        await assert_last_error_row_coherence(
+            lambda **kw: insert_execution(db_svc, job_id, session_id, **kw),
+            lambda: query_service.get_job_summary("test_app", 0),
+            [
+                {
+                    "error_type": "OldError",
+                    "error_message": "old message",
+                    "error_traceback": "old traceback",
+                    "execution_start_ts": base_ts + 1.0,
+                },
+                {
+                    "error_type": "NewError",
+                    "error_message": "new message",
+                    "error_traceback": "new traceback",
+                    "execution_start_ts": base_ts + 10.0,
+                },
+            ],
+            trailing_success_ts=base_ts + 20.0,
+        )
 
     async def test_single_error_returned(
         self,
@@ -290,23 +274,18 @@ class TestJobSummaryLastErrorRowCoherence:
         db_svc, session_id = db
         job_id = await insert_job(db_svc, job_name="single_err_job")
 
-        await insert_execution(
-            db_svc,
-            job_id,
-            session_id,
-            status="error",
-            error_type="RuntimeError",
-            error_message="runtime boom",
-            error_traceback="tb: boom at line 1",
-            execution_start_ts=BASE_TS + 5.0,
+        await assert_last_error_row_coherence(
+            lambda **kw: insert_execution(db_svc, job_id, session_id, **kw),
+            lambda: query_service.get_job_summary("test_app", 0),
+            [
+                {
+                    "error_type": "RuntimeError",
+                    "error_message": "runtime boom",
+                    "error_traceback": "tb: boom at line 1",
+                    "execution_start_ts": BASE_TS + 5.0,
+                },
+            ],
         )
-
-        rows = await query_service.get_job_summary("test_app", 0)
-        assert len(rows) == 1
-        row = rows[0]
-        assert row.last_error_type == "RuntimeError"
-        assert row.last_error_message == "runtime boom"
-        assert row.last_error_traceback == "tb: boom at line 1"
 
     async def test_no_errors_returns_none(
         self,
@@ -340,33 +319,24 @@ class TestJobSummaryLastErrorRowCoherence:
         base_ts = BASE_TS
         since_ts = base_ts + 50.0
 
-        await insert_execution(
-            db_svc,
-            job_id,
-            session_id,
-            status="error",
-            error_type="OldError",
-            error_message="before window",
-            error_traceback="old tb",
-            execution_start_ts=base_ts + 1.0,
+        await assert_last_error_row_coherence(
+            lambda **kw: insert_execution(db_svc, job_id, session_id, **kw),
+            lambda: query_service.get_job_summary("test_app", 0, since=since_ts),
+            [
+                {
+                    "error_type": "OldError",
+                    "error_message": "before window",
+                    "error_traceback": "old tb",
+                    "execution_start_ts": base_ts + 1.0,
+                },
+                {
+                    "error_type": "NewError",
+                    "error_message": "inside window",
+                    "error_traceback": "new tb",
+                    "execution_start_ts": base_ts + 100.0,
+                },
+            ],
         )
-        await insert_execution(
-            db_svc,
-            job_id,
-            session_id,
-            status="error",
-            error_type="NewError",
-            error_message="inside window",
-            error_traceback="new tb",
-            execution_start_ts=base_ts + 100.0,
-        )
-
-        rows = await query_service.get_job_summary("test_app", 0, since=since_ts)
-        assert len(rows) == 1
-        row = rows[0]
-        assert row.last_error_type == "NewError"
-        assert row.last_error_message == "inside window"
-        assert row.last_error_traceback == "new tb"
 
     async def test_since_filter_excludes_all_errors_returns_none(
         self,

--- a/tests/integration/telemetry/test_listener_queries.py
+++ b/tests/integration/telemetry/test_listener_queries.py
@@ -6,7 +6,7 @@ from hassette.core.database_service import DatabaseService
 from hassette.core.telemetry.query_service import TelemetryQueryService
 from hassette.schemas.listener_models import ListenerSummary
 
-from .helpers import BASE_TS, insert_invocation, insert_listener
+from .helpers import BASE_TS, assert_last_error_row_coherence, insert_invocation, insert_listener
 
 
 class TestGetListenerSummary:
@@ -214,55 +214,32 @@ class TestListenerSummaryLastErrorRowCoherence:
         listener_id = await insert_listener(db_svc, handler_method="on_err")
 
         base_ts = BASE_TS
-        # Older error with distinct values
-        await insert_invocation(
-            db_svc,
-            listener_id,
-            session_id,
-            status="error",
-            error_type="OldError",
-            error_message="old message",
-            error_traceback="old traceback",
-            execution_start_ts=base_ts + 1.0,
-        )
-        # Middle error
-        await insert_invocation(
-            db_svc,
-            listener_id,
-            session_id,
-            status="error",
-            error_type="MiddleError",
-            error_message="middle message",
-            error_traceback="middle traceback",
-            execution_start_ts=base_ts + 5.0,
-        )
-        # Most recent error — all three columns should come from this row
-        await insert_invocation(
-            db_svc,
-            listener_id,
-            session_id,
-            status="error",
-            error_type="NewError",
-            error_message="new message",
-            error_traceback="new traceback",
-            execution_start_ts=base_ts + 10.0,
-        )
-        # A success after the errors — should not affect error fields
-        await insert_invocation(
-            db_svc,
-            listener_id,
-            session_id,
-            status="success",
-            execution_start_ts=base_ts + 15.0,
-        )
 
-        rows = await query_service.get_listener_summary("test_app", 0)
-        assert len(rows) == 1
-        row = rows[0]
-        # All three error columns must come from the same (most recent) row
-        assert row.last_error_type == "NewError"
-        assert row.last_error_message == "new message"
-        assert row.last_error_traceback == "new traceback"
+        await assert_last_error_row_coherence(
+            lambda **kw: insert_invocation(db_svc, listener_id, session_id, **kw),
+            lambda: query_service.get_listener_summary("test_app", 0),
+            [
+                {
+                    "error_type": "OldError",
+                    "error_message": "old message",
+                    "error_traceback": "old traceback",
+                    "execution_start_ts": base_ts + 1.0,
+                },
+                {
+                    "error_type": "MiddleError",
+                    "error_message": "middle message",
+                    "error_traceback": "middle traceback",
+                    "execution_start_ts": base_ts + 5.0,
+                },
+                {
+                    "error_type": "NewError",
+                    "error_message": "new message",
+                    "error_traceback": "new traceback",
+                    "execution_start_ts": base_ts + 10.0,
+                },
+            ],
+            trailing_success_ts=base_ts + 15.0,
+        )
 
     async def test_single_error_returned(
         self,
@@ -322,35 +299,24 @@ class TestListenerSummaryLastErrorRowCoherence:
         base_ts = BASE_TS
         since_ts = base_ts + 50.0
 
-        # Error before the window — must be excluded
-        await insert_invocation(
-            db_svc,
-            listener_id,
-            session_id,
-            status="error",
-            error_type="OldError",
-            error_message="before window",
-            error_traceback="old tb",
-            execution_start_ts=base_ts + 1.0,
+        await assert_last_error_row_coherence(
+            lambda **kw: insert_invocation(db_svc, listener_id, session_id, **kw),
+            lambda: query_service.get_listener_summary("test_app", 0, since=since_ts),
+            [
+                {
+                    "error_type": "OldError",
+                    "error_message": "before window",
+                    "error_traceback": "old tb",
+                    "execution_start_ts": base_ts + 1.0,
+                },
+                {
+                    "error_type": "NewError",
+                    "error_message": "inside window",
+                    "error_traceback": "new tb",
+                    "execution_start_ts": base_ts + 100.0,
+                },
+            ],
         )
-        # Error inside the window — must be returned
-        await insert_invocation(
-            db_svc,
-            listener_id,
-            session_id,
-            status="error",
-            error_type="NewError",
-            error_message="inside window",
-            error_traceback="new tb",
-            execution_start_ts=base_ts + 100.0,
-        )
-
-        rows = await query_service.get_listener_summary("test_app", 0, since=since_ts)
-        assert len(rows) == 1
-        row = rows[0]
-        assert row.last_error_type == "NewError"
-        assert row.last_error_message == "inside window"
-        assert row.last_error_traceback == "new tb"
 
     async def test_since_filter_excludes_all_errors_returns_none(
         self,

--- a/tests/integration/test_app_factory_lifecycle.py
+++ b/tests/integration/test_app_factory_lifecycle.py
@@ -368,29 +368,25 @@ class TestAppLifecycleServiceIntegration:
         assert "Intentional init failure" in failed[0].error_message
 
     async def test_lifecycle_continues_after_failed_instance(
-        self, hassette_with_app_handler: "HassetteHarness", app_registry: AppRegistry
+        self, app_factory: AppFactory, app_lifecycle: AppLifecycleService, app_registry: AppRegistry
     ):
         """Other instances still initialize after one fails."""
-        # Create a custom setup with one failing and one succeeding app
-        factory = AppFactory(hassette_with_app_handler.hassette, app_registry)
-        lifecycle = AppLifecycleService(hassette_with_app_handler.hassette, parent=None, registry=app_registry)
-
         # Create failing app first
         failing_manifest = make_manifest("failing", "failing_init_app.py", "FailingInitApp")
         app_registry.set_manifests({"failing": failing_manifest})
-        factory.create_instances("failing", failing_manifest)
+        app_factory.create_instances("failing", failing_manifest)
 
         # Create succeeding app
         success_manifest = make_manifest("multi_instance", "multi_instance_app.py", "MultiInstanceApp")
         app_registry.set_manifests({"failing": failing_manifest, "multi_instance": success_manifest})
-        factory.create_instances("multi_instance", success_manifest)
+        app_factory.create_instances("multi_instance", success_manifest)
 
         # Initialize all together
         failing_instances = app_registry.get_apps_by_key("failing")
         success_instances = app_registry.get_apps_by_key("multi_instance")
 
-        await lifecycle.initialize_instances("failing", failing_instances, failing_manifest)
-        await lifecycle.initialize_instances("multi_instance", success_instances, success_manifest)
+        await app_lifecycle.initialize_instances("failing", failing_instances, failing_manifest)
+        await app_lifecycle.initialize_instances("multi_instance", success_instances, success_manifest)
 
         # Failing app should be stopped
         assert failing_instances[0].status == ResourceStatus.STOPPED
@@ -400,8 +396,6 @@ class TestAppLifecycleServiceIntegration:
         # Success app should be running
         success_instance = get_app(app_registry, "multi_instance", 0)
         assert success_instance.status == ResourceStatus.RUNNING
-
-        await lifecycle.shutdown_all()
 
     async def test_lifecycle_shuts_down_real_app(
         self, app_factory: AppFactory, app_lifecycle: AppLifecycleService, app_registry: AppRegistry
@@ -442,36 +436,28 @@ class TestFullIntegrationFlow:
     """Full integration flow tests for Factory → Lifecycle pipeline."""
 
     async def test_full_flow_create_and_initialize(
-        self, hassette_with_app_handler: "HassetteHarness", app_registry: AppRegistry
+        self, app_factory: AppFactory, app_lifecycle: AppLifecycleService, app_registry: AppRegistry
     ):
         """Factory creates, lifecycle initializes, app runs."""
-        factory = AppFactory(hassette_with_app_handler.hassette, app_registry)
-        lifecycle = AppLifecycleService(hassette_with_app_handler.hassette, parent=None, registry=app_registry)
-
         manifest = make_manifest("multi_instance", "multi_instance_app.py", "MultiInstanceApp")
         app_registry.set_manifests({"multi_instance": manifest})
 
         # Create
-        factory.create_instances("multi_instance", manifest)
+        app_factory.create_instances("multi_instance", manifest)
         assert "multi_instance" in app_registry
 
         # Initialize
         instances = app_registry.get_apps_by_key("multi_instance")
-        await lifecycle.initialize_instances("multi_instance", instances, manifest)
+        await app_lifecycle.initialize_instances("multi_instance", instances, manifest)
 
         # Verify running
         app = get_app(app_registry, "multi_instance", 0)
         assert app.status == ResourceStatus.RUNNING
 
-        await lifecycle.shutdown_all()
-
     async def test_full_flow_with_registry_state(
-        self, hassette_with_app_handler: "HassetteHarness", app_registry: AppRegistry
+        self, app_factory: AppFactory, app_lifecycle: AppLifecycleService, app_registry: AppRegistry
     ):
         """Verify registry state at each step."""
-        factory = AppFactory(hassette_with_app_handler.hassette, app_registry)
-        lifecycle = AppLifecycleService(hassette_with_app_handler.hassette, parent=None, registry=app_registry)
-
         manifest = make_manifest("multi_instance", "multi_instance_app.py", "MultiInstanceApp")
         app_registry.set_manifests({"multi_instance": manifest})
 
@@ -479,26 +465,24 @@ class TestFullIntegrationFlow:
         assert app_registry.get("multi_instance", 0) is None
 
         # After creation
-        factory.create_instances("multi_instance", manifest)
+        app_factory.create_instances("multi_instance", manifest)
         app = get_app(app_registry, "multi_instance", 0)
         assert app.status == ResourceStatus.NOT_STARTED
 
         # After initialization
         instances = app_registry.get_apps_by_key("multi_instance")
-        await lifecycle.initialize_instances("multi_instance", instances, manifest)
+        await app_lifecycle.initialize_instances("multi_instance", instances, manifest)
         assert app.status == ResourceStatus.RUNNING
 
-        # After shutdown
-        await lifecycle.shutdown_all()
+        # After shutdown — asserted here (not deferred to fixture teardown), so the
+        # explicit call stays; the fixture's own shutdown_all() afterward is a harmless no-op.
+        await app_lifecycle.shutdown_all()
         assert app_registry.get("multi_instance", 0) is None
 
     async def test_full_flow_multiple_apps(
-        self, hassette_with_app_handler: "HassetteHarness", app_registry: AppRegistry
+        self, app_factory: AppFactory, app_lifecycle: AppLifecycleService, app_registry: AppRegistry
     ):
         """Multiple app types created and initialized together."""
-        factory = AppFactory(hassette_with_app_handler.hassette, app_registry)
-        lifecycle = AppLifecycleService(hassette_with_app_handler.hassette, parent=None, registry=app_registry)
-
         manifest1 = make_manifest(
             "multi1",
             "multi_instance_app.py",
@@ -510,8 +494,8 @@ class TestFullIntegrationFlow:
         app_registry.set_manifests({"multi1": manifest1, "my_app": manifest2})
 
         # Create both
-        factory.create_instances("multi1", manifest1)
-        factory.create_instances("my_app", manifest2)
+        app_factory.create_instances("multi1", manifest1)
+        app_factory.create_instances("my_app", manifest2)
 
         assert "multi1" in app_registry
         assert "my_app" in app_registry
@@ -519,8 +503,8 @@ class TestFullIntegrationFlow:
         # Initialize both
         instances1 = app_registry.get_apps_by_key("multi1")
         instances2 = app_registry.get_apps_by_key("my_app")
-        await lifecycle.initialize_instances("multi1", instances1, manifest1)
-        await lifecycle.initialize_instances("my_app", instances2, manifest2)
+        await app_lifecycle.initialize_instances("multi1", instances1, manifest1)
+        await app_lifecycle.initialize_instances("my_app", instances2, manifest2)
 
         # Both should be running
         multi1_instance = app_registry.get("multi1", 0)
@@ -530,47 +514,35 @@ class TestFullIntegrationFlow:
         assert multi1_instance.status == ResourceStatus.RUNNING
         assert my_app_instance.status == ResourceStatus.RUNNING
 
-        await lifecycle.shutdown_all()
-
     async def test_snapshot_shows_running_apps(
-        self, hassette_with_app_handler: "HassetteHarness", app_registry: AppRegistry
+        self, app_factory: AppFactory, app_lifecycle: AppLifecycleService, app_registry: AppRegistry
     ):
         """Running apps appear in snapshot.running."""
-        factory = AppFactory(hassette_with_app_handler.hassette, app_registry)
-        lifecycle = AppLifecycleService(hassette_with_app_handler.hassette, parent=None, registry=app_registry)
-
         manifest = make_manifest("multi_instance", "multi_instance_app.py", "MultiInstanceApp")
         app_registry.set_manifests({"multi_instance": manifest})
 
-        factory.create_instances("multi_instance", manifest)
+        app_factory.create_instances("multi_instance", manifest)
         instances = app_registry.get_apps_by_key("multi_instance")
-        await lifecycle.initialize_instances("multi_instance", instances, manifest)
+        await app_lifecycle.initialize_instances("multi_instance", instances, manifest)
 
         snapshot = app_registry.get_snapshot()
         assert snapshot.running_count == 1
         assert "multi_instance" in snapshot.running_apps
 
-        await lifecycle.shutdown_all()
-
     async def test_snapshot_shows_failed_apps(
-        self, hassette_with_app_handler: "HassetteHarness", app_registry: AppRegistry
+        self, app_factory: AppFactory, app_lifecycle: AppLifecycleService, app_registry: AppRegistry
     ):
         """Failed apps appear in snapshot.failed."""
-        factory = AppFactory(hassette_with_app_handler.hassette, app_registry)
-        lifecycle = AppLifecycleService(hassette_with_app_handler.hassette, parent=None, registry=app_registry)
-
         manifest = make_manifest("failing", "failing_init_app.py", "FailingInitApp")
         app_registry.set_manifests({"failing": manifest})
 
-        factory.create_instances("failing", manifest)
+        app_factory.create_instances("failing", manifest)
         instances = app_registry.get_apps_by_key("failing")
-        await lifecycle.initialize_instances("failing", instances, manifest)
+        await app_lifecycle.initialize_instances("failing", instances, manifest)
 
         snapshot = app_registry.get_snapshot()
         assert snapshot.failed_count == 1
         assert "failing" in snapshot.failed_apps
-
-        await lifecycle.shutdown_all()
 
 
 class TestAppRestartPreservesChildren:

--- a/tests/integration/test_command_executor_error_handler.py
+++ b/tests/integration/test_command_executor_error_handler.py
@@ -13,6 +13,7 @@ from hassette.core.database_service import DatabaseService
 from hassette.scheduler.error_context import SchedulerErrorContext
 from hassette.test_utils import wait_for
 from hassette.test_utils.factories import make_mock_listener
+from hassette.test_utils.helpers import settle
 
 from .conftest import make_mock_job
 
@@ -157,8 +158,7 @@ async def test_cancelled_error_not_routed_to_handler(executor: CommandExecutor) 
     with pytest.raises(asyncio.CancelledError):
         await executor.execute(cmd)
 
-    # negative-assertion: no event-driven alternative
-    await asyncio.sleep(0.05)
+    await settle()
     assert not handler_called.is_set(), "Error handler must not be called for CancelledError"
 
 

--- a/tests/integration/test_event_stream_service.py
+++ b/tests/integration/test_event_stream_service.py
@@ -8,6 +8,7 @@ import pytest
 
 from hassette.core.event_stream_service import EventStreamService
 from hassette.test_utils import make_mock_hassette
+from hassette.test_utils.helpers import settle
 
 
 @pytest.fixture
@@ -67,8 +68,7 @@ async def test_custom_buffer_size() -> None:
             send_completed = True
 
         task = asyncio.create_task(try_send())
-        # negative-assertion: no event-driven alternative
-        await asyncio.sleep(0.05)
+        await settle()
         assert not send_completed, "Expected send to block on full buffer"
         task.cancel()
         with pytest.raises(asyncio.CancelledError):

--- a/tests/integration/test_listeners.py
+++ b/tests/integration/test_listeners.py
@@ -12,7 +12,7 @@ from hassette.exceptions import DependencyResolutionError
 from hassette.models import states
 from hassette.task_bucket import TaskBucket
 from hassette.test_utils import make_full_state_change_event, make_light_state_dict, make_state_dict, wait_for
-from hassette.test_utils.helpers import create_listener
+from hassette.test_utils.helpers import create_listener, settle
 
 
 @dataclass(frozen=True, slots=True)
@@ -213,8 +213,7 @@ class TestRateLimiterCancel:
         limiter.cancel()
         assert limiter._debounce_task is None
 
-        # negative-assertion: no event-driven alternative
-        await asyncio.sleep(0.6)
+        await settle(0.6)
         assert calls == [], "Handler should not fire after cancel"
 
     async def test_cancel_when_no_task(self, bucket: TaskBucket):

--- a/tests/integration/test_state_proxy.py
+++ b/tests/integration/test_state_proxy.py
@@ -1,5 +1,5 @@
 import asyncio
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Awaitable, Callable
 from unittest.mock import AsyncMock, Mock
 
 import pytest
@@ -46,6 +46,34 @@ def build_state_proxy(*, disable_state_proxy_polling: bool = True) -> StateProxy
 def with_websocket_generation(event: RawStateChangeEvent, generation: int) -> RawStateChangeEvent:
     stamp_websocket_generation(event, generation)
     return event
+
+
+def gated_get_states_raw_factory(
+    result: list[dict[str, object]] | None = None,
+    error: Exception | None = None,
+) -> tuple[asyncio.Event, asyncio.Event, Callable[[], Awaitable[list[dict[str, object]]]]]:
+    """Build a gated ``api.get_states_raw`` side effect for ``AsyncMock(side_effect=...)``.
+
+    Collapses the repeated snapshot_entered/release_snapshot gate scaffold duplicated across
+    this file's reconnect/retry tests (issue #1493) into one helper.
+
+    Returns ``(entered, release, side_effect)``: ``entered`` is set the moment the side effect
+    starts running — await it to know the snapshot call has begun. The side effect then blocks
+    on ``release`` (call ``.set()`` to let it proceed) before returning ``result`` (default
+    ``[]``) or raising ``error`` if given. If ``release`` is never set, the call blocks
+    forever — useful for tests that assert on cancellation rather than completion.
+    """
+    entered = asyncio.Event()
+    release = asyncio.Event()
+
+    async def side_effect() -> list[dict[str, object]]:
+        entered.set()
+        await release.wait()
+        if error is not None:
+            raise error
+        return result if result is not None else []
+
+    return entered, release, side_effect
 
 
 @pytest.fixture
@@ -135,13 +163,7 @@ async def test_pre_capability_event_does_not_unlock_partial_cold_cache() -> None
 
 async def test_pre_capability_event_during_failed_initial_sync_keeps_cold_cache_blocked() -> None:
     proxy = build_state_proxy()
-    snapshot_entered = asyncio.Event()
-    release_snapshot = asyncio.Event()
-
-    async def failing_snapshot() -> list[dict[str, object]]:
-        snapshot_entered.set()
-        await release_snapshot.wait()
-        raise RuntimeError("boom")
+    snapshot_entered, release_snapshot, failing_snapshot = gated_get_states_raw_factory(error=RuntimeError("boom"))
 
     proxy.hassette.api.get_states_raw = AsyncMock(side_effect=failing_snapshot)
     await proxy.on_initialize()
@@ -165,8 +187,6 @@ async def test_duplicate_startup_and_connected_signals_coalesce_one_initial_sync
     proxy = build_state_proxy()
     wait_entered = asyncio.Event()
     release_wait = asyncio.Event()
-    snapshot_entered = asyncio.Event()
-    release_snapshot = asyncio.Event()
 
     async def blocked_wait_initial_connection(*, timeout: float | None = None) -> bool:
         assert timeout == TEST_TOTAL_TIMEOUT_SECONDS
@@ -174,10 +194,9 @@ async def test_duplicate_startup_and_connected_signals_coalesce_one_initial_sync
         await release_wait.wait()
         return True
 
-    async def gated_get_states_raw() -> list[dict[str, object]]:
-        snapshot_entered.set()
-        await release_snapshot.wait()
-        return [make_light_state_dict("light.kitchen", "on")]
+    snapshot_entered, release_snapshot, gated_get_states_raw = gated_get_states_raw_factory(
+        result=[make_light_state_dict("light.kitchen", "on")]
+    )
 
     proxy.hassette.websocket_service.wait_initial_connection = AsyncMock(side_effect=blocked_wait_initial_connection)
     proxy.hassette.api.get_states_raw = AsyncMock(side_effect=gated_get_states_raw)
@@ -200,13 +219,7 @@ async def test_duplicate_startup_and_connected_signals_coalesce_one_initial_sync
 
 async def test_duplicate_initial_signal_waiters_do_not_retry_immediately_after_failure() -> None:
     proxy = build_state_proxy()
-    snapshot_entered = asyncio.Event()
-    release_snapshot = asyncio.Event()
-
-    async def failing_snapshot() -> list[dict[str, object]]:
-        snapshot_entered.set()
-        await release_snapshot.wait()
-        raise RuntimeError("boom")
+    snapshot_entered, release_snapshot, failing_snapshot = gated_get_states_raw_factory(error=RuntimeError("boom"))
 
     proxy.hassette.api.get_states_raw = AsyncMock(side_effect=failing_snapshot)
 
@@ -289,13 +302,9 @@ async def test_poll_skips_during_active_sync_and_reconnect_afterward_runs_once(s
 
 async def test_obsolete_generation_sync_cannot_publish_freshness_or_capability() -> None:
     proxy = build_state_proxy()
-    snapshot_entered = asyncio.Event()
-    release_snapshot = asyncio.Event()
-
-    async def gated_get_states_raw() -> list[dict[str, object]]:
-        snapshot_entered.set()
-        await release_snapshot.wait()
-        return [make_light_state_dict("light.kitchen", "on")]
+    snapshot_entered, release_snapshot, gated_get_states_raw = gated_get_states_raw_factory(
+        result=[make_light_state_dict("light.kitchen", "on")]
+    )
 
     proxy.hassette.api.get_states_raw = AsyncMock(side_effect=gated_get_states_raw)
     await proxy.on_initialize()
@@ -317,13 +326,9 @@ async def test_obsolete_generation_failure_cannot_publish_freshness(state_proxy:
     state_proxy.states = {"light.kitchen": make_light_state_dict("light.kitchen", "on")}
     assert state_proxy.cache_freshness == StateCacheFreshness.FRESH
 
-    snapshot_entered = asyncio.Event()
-    release_snapshot = asyncio.Event()
-
-    async def failing_get_states_raw() -> list[dict[str, object]]:
-        snapshot_entered.set()
-        await release_snapshot.wait()
-        raise RuntimeError("obsolete generation failed")
+    snapshot_entered, release_snapshot, failing_get_states_raw = gated_get_states_raw_factory(
+        error=RuntimeError("obsolete generation failed")
+    )
 
     state_proxy.hassette.api.get_states_raw = AsyncMock(side_effect=failing_get_states_raw)
     state_proxy.hassette.websocket_service.get_connected_generation.return_value = 1
@@ -367,16 +372,12 @@ async def test_journaled_updates_and_tombstones_win_over_snapshot(state_proxy: S
     await state_proxy.on_disconnect()
     state_proxy.hassette.websocket_service.get_connected_generation.return_value = 2
 
-    snapshot_entered = asyncio.Event()
-    release_snapshot = asyncio.Event()
-
-    async def gated_get_states_raw() -> list[dict[str, object]]:
-        snapshot_entered.set()
-        await release_snapshot.wait()
-        return [
+    snapshot_entered, release_snapshot, gated_get_states_raw = gated_get_states_raw_factory(
+        result=[
             make_light_state_dict("light.kitchen", "off", last_updated="2024-01-01T00:00:01+00:00"),
             make_light_state_dict("light.garage", "on", last_updated="2024-01-01T00:00:01+00:00"),
         ]
+    )
 
     state_proxy.hassette.api.get_states_raw = AsyncMock(side_effect=gated_get_states_raw)
     reconnect_task = asyncio.create_task(state_proxy.on_reconnect())
@@ -415,13 +416,9 @@ async def test_pre_sync_state_event_does_not_overwrite_reconnect_snapshot(state_
 
     await state_proxy.on_disconnect()
     state_proxy.hassette.websocket_service.get_connected_generation.return_value = 2
-    snapshot_entered = asyncio.Event()
-    release_snapshot = asyncio.Event()
-
-    async def gated_snapshot() -> list[dict[str, object]]:
-        snapshot_entered.set()
-        await release_snapshot.wait()
-        return [make_light_state_dict("light.kitchen", "on", last_updated="2024-01-01T00:00:01+00:00")]
+    snapshot_entered, release_snapshot, gated_snapshot = gated_get_states_raw_factory(
+        result=[make_light_state_dict("light.kitchen", "on", last_updated="2024-01-01T00:00:01+00:00")]
+    )
 
     state_proxy.hassette.api.get_states_raw = AsyncMock(side_effect=gated_snapshot)
     reconnect_task = asyncio.create_task(state_proxy.on_reconnect())
@@ -600,13 +597,7 @@ async def test_duplicate_reconnect_waiters_do_not_retry_immediately_after_failur
     state_proxy.states = {"light.kitchen": make_light_state_dict("light.kitchen", "on")}
     await state_proxy.on_disconnect()
     state_proxy.hassette.websocket_service.get_connected_generation.return_value = 2
-    snapshot_entered = asyncio.Event()
-    release_snapshot = asyncio.Event()
-
-    async def failing_snapshot() -> list[dict[str, object]]:
-        snapshot_entered.set()
-        await release_snapshot.wait()
-        raise RuntimeError("boom")
+    snapshot_entered, release_snapshot, failing_snapshot = gated_get_states_raw_factory(error=RuntimeError("boom"))
 
     state_proxy.hassette.api.get_states_raw = AsyncMock(side_effect=failing_snapshot)
 
@@ -622,13 +613,11 @@ async def test_duplicate_reconnect_waiters_do_not_retry_immediately_after_failur
 
 
 async def test_disconnect_cancels_active_sync_so_reconnect_can_start_fresh(state_proxy: StateProxy) -> None:
-    sync_entered = asyncio.Event()
-    never_release = asyncio.Event()
-
-    async def blocked_snapshot() -> list[dict[str, object]]:
-        sync_entered.set()
-        await never_release.wait()
-        return [make_light_state_dict("light.kitchen", "on")]
+    # The release event is deliberately never set() — the snapshot call blocks forever, so
+    # on_disconnect() must cancel it rather than wait for a result.
+    sync_entered, _never_release, blocked_snapshot = gated_get_states_raw_factory(
+        result=[make_light_state_dict("light.kitchen", "on")]
+    )
 
     state_proxy.hassette.api.get_states_raw = AsyncMock(side_effect=blocked_snapshot)
     state_proxy.hassette.websocket_service.get_connected_generation.return_value = 1

--- a/tests/integration/test_websocket_service.py
+++ b/tests/integration/test_websocket_service.py
@@ -22,7 +22,18 @@ from hassette.exceptions import (
     RetryableConnectionClosedError,
 )
 from hassette.resources.base import ResourceStatus
-from hassette.test_utils import EventCapture, build_fake_ws, mark_websocket_service_connected
+from hassette.test_utils import (
+    EventCapture,
+    build_fake_ws,
+    make_task_bucket_spawn_stub,
+    mark_websocket_service_connected,
+)
+from hassette.test_utils.config import (
+    TEST_EARLY_DROP_BACKOFF_INITIAL_SECONDS,
+    TEST_EARLY_DROP_BACKOFF_MAX_SECONDS,
+    TEST_EARLY_DROP_MAX_RETRIES,
+    TEST_EARLY_DROP_STABLE_WINDOW_SECONDS,
+)
 from hassette.types import Topic
 from hassette.types.enums import ConnectionState
 
@@ -564,15 +575,9 @@ async def test_start_recv_and_subscribe_emits_connected_only_after_subscription_
     capture = EventCapture()
     capture.install(websocket_service.hassette)
 
-    fake_task = asyncio.create_task(asyncio.sleep(0))
+    spawned_coros, spawn_stub = make_task_bucket_spawn_stub()
     websocket_service.task_bucket = MagicMock()
-    spawned_coros = []
-
-    def _spawn_side_effect(coro, *, name=None):  # noqa: ARG001
-        spawned_coros.append(coro)
-        return fake_task
-
-    websocket_service.task_bucket.spawn = Mock(side_effect=_spawn_side_effect)
+    websocket_service.task_bucket.spawn = spawn_stub
     websocket_service._emit_readiness_event = AsyncMock()
     websocket_service._connection_state = ConnectionState.CONNECTING
 
@@ -584,7 +589,7 @@ async def test_start_recv_and_subscribe_emits_connected_only_after_subscription_
 
     websocket_service.subscribe_events = AsyncMock(side_effect=fake_subscribe_events)
 
-    await websocket_service.start_recv_and_subscribe()
+    result_task = await websocket_service.start_recv_and_subscribe()
 
     assert websocket_service.is_connected is True
     assert websocket_service.has_ever_connected is True
@@ -593,7 +598,7 @@ async def test_start_recv_and_subscribe_emits_connected_only_after_subscription_
     assert capture.by_topic(Topic.HASSETTE_EVENT_WEBSOCKET_CONNECTED)
     for coro in spawned_coros:
         coro.close()
-    fake_task.cancel()
+    result_task.cancel()
 
 
 async def test_subscription_failure_before_external_readiness_leaves_history_false_and_emits_no_public_signal(
@@ -603,15 +608,9 @@ async def test_subscription_failure_before_external_readiness_leaves_history_fal
     capture = EventCapture()
     capture.install(websocket_service.hassette)
 
-    fake_task = asyncio.create_task(asyncio.sleep(0))
+    spawned_coros, spawn_stub = make_task_bucket_spawn_stub()
     websocket_service.task_bucket = MagicMock()
-    spawned_coros = []
-
-    def _spawn_side_effect(coro, *, name=None):  # noqa: ARG001
-        spawned_coros.append(coro)
-        return fake_task
-
-    websocket_service.task_bucket.spawn = Mock(side_effect=_spawn_side_effect)
+    websocket_service.task_bucket.spawn = spawn_stub
     websocket_service._connection_state = ConnectionState.CONNECTING
     websocket_service.subscribe_events = AsyncMock(side_effect=FailedMessageError("subscribe failed"))
 
@@ -626,7 +625,7 @@ async def test_subscription_failure_before_external_readiness_leaves_history_fal
     assert capture.by_topic(Topic.HASSETTE_EVENT_WEBSOCKET_DISCONNECTED) == []
     for coro in spawned_coros:
         coro.close()
-    fake_task.cancel()
+    websocket_service._recv_task.cancel()
 
 
 async def test_pre_readiness_failure_after_prior_disconnect_emits_no_second_public_disconnect(
@@ -721,6 +720,96 @@ async def test_partial_cleanup_timeout_on_gather(websocket_service: WebsocketSer
         await asyncio.gather(stuck_task, return_exceptions=True)
 
 
+class FailingConnection:
+    """Callable ``make_connection`` stub that fails the recv task N times, then succeeds.
+
+    Collapses the near-identical ``fake_make_connection`` closures duplicated across the
+    early-drop test suite (issue #1493) into one parametrized helper.
+
+    Each call sets ``_connected_at`` to ``time.monotonic() - connected_at_offset`` and marks
+    the service connected before returning a task. The task raises ``error`` for the first
+    ``fail_after`` calls (or forever when ``fail_after`` is ``None``); after that it exits
+    cleanly — unless ``final_error`` is given, in which case call number ``fail_after + 1``
+    raises ``final_error`` synchronously instead of returning a task at all (simulating e.g.
+    an auth failure discovered on the reconnect attempt itself, rather than inside the
+    retryable recv loop).
+
+    Pass ``mark_fully_connected=True`` for tests that assert on the public
+    WEBSOCKET_DISCONNECTED signal — it wires the full external-readiness state via
+    ``mark_websocket_service_connected`` (which flips ``_ever_connected``) instead of only
+    lifecycle ``mark_ready``, matching what the ``has_ever_connected`` guard on that signal
+    requires. Other tests only need lifecycle readiness, so that's the default.
+
+    ``call_count`` is mutated in place so callers can assert on it after ``serve()`` returns.
+    """
+
+    def __init__(
+        self,
+        websocket_service: WebsocketService,
+        *,
+        fail_after: int | None,
+        error: Exception,
+        connected_at_offset: float = 0.0,
+        final_error: Exception | None = None,
+        mark_fully_connected: bool = False,
+    ) -> None:
+        self.websocket_service = websocket_service
+        self.fail_after = fail_after
+        self.error = error
+        self.connected_at_offset = connected_at_offset
+        self.final_error = final_error
+        self.mark_fully_connected = mark_fully_connected
+        self.call_count = 0
+
+    async def __call__(self, _session: object) -> asyncio.Task:
+        self.call_count += 1
+        call_count = self.call_count
+        ws = self.websocket_service
+
+        if self.final_error is not None and self.fail_after is not None and call_count == self.fail_after + 1:
+            raise self.final_error
+
+        ws._connected_at = time.monotonic() - self.connected_at_offset
+        if self.mark_fully_connected:
+            mark_websocket_service_connected(ws, reason="test: simulating successful connection")
+        else:
+            lifecycle_module.mark_ready(ws, reason="test: simulating successful connection")
+
+        if self.fail_after is None or call_count <= self.fail_after:
+            error = self.error
+
+            async def _fail() -> None:
+                raise error
+
+            return asyncio.create_task(_fail())
+
+        async def _clean() -> None:
+            pass
+
+        return asyncio.create_task(_clean())
+
+
+def apply_early_drop_config(
+    monkeypatch: pytest.MonkeyPatch,
+    websocket_service: WebsocketService,
+    *,
+    max_retries: int = TEST_EARLY_DROP_MAX_RETRIES,
+    stable_window_seconds: float = TEST_EARLY_DROP_STABLE_WINDOW_SECONDS,
+    backoff_initial_seconds: float = TEST_EARLY_DROP_BACKOFF_INITIAL_SECONDS,
+    backoff_max_seconds: float = TEST_EARLY_DROP_BACKOFF_MAX_SECONDS,
+) -> None:
+    """Patch the four early-drop config knobs on ``websocket_service.hassette.config.websocket``.
+
+    Defaults match the shared test constants (``hassette.test_utils.config``); pass an override
+    only for the value a given test needs to differ (e.g. proving retry-budget exhaustion).
+    """
+    config = websocket_service.hassette.config.websocket
+    monkeypatch.setattr(config, "early_drop_max_retries", max_retries)
+    monkeypatch.setattr(config, "early_drop_stable_window_seconds", stable_window_seconds)
+    monkeypatch.setattr(config, "early_drop_backoff_initial_seconds", backoff_initial_seconds)
+    monkeypatch.setattr(config, "early_drop_backoff_max_seconds", backoff_max_seconds)
+
+
 async def test_early_drop_retries_and_succeeds(
     monkeypatch: pytest.MonkeyPatch,
     websocket_service: WebsocketService,
@@ -736,30 +825,14 @@ async def test_early_drop_retries_and_succeeds(
 
     # First two make_connection calls succeed but recv task fails immediately.
     # Third call succeeds with clean exit.
-    call_count = 0
     partial_cleanup_count = 0
-    make_connection_count = 0
 
-    async def fake_make_connection(_session):
-        nonlocal call_count, make_connection_count
-        call_count += 1
-        make_connection_count += 1
-        # Simulate _connected_at being set (within stable window) and mark_ready
-        websocket_service._connected_at = time.monotonic()
-        # Real start_recv_and_subscribe sets CONNECTED via set_connection_state, which flips
-        # _ever_connected; mirror that so the has_ever_connected guard lets DISCONNECTED through.
-        mark_websocket_service_connected(websocket_service, reason="test: simulating successful connection")
-        if call_count <= 2:
-
-            async def _fail():
-                raise RetryableConnectionClosedError("peer gone")
-
-            return asyncio.create_task(_fail())
-
-        async def _clean():
-            pass
-
-        return asyncio.create_task(_clean())
+    fake_make_connection = FailingConnection(
+        websocket_service,
+        fail_after=2,
+        error=RetryableConnectionClosedError("peer gone"),
+        mark_fully_connected=True,
+    )
 
     async def fake_partial_cleanup():
         nonlocal partial_cleanup_count
@@ -767,14 +840,13 @@ async def test_early_drop_retries_and_succeeds(
 
     websocket_service.make_connection = fake_make_connection  # pyright: ignore[reportAttributeAccessIssue]
     websocket_service.partial_cleanup = fake_partial_cleanup  # pyright: ignore[reportAttributeAccessIssue]
-    monkeypatch.setattr(websocket_service.hassette.config.websocket, "early_drop_max_retries", 5)
-    monkeypatch.setattr(websocket_service.hassette.config.websocket, "early_drop_stable_window_seconds", 30.0)
-    monkeypatch.setattr(websocket_service.hassette.config.websocket, "early_drop_backoff_initial_seconds", 0.001)
-    monkeypatch.setattr(websocket_service.hassette.config.websocket, "early_drop_backoff_max_seconds", 0.01)
+    apply_early_drop_config(monkeypatch, websocket_service)
 
     await websocket_service.serve()
 
-    assert make_connection_count == 3, f"Expected 3 make_connection calls, got {make_connection_count}"
+    assert fake_make_connection.call_count == 3, (
+        f"Expected 3 make_connection calls, got {fake_make_connection.call_count}"
+    )
     assert partial_cleanup_count == 2, f"Expected 2 partial_cleanup calls, got {partial_cleanup_count}"
 
     # DISCONNECTED should have been sent 2 times (once per early drop)
@@ -789,31 +861,24 @@ async def test_early_drop_exhausts_retry_budget(
     """After exhausting early-drop retry count, exception propagates out of serve()."""
     websocket_service.hassette.send_event = AsyncMock()
 
-    call_count = 0
-
-    async def fake_make_connection(_session):
-        nonlocal call_count
-        call_count += 1
-        websocket_service._connected_at = time.monotonic()
-        lifecycle_module.mark_ready(websocket_service, reason="test: simulating successful connection")
-
-        async def _fail():
-            raise RetryableConnectionClosedError("dropped")
-
-        return asyncio.create_task(_fail())
+    fake_make_connection = FailingConnection(
+        websocket_service,
+        fail_after=None,
+        error=RetryableConnectionClosedError("dropped"),
+    )
 
     websocket_service.make_connection = fake_make_connection  # pyright: ignore[reportAttributeAccessIssue]
     websocket_service.partial_cleanup = AsyncMock()  # pyright: ignore[reportAttributeAccessIssue]
-    monkeypatch.setattr(websocket_service.hassette.config.websocket, "early_drop_max_retries", 2)
-    monkeypatch.setattr(websocket_service.hassette.config.websocket, "early_drop_stable_window_seconds", 30.0)
-    monkeypatch.setattr(websocket_service.hassette.config.websocket, "early_drop_backoff_initial_seconds", 0.001)
-    monkeypatch.setattr(websocket_service.hassette.config.websocket, "early_drop_backoff_max_seconds", 0.01)
+    # max_retries=2 is specific to this test (proves the budget is exhausted).
+    apply_early_drop_config(monkeypatch, websocket_service, max_retries=2)
 
     with pytest.raises(RetryableConnectionClosedError):
         await websocket_service.serve()
 
     # Initial + 2 retries = 3 total attempts, then propagates
-    assert call_count == 3, f"Expected 3 total make_connection calls, got {call_count}"
+    assert fake_make_connection.call_count == 3, (
+        f"Expected 3 total make_connection calls, got {fake_make_connection.call_count}"
+    )
     assert not websocket_service.is_ready()
 
 
@@ -824,34 +889,27 @@ async def test_early_drop_exhausts_recovery_timeout(
     """When recovery_elapsed exceeds max_recovery, failure propagates without further retry."""
     websocket_service.hassette.send_event = AsyncMock()
 
-    call_count = 0
-
-    async def fake_make_connection(_session):
-        nonlocal call_count
-        call_count += 1
-        websocket_service._connected_at = time.monotonic()
-        lifecycle_module.mark_ready(websocket_service, reason="test: simulating successful connection")
-
-        async def _fail():
-            raise RetryableConnectionClosedError("dropped")
-
-        return asyncio.create_task(_fail())
+    fake_make_connection = FailingConnection(
+        websocket_service,
+        fail_after=None,
+        error=RetryableConnectionClosedError("dropped"),
+    )
 
     websocket_service.make_connection = fake_make_connection  # pyright: ignore[reportAttributeAccessIssue]
     websocket_service.partial_cleanup = AsyncMock()  # pyright: ignore[reportAttributeAccessIssue]
 
-    # Configure very short max recovery (effectively 0)
-    monkeypatch.setattr(websocket_service.hassette.config.websocket, "early_drop_max_retries", 10)
-    monkeypatch.setattr(websocket_service.hassette.config.websocket, "early_drop_stable_window_seconds", 30.0)
+    # max_retries=10 and max_recovery_seconds=0.0 are specific to this test (a huge retry
+    # budget that the recovery timeout — not the retry count — should cut off first).
+    apply_early_drop_config(monkeypatch, websocket_service, max_retries=10)
     monkeypatch.setattr(websocket_service.hassette.config.websocket, "max_recovery_seconds", 0.0)
-    monkeypatch.setattr(websocket_service.hassette.config.websocket, "early_drop_backoff_initial_seconds", 0.001)
-    monkeypatch.setattr(websocket_service.hassette.config.websocket, "early_drop_backoff_max_seconds", 0.01)
 
     with pytest.raises(RetryableConnectionClosedError):
         await websocket_service.serve()
 
     # Should have made only 1 attempt then stopped due to recovery timeout
-    assert call_count == 1, f"Expected 1 make_connection call (recovery timeout), got {call_count}"
+    assert fake_make_connection.call_count == 1, (
+        f"Expected 1 make_connection call (recovery timeout), got {fake_make_connection.call_count}"
+    )
 
 
 async def test_stable_connection_failure_propagates_immediately(
@@ -861,28 +919,28 @@ async def test_stable_connection_failure_propagates_immediately(
     """A drop outside the stable window propagates immediately without retry."""
     websocket_service.hassette.send_event = AsyncMock()
 
-    call_count = 0
-
-    async def fake_make_connection(_session):
-        nonlocal call_count
-        call_count += 1
-        # Set _connected_at to 60 seconds ago — outside any stable window
-        websocket_service._connected_at = time.monotonic() - 60.0
-        lifecycle_module.mark_ready(websocket_service, reason="test: simulating successful connection")
-
-        async def _fail():
-            raise RetryableConnectionClosedError("stable drop")
-
-        return asyncio.create_task(_fail())
+    # connected_at_offset=60.0 puts _connected_at 60 seconds in the past — outside any stable window.
+    fake_make_connection = FailingConnection(
+        websocket_service,
+        fail_after=None,
+        error=RetryableConnectionClosedError("stable drop"),
+        connected_at_offset=60.0,
+    )
 
     websocket_service.make_connection = fake_make_connection  # pyright: ignore[reportAttributeAccessIssue]
-    monkeypatch.setattr(websocket_service.hassette.config.websocket, "early_drop_stable_window_seconds", 30.0)
+    monkeypatch.setattr(
+        websocket_service.hassette.config.websocket,
+        "early_drop_stable_window_seconds",
+        TEST_EARLY_DROP_STABLE_WINDOW_SECONDS,
+    )
 
     with pytest.raises(RetryableConnectionClosedError):
         await websocket_service.serve()
 
     # Only 1 attempt — stable drop doesn't retry
-    assert call_count == 1, f"Expected 1 make_connection call, got {call_count}"
+    assert fake_make_connection.call_count == 1, (
+        f"Expected 1 make_connection call, got {fake_make_connection.call_count}"
+    )
 
 
 async def test_non_retryable_exception_in_stable_window(
@@ -892,26 +950,25 @@ async def test_non_retryable_exception_in_stable_window(
     """RuntimeError within stable window propagates immediately — not an early drop."""
     websocket_service.hassette.send_event = AsyncMock()
 
-    call_count = 0
-
-    async def fake_make_connection(_session):
-        nonlocal call_count
-        call_count += 1
-        websocket_service._connected_at = time.monotonic()
-        lifecycle_module.mark_ready(websocket_service, reason="test: simulating successful connection")
-
-        async def _fail():
-            raise RuntimeError("unexpected internal error")
-
-        return asyncio.create_task(_fail())
+    fake_make_connection = FailingConnection(
+        websocket_service,
+        fail_after=None,
+        error=RuntimeError("unexpected internal error"),
+    )
 
     websocket_service.make_connection = fake_make_connection  # pyright: ignore[reportAttributeAccessIssue]
-    monkeypatch.setattr(websocket_service.hassette.config.websocket, "early_drop_stable_window_seconds", 30.0)
+    monkeypatch.setattr(
+        websocket_service.hassette.config.websocket,
+        "early_drop_stable_window_seconds",
+        TEST_EARLY_DROP_STABLE_WINDOW_SECONDS,
+    )
 
     with pytest.raises(RuntimeError):
         await websocket_service.serve()
 
-    assert call_count == 1, f"Expected 1 make_connection call, got {call_count}"
+    assert fake_make_connection.call_count == 1, (
+        f"Expected 1 make_connection call, got {fake_make_connection.call_count}"
+    )
 
 
 async def test_auth_failure_on_reconnect_logs_distinctive_message(
@@ -921,33 +978,21 @@ async def test_auth_failure_on_reconnect_logs_distinctive_message(
     """InvalidAuthError after at least one early-drop retry propagates and leaves DISCONNECTED."""
     websocket_service.hassette.send_event = AsyncMock()
 
-    call_count = 0
-
-    async def fake_make_connection(_session):
-        nonlocal call_count
-        call_count += 1
-
-        if call_count == 1:
-            websocket_service._connected_at = time.monotonic()
-            lifecycle_module.mark_ready(websocket_service, reason="test: simulating successful connection")
-
-            async def _fail():
-                raise RetryableConnectionClosedError("dropped")
-
-            return asyncio.create_task(_fail())
-        raise InvalidAuthError("token revoked")
+    fake_make_connection = FailingConnection(
+        websocket_service,
+        fail_after=1,
+        error=RetryableConnectionClosedError("dropped"),
+        final_error=InvalidAuthError("token revoked"),
+    )
 
     websocket_service.make_connection = fake_make_connection  # pyright: ignore[reportAttributeAccessIssue]
     websocket_service.partial_cleanup = AsyncMock()  # pyright: ignore[reportAttributeAccessIssue]
-    monkeypatch.setattr(websocket_service.hassette.config.websocket, "early_drop_max_retries", 5)
-    monkeypatch.setattr(websocket_service.hassette.config.websocket, "early_drop_stable_window_seconds", 30.0)
-    monkeypatch.setattr(websocket_service.hassette.config.websocket, "early_drop_backoff_initial_seconds", 0.001)
-    monkeypatch.setattr(websocket_service.hassette.config.websocket, "early_drop_backoff_max_seconds", 0.01)
+    apply_early_drop_config(monkeypatch, websocket_service)
 
     with pytest.raises(InvalidAuthError):
         await websocket_service.serve()
 
-    assert call_count >= 2
+    assert fake_make_connection.call_count >= 2
     assert websocket_service.connection_state == ConnectionState.DISCONNECTED
 
 
@@ -1030,25 +1075,12 @@ async def test_service_status_stays_running_during_early_drop(
     websocket_service.hassette.send_event = AsyncMock()
 
     statuses_during_retry: list[tuple[ResourceStatus, bool]] = []
-    call_count = 0
 
-    async def fake_make_connection(_session):
-        nonlocal call_count
-        call_count += 1
-        websocket_service._connected_at = time.monotonic()
-        lifecycle_module.mark_ready(websocket_service, reason="test: simulating successful connection")
-
-        if call_count == 1:
-
-            async def _fail():
-                raise RetryableConnectionClosedError("dropped")
-
-            return asyncio.create_task(_fail())
-
-        async def _clean():
-            pass
-
-        return asyncio.create_task(_clean())
+    fake_make_connection = FailingConnection(
+        websocket_service,
+        fail_after=1,
+        error=RetryableConnectionClosedError("dropped"),
+    )
 
     original_mark_not_ready = lifecycle_module.mark_not_ready
 
@@ -1058,10 +1090,7 @@ async def test_service_status_stays_running_during_early_drop(
 
     websocket_service.make_connection = fake_make_connection  # pyright: ignore[reportAttributeAccessIssue]
     websocket_service.partial_cleanup = AsyncMock()  # pyright: ignore[reportAttributeAccessIssue]
-    monkeypatch.setattr(websocket_service.hassette.config.websocket, "early_drop_max_retries", 5)
-    monkeypatch.setattr(websocket_service.hassette.config.websocket, "early_drop_stable_window_seconds", 30.0)
-    monkeypatch.setattr(websocket_service.hassette.config.websocket, "early_drop_backoff_initial_seconds", 0.001)
-    monkeypatch.setattr(websocket_service.hassette.config.websocket, "early_drop_backoff_max_seconds", 0.01)
+    apply_early_drop_config(monkeypatch, websocket_service)
 
     # Set service to RUNNING state using ._status bypass — deliberate test fixture setup,
     # not a lifecycle operation. handle_running() requires STARTING → RUNNING which needs

--- a/tests/integration/test_websocket_service.py
+++ b/tests/integration/test_websocket_service.py
@@ -753,6 +753,8 @@ class FailingConnection:
         final_error: Exception | None = None,
         mark_fully_connected: bool = False,
     ) -> None:
+        if final_error is not None and fail_after is None:
+            raise ValueError("final_error requires fail_after to be set — there is no call to trigger it on")
         self.websocket_service = websocket_service
         self.fail_after = fail_after
         self.error = error

--- a/tests/integration/test_websocket_service.py
+++ b/tests/integration/test_websocket_service.py
@@ -176,8 +176,8 @@ async def test_send_and_wait_returns_response(websocket_service: WebsocketServic
     """Resolve send_and_wait when the websocket replies with success."""
 
     async def send_side_effect(**data: object) -> None:
-        message_id = data["id"]
-        response_future = websocket_service._response_futures[message_id]  # pyright: ignore
+        msg_id = data["id"]
+        response_future = websocket_service._response_futures[msg_id]  # pyright: ignore
         response_future.set_result({"ok": True})
 
     websocket_service.send_json = AsyncMock(side_effect=send_side_effect)

--- a/tests/integration/web_api/test_auth.py
+++ b/tests/integration/web_api/test_auth.py
@@ -106,6 +106,41 @@ async def _mint_cookie_at(token: str, seconds_ago: int) -> str:
         return mint_session_cookie(token)
 
 
+async def _request_from_peer(
+    auth_hassette,
+    peer: str,
+    *,
+    trusted_proxies,
+    method: str = "get",
+    path: str = "/api/config",
+    headers: dict[str, str] | None = None,
+    json: dict | None = None,
+    **app_kwargs,
+) -> Response:
+    """Issue one request from `peer` against a fresh app built with `trusted_proxies`.
+
+    Builds `create_fastapi_app(auth_hassette, trusted_proxies=trusted_proxies, **app_kwargs)`,
+    wraps it in an `ASGITransport` whose ASGI `client` is `(peer, 12345)`, opens an `AsyncClient`
+    against it, and issues one `method` request to `path`. Extracted because this exact
+    build-app/wrap-transport/open-client/issue-request sequence repeated near-verbatim across the
+    trusted-proxy, sliding-renewal, and cookie-secure-flag tests, differing only in the peer IP,
+    the `trusted_proxies`/`auth_token` app kwargs, and the request itself.
+
+    `trusted_proxies` takes an already-resolved set (not raw hostnames/IPs) -- resolution differs
+    enough across callers (plain IP/CIDR, mocked-DNS hostname, post-refresh) that it stays in each
+    test body rather than being folded into this helper.
+    """
+    app = create_fastapi_app(auth_hassette, trusted_proxies=trusted_proxies, **app_kwargs)
+    transport = ASGITransport(app=app, client=(peer, 12345))
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        request_kwargs: dict = {}
+        if headers is not None:
+            request_kwargs["headers"] = headers
+        if json is not None:
+            request_kwargs["json"] = json
+        return await getattr(client, method)(path, **request_kwargs)
+
+
 async def _trusted_peer_get_config(auth_hassette, headers: dict[str, str] | None = None) -> Response:
     """`GET /api/config` from a peer inside `trusted_proxies`, against an app with a real token.
 
@@ -114,10 +149,9 @@ async def _trusted_peer_get_config(auth_hassette, headers: dict[str, str] | None
     no-token apps `TestTrustedProxyPeerAuth` builds.
     """
     trusted = await resolve_trusted_proxies((_TRUSTED_PEER_IP,))
-    app = create_fastapi_app(auth_hassette, auth_token=WEB_API_TEST_TOKEN, trusted_proxies=trusted)
-    transport = ASGITransport(app=app, client=(_TRUSTED_PEER_IP, 12345))
-    async with AsyncClient(transport=transport, base_url="http://test") as client:
-        return await client.get("/api/config", headers=headers)
+    return await _request_from_peer(
+        auth_hassette, _TRUSTED_PEER_IP, trusted_proxies=trusted, headers=headers, auth_token=WEB_API_TEST_TOKEN
+    )
 
 
 class TestDefaultDenyNoCredential:
@@ -267,10 +301,9 @@ class TestSlidingRenewal:
 
     async def test_trusted_proxy_authenticated_request_is_not_renewed(self, auth_hassette) -> None:
         trusted = await resolve_trusted_proxies((_TRUSTED_PEER_IP,))
-        app = create_fastapi_app(auth_hassette, auth_token=WEB_API_TEST_TOKEN, trusted_proxies=trusted)
-        transport = ASGITransport(app=app, client=(_TRUSTED_PEER_IP, 12345))
-        async with AsyncClient(transport=transport, base_url="http://test") as client:
-            resp = await client.get("/api/config")
+        resp = await _request_from_peer(
+            auth_hassette, _TRUSTED_PEER_IP, trusted_proxies=trusted, auth_token=WEB_API_TEST_TOKEN
+        )
 
         assert resp.status_code == 200
         assert resp.cookies.get(SESSION_COOKIE_NAME) is None
@@ -422,28 +455,19 @@ class TestTrustedProxyPeerAuth:
 
     async def test_ip_entry_peer_returns_200_with_no_credential(self, auth_hassette) -> None:
         trusted = await resolve_trusted_proxies((_TRUSTED_PEER_IP,))
-        app = create_fastapi_app(auth_hassette, trusted_proxies=trusted)
-        transport = ASGITransport(app=app, client=(_TRUSTED_PEER_IP, 12345))
-        async with AsyncClient(transport=transport, base_url="http://test") as client:
-            resp = await client.get("/api/config")
+        resp = await _request_from_peer(auth_hassette, _TRUSTED_PEER_IP, trusted_proxies=trusted)
 
         assert resp.status_code == 200
 
     async def test_cidr_entry_peer_returns_200_with_no_credential(self, auth_hassette) -> None:
         trusted = await resolve_trusted_proxies(("10.0.0.0/24",))
-        app = create_fastapi_app(auth_hassette, trusted_proxies=trusted)
-        transport = ASGITransport(app=app, client=("10.0.0.42", 12345))
-        async with AsyncClient(transport=transport, base_url="http://test") as client:
-            resp = await client.get("/api/config")
+        resp = await _request_from_peer(auth_hassette, "10.0.0.42", trusted_proxies=trusted)
 
         assert resp.status_code == 200
 
     async def test_non_matching_peer_still_requires_credential(self, auth_hassette) -> None:
         trusted = await resolve_trusted_proxies((_TRUSTED_PEER_IP,))
-        app = create_fastapi_app(auth_hassette, trusted_proxies=trusted)
-        transport = ASGITransport(app=app, client=(_UNTRUSTED_PEER_IP, 12345))
-        async with AsyncClient(transport=transport, base_url="http://test") as client:
-            resp = await client.get("/api/config")
+        resp = await _request_from_peer(auth_hassette, _UNTRUSTED_PEER_IP, trusted_proxies=trusted)
 
         assert resp.status_code == 401
 
@@ -512,10 +536,7 @@ class TestTrustedProxyHostnameAuth:
         with patch_loop_getaddrinfo(return_value=[make_addrinfo("172.30.32.2")]):
             trusted = await resolve_trusted_proxies(("proxy.internal",))
 
-        app = create_fastapi_app(auth_hassette, trusted_proxies=trusted)
-        transport = ASGITransport(app=app, client=("172.30.32.2", 12345))
-        async with AsyncClient(transport=transport, base_url="http://test") as client:
-            resp = await client.get("/api/config")
+        resp = await _request_from_peer(auth_hassette, "172.30.32.2", trusted_proxies=trusted)
 
         assert resp.status_code == 200
 
@@ -528,17 +549,11 @@ class TestTrustedProxyHostnameAuth:
         with patch_loop_getaddrinfo(return_value=[make_addrinfo("172.30.32.9")]):
             refreshed = await refresh_trusted_proxies(trusted)
 
-        app = create_fastapi_app(auth_hassette, trusted_proxies=refreshed)
-
-        new_transport = ASGITransport(app=app, client=("172.30.32.9", 12345))
-        async with AsyncClient(transport=new_transport, base_url="http://test") as client:
-            new_resp = await client.get("/api/config")
+        new_resp = await _request_from_peer(auth_hassette, "172.30.32.9", trusted_proxies=refreshed)
         assert new_resp.status_code == 200
 
         # The pre-refresh address is no longer part of the current resolution.
-        old_transport = ASGITransport(app=app, client=("172.30.32.2", 12345))
-        async with AsyncClient(transport=old_transport, base_url="http://test") as client:
-            old_resp = await client.get("/api/config")
+        old_resp = await _request_from_peer(auth_hassette, "172.30.32.2", trusted_proxies=refreshed)
         assert old_resp.status_code == 401
 
 
@@ -551,12 +566,11 @@ class TestSpoofedForwardedForRejected:
 
     async def test_spoofed_x_forwarded_for_from_untrusted_peer_returns_401(self, auth_hassette) -> None:
         trusted = await resolve_trusted_proxies((_TRUSTED_PEER_IP,))
-        app = create_fastapi_app(auth_hassette, trusted_proxies=trusted)
         # The direct ASGI peer is untrusted -- only the client-suppliable header claims the
         # trusted IP, which `is_trusted_peer` must never consult.
-        transport = ASGITransport(app=app, client=(_UNTRUSTED_PEER_IP, 12345))
-        async with AsyncClient(transport=transport, base_url="http://test") as client:
-            resp = await client.get("/api/config", headers={"X-Forwarded-For": _TRUSTED_PEER_IP})
+        resp = await _request_from_peer(
+            auth_hassette, _UNTRUSTED_PEER_IP, trusted_proxies=trusted, headers={"X-Forwarded-For": _TRUSTED_PEER_IP}
+        )
 
         assert resp.status_code == 401
 
@@ -590,14 +604,16 @@ class TestCookieSecureFlag:
 
     async def test_trusted_peer_with_https_forwarded_proto_gets_secure_cookie(self, auth_hassette) -> None:
         trusted = await resolve_trusted_proxies((_TRUSTED_PEER_IP,))
-        app = create_fastapi_app(auth_hassette, auth_token=WEB_API_TEST_TOKEN, trusted_proxies=trusted)
-        transport = ASGITransport(app=app, client=(_TRUSTED_PEER_IP, 12345))
-        async with AsyncClient(transport=transport, base_url="http://test") as client:
-            resp = await client.post(
-                "/api/auth/session",
-                json={"token": WEB_API_TEST_TOKEN},
-                headers={"X-Forwarded-Proto": "https"},
-            )
+        resp = await _request_from_peer(
+            auth_hassette,
+            _TRUSTED_PEER_IP,
+            trusted_proxies=trusted,
+            auth_token=WEB_API_TEST_TOKEN,
+            method="post",
+            path="/api/auth/session",
+            json={"token": WEB_API_TEST_TOKEN},
+            headers={"X-Forwarded-Proto": "https"},
+        )
 
         assert resp.status_code == 200
         set_cookie_header = resp.headers.get("set-cookie")
@@ -606,16 +622,18 @@ class TestCookieSecureFlag:
 
     async def test_non_trusted_peer_with_spoofed_https_header_gets_no_secure_cookie(self, auth_hassette) -> None:
         trusted = await resolve_trusted_proxies((_TRUSTED_PEER_IP,))
-        app = create_fastapi_app(auth_hassette, auth_token=WEB_API_TEST_TOKEN, trusted_proxies=trusted)
         # Direct peer does not match trusted_proxies -- the header is spoofed and must be ignored
         # per `should_set_secure_cookie_flag`'s contract.
-        transport = ASGITransport(app=app, client=(_UNTRUSTED_PEER_IP, 12345))
-        async with AsyncClient(transport=transport, base_url="http://test") as client:
-            resp = await client.post(
-                "/api/auth/session",
-                json={"token": WEB_API_TEST_TOKEN},
-                headers={"X-Forwarded-Proto": "https"},
-            )
+        resp = await _request_from_peer(
+            auth_hassette,
+            _UNTRUSTED_PEER_IP,
+            trusted_proxies=trusted,
+            auth_token=WEB_API_TEST_TOKEN,
+            method="post",
+            path="/api/auth/session",
+            json={"token": WEB_API_TEST_TOKEN},
+            headers={"X-Forwarded-Proto": "https"},
+        )
 
         assert resp.status_code == 200
         set_cookie_header = resp.headers.get("set-cookie")

--- a/tests/integration/web_api/test_auth.py
+++ b/tests/integration/web_api/test_auth.py
@@ -18,6 +18,7 @@ import logging
 import time
 from collections.abc import Generator
 from pathlib import Path
+from typing import Literal
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -111,7 +112,7 @@ async def _request_from_peer(
     peer: str,
     *,
     trusted_proxies,
-    method: str = "get",
+    method: Literal["get", "post"] = "get",
     path: str = "/api/config",
     headers: dict[str, str] | None = None,
     json: dict | None = None,

--- a/tests/integration/web_api/test_endpoints.py
+++ b/tests/integration/web_api/test_endpoints.py
@@ -16,11 +16,26 @@ from .conftest import make_log_record, set_app_status_snapshot, set_websocket_st
 if TYPE_CHECKING:
     from httpx2 import AsyncClient
 
+# Route paths hit by multiple tests below — single source of truth so a route rename only
+# needs to change here.
+HEALTH_PATH = "/api/health"
+HEALTH_READY_PATH = "/api/health/ready"
+APP_START_PATH = "/api/apps/my_app/start"
+APP_STOP_PATH = "/api/apps/my_app/stop"
+APP_RELOAD_PATH = "/api/apps/my_app/reload"
+APP_MANIFEST_PATH = "/api/apps/my_app/manifest"
+APP_MANIFESTS_PATH = "/api/apps/manifests"
+BUS_LISTENERS_PATH = "/api/bus/listeners"
+LOGS_RECENT_PATH = "/api/logs/recent"
+LOGS_LEVEL_PATH = "/api/logs/level"
+CONFIG_PATH = "/api/config"
+OPENAPI_PATH = "/api/openapi.json"
+
 
 class TestHealthEndpoints:
     async def test_health_returns_200_when_ok(self, client: "AsyncClient") -> None:
         """GET /api/health returns 200 with status 'ok' when WebSocket is connected."""
-        response = await client.get("/api/health")
+        response = await client.get(HEALTH_PATH)
         assert response.status_code == 200
         data = response.json()
         assert data["status"] == "ok"
@@ -31,7 +46,7 @@ class TestHealthEndpoints:
     async def test_health_returns_200_when_degraded(self, client: "AsyncClient", mock_hassette) -> None:
         """GET /api/health returns 200 with status 'degraded' when WebSocket is not connected."""
         set_websocket_state(mock_hassette, connected=False, ever_connected=True)
-        response = await client.get("/api/health")
+        response = await client.get(HEALTH_PATH)
         assert response.status_code == 200
         data = response.json()
         assert data["status"] == "degraded"
@@ -40,7 +55,7 @@ class TestHealthEndpoints:
     async def test_health_returns_200_when_starting(self, client: "AsyncClient", mock_hassette) -> None:
         """GET /api/health returns 200 (not 503) with status 'starting' during startup."""
         set_websocket_state(mock_hassette, connected=False, ever_connected=False)
-        response = await client.get("/api/health")
+        response = await client.get(HEALTH_PATH)
         assert response.status_code == 200
         data = response.json()
         assert data["status"] == "starting"
@@ -55,7 +70,7 @@ class TestHealthEndpoints:
 
     async def test_health_ready_returns_200_when_ok(self, client: "AsyncClient") -> None:
         """GET /api/health/ready returns 200 when status is 'ok'."""
-        response = await client.get("/api/health/ready")
+        response = await client.get(HEALTH_READY_PATH)
         assert response.status_code == 200
         data = response.json()
         assert data["ready"] is True
@@ -64,7 +79,7 @@ class TestHealthEndpoints:
     async def test_health_ready_returns_503_when_degraded(self, client: "AsyncClient", mock_hassette) -> None:
         """GET /api/health/ready returns 503 when status is 'degraded'."""
         set_websocket_state(mock_hassette, connected=False, ever_connected=True)
-        response = await client.get("/api/health/ready")
+        response = await client.get(HEALTH_READY_PATH)
         assert response.status_code == 503
         data = response.json()
         assert data["ready"] is False
@@ -73,7 +88,7 @@ class TestHealthEndpoints:
     async def test_health_ready_returns_503_when_starting(self, client: "AsyncClient", mock_hassette) -> None:
         """GET /api/health/ready returns 503 when status is 'starting'."""
         set_websocket_state(mock_hassette, connected=False, ever_connected=False)
-        response = await client.get("/api/health/ready")
+        response = await client.get(HEALTH_READY_PATH)
         assert response.status_code == 503
         data = response.json()
         assert data["ready"] is False
@@ -94,7 +109,7 @@ class TestHealthEndpoints:
         """
         set_websocket_state(mock_hassette, connected=False, ever_connected=False)
         set_app_status_snapshot(mock_hassette, running=[], failed=[])
-        response = await client.get("/api/health")
+        response = await client.get(HEALTH_PATH)
         assert response.status_code == 200
         data = response.json()
         assert data["status"] == "starting"
@@ -130,7 +145,7 @@ class TestAppEndpoints:
         assert response.status_code == 404
 
     async def test_start_app(self, client: "AsyncClient") -> None:
-        response = await client.post("/api/apps/my_app/start")
+        response = await client.post(APP_START_PATH)
         assert response.status_code == 202
         data = response.json()
         assert data["action"] == "start"
@@ -140,12 +155,12 @@ class TestAppEndpoints:
     ) -> None:
         mock_hassette.app_handler.start_app = AsyncMock(side_effect=AppBootstrapNotReleasedError("not released"))
 
-        response = await client.post("/api/apps/my_app/start")
+        response = await client.post(APP_START_PATH)
 
         assert response.status_code == 409
 
     async def test_stop_app(self, client: "AsyncClient") -> None:
-        response = await client.post("/api/apps/my_app/stop")
+        response = await client.post(APP_STOP_PATH)
         assert response.status_code == 202
         data = response.json()
         assert data["action"] == "stop"
@@ -156,7 +171,7 @@ class TestAppEndpoints:
         The force_reload=True assertion guards #1005: without it the endpoint reused the
         cached (failed) class, so a fix on disk never took effect.
         """
-        response = await client.post("/api/apps/my_app/reload")
+        response = await client.post(APP_RELOAD_PATH)
         assert response.status_code == 202
         data = response.json()
         assert data["action"] == "reload"
@@ -167,16 +182,16 @@ class TestAppEndpoints:
     ) -> None:
         mock_hassette.app_handler.reload_app = AsyncMock(side_effect=AppBootstrapNotReleasedError("not released"))
 
-        response = await client.post("/api/apps/my_app/reload")
+        response = await client.post(APP_RELOAD_PATH)
 
         assert response.status_code == 409
 
     async def test_app_management_works_without_dev_mode(self, client: "AsyncClient", mock_hassette) -> None:
         mock_hassette.config.dev_mode = False
         mock_hassette.config.allow_reload_in_prod = False
-        assert (await client.post("/api/apps/my_app/start")).status_code == 202
-        assert (await client.post("/api/apps/my_app/stop")).status_code == 202
-        assert (await client.post("/api/apps/my_app/reload")).status_code == 202
+        assert (await client.post(APP_START_PATH)).status_code == 202
+        assert (await client.post(APP_STOP_PATH)).status_code == 202
+        assert (await client.post(APP_RELOAD_PATH)).status_code == 202
 
 
 class TestAppManifestEndpoint:
@@ -187,7 +202,7 @@ class TestAppManifestEndpoint:
         )
         mock_hassette.telemetry_query_service.get_recent_invocations_1h_all_apps.return_value = {"my_app": 5}
 
-        response = await client.get("/api/apps/my_app/manifest")
+        response = await client.get(APP_MANIFEST_PATH)
         assert response.status_code == 200
         data = response.json()
         assert data["app_key"] == "my_app"
@@ -219,7 +234,7 @@ class TestAppManifestEndpoint:
             side_effect=TelemetryUnavailableError("db down")
         )
 
-        response = await client.get("/api/apps/my_app/manifest")
+        response = await client.get(APP_MANIFEST_PATH)
         assert response.status_code == 200
         assert response.json()["recent_invocations_1h"] == 0
 
@@ -229,7 +244,7 @@ class TestAppManifestEndpoint:
             side_effect=TelemetryUnavailableError("db down")
         )
 
-        response = await client.get("/api/apps/my_app/manifest")
+        response = await client.get(APP_MANIFEST_PATH)
         assert response.status_code == 503
 
 
@@ -240,7 +255,7 @@ class TestAppManifestListEndpoint:
             return_value=[make_manifest_db_row(app_key="orphan_app", display_name="Orphan App")]
         )
 
-        response = await client.get("/api/apps/manifests")
+        response = await client.get(APP_MANIFESTS_PATH)
         assert response.status_code == 200
         data = response.json()
         assert data["total"] == 1
@@ -258,7 +273,7 @@ class TestAppManifestListEndpoint:
             side_effect=TelemetryUnavailableError("db down")
         )
 
-        response = await client.get("/api/apps/manifests")
+        response = await client.get(APP_MANIFESTS_PATH)
         assert response.status_code == 503
         assert response.json()["manifests"] == []
 
@@ -273,7 +288,7 @@ class TestSchedulerEndpoints:
 
 class TestConfigEndpoint:
     async def test_get_config(self, client: "AsyncClient") -> None:
-        response = await client.get("/api/config")
+        response = await client.get(CONFIG_PATH)
         assert response.status_code == 200
         data = response.json()
         assert "config_schema" in data
@@ -283,13 +298,13 @@ class TestConfigEndpoint:
 class TestBusEndpoints:
     async def test_get_bus_listeners_empty(self, client: "AsyncClient") -> None:
         # Returns empty when no app_key is provided (TelemetryDep stubs return [])
-        response = await client.get("/api/bus/listeners")
+        response = await client.get(BUS_LISTENERS_PATH)
         assert response.status_code == 200
         assert response.json() == []
 
     async def test_get_bus_listeners_with_app_key_returns_empty_stub(self, client: "AsyncClient") -> None:
         # TelemetryQueryService stubs return [] for all app_key queries
-        response = await client.get("/api/bus/listeners?app_key=my_app")
+        response = await client.get(f"{BUS_LISTENERS_PATH}?app_key=my_app")
         assert response.status_code == 200
         assert response.json() == []
 
@@ -330,7 +345,7 @@ class TestBusEndpoints:
         )
         mock_hassette.telemetry_query_service.get_listener_summary = AsyncMock(return_value=[sample])
 
-        response = await client.get("/api/bus/listeners?app_key=test_app")
+        response = await client.get(f"{BUS_LISTENERS_PATH}?app_key=test_app")
         assert response.status_code == 200
         data = response.json()
         assert len(data) == 1
@@ -373,7 +388,7 @@ class TestLogsEndpoints:
         self, client: "AsyncClient", mock_hassette: MagicMock, sample_records: list[dict]
     ) -> None:
         mock_hassette.telemetry_query_service.get_log_records = AsyncMock(return_value=sample_records)
-        response = await client.get("/api/logs/recent")
+        response = await client.get(LOGS_RECENT_PATH)
         assert response.status_code == 200
         data = response.json()
         assert isinstance(data, list)
@@ -392,7 +407,7 @@ class TestLogsEndpoints:
         records[2]["timestamp"] = 2.0
         mock_hassette.telemetry_query_service.get_log_records = AsyncMock(return_value=records)
 
-        response = await client.get("/api/logs/recent")
+        response = await client.get(LOGS_RECENT_PATH)
 
         assert response.status_code == 200
         assert [entry["message"] for entry in response.json()] == [
@@ -407,7 +422,7 @@ class TestLogsEndpoints:
     ) -> None:
         """New fields (execution_id, instance_name, instance_index, source_tier) are in the response."""
         mock_hassette.telemetry_query_service.get_log_records = AsyncMock(return_value=sample_records[:1])
-        response = await client.get("/api/logs/recent")
+        response = await client.get(LOGS_RECENT_PATH)
         assert response.status_code == 200
         entry = response.json()[0]
         assert "execution_id" in entry
@@ -421,7 +436,7 @@ class TestLogsEndpoints:
         mock_hassette.telemetry_query_service.get_log_records = AsyncMock(
             side_effect=TelemetryUnavailableError("db error")
         )
-        response = await client.get("/api/logs/recent")
+        response = await client.get(LOGS_RECENT_PATH)
         assert response.status_code == 503
         assert response.json() == []
 
@@ -429,33 +444,33 @@ class TestLogsEndpoints:
         self, client: "AsyncClient", mock_hassette: MagicMock
     ) -> None:
         mock_hassette.telemetry_query_service.get_log_records = AsyncMock(return_value=[])
-        response = await client.get("/api/logs/recent?execution_id=abc-123")
+        response = await client.get(f"{LOGS_RECENT_PATH}?execution_id=abc-123")
         assert response.status_code == 200
 
     async def test_get_logs_recent_accepts_source_tier_param(
         self, client: "AsyncClient", mock_hassette: MagicMock
     ) -> None:
         mock_hassette.telemetry_query_service.get_log_records = AsyncMock(return_value=[])
-        response = await client.get("/api/logs/recent?source_tier=app")
+        response = await client.get(f"{LOGS_RECENT_PATH}?source_tier=app")
         assert response.status_code == 200
 
     async def test_put_log_level_valid(self, client: "AsyncClient") -> None:
-        response = await client.put("/api/logs/level", json={"logger": "hassette.test", "level": "DEBUG"})
+        response = await client.put(LOGS_LEVEL_PATH, json={"logger": "hassette.test", "level": "DEBUG"})
         assert response.status_code == 200
         data = response.json()
         assert data["logger"] == "hassette.test"
         assert data["effective_level"] == "DEBUG"
 
     async def test_put_log_level_invalid_level(self, client: "AsyncClient") -> None:
-        response = await client.put("/api/logs/level", json={"logger": "hassette.test", "level": "VERBOSE"})
+        response = await client.put(LOGS_LEVEL_PATH, json={"logger": "hassette.test", "level": "VERBOSE"})
         assert response.status_code == 422
 
     async def test_put_log_level_changes_take_effect(self, client: "AsyncClient") -> None:
         """Setting DEBUG then INFO changes the effective level each time."""
-        await client.put("/api/logs/level", json={"logger": "hassette.rqs.test.lvl", "level": "DEBUG"})
+        await client.put(LOGS_LEVEL_PATH, json={"logger": "hassette.rqs.test.lvl", "level": "DEBUG"})
         assert logging.getLogger("hassette.rqs.test.lvl").level == logging.DEBUG
 
-        r2 = await client.put("/api/logs/level", json={"logger": "hassette.rqs.test.lvl", "level": "INFO"})
+        r2 = await client.put(LOGS_LEVEL_PATH, json={"logger": "hassette.rqs.test.lvl", "level": "INFO"})
         assert r2.status_code == 200
         assert logging.getLogger("hassette.rqs.test.lvl").level == logging.INFO
 
@@ -463,7 +478,7 @@ class TestLogsEndpoints:
 class TestConfigEndpointExpanded:
     async def test_response_has_nested_groups(self, client: "AsyncClient", mock_hassette) -> None:
         """Response envelope contains standard config groups in config_values, including previously-omitted ones."""
-        response = await client.get("/api/config")
+        response = await client.get(CONFIG_PATH)
         assert response.status_code == 200
         data = response.json()
         config_values = data["config_values"]
@@ -480,7 +495,7 @@ class TestConfigEndpointExpanded:
 
     async def test_token_not_in_response(self, client: "AsyncClient", mock_hassette) -> None:
         """Token is present in config_values as None or masked; plaintext is never returned."""
-        response = await client.get("/api/config")
+        response = await client.get(CONFIG_PATH)
         assert response.status_code == 200
         data = response.json()
         config_values = data["config_values"]
@@ -498,7 +513,7 @@ class TestConfigEndpointExpanded:
         """
         secret = "super-secret-plaintext-xyz"
         mock_hassette.config.model_dump.return_value["token"] = secret
-        response = await client.get("/api/config")
+        response = await client.get(CONFIG_PATH)
         assert response.status_code == 200
         data = response.json()
         assert data["config_values"]["token"] == MASK_SENTINEL
@@ -506,14 +521,14 @@ class TestConfigEndpointExpanded:
 
     async def test_dev_mode_present_at_root(self, client: "AsyncClient", mock_hassette) -> None:
         """dev_mode is present in config_values."""
-        response = await client.get("/api/config")
+        response = await client.get(CONFIG_PATH)
         data = response.json()
         assert "dev_mode" in data["config_values"]
         assert isinstance(data["config_values"]["dev_mode"], bool)
 
     async def test_dir_fields_present_as_strings(self, client: "AsyncClient", mock_hassette) -> None:
         """data_dir and config_dir are present in config_values; apps.directory is under the apps group."""
-        response = await client.get("/api/config")
+        response = await client.get(CONFIG_PATH)
         assert response.status_code == 200
         data = response.json()
         config_values = data["config_values"]
@@ -523,7 +538,7 @@ class TestConfigEndpointExpanded:
 
     async def test_web_api_fields_nested(self, client: "AsyncClient", mock_hassette) -> None:
         """web_api group in config_values contains host and port fields."""
-        response = await client.get("/api/config")
+        response = await client.get(CONFIG_PATH)
         assert response.status_code == 200
         data = response.json()
         web_api = data["config_values"]["web_api"]
@@ -533,14 +548,14 @@ class TestConfigEndpointExpanded:
 
 class TestOpenApiDocs:
     async def test_openapi_json(self, client: "AsyncClient") -> None:
-        response = await client.get("/api/openapi.json")
+        response = await client.get(OPENAPI_PATH)
         assert response.status_code == 200
         data = response.json()
         assert data["info"]["title"] == "Hassette Web API"
 
     async def test_instance_index_has_description_on_telemetry_health(self, client: "AsyncClient") -> None:
         """instance_index parameter on telemetry app health route has a description."""
-        response = await client.get("/api/openapi.json")
+        response = await client.get(OPENAPI_PATH)
         spec = response.json()
         paths = spec.get("paths", {})
         # Find the app health route
@@ -553,12 +568,11 @@ class TestOpenApiDocs:
 
     async def test_instance_index_has_description_on_bus_listeners(self, client: "AsyncClient") -> None:
         """instance_index parameter on bus listeners route has a description."""
-        response = await client.get("/api/openapi.json")
+        response = await client.get(OPENAPI_PATH)
         spec = response.json()
         paths = spec.get("paths", {})
-        bus_path = "/api/bus/listeners"
-        assert bus_path in paths
-        params = paths[bus_path]["get"].get("parameters", [])
+        assert BUS_LISTENERS_PATH in paths
+        params = paths[BUS_LISTENERS_PATH]["get"].get("parameters", [])
         instance_params = [p for p in params if p.get("name") == "instance_index"]
         assert instance_params, "instance_index parameter must be present on bus/listeners route"
         assert instance_params[0].get("description"), "instance_index must have a non-empty description"

--- a/tests/integration/web_api/test_ws_endpoint.py
+++ b/tests/integration/web_api/test_ws_endpoint.py
@@ -36,6 +36,10 @@ LOOPBACK_PEER_IP = "127.0.0.1"
 """The peer address uvicorn reports for the live-server tests' own client, so a `trusted_proxies`
 entry naming it makes those connections trusted."""
 
+WS_PATH = "/api/ws"
+"""The WebSocket route path, hit by every test in this file — single source of truth so a route
+rename only needs to change here."""
+
 
 @pytest.fixture
 def mock_hassette():
@@ -122,7 +126,7 @@ def sync_via_ping(ws) -> None:
 
 class TestWebSocketConnection:
     def test_connect_receives_connected_message(self, client: "TestClient") -> None:
-        with client.websocket_connect("/api/ws") as ws:
+        with client.websocket_connect(WS_PATH) as ws:
             msg = ws.receive_json()
             assert msg["type"] == "connected"
             assert msg["data"]["entity_count"] == 1
@@ -136,13 +140,13 @@ class TestWebSocketConnection:
         """
         set_websocket_state(mock_hassette, connected=False, ever_connected=False)
         set_app_status_snapshot(mock_hassette, running=[], failed=[])
-        with client.websocket_connect("/api/ws") as ws:
+        with client.websocket_connect(WS_PATH) as ws:
             msg = ws.receive_json()
             assert msg["type"] == "connected"
             assert msg["data"]["app_count"] == 0
 
     def test_ping_pong(self, client: "TestClient") -> None:
-        with client.websocket_connect("/api/ws") as ws:
+        with client.websocket_connect(WS_PATH) as ws:
             ws.receive_json()  # consume connected message
             ws.send_json({"type": "ping"})
             msg = ws.receive_json()
@@ -151,7 +155,7 @@ class TestWebSocketConnection:
     def test_subscribe_logs_enables_log_forwarding(
         self, client: "TestClient", runtime_query_service: RuntimeQueryService
     ) -> None:
-        with client.websocket_connect("/api/ws") as ws:
+        with client.websocket_connect(WS_PATH) as ws:
             ws.receive_json()  # connected
             ws.send_json({"type": "subscribe", "data": {"logs": True}})
             sync_via_ping(ws)
@@ -166,7 +170,7 @@ class TestWebSocketConnection:
     def test_log_messages_blocked_when_not_subscribed(
         self, client: "TestClient", runtime_query_service: RuntimeQueryService
     ) -> None:
-        with client.websocket_connect("/api/ws") as ws:
+        with client.websocket_connect(WS_PATH) as ws:
             ws.receive_json()  # connected
             # Log should be filtered (subscribe_logs is False by default)
             put_to_all_queues(
@@ -184,7 +188,7 @@ class TestWebSocketConnection:
     def test_non_log_messages_pass_through_without_subscription(
         self, client: "TestClient", runtime_query_service: RuntimeQueryService
     ) -> None:
-        with client.websocket_connect("/api/ws") as ws:
+        with client.websocket_connect(WS_PATH) as ws:
             ws.receive_json()  # connected
             put_to_all_queues(
                 runtime_query_service,
@@ -196,7 +200,7 @@ class TestWebSocketConnection:
     def test_subscribe_min_log_level_filters_below_threshold(
         self, client: "TestClient", runtime_query_service: RuntimeQueryService
     ) -> None:
-        with client.websocket_connect("/api/ws") as ws:
+        with client.websocket_connect(WS_PATH) as ws:
             ws.receive_json()  # connected
             ws.send_json({"type": "subscribe", "data": {"logs": True, "min_log_level": "WARNING"}})
             sync_via_ping(ws)
@@ -221,7 +225,7 @@ class TestWebSocketConnection:
     def test_subscribe_error_level_passes(
         self, client: "TestClient", runtime_query_service: RuntimeQueryService
     ) -> None:
-        with client.websocket_connect("/api/ws") as ws:
+        with client.websocket_connect(WS_PATH) as ws:
             ws.receive_json()  # connected
             ws.send_json({"type": "subscribe", "data": {"logs": True, "min_log_level": "ERROR"}})
             sync_via_ping(ws)
@@ -244,7 +248,7 @@ class TestWebSocketConnection:
     def test_subscribe_invalid_log_level_defaults_to_info(
         self, client: "TestClient", runtime_query_service: RuntimeQueryService
     ) -> None:
-        with client.websocket_connect("/api/ws") as ws:
+        with client.websocket_connect(WS_PATH) as ws:
             ws.receive_json()  # connected
             ws.send_json({"type": "subscribe", "data": {"logs": True, "min_log_level": "INVALID"}})
             sync_via_ping(ws)
@@ -265,7 +269,7 @@ class TestWebSocketConnection:
     def test_sentinel_causes_graceful_close(
         self, client: "TestClient", runtime_query_service: RuntimeQueryService
     ) -> None:
-        with client.websocket_connect("/api/ws") as ws:
+        with client.websocket_connect(WS_PATH) as ws:
             ws.receive_json()  # connected
             assert len(runtime_query_service._ws_clients) == 1
             # Send None sentinel to trigger graceful queue shutdown
@@ -278,7 +282,7 @@ class TestWebSocketConnection:
     def test_disconnect_unregisters_client(
         self, client: "TestClient", runtime_query_service: RuntimeQueryService
     ) -> None:
-        with client.websocket_connect("/api/ws") as ws:
+        with client.websocket_connect(WS_PATH) as ws:
             ws.receive_json()  # connected
             assert len(runtime_query_service._ws_clients) == 1
         # After disconnect, client should be unregistered
@@ -287,7 +291,7 @@ class TestWebSocketConnection:
     def test_multiple_subscribe_updates_state(
         self, client: "TestClient", runtime_query_service: RuntimeQueryService
     ) -> None:
-        with client.websocket_connect("/api/ws") as ws:
+        with client.websocket_connect(WS_PATH) as ws:
             ws.receive_json()  # connected
             # First subscribe with ERROR level
             ws.send_json({"type": "subscribe", "data": {"logs": True, "min_log_level": "ERROR"}})
@@ -312,7 +316,7 @@ class TestWebSocketEdgeCases:
         self, client: "TestClient", runtime_query_service: RuntimeQueryService
     ) -> None:
         """Sending an unknown message type is silently ignored; connection stays open."""
-        with client.websocket_connect("/api/ws") as ws:
+        with client.websocket_connect(WS_PATH) as ws:
             ws.receive_json()  # connected
             ws.send_json({"type": "unknown_type", "data": {}})
             # Verify the connection is still alive by sending ping and receiving pong
@@ -324,7 +328,7 @@ class TestWebSocketEdgeCases:
         self, client: "TestClient", runtime_query_service: RuntimeQueryService
     ) -> None:
         """Subscribe with an empty data dict uses defaults: logs=False, min_log_level=INFO."""
-        with client.websocket_connect("/api/ws") as ws:
+        with client.websocket_connect(WS_PATH) as ws:
             ws.receive_json()  # connected
             ws.send_json({"type": "subscribe", "data": {}})
             sync_via_ping(ws)
@@ -345,7 +349,7 @@ class TestWebSocketEdgeCases:
         self, client: "TestClient", runtime_query_service: RuntimeQueryService
     ) -> None:
         """Subscribe message without a 'data' key treats data as empty dict."""
-        with client.websocket_connect("/api/ws") as ws:
+        with client.websocket_connect(WS_PATH) as ws:
             ws.receive_json()  # connected
             # Send subscribe without 'data' key at all
             ws.send_json({"type": "subscribe"})
@@ -443,7 +447,7 @@ class TestWebSocketEdgeCases:
 
     def test_unknown_message_type_without_data_key_ignored(self, client: "TestClient") -> None:
         """Unknown message with no 'data' key is silently ignored; connection survives."""
-        with client.websocket_connect("/api/ws") as ws:
+        with client.websocket_connect(WS_PATH) as ws:
             ws.receive_json()  # connected
             ws.send_json({"type": "whatisthis"})
             # Should still respond to ping
@@ -485,7 +489,7 @@ def serve_ws_app(app: FastAPI) -> Iterator[str]:
     # (see conftest.py's live_server_ws, which needs the same setting for the same reason).
     server, thread, port = start_uvicorn_server(app, ws="websockets-sansio", timeout_graceful_shutdown=1)
     try:
-        yield f"ws://127.0.0.1:{port}/api/ws"
+        yield f"ws://127.0.0.1:{port}{WS_PATH}"
     finally:
         stop_uvicorn_server(server, thread)
 

--- a/tests/system/.env
+++ b/tests/system/.env
@@ -1,0 +1,1 @@
+../../scripts/docker/.env

--- a/tests/system/conftest.py
+++ b/tests/system/conftest.py
@@ -126,7 +126,14 @@ def ha_container(tmp_path_factory: pytest.TempPathFactory) -> Iterator[str]:
     config_tmp = tmp_path_factory.mktemp("ha-config")
     shutil.copytree(FIXTURE_DIR, config_tmp, dirs_exist_ok=True, ignore=_ignore)
 
-    env = {**os.environ, "HA_CONFIG_PATH": str(config_tmp)}
+    # Pin HA_ACCESS_TOKEN to the fixture value even if the invoking shell exports its own —
+    # Docker Compose's interpolation precedence favors the process env over the .env file
+    # (docs.docker.com/compose/how-tos/environment-variables/variable-interpolation), so an
+    # inherited HA_ACCESS_TOKEN would otherwise silently override the token baked into
+    # tests/fixtures/ha-config/.storage/auth and break the HA container's healthcheck.
+    # Keep in sync with scripts/demo_stack.py's DemoStack.__enter__ (same pinning, plus
+    # DEMO_AUTH_TOKEN there since that compose stack also runs a hassette service).
+    env = {**os.environ, "HA_CONFIG_PATH": str(config_tmp), "HA_ACCESS_TOKEN": HA_TOKEN}
     subprocess.run(
         ["docker", "compose", "-f", str(COMPOSE_FILE), "up", "-d", "homeassistant"],
         check=True,

--- a/tests/system/conftest.py
+++ b/tests/system/conftest.py
@@ -18,6 +18,7 @@ from pathlib import Path
 
 import httpx2 as httpx
 import pytest
+from dotenv import dotenv_values
 from pydantic_settings import SettingsConfigDict
 from websockets.sync.client import connect
 
@@ -33,7 +34,13 @@ logger = logging.getLogger(__name__)
 COMPOSE_FILE = Path(__file__).parent / "docker-compose.yml"
 FIXTURE_DIR = Path(__file__).parent.parent / "fixtures" / "ha-config"
 HA_URL = "http://localhost:18123"
-HA_TOKEN = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiIwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMyIsImlhdCI6MTczNTY4OTYwMCwiZXhwIjoyMDUxMDQ5NjAwfQ.q-p85dOe-MMnKQhSNh_LEWnWJGK-GA3xdmqb4LKvkU0"  # noqa: E501 — JWT cannot be line-wrapped
+
+# Single source of truth: scripts/docker/.env (tests/system/.env symlinks to it).
+_DEMO_ENV_PATH = Path(__file__).parent / ".env"
+_DEMO_ENV = dotenv_values(_DEMO_ENV_PATH)
+HA_TOKEN = _DEMO_ENV.get("HA_ACCESS_TOKEN")
+if not HA_TOKEN:
+    raise RuntimeError(f"HA_ACCESS_TOKEN not found in {_DEMO_ENV_PATH}")
 HA_CONTAINER_NAME = "hassette-system-ha"
 STARTUP_TIMEOUT = 60  # seconds
 SHUTDOWN_TIMEOUT = 30  # seconds — matches Hassette's total_shutdown_timeout_seconds

--- a/tests/system/docker-compose.yml
+++ b/tests/system/docker-compose.yml
@@ -1,12 +1,14 @@
 services:
   homeassistant:
-    image: homeassistant/home-assistant:2026.8
+    image: homeassistant/home-assistant:${HA_VERSION}
     container_name: hassette-system-ha
     volumes:
       - ${HA_CONFIG_PATH:-../../tests/fixtures/ha-config}:/config
     ports:
       - "18123:8123"
     restart: "no"
+    # HA_ACCESS_TOKEN (.env, symlinked from scripts/docker/.env) must match
+    # tests/fixtures/ha-config/.storage/auth and conftest.py's HA_TOKEN constant.
     healthcheck:
       test:
         [
@@ -15,7 +17,7 @@ services:
           "-sf",
           "http://localhost:8123/api/",
           "-H",
-          "Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiIwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMyIsImlhdCI6MTczNTY4OTYwMCwiZXhwIjoyMDUxMDQ5NjAwfQ.q-p85dOe-MMnKQhSNh_LEWnWJGK-GA3xdmqb4LKvkU0",
+          "Authorization: Bearer ${HA_ACCESS_TOKEN}",
         ]
       interval: 5s
       timeout: 5s

--- a/tests/system/docker-compose.yml
+++ b/tests/system/docker-compose.yml
@@ -7,8 +7,9 @@ services:
     ports:
       - "18123:8123"
     restart: "no"
-    # HA_ACCESS_TOKEN (.env, symlinked from scripts/docker/.env) must match
-    # tests/fixtures/ha-config/.storage/auth and conftest.py's HA_TOKEN constant.
+    # HA_ACCESS_TOKEN (.env, symlinked from scripts/docker/.env) must match the
+    # token baked into tests/fixtures/ha-config/.storage/auth. conftest.py's
+    # HA_TOKEN reads the same .env file, so it no longer needs a separate sync note.
     healthcheck:
       test:
         [

--- a/tests/unit/core/CLAUDE.md
+++ b/tests/unit/core/CLAUDE.md
@@ -14,7 +14,7 @@
 - `make_mock_cmd_listener(**kw)` — `MagicMock` Listener for `CommandExecutor` tests (side_effect, error_handler)
 - `make_execute_job_cmd(**kw)` — `MagicMock` spec'd to `ExecuteJob` for executor tests
 - `make_bus_service(**kw)`, `make_scheduler_service(**kw)` — service instances bypassing `Resource.__init__`
-- `make_watcher(hassette)`, `build_watcher_hassette(**kw)` — `ServiceWatcher` test setup
+- `make_watcher(hassette)`, `make_watcher_hassette(**kw)` — `ServiceWatcher` test setup
 - `make_blocking_io_hassette(**kw)` — minimal mock Hassette for watchdog and monkeypatch guard tests
 - `make_marker_executor(**kw)` — mock executor with `ExecutionMarker` on `current_execution`
 

--- a/tests/unit/core/conftest.py
+++ b/tests/unit/core/conftest.py
@@ -343,7 +343,7 @@ class TempService(Service):
             raise
 
 
-def build_watcher_hassette(*, strict_lifecycle: bool = False) -> AsyncMock:
+def make_watcher_hassette(*, strict_lifecycle: bool = False) -> AsyncMock:
     """Minimal Hassette stub for ServiceWatcher unit tests."""
     hassette = make_mock_hassette(
         sealed=False,

--- a/tests/unit/core/test_app_lifecycle_service.py
+++ b/tests/unit/core/test_app_lifecycle_service.py
@@ -135,7 +135,7 @@ class TestBootstrapAppsAdmission:
 
         lifecycle_service.start_apps.assert_awaited_once_with(admission_mode=AppAdmissionMode.WAIT_FOR_RELEASE)
         lifecycle_service.apply_changes.assert_awaited_once()
-        assert lifecycle_service._pending_pre_release_reconciliation is False
+        assert lifecycle_service._pending_reconciliation is None
 
     async def test_bootstrap_replays_deferred_reconciliation_when_no_manifests(
         self,
@@ -171,7 +171,7 @@ class TestBootstrapAppsAdmission:
 
         mock_hassette.app_bootstrap_coordinator.wait_released.assert_awaited_once()
         lifecycle_service.apply_changes.assert_awaited_once()
-        assert lifecycle_service._pending_pre_release_reconciliation is False
+        assert lifecycle_service._pending_reconciliation is None
 
 
 class TestAppLifecycleServiceProperties:

--- a/tests/unit/core/test_app_lifecycle_service.py
+++ b/tests/unit/core/test_app_lifecycle_service.py
@@ -127,7 +127,7 @@ class TestBootstrapAppsAdmission:
         lifecycle_service.apply_changes = AsyncMock()
         lifecycle_service._record_pre_release_reconciliation(
             original_apps_config={"old_app": original_manifest},
-            curr_apps_config={"app_a": manifest},
+            current_apps_config={"app_a": manifest},
             changed_file_paths=frozenset(),
         )
 
@@ -163,7 +163,7 @@ class TestBootstrapAppsAdmission:
         lifecycle_service.apply_changes = AsyncMock()
         lifecycle_service._record_pre_release_reconciliation(
             original_apps_config={"old_app": MagicMock()},
-            curr_apps_config={"app_a": MagicMock()},
+            current_apps_config={"app_a": MagicMock()},
             changed_file_paths=frozenset(),
         )
 

--- a/tests/unit/core/test_app_lifecycle_service_coverage.py
+++ b/tests/unit/core/test_app_lifecycle_service_coverage.py
@@ -209,6 +209,33 @@ class TestHandleChangeEventBranches:
         assert pending.changed_paths == frozenset({Path("/tmp/first.py"), Path("/tmp/second.py")})
         assert event_capture.by_topic(Topic.HASSETTE_EVENT_APP_LOAD_COMPLETED) == []
 
+    async def test_pre_release_second_change_with_unscoped_paths_degrades_scope_to_unknown(
+        self,
+        lifecycle_service: AppLifecycleService,
+        mock_hassette: MagicMock,
+    ) -> None:
+        """A second deferred change whose changed_file_paths is None can't be scoped, so the
+        queued paths degrade to None ("assume everything may have changed") instead of being
+        unioned -- the merged baseline still comes from the first (queue-opening) change.
+        """
+        mock_hassette.app_bootstrap_coordinator.is_released.return_value = False
+        lifecycle_service.change_detector.detect_changes = Mock(  # pyright: ignore[reportAttributeAccessIssue]
+            return_value=ChangeSet(
+                orphans=frozenset(), new_apps=frozenset({"my_app"}), reimport_apps=frozenset(), reload_apps=frozenset()
+            )
+        )
+        lifecycle_service.apply_changes = AsyncMock()
+
+        await lifecycle_service.handle_change_event(changed_file_paths=frozenset({Path("/tmp/first.py")}))
+        first_original_snapshot = lifecycle_service._pending_reconciliation.original_apps_config  # pyright: ignore[reportOptionalMemberAccess]
+
+        await lifecycle_service.handle_change_event(changed_file_paths=None)
+
+        pending = lifecycle_service._pending_reconciliation
+        assert pending is not None
+        assert pending.original_apps_config is first_original_snapshot
+        assert pending.changed_paths is None
+
     async def test_stale_pre_release_diff_is_merged_into_post_release_change(
         self,
         lifecycle_service: AppLifecycleService,
@@ -373,6 +400,19 @@ class TestReplayPreReleaseReconciliationSerialization:
         await asyncio.wait_for(task2, timeout=1.0)
 
         assert call_count == 2
+
+
+class TestTakePreReleaseReconciliation:
+    def test_returns_all_none_when_nothing_is_queued(self, lifecycle_service: AppLifecycleService) -> None:
+        """With no pending reconciliation, take() returns (None, None, None) rather than raising --
+        the caller-side null check this enables is what lets callers treat a fresh queue and an
+        emptied one identically.
+        """
+        assert lifecycle_service._pending_reconciliation is None
+
+        result = lifecycle_service._take_pre_release_reconciliation()
+
+        assert result == (None, None, None)
 
 
 class TestRefreshConfigFailure:

--- a/tests/unit/core/test_app_lifecycle_service_coverage.py
+++ b/tests/unit/core/test_app_lifecycle_service_coverage.py
@@ -13,7 +13,7 @@ from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, Mock, seal
 
 from hassette.core.app_change_detector import ChangeSet
-from hassette.core.app_lifecycle_service import AppAdmissionMode, AppLifecycleService
+from hassette.core.app_lifecycle_service import AppAdmissionMode, AppLifecycleService, PendingReconciliation
 from hassette.exceptions import InvalidInheritanceError, UndefinedUserConfigError
 from hassette.test_utils import EventCapture, wait_for
 from hassette.types import Topic
@@ -202,12 +202,11 @@ class TestHandleChangeEventBranches:
         await lifecycle_service.handle_change_event(changed_file_paths=frozenset({Path("/tmp/second.py")}))
 
         lifecycle_service.apply_changes.assert_not_called()
-        assert lifecycle_service._pending_pre_release_reconciliation is True
-        assert lifecycle_service._pending_pre_release_original_apps_config is not None
-        assert lifecycle_service._pending_pre_release_current_apps_config is not None
-        assert lifecycle_service._pending_pre_release_changed_paths == frozenset(
-            {Path("/tmp/first.py"), Path("/tmp/second.py")}
-        )
+        pending = lifecycle_service._pending_reconciliation
+        assert pending is not None
+        assert pending.original_apps_config is not None
+        assert pending.current_apps_config is not None
+        assert pending.changed_paths == frozenset({Path("/tmp/first.py"), Path("/tmp/second.py")})
         assert event_capture.by_topic(Topic.HASSETTE_EVENT_APP_LOAD_COMPLETED) == []
 
     async def test_stale_pre_release_diff_is_merged_into_post_release_change(
@@ -233,8 +232,9 @@ class TestHandleChangeEventBranches:
 
         await lifecycle_service.handle_change_event(changed_file_paths=frozenset({Path("/tmp/pre.py")}))
 
-        assert lifecycle_service._pending_pre_release_reconciliation is True
-        pending_original_snapshot = lifecycle_service._pending_pre_release_original_apps_config
+        pending = lifecycle_service._pending_reconciliation
+        assert pending is not None
+        pending_original_snapshot = pending.original_apps_config
         assert pending_original_snapshot is not None
 
         # Release opens; a newer post-release change arrives with its own fresh baseline.
@@ -263,7 +263,7 @@ class TestHandleChangeEventBranches:
         assert captured_calls[0][2] == frozenset({Path("/tmp/pre.py"), Path("/tmp/post.py")})
 
         # The queue is cleared so bootstrap's later replay can't re-apply this stale snapshot.
-        assert lifecycle_service._pending_pre_release_reconciliation is False
+        assert lifecycle_service._pending_reconciliation is None
         lifecycle_service.apply_changes.assert_awaited_once()
 
     async def test_concurrent_invocations_are_serialized_by_the_change_event_lock(
@@ -325,7 +325,7 @@ class TestReplayPreReleaseReconciliationSerialization:
         mock_hassette: MagicMock,
     ) -> None:
         """_replay_pre_release_reconciliation_if_needed() (called from bootstrap_apps()) reads and
-        clears the same _pending_pre_release_* state as handle_change_event(); both must serialize on
+        clears the same _pending_reconciliation state as handle_change_event(); both must serialize on
         _change_event_lock. Without that, a file-watcher event arriving while bootstrap is replaying
         could race the take/clear of that state.
         """
@@ -341,10 +341,11 @@ class TestReplayPreReleaseReconciliationSerialization:
                 first_entered.set()
                 await gate.wait()
 
-        lifecycle_service._pending_pre_release_reconciliation = True
-        lifecycle_service._pending_pre_release_original_apps_config = {}
-        lifecycle_service._pending_pre_release_current_apps_config = {}
-        lifecycle_service._pending_pre_release_changed_paths = None
+        lifecycle_service._pending_reconciliation = PendingReconciliation(
+            original_apps_config={},
+            current_apps_config={},
+            changed_paths=None,
+        )
 
         lifecycle_service.resolve_only_apps = gated_resolve_only_apps  # pyright: ignore[reportAttributeAccessIssue]
         lifecycle_service.refresh_config = AsyncMock(return_value=({}, {}))  # pyright: ignore[reportAttributeAccessIssue]
@@ -355,7 +356,7 @@ class TestReplayPreReleaseReconciliationSerialization:
 
         # The lock-holding take() already ran before the gated await, so the pending state is
         # already cleared even though task1 hasn't finished — proving the take happens inside the lock.
-        assert lifecycle_service._pending_pre_release_reconciliation is False
+        assert lifecycle_service._pending_reconciliation is None
 
         task2 = asyncio.create_task(lifecycle_service.handle_change_event())
         # Deterministically wait until task2 has actually queued on the lock (asyncio.Lock.acquire()

--- a/tests/unit/core/test_migration_runner.py
+++ b/tests/unit/core/test_migration_runner.py
@@ -21,32 +21,24 @@ from hassette.core.migration_runner import (
     run_migrations,
 )
 from hassette.test_utils.config import LATEST_MIGRATION_VERSION
+from hassette.test_utils.sql_helpers import insert_execution_row, sqlite_conn
 
 
 def _user_version(db_path: Path) -> int:
-    conn = sqlite3.connect(db_path)
-    try:
+    with sqlite_conn(db_path) as conn:
         return conn.execute("PRAGMA user_version").fetchone()[0]
-    finally:
-        conn.close()
 
 
 def tables(db_path: Path) -> set[str]:
-    conn = sqlite3.connect(db_path)
-    try:
+    with sqlite_conn(db_path) as conn:
         cursor = conn.execute("SELECT name FROM sqlite_master WHERE type='table'")
         return {row[0] for row in cursor.fetchall()}
-    finally:
-        conn.close()
 
 
 def columns(db_path: Path, table: str) -> set[str]:
-    conn = sqlite3.connect(db_path)
-    try:
+    with sqlite_conn(db_path) as conn:
         cursor = conn.execute(f"PRAGMA table_info({table})")
         return {row[1] for row in cursor.fetchall()}
-    finally:
-        conn.close()
 
 
 def test_collect_migrations_finds_sql_files(tmp_path: Path) -> None:
@@ -111,11 +103,8 @@ def test_set_auto_vacuum_sets_incremental(tmp_path: Path) -> None:
 
     _set_auto_vacuum(db_path)
 
-    conn = sqlite3.connect(db_path)
-    try:
+    with sqlite_conn(db_path) as conn:
         mode = conn.execute("PRAGMA auto_vacuum").fetchone()[0]
-    finally:
-        conn.close()
 
     assert mode == 2
 
@@ -130,11 +119,8 @@ def test_set_auto_vacuum_noop_if_already_incremental(tmp_path: Path) -> None:
     # Should not raise
     _set_auto_vacuum(db_path)
 
-    conn = sqlite3.connect(db_path)
-    try:
+    with sqlite_conn(db_path) as conn:
         mode = conn.execute("PRAGMA auto_vacuum").fetchone()[0]
-    finally:
-        conn.close()
 
     assert mode == 2
 
@@ -248,9 +234,7 @@ def test_kind_check_rejects_invalid_values(tmp_path: Path) -> None:
     db_path = tmp_path / "test.db"
     run_migrations(db_path)
 
-    conn = sqlite3.connect(db_path)
-    conn.execute("PRAGMA foreign_keys = ON")
-    try:
+    with sqlite_conn(db_path, foreign_keys=True) as conn:
         conn.execute("INSERT INTO sessions (started_at, last_heartbeat_at, status) VALUES (1.0, 1.0, 'running')")
         conn.execute(
             "INSERT INTO listeners (app_key, instance_index, name, handler_method, topic, source_location)"
@@ -259,22 +243,14 @@ def test_kind_check_rejects_invalid_values(tmp_path: Path) -> None:
         conn.commit()
 
         # Valid kind values must succeed
-        conn.execute(
-            "INSERT INTO executions "
-            "(kind, listener_id, session_id, execution_start_ts, duration_ms, status, source_tier) "
-            "VALUES ('handler', 1, 1, 1.0, 5.0, 'success', 'app')"
-        )
+        insert_execution_row(conn, kind="handler", listener_id=1, session_id=1, execution_start_ts=1.0, duration_ms=5.0)
         conn.commit()
 
         # Invalid kind must raise IntegrityError
         with pytest.raises(sqlite3.IntegrityError):
-            conn.execute(
-                "INSERT INTO executions "
-                "(kind, listener_id, session_id, execution_start_ts, duration_ms, status, source_tier) "
-                "VALUES ('invalid_kind', 1, 1, 2.0, 5.0, 'success', 'app')"
+            insert_execution_row(
+                conn, kind="invalid_kind", listener_id=1, session_id=1, execution_start_ts=2.0, duration_ms=5.0
             )
-    finally:
-        conn.close()
 
 
 def test_kind_check_accepts_job(tmp_path: Path) -> None:
@@ -282,9 +258,7 @@ def test_kind_check_accepts_job(tmp_path: Path) -> None:
     db_path = tmp_path / "test.db"
     run_migrations(db_path)
 
-    conn = sqlite3.connect(db_path)
-    conn.execute("PRAGMA foreign_keys = ON")
-    try:
+    with sqlite_conn(db_path, foreign_keys=True) as conn:
         conn.execute("INSERT INTO sessions (started_at, last_heartbeat_at, status) VALUES (1.0, 1.0, 'running')")
         conn.execute(
             "INSERT INTO scheduled_jobs "
@@ -293,17 +267,11 @@ def test_kind_check_accepts_job(tmp_path: Path) -> None:
         )
         conn.commit()
 
-        conn.execute(
-            "INSERT INTO executions "
-            "(kind, job_id, session_id, execution_start_ts, duration_ms, status, source_tier) "
-            "VALUES ('job', 1, 1, 1.0, 5.0, 'success', 'app')"
-        )
+        insert_execution_row(conn, kind="job", job_id=1, session_id=1, execution_start_ts=1.0, duration_ms=5.0)
         conn.commit()
 
         cursor = conn.execute("SELECT kind FROM executions WHERE id = 1")
         assert cursor.fetchone()[0] == "job"
-    finally:
-        conn.close()
 
 
 def test_fk_mutex_check_rejects_both_null(tmp_path: Path) -> None:
@@ -311,20 +279,20 @@ def test_fk_mutex_check_rejects_both_null(tmp_path: Path) -> None:
     db_path = tmp_path / "test.db"
     run_migrations(db_path)
 
-    conn = sqlite3.connect(db_path)
-    conn.execute("PRAGMA foreign_keys = ON")
-    try:
+    with sqlite_conn(db_path, foreign_keys=True) as conn:
         conn.execute("INSERT INTO sessions (started_at, last_heartbeat_at, status) VALUES (1.0, 1.0, 'running')")
         conn.commit()
 
         with pytest.raises(sqlite3.IntegrityError):
-            conn.execute(
-                "INSERT INTO executions "
-                "(kind, listener_id, job_id, session_id, execution_start_ts, duration_ms, status, source_tier) "
-                "VALUES ('handler', NULL, NULL, 1, 1.0, 5.0, 'success', 'app')"
+            insert_execution_row(
+                conn,
+                kind="handler",
+                listener_id=None,
+                job_id=None,
+                session_id=1,
+                execution_start_ts=1.0,
+                duration_ms=5.0,
             )
-    finally:
-        conn.close()
 
 
 def test_fk_mutex_check_rejects_both_set(tmp_path: Path) -> None:
@@ -332,9 +300,7 @@ def test_fk_mutex_check_rejects_both_set(tmp_path: Path) -> None:
     db_path = tmp_path / "test.db"
     run_migrations(db_path)
 
-    conn = sqlite3.connect(db_path)
-    conn.execute("PRAGMA foreign_keys = ON")
-    try:
+    with sqlite_conn(db_path, foreign_keys=True) as conn:
         conn.execute("INSERT INTO sessions (started_at, last_heartbeat_at, status) VALUES (1.0, 1.0, 'running')")
         conn.execute(
             "INSERT INTO listeners (app_key, instance_index, name, handler_method, topic, source_location)"
@@ -348,13 +314,9 @@ def test_fk_mutex_check_rejects_both_set(tmp_path: Path) -> None:
         conn.commit()
 
         with pytest.raises(sqlite3.IntegrityError):
-            conn.execute(
-                "INSERT INTO executions "
-                "(kind, listener_id, job_id, session_id, execution_start_ts, duration_ms, status, source_tier) "
-                "VALUES ('handler', 1, 1, 1, 1.0, 5.0, 'success', 'app')"
+            insert_execution_row(
+                conn, kind="handler", listener_id=1, job_id=1, session_id=1, execution_start_ts=1.0, duration_ms=5.0
             )
-    finally:
-        conn.close()
 
 
 def test_listeners_natural_key_unique_index(tmp_path: Path) -> None:
@@ -362,12 +324,9 @@ def test_listeners_natural_key_unique_index(tmp_path: Path) -> None:
     db_path = tmp_path / "test.db"
     run_migrations(db_path)
 
-    conn = sqlite3.connect(db_path)
-    try:
+    with sqlite_conn(db_path) as conn:
         cursor = conn.execute("SELECT sql FROM sqlite_master WHERE type='index' AND name='idx_listeners_natural'")
         row = cursor.fetchone()
-    finally:
-        conn.close()
 
     assert row is not None, "idx_listeners_natural index not found"
     index_sql = row[0].lower()

--- a/tests/unit/core/test_service_watcher_coverage.py
+++ b/tests/unit/core/test_service_watcher_coverage.py
@@ -21,7 +21,7 @@ from hassette.test_utils import make_mock_hassette, make_service_failed_event, m
 from hassette.types import ResourceStatus, Topic
 from hassette.types.enums import ResourceRole, RestartType
 
-from .conftest import DummyService, build_watcher_hassette, make_watcher
+from .conftest import DummyService, make_watcher, make_watcher_hassette
 
 
 class TestConfigLogLevel:
@@ -36,7 +36,7 @@ class TestConfigLogLevel:
 class TestOnInitialize:
     async def test_marks_ready_and_registers_listeners(self) -> None:
         """on_initialize() registers listeners then marks the watcher ready."""
-        hassette = build_watcher_hassette()
+        hassette = make_watcher_hassette()
         watcher = make_watcher(hassette)
 
         watcher.register_internal_event_listeners = AsyncMock()
@@ -52,7 +52,7 @@ class TestOnInitialize:
 class TestRegisterInternalEventListeners:
     async def test_registers_five_listeners_with_correct_status_filters(self) -> None:
         """Registers restart/shutdown/log/running/bus-recovery handlers on the correct statuses."""
-        hassette = build_watcher_hassette()
+        hassette = make_watcher_hassette()
         watcher = make_watcher(hassette)
 
         await watcher.register_internal_event_listeners()
@@ -92,7 +92,7 @@ class TestLogServiceEvent:
 
     async def test_skips_logging_when_status_unchanged(self) -> None:
         """No transition (status == previous_status) logs at debug without a transition message."""
-        hassette = build_watcher_hassette()
+        hassette = make_watcher_hassette()
         watcher = make_watcher(hassette)
         watcher.logger = Mock()
 
@@ -114,7 +114,7 @@ class TestLogServiceEvent:
 
     async def test_logs_transition_when_status_changed(self) -> None:
         """A real transition logs once at debug (the transition message)."""
-        hassette = build_watcher_hassette()
+        hassette = make_watcher_hassette()
         watcher = make_watcher(hassette)
         watcher.logger = Mock()
 
@@ -140,7 +140,7 @@ class TestLogServiceEvent:
 class TestOnBusServiceRunning:
     async def test_ignores_non_bus_service_events(self) -> None:
         """Events for a resource other than BusService do not trigger reconciliation."""
-        hassette = build_watcher_hassette()
+        hassette = make_watcher_hassette()
         watcher = make_watcher(hassette)
         watcher.reconcile_after_bus_recovery = AsyncMock()
 
@@ -153,7 +153,7 @@ class TestOnBusServiceRunning:
 
     async def test_triggers_reconciliation_for_bus_service(self) -> None:
         """A RUNNING event for BusService itself triggers the reconciliation scan."""
-        hassette = build_watcher_hassette()
+        hassette = make_watcher_hassette()
         watcher = make_watcher(hassette)
         watcher.reconcile_after_bus_recovery = AsyncMock()
 
@@ -175,7 +175,7 @@ class TestOnBusServiceRunning:
 class TestOnServiceRunningEarlyReturns:
     async def test_returns_early_when_no_budget_and_not_restarting(self) -> None:
         """A RUNNING event for a service with no budget entry and no in-progress restart is a no-op."""
-        hassette = build_watcher_hassette()
+        hassette = make_watcher_hassette()
         watcher = make_watcher(hassette)
         dummy = DummyService(hassette)
         hassette.children = [dummy]
@@ -191,7 +191,7 @@ class TestOnServiceRunningEarlyReturns:
 
     async def test_returns_early_when_service_not_found(self) -> None:
         """A RUNNING event for a service no longer present in hassette.children is a no-op."""
-        hassette = build_watcher_hassette()
+        hassette = make_watcher_hassette()
         watcher = make_watcher(hassette)
         dummy = DummyService(hassette)
         # Budget exists (so the first guard passes) but the service itself is gone.
@@ -208,7 +208,7 @@ class TestOnServiceRunningEarlyReturns:
 class TestCooldownAndRetry:
     async def test_aborts_without_restart_when_shutdown_requested(self) -> None:
         """cooldown_and_retry does not attempt a restart if shutdown fires during the cooldown sleep."""
-        hassette = build_watcher_hassette()
+        hassette = make_watcher_hassette()
         watcher = make_watcher(hassette)
         dummy = DummyService(hassette)
         hassette.children = [dummy]
@@ -228,7 +228,7 @@ class TestCooldownAndRetry:
 
     async def test_restart_exception_after_cooldown_is_caught(self) -> None:
         """A service.restart() failure after cooldown is logged, not propagated."""
-        hassette = build_watcher_hassette()
+        hassette = make_watcher_hassette()
         watcher = make_watcher(hassette)
         dummy = DummyService(hassette)
         hassette.children = [dummy]
@@ -246,7 +246,7 @@ class TestCooldownAndRetry:
 
     async def test_skips_restart_when_service_gone_after_cooldown(self) -> None:
         """If the service disappears during cooldown, restart is skipped without error."""
-        hassette = build_watcher_hassette()
+        hassette = make_watcher_hassette()
         watcher = make_watcher(hassette)
         hassette.children = []
 
@@ -259,7 +259,7 @@ class TestCooldownAndRetry:
 class TestGetService:
     def test_returns_the_matching_service(self) -> None:
         """get_service resolves a child by class_name/role."""
-        hassette = build_watcher_hassette()
+        hassette = make_watcher_hassette()
         watcher = make_watcher(hassette)
         dummy = DummyService(hassette)
         hassette.children = [dummy]
@@ -268,7 +268,7 @@ class TestGetService:
 
     def test_returns_none_when_no_match(self) -> None:
         """get_service returns None rather than an empty collection when nothing matches."""
-        hassette = build_watcher_hassette()
+        hassette = make_watcher_hassette()
         watcher = make_watcher(hassette)
         hassette.children = [DummyService(hassette)]
 
@@ -276,7 +276,7 @@ class TestGetService:
 
     def test_ignores_non_service_children(self) -> None:
         """A non-Service child sharing the name is not returned."""
-        hassette = build_watcher_hassette()
+        hassette = make_watcher_hassette()
         watcher = make_watcher(hassette)
         not_a_service = MagicMock()
         not_a_service.class_name = "DummyService"
@@ -289,7 +289,7 @@ class TestGetService:
 class TestRestartServiceNoServiceFound:
     async def test_returns_early_without_side_effects(self) -> None:
         """restart_service for a resource_name with no matching child is a no-op."""
-        hassette = build_watcher_hassette()
+        hassette = make_watcher_hassette()
         watcher = make_watcher(hassette)
         hassette.children = []
 
@@ -306,7 +306,7 @@ class TestRestartServiceNoServiceFound:
 class TestShutdownIfCrashed:
     async def test_reason_omits_exception_type_when_none(self) -> None:
         """When exception_type is falsy, the fatal reason has no ': <type>' suffix."""
-        hassette = build_watcher_hassette()
+        hassette = make_watcher_hassette()
         hassette.record_fatal_reason = Mock()
         watcher = make_watcher(hassette)
 
@@ -330,7 +330,7 @@ class TestShutdownIfCrashed:
 
     async def test_reraises_on_unexpected_internal_failure(self) -> None:
         """If record_fatal_reason itself raises, shutdown_if_crashed logs and re-raises."""
-        hassette = build_watcher_hassette()
+        hassette = make_watcher_hassette()
         hassette.record_fatal_reason = Mock(side_effect=RuntimeError("state corrupted"))
         watcher = make_watcher(hassette)
 
@@ -360,7 +360,7 @@ class TestOnServiceRunningBudgetNoneBranch:
         """A RUNNING event while restarting (but with no budget entry yet) clears the flag,
         without fabricating a budget.
         """
-        hassette = build_watcher_hassette()
+        hassette = make_watcher_hassette()
         watcher = make_watcher(hassette)
         dummy = DummyService(hassette)
         mark_ready(dummy, reason="test")
@@ -381,7 +381,7 @@ class TestOnServiceRunningBudgetNoneBranch:
 class TestReconcileAfterBusRecoverySkips:
     async def test_skips_non_service_children(self) -> None:
         """Non-Service children (e.g. plain resources) are ignored by the reconciliation scan."""
-        hassette = build_watcher_hassette()
+        hassette = make_watcher_hassette()
         watcher = make_watcher(hassette)
         watcher.restart_service = AsyncMock()
 
@@ -394,7 +394,7 @@ class TestReconcileAfterBusRecoverySkips:
 
     async def test_skips_services_not_in_failed_state(self) -> None:
         """Services that are not FAILED are left alone."""
-        hassette = build_watcher_hassette()
+        hassette = make_watcher_hassette()
         watcher = make_watcher(hassette)
         watcher.restart_service = AsyncMock()
 
@@ -408,7 +408,7 @@ class TestReconcileAfterBusRecoverySkips:
 
     async def test_skips_failed_services_with_existing_budget(self) -> None:
         """A FAILED service that already has a budget entry was handled normally — skip it."""
-        hassette = build_watcher_hassette()
+        hassette = make_watcher_hassette()
         watcher = make_watcher(hassette)
         watcher.restart_service = AsyncMock()
 

--- a/tests/unit/core/test_service_watcher_exhausted.py
+++ b/tests/unit/core/test_service_watcher_exhausted.py
@@ -15,7 +15,7 @@ from hassette.resources.service import Service
 from hassette.types import ResourceStatus
 from hassette.types.enums import ResourceRole, RestartType
 
-from .conftest import DummyService, TempService, build_watcher_hassette, make_watcher
+from .conftest import DummyService, TempService, make_watcher, make_watcher_hassette
 
 
 def make_failed_payload(service: Service) -> ServiceStatusPayload:
@@ -35,7 +35,7 @@ def make_failed_payload(service: Service) -> ServiceStatusPayload:
 
 async def test_exhausted_cooling_sets_status_on_instance():
     """TRANSIENT service: handle_exhaustion sets EXHAUSTED_COOLING on the service instance."""
-    hassette = build_watcher_hassette()
+    hassette = make_watcher_hassette()
     service = DummyService(hassette)
     service._status = ResourceStatus.FAILED
     hassette.children = [service]
@@ -73,7 +73,7 @@ async def test_exhausted_cooling_sets_status_on_instance():
 
 async def test_exhausted_dead_sets_status_on_instance():
     """TEMPORARY service: handle_exhaustion sets EXHAUSTED_DEAD on the service instance."""
-    hassette = build_watcher_hassette()
+    hassette = make_watcher_hassette()
     service = TempService(hassette)
     service._status = ResourceStatus.FAILED
     hassette.children = [service]
@@ -97,7 +97,7 @@ async def test_exhausted_dead_sets_status_on_instance():
 
 async def test_cooldown_exceeded_sets_exhausted_dead():
     """cooldown_and_retry transitions EXHAUSTED_COOLING → EXHAUSTED_DEAD when max_cooldown_cycles exceeded."""
-    hassette = build_watcher_hassette()
+    hassette = make_watcher_hassette()
     service = DummyService(hassette)
     service._status = ResourceStatus.EXHAUSTED_COOLING
     hassette.children = [service]
@@ -126,7 +126,7 @@ async def test_cooldown_exceeded_sets_exhausted_dead():
 
 async def test_exhausted_status_skipped_when_service_not_found():
     """When get_service returns None, status set is skipped — no exception, event still emitted."""
-    hassette = build_watcher_hassette()
+    hassette = make_watcher_hassette()
     hassette.children = []
 
     watcher = make_watcher(hassette)

--- a/tests/unit/core/test_telemetry_repository.py
+++ b/tests/unit/core/test_telemetry_repository.py
@@ -9,6 +9,7 @@ from hassette.core.execution_record import ExecutionRecord
 from hassette.core.telemetry.repository import TelemetryRepository
 from hassette.test_utils.config import DEFAULT_TEST_APP_KEY
 from hassette.test_utils.factories import make_job_registration, make_listener_registration
+from hassette.test_utils.sql_helpers import insert_execution_row
 
 ONCE_LISTENER_NAME = "test_app.on_event.once"
 
@@ -163,15 +164,21 @@ async def test_reconcile_retires_stale_with_history(
     job_id = await telemetry_repo.register_job(make_job_registration())
 
     # Create history in the unified executions table
-    await telemetry_db.execute(
-        "INSERT INTO executions (kind, listener_id, session_id, execution_start_ts, duration_ms, status)"
-        " VALUES ('handler', ?, ?, ?, ?, ?)",
-        (listener_id, telemetry_session_id, time.time(), 1.0, "success"),
+    await insert_execution_row(
+        telemetry_db,
+        kind="handler",
+        listener_id=listener_id,
+        session_id=telemetry_session_id,
+        execution_start_ts=time.time(),
+        duration_ms=1.0,
     )
-    await telemetry_db.execute(
-        "INSERT INTO executions (kind, job_id, session_id, execution_start_ts, duration_ms, status)"
-        " VALUES ('job', ?, ?, ?, ?, ?)",
-        (job_id, telemetry_session_id, time.time(), 1.0, "success"),
+    await insert_execution_row(
+        telemetry_db,
+        kind="job",
+        job_id=job_id,
+        session_id=telemetry_session_id,
+        execution_start_ts=time.time(),
+        duration_ms=1.0,
     )
     await telemetry_db.commit()
 
@@ -244,10 +251,13 @@ async def test_reconcile_preserves_once_true_with_current_executions(
     once_id = await telemetry_repo.register_listener(once_reg)
 
     # Create an execution in the CURRENT session
-    await telemetry_db.execute(
-        "INSERT INTO executions (kind, listener_id, session_id, execution_start_ts, duration_ms, status)"
-        " VALUES ('handler', ?, ?, ?, ?, ?)",
-        (once_id, telemetry_session_id, time.time(), 1.0, "success"),
+    await insert_execution_row(
+        telemetry_db,
+        kind="handler",
+        listener_id=once_id,
+        session_id=telemetry_session_id,
+        execution_start_ts=time.time(),
+        duration_ms=1.0,
     )
     await telemetry_db.commit()
 
@@ -275,10 +285,13 @@ async def test_reconcile_resets_retired_at_on_reupsert(
     listener_id = await telemetry_repo.register_listener(reg)
 
     # Create history so reconciliation retires rather than deletes
-    await telemetry_db.execute(
-        "INSERT INTO executions (kind, listener_id, session_id, execution_start_ts, duration_ms, status)"
-        " VALUES ('handler', ?, ?, ?, ?, ?)",
-        (listener_id, telemetry_session_id, time.time(), 1.0, "success"),
+    await insert_execution_row(
+        telemetry_db,
+        kind="handler",
+        listener_id=listener_id,
+        session_id=telemetry_session_id,
+        execution_start_ts=time.time(),
+        duration_ms=1.0,
     )
     await telemetry_db.commit()
 
@@ -586,10 +599,13 @@ async def test_reconcile_retires_stale_job_with_history_non_empty_live_set(
     job_id_a = await telemetry_repo.register_job(make_job_registration(job_name="job_a"))
     job_id_b = await telemetry_repo.register_job(make_job_registration(job_name="job_b"))
 
-    await telemetry_db.execute(
-        "INSERT INTO executions (kind, job_id, session_id, execution_start_ts, duration_ms, status)"
-        " VALUES ('job', ?, ?, ?, ?, ?)",
-        (job_id_b, telemetry_session_id, time.time(), 1.0, "success"),
+    await insert_execution_row(
+        telemetry_db,
+        kind="job",
+        job_id=job_id_b,
+        session_id=telemetry_session_id,
+        execution_start_ts=time.time(),
+        duration_ms=1.0,
     )
     await telemetry_db.commit()
 

--- a/tests/unit/core/test_websocket_readiness_events.py
+++ b/tests/unit/core/test_websocket_readiness_events.py
@@ -6,7 +6,6 @@ in the serve() reconnect paths.
 
 import asyncio
 import time
-import typing
 from unittest.mock import AsyncMock, Mock
 
 import pytest
@@ -14,7 +13,7 @@ import pytest
 from hassette.core.websocket_service import WebsocketService
 from hassette.exceptions import RetryableConnectionClosedError
 from hassette.resources.lifecycle import mark_ready
-from hassette.test_utils import EventCapture, make_ws_hassette_stub
+from hassette.test_utils import EventCapture, make_task_bucket_spawn_stub, make_ws_hassette_stub
 from hassette.types import Topic
 from hassette.types.enums import ConnectionState
 
@@ -24,26 +23,6 @@ async def websocket_service() -> WebsocketService:
     """Create a WebsocketService with a fully-mocked hassette stub."""
     hassette = make_ws_hassette_stub(sealed=False)
     return WebsocketService(hassette=hassette)
-
-
-def make_task_bucket_spawn_stub() -> tuple[list[typing.Coroutine], Mock]:
-    """Build a ``task_bucket.spawn`` stub that records coroutines without running them.
-
-    Returns the list that gets populated with each spawned coroutine (callers close()
-    them after the test to suppress ResourceWarning) and the ``Mock`` to assign as
-    ``websocket_service.task_bucket.spawn``.
-    """
-    spawned_coros: list[typing.Coroutine] = []
-
-    def _spawn_side_effect(coro, *, name=None):  # noqa: ARG001
-        spawned_coros.append(coro)
-
-        async def _noop():
-            pass
-
-        return asyncio.create_task(_noop())
-
-    return spawned_coros, Mock(side_effect=_spawn_side_effect)
 
 
 class TestWebsocketReadinessEvents:

--- a/tests/unit/core/test_ws_connection_state.py
+++ b/tests/unit/core/test_ws_connection_state.py
@@ -15,6 +15,11 @@ from hassette.core.websocket_service import WebsocketService
 from hassette.exceptions import InvalidAuthError, InvalidLifecycleTransitionError, RetryableConnectionClosedError
 from hassette.resources.lifecycle import mark_ready
 from hassette.test_utils import make_ws_hassette_stub
+from hassette.test_utils.config import (
+    TEST_EARLY_DROP_BACKOFF_INITIAL_SECONDS,
+    TEST_EARLY_DROP_BACKOFF_MAX_SECONDS,
+    TEST_EARLY_DROP_STABLE_WINDOW_SECONDS,
+)
 from hassette.types.enums import ConnectionState
 
 
@@ -314,10 +319,14 @@ class TestMaxRetriesDisconnects:
 
         websocket_service.make_connection = fake_make_connection  # pyright: ignore[reportAttributeAccessIssue]
         websocket_service.partial_cleanup = AsyncMock()  # pyright: ignore[reportAttributeAccessIssue]
-        websocket_service.hassette.config.websocket.early_drop_max_retries = 1
-        websocket_service.hassette.config.websocket.early_drop_stable_window_seconds = 30.0
-        websocket_service.hassette.config.websocket.early_drop_backoff_initial_seconds = 0.001
-        websocket_service.hassette.config.websocket.early_drop_backoff_max_seconds = 0.01
+        # max_retries=1 is specific to this test (proves DISCONNECTED after budget exhaustion);
+        # the other three values match the shared defaults used across the early-drop test
+        # suite (tests/integration/test_websocket_service.py).
+        ws_config = websocket_service.hassette.config.websocket
+        ws_config.early_drop_max_retries = 1
+        ws_config.early_drop_stable_window_seconds = TEST_EARLY_DROP_STABLE_WINDOW_SECONDS
+        ws_config.early_drop_backoff_initial_seconds = TEST_EARLY_DROP_BACKOFF_INITIAL_SECONDS
+        ws_config.early_drop_backoff_max_seconds = TEST_EARLY_DROP_BACKOFF_MAX_SECONDS
 
         with pytest.raises(RetryableConnectionClosedError):
             await websocket_service.serve()

--- a/tests/unit/test_migration_002.py
+++ b/tests/unit/test_migration_002.py
@@ -10,6 +10,7 @@ from pathlib import Path
 import pytest
 
 from hassette.core.migration_runner import run_migrations
+from hassette.test_utils.sql_helpers import sqlite_conn
 
 
 class TestScheduledJobsSchema:
@@ -18,22 +19,18 @@ class TestScheduledJobsSchema:
         db_path = tmp_path / "test.db"
         run_migrations(db_path)
 
-        conn = sqlite3.connect(db_path)
-        try:
+        with sqlite_conn(db_path) as conn:
             cursor = conn.execute("PRAGMA table_info(scheduled_jobs)")
             columns = {row[1] for row in cursor.fetchall()}
             assert "trigger_label" in columns, "trigger_label column missing from scheduled_jobs"
             assert "trigger_detail" in columns, "trigger_detail column missing from scheduled_jobs"
-        finally:
-            conn.close()
 
     def test_insert_with_known_trigger_type_succeeds(self, tmp_path: Path) -> None:
         """INSERT with a known trigger_type value must succeed."""
         db_path = tmp_path / "test.db"
         run_migrations(db_path)
 
-        conn = sqlite3.connect(db_path)
-        try:
+        with sqlite_conn(db_path) as conn:
             conn.execute(
                 """
                 INSERT INTO scheduled_jobs (
@@ -54,40 +51,33 @@ class TestScheduledJobsSchema:
             assert row is not None
             assert row[0] == "once"
             assert row[1] is None
-        finally:
-            conn.close()
 
     def test_rejects_unknown_trigger_type(self, tmp_path: Path) -> None:
         """CHECK constraint on trigger_type rejects unknown values."""
         db_path = tmp_path / "test.db"
         run_migrations(db_path)
 
-        conn = sqlite3.connect(db_path)
-        try:
-            with pytest.raises(sqlite3.IntegrityError):
-                conn.execute(
-                    """
-                    INSERT INTO scheduled_jobs (
-                        app_key, instance_index, job_name, handler_method,
-                        trigger_type, trigger_label,
-                        args_json, kwargs_json, source_location, source_tier, schedule_status
-                    ) VALUES (
-                        'my_app', 0, 'bad_job', 'my_app.MyApp.my_handler',
-                        'unknown_type', '',
-                        '[]', '{}', 'app.py:10', 'app', 'scheduled'
-                    )
-                    """
+        with sqlite_conn(db_path) as conn, pytest.raises(sqlite3.IntegrityError):
+            conn.execute(
+                """
+                INSERT INTO scheduled_jobs (
+                    app_key, instance_index, job_name, handler_method,
+                    trigger_type, trigger_label,
+                    args_json, kwargs_json, source_location, source_tier, schedule_status
+                ) VALUES (
+                    'my_app', 0, 'bad_job', 'my_app.MyApp.my_handler',
+                    'unknown_type', '',
+                    '[]', '{}', 'app.py:10', 'app', 'scheduled'
                 )
-        finally:
-            conn.close()
+                """
+            )
 
     def test_trigger_label_defaults_to_empty_string(self, tmp_path: Path) -> None:
         """trigger_label defaults to empty string when not supplied explicitly."""
         db_path = tmp_path / "test.db"
         run_migrations(db_path)
 
-        conn = sqlite3.connect(db_path)
-        try:
+        with sqlite_conn(db_path) as conn:
             conn.execute(
                 """
                 INSERT INTO scheduled_jobs (
@@ -105,5 +95,3 @@ class TestScheduledJobsSchema:
             row = cursor.fetchone()
             assert row is not None
             assert row[0] == ""
-        finally:
-            conn.close()

--- a/tests/unit/test_migration_012.py
+++ b/tests/unit/test_migration_012.py
@@ -12,6 +12,7 @@ import pytest
 
 from hassette.core.migration_runner import run_migrations
 from hassette.test_utils.config import TEST_SOURCE_LOCATION
+from hassette.test_utils.sql_helpers import insert_execution_row, sqlite_conn
 
 
 def _pre_migration_db(tmp_path: Path) -> Path:
@@ -19,8 +20,7 @@ def _pre_migration_db(tmp_path: Path) -> Path:
     db_path = tmp_path / "test.db"
     run_migrations(db_path, target=11)
 
-    conn = sqlite3.connect(db_path)
-    try:
+    with sqlite_conn(db_path) as conn:
         conn.execute("INSERT INTO sessions (started_at, last_heartbeat_at, status) VALUES (1.0, 1.0, 'running')")
         conn.execute(
             "INSERT INTO listeners (app_key, instance_index, name, handler_method, topic, source_location) "
@@ -33,18 +33,9 @@ def _pre_migration_db(tmp_path: Path) -> Path:
             (TEST_SOURCE_LOCATION,),
         )
         conn.commit()
-        conn.execute(
-            "INSERT INTO executions (kind, job_id, session_id, execution_start_ts, duration_ms, status, source_tier) "
-            "VALUES ('job', 1, 1, 1.0, 5.0, 'success', 'app')"
-        )
-        conn.execute(
-            "INSERT INTO executions "
-            "(kind, listener_id, session_id, execution_start_ts, duration_ms, status, source_tier) "
-            "VALUES ('handler', 1, 1, 2.0, 3.0, 'success', 'app')"
-        )
+        insert_execution_row(conn, kind="job", job_id=1, session_id=1, execution_start_ts=1.0, duration_ms=5.0)
+        insert_execution_row(conn, kind="handler", listener_id=1, session_id=1, execution_start_ts=2.0, duration_ms=3.0)
         conn.commit()
-    finally:
-        conn.close()
 
     return db_path
 
@@ -55,41 +46,31 @@ class TestIdPreservationAndForeignKeys:
         db_path = _pre_migration_db(tmp_path)
         run_migrations(db_path)
 
-        conn = sqlite3.connect(db_path)
-        conn.execute("PRAGMA foreign_keys = ON")
-        try:
+        with sqlite_conn(db_path, foreign_keys=True) as conn:
             violations = conn.execute("PRAGMA foreign_key_check").fetchall()
             assert violations == [], f"Unexpected FK violations after migration 012: {violations}"
-        finally:
-            conn.close()
 
     def test_executions_job_id_still_resolves(self, tmp_path: Path) -> None:
         """executions.job_id inserted before the migration still resolves to the same job row."""
         db_path = _pre_migration_db(tmp_path)
         run_migrations(db_path)
 
-        conn = sqlite3.connect(db_path)
-        try:
+        with sqlite_conn(db_path) as conn:
             row = conn.execute(
                 "SELECT sj.job_name FROM executions e JOIN scheduled_jobs sj ON sj.id = e.job_id WHERE e.kind = 'job'"
             ).fetchone()
             assert row == ("my_job",), "executions.job_id no longer resolves to the pre-migration job row"
-        finally:
-            conn.close()
 
     def test_executions_listener_id_still_resolves(self, tmp_path: Path) -> None:
         """executions.listener_id inserted before the migration still resolves after the listeners rename."""
         db_path = _pre_migration_db(tmp_path)
         run_migrations(db_path)
 
-        conn = sqlite3.connect(db_path)
-        try:
+        with sqlite_conn(db_path) as conn:
             row = conn.execute(
                 "SELECT l.name FROM executions e JOIN listeners l ON l.id = e.listener_id WHERE e.kind = 'handler'"
             ).fetchone()
             assert row == ("my_listener",)
-        finally:
-            conn.close()
 
 
 class TestRemovedAtRename:
@@ -97,50 +78,38 @@ class TestRemovedAtRename:
         db_path = _pre_migration_db(tmp_path)
         run_migrations(db_path)
 
-        conn = sqlite3.connect(db_path)
-        try:
+        with sqlite_conn(db_path) as conn:
             cols = {row[1] for row in conn.execute("PRAGMA table_info(scheduled_jobs)")}
             assert "removed_at" in cols
             assert "cancelled_at" not in cols
-        finally:
-            conn.close()
 
     def test_listeners_has_removed_at_not_cancelled_at(self, tmp_path: Path) -> None:
         db_path = _pre_migration_db(tmp_path)
         run_migrations(db_path)
 
-        conn = sqlite3.connect(db_path)
-        try:
+        with sqlite_conn(db_path) as conn:
             cols = {row[1] for row in conn.execute("PRAGMA table_info(listeners)")}
             assert "removed_at" in cols
             assert "cancelled_at" not in cols
-        finally:
-            conn.close()
 
     def test_cancelled_at_timestamp_preserved_as_removed_at(self, tmp_path: Path) -> None:
         """A cancelled_at value written before the migration survives as removed_at."""
         db_path = _pre_migration_db(tmp_path)
 
-        conn = sqlite3.connect(db_path)
-        try:
+        with sqlite_conn(db_path) as conn:
             conn.execute("UPDATE scheduled_jobs SET cancelled_at = 999.5 WHERE job_name = 'my_job'")
             conn.execute("UPDATE listeners SET cancelled_at = 888.5 WHERE name = 'my_listener'")
             conn.commit()
-        finally:
-            conn.close()
 
         run_migrations(db_path)
 
-        conn = sqlite3.connect(db_path)
-        try:
+        with sqlite_conn(db_path) as conn:
             job_removed_at = conn.execute("SELECT removed_at FROM scheduled_jobs WHERE job_name = 'my_job'").fetchone()[
                 0
             ]
             listener_removed_at = conn.execute(
                 "SELECT removed_at FROM listeners WHERE name = 'my_listener'"
             ).fetchone()[0]
-        finally:
-            conn.close()
 
         assert job_removed_at == 999.5
         assert listener_removed_at == 888.5
@@ -151,13 +120,10 @@ class TestLegacyBackfill:
         db_path = _pre_migration_db(tmp_path)
         run_migrations(db_path)
 
-        conn = sqlite3.connect(db_path)
-        try:
+        with sqlite_conn(db_path) as conn:
             row = conn.execute(
                 "SELECT schedule_status, schedule_status_reason FROM scheduled_jobs WHERE job_name = 'my_job'"
             ).fetchone()
-        finally:
-            conn.close()
 
         assert row == ("scheduled", "legacy_unknown")
 
@@ -166,21 +132,15 @@ class TestRemovedRowsExcludedFromActiveViews:
     def test_removed_legacy_row_excluded_from_active_scheduled_jobs(self, tmp_path: Path) -> None:
         db_path = _pre_migration_db(tmp_path)
 
-        conn = sqlite3.connect(db_path)
-        try:
+        with sqlite_conn(db_path) as conn:
             conn.execute("UPDATE scheduled_jobs SET cancelled_at = 500.0 WHERE job_name = 'my_job'")
             conn.commit()
-        finally:
-            conn.close()
 
         run_migrations(db_path)
 
-        conn = sqlite3.connect(db_path)
-        try:
+        with sqlite_conn(db_path) as conn:
             active = conn.execute("SELECT * FROM active_scheduled_jobs").fetchall()
             active_app = conn.execute("SELECT * FROM active_app_scheduled_jobs").fetchall()
-        finally:
-            conn.close()
 
         assert active == []
         assert active_app == []
@@ -188,21 +148,15 @@ class TestRemovedRowsExcludedFromActiveViews:
     def test_removed_listener_excluded_from_active_listeners(self, tmp_path: Path) -> None:
         db_path = _pre_migration_db(tmp_path)
 
-        conn = sqlite3.connect(db_path)
-        try:
+        with sqlite_conn(db_path) as conn:
             conn.execute("UPDATE listeners SET cancelled_at = 500.0 WHERE name = 'my_listener'")
             conn.commit()
-        finally:
-            conn.close()
 
         run_migrations(db_path)
 
-        conn = sqlite3.connect(db_path)
-        try:
+        with sqlite_conn(db_path) as conn:
             active = conn.execute("SELECT * FROM active_listeners").fetchall()
             active_app = conn.execute("SELECT * FROM active_app_listeners").fetchall()
-        finally:
-            conn.close()
 
         assert active == []
         assert active_app == []
@@ -212,12 +166,9 @@ class TestRemovedRowsExcludedFromActiveViews:
         db_path = _pre_migration_db(tmp_path)
         run_migrations(db_path)
 
-        conn = sqlite3.connect(db_path)
-        try:
+        with sqlite_conn(db_path) as conn:
             active_jobs = conn.execute("SELECT job_name FROM active_scheduled_jobs").fetchall()
             active_listeners = conn.execute("SELECT name FROM active_listeners").fetchall()
-        finally:
-            conn.close()
 
         assert active_jobs == [("my_job",)]
         assert active_listeners == [("my_listener",)]
@@ -231,8 +182,7 @@ class TestReRegistrationClearsLegacyUnknown:
         db_path = _pre_migration_db(tmp_path)
         run_migrations(db_path)
 
-        conn = sqlite3.connect(db_path)
-        try:
+        with sqlite_conn(db_path) as conn:
             before = conn.execute(
                 "SELECT schedule_status, schedule_status_reason FROM scheduled_jobs WHERE job_name = 'my_job'"
             ).fetchone()
@@ -261,8 +211,6 @@ class TestReRegistrationClearsLegacyUnknown:
             after = conn.execute(
                 "SELECT schedule_status, schedule_status_reason FROM scheduled_jobs WHERE job_name = 'my_job'"
             ).fetchone()
-        finally:
-            conn.close()
 
         assert after == ("manual", None)
 
@@ -272,42 +220,33 @@ class TestCheckConstraints:
         db_path = _pre_migration_db(tmp_path)
         run_migrations(db_path)
 
-        conn = sqlite3.connect(db_path)
-        try:
-            with pytest.raises(sqlite3.IntegrityError):
-                conn.execute(
-                    "INSERT INTO scheduled_jobs "
-                    "(app_key, instance_index, job_name, handler_method, source_location, schedule_status) "
-                    "VALUES ('my_app', 0, 'bad_status_job', 'do_thing', ?, 'not_a_real_status')",
-                    (TEST_SOURCE_LOCATION,),
-                )
-        finally:
-            conn.close()
+        with sqlite_conn(db_path) as conn, pytest.raises(sqlite3.IntegrityError):
+            conn.execute(
+                "INSERT INTO scheduled_jobs "
+                "(app_key, instance_index, job_name, handler_method, source_location, schedule_status) "
+                "VALUES ('my_app', 0, 'bad_status_job', 'do_thing', ?, 'not_a_real_status')",
+                (TEST_SOURCE_LOCATION,),
+            )
 
     def test_rejects_invalid_schedule_status_reason(self, tmp_path: Path) -> None:
         db_path = _pre_migration_db(tmp_path)
         run_migrations(db_path)
 
-        conn = sqlite3.connect(db_path)
-        try:
-            with pytest.raises(sqlite3.IntegrityError):
-                conn.execute(
-                    "INSERT INTO scheduled_jobs "
-                    "(app_key, instance_index, job_name, handler_method, source_location, "
-                    "schedule_status, schedule_status_reason) "
-                    "VALUES ('my_app', 0, 'bad_reason_job', 'do_thing', ?, 'scheduled', 'not_a_real_reason')",
-                    (TEST_SOURCE_LOCATION,),
-                )
-        finally:
-            conn.close()
+        with sqlite_conn(db_path) as conn, pytest.raises(sqlite3.IntegrityError):
+            conn.execute(
+                "INSERT INTO scheduled_jobs "
+                "(app_key, instance_index, job_name, handler_method, source_location, "
+                "schedule_status, schedule_status_reason) "
+                "VALUES ('my_app', 0, 'bad_reason_job', 'do_thing', ?, 'scheduled', 'not_a_real_reason')",
+                (TEST_SOURCE_LOCATION,),
+            )
 
     def test_null_schedule_status_reason_is_accepted(self, tmp_path: Path) -> None:
         """schedule_status_reason is nullable -- a fresh manual registration has no reason."""
         db_path = _pre_migration_db(tmp_path)
         run_migrations(db_path)
 
-        conn = sqlite3.connect(db_path)
-        try:
+        with sqlite_conn(db_path) as conn:
             conn.execute(
                 "INSERT INTO scheduled_jobs "
                 "(app_key, instance_index, job_name, handler_method, source_location, "
@@ -319,8 +258,6 @@ class TestCheckConstraints:
             row = conn.execute(
                 "SELECT schedule_status_reason FROM scheduled_jobs WHERE job_name = 'clean_job'"
             ).fetchone()
-        finally:
-            conn.close()
 
         assert row == (None,)
 
@@ -329,16 +266,12 @@ class TestCheckConstraints:
         db_path = _pre_migration_db(tmp_path)
         run_migrations(db_path)
 
-        conn = sqlite3.connect(db_path)
-        try:
-            with pytest.raises(sqlite3.IntegrityError):
-                conn.execute(
-                    "INSERT INTO scheduled_jobs (app_key, instance_index, job_name, handler_method, source_location) "
-                    "VALUES ('my_app', 0, 'no_status_job', 'do_thing', ?)",
-                    (TEST_SOURCE_LOCATION,),
-                )
-        finally:
-            conn.close()
+        with sqlite_conn(db_path) as conn, pytest.raises(sqlite3.IntegrityError):
+            conn.execute(
+                "INSERT INTO scheduled_jobs (app_key, instance_index, job_name, handler_method, source_location) "
+                "VALUES ('my_app', 0, 'no_status_job', 'do_thing', ?)",
+                (TEST_SOURCE_LOCATION,),
+            )
 
 
 class TestManualTriggerType:
@@ -346,8 +279,7 @@ class TestManualTriggerType:
         db_path = _pre_migration_db(tmp_path)
         run_migrations(db_path)
 
-        conn = sqlite3.connect(db_path)
-        try:
+        with sqlite_conn(db_path) as conn:
             conn.execute(
                 "INSERT INTO scheduled_jobs "
                 "(app_key, instance_index, job_name, handler_method, source_location, "
@@ -359,8 +291,6 @@ class TestManualTriggerType:
             row = conn.execute(
                 "SELECT trigger_type, schedule_status FROM scheduled_jobs WHERE job_name = 'manual_job'"
             ).fetchone()
-        finally:
-            conn.close()
 
         assert row == ("manual", "manual")
 
@@ -369,8 +299,7 @@ class TestManualTriggerType:
         db_path = _pre_migration_db(tmp_path)
         run_migrations(db_path)
 
-        conn = sqlite3.connect(db_path)
-        try:
+        with sqlite_conn(db_path) as conn:
             for trigger_type in ("interval", "cron", "once", "after", "custom"):
                 conn.execute(
                     "INSERT INTO scheduled_jobs "
@@ -380,5 +309,3 @@ class TestManualTriggerType:
                     (f"job_{trigger_type}", TEST_SOURCE_LOCATION, trigger_type),
                 )
             conn.commit()
-        finally:
-            conn.close()

--- a/tests/unit/test_schema_migration.py
+++ b/tests/unit/test_schema_migration.py
@@ -12,6 +12,7 @@ from hassette.config.config import HassetteConfig
 from hassette.core.database_service import DatabaseService
 from hassette.core.migration_runner import run_migrations
 from hassette.test_utils.config import LATEST_MIGRATION_VERSION, TEST_TOKEN
+from hassette.test_utils.sql_helpers import insert_execution_row, sqlite_conn
 from hassette.types.types import SourceTier
 
 
@@ -28,12 +29,9 @@ class TestFreshMigration:
         db_path = tmp_path / "test.db"
         run_migrations(db_path)
 
-        conn = sqlite3.connect(db_path)
-        try:
+        with sqlite_conn(db_path) as conn:
             cursor = conn.execute("SELECT name FROM sqlite_master WHERE type='table' ORDER BY name")
             tables = {row[0] for row in cursor.fetchall()}
-        finally:
-            conn.close()
 
         expected = {"sessions", "listeners", "scheduled_jobs", "executions", "log_records"}
         assert expected.issubset(tables)
@@ -43,49 +41,38 @@ class TestFreshMigration:
         db_path = tmp_path / "test.db"
         run_migrations(db_path)
 
-        conn = sqlite3.connect(db_path)
-        try:
+        with sqlite_conn(db_path) as conn:
             for table in ("listeners", "scheduled_jobs", "executions"):
                 cursor = conn.execute(f"PRAGMA table_info({table})")
                 cols = {row[1] for row in cursor.fetchall()}
                 assert "source_tier" in cols, f"source_tier missing from {table}"
-        finally:
-            conn.close()
 
     def test_executions_has_kind_column(self, tmp_path: Path) -> None:
         """Executions table has kind column."""
         db_path = tmp_path / "test.db"
         run_migrations(db_path)
 
-        conn = sqlite3.connect(db_path)
-        try:
+        with sqlite_conn(db_path) as conn:
             cursor = conn.execute("PRAGMA table_info(executions)")
             cols = {row[1] for row in cursor.fetchall()}
             assert "kind" in cols
-        finally:
-            conn.close()
 
     def test_executions_has_is_di_failure(self, tmp_path: Path) -> None:
         """Executions table has is_di_failure column."""
         db_path = tmp_path / "test.db"
         run_migrations(db_path)
 
-        conn = sqlite3.connect(db_path)
-        try:
+        with sqlite_conn(db_path) as conn:
             cursor = conn.execute("PRAGMA table_info(executions)")
             cols = {row[1] for row in cursor.fetchall()}
             assert "is_di_failure" in cols
-        finally:
-            conn.close()
 
     def test_check_constraints_reject_invalid_status(self, tmp_path: Path) -> None:
         """Executions with invalid status raises IntegrityError."""
         db_path = tmp_path / "test.db"
         run_migrations(db_path)
 
-        conn = sqlite3.connect(db_path)
-        conn.execute("PRAGMA foreign_keys = ON")
-        try:
+        with sqlite_conn(db_path, foreign_keys=True) as conn:
             conn.execute("INSERT INTO sessions (started_at, last_heartbeat_at, status) VALUES (1.0, 1.0, 'running')")
             conn.execute(
                 "INSERT INTO listeners (app_key, instance_index, name, handler_method, topic, source_location)"
@@ -93,22 +80,22 @@ class TestFreshMigration:
             )
             conn.commit()
             with pytest.raises(sqlite3.IntegrityError):
-                conn.execute(
-                    "INSERT INTO executions "
-                    "(kind, listener_id, session_id, execution_start_ts, duration_ms, status, source_tier) "
-                    "VALUES ('handler', 1, 1, 1.0, 10.0, 'invalid', 'app')"
+                insert_execution_row(
+                    conn,
+                    kind="handler",
+                    listener_id=1,
+                    session_id=1,
+                    execution_start_ts=1.0,
+                    duration_ms=10.0,
+                    status="invalid",
                 )
-        finally:
-            conn.close()
 
     def test_check_constraints_accept_skipped_status(self, tmp_path: Path) -> None:
         """Executions with status='skipped' is accepted by the CHECK constraint (added in 009.sql)."""
         db_path = tmp_path / "test.db"
         run_migrations(db_path)
 
-        conn = sqlite3.connect(db_path)
-        conn.execute("PRAGMA foreign_keys = ON")
-        try:
+        with sqlite_conn(db_path, foreign_keys=True) as conn:
             conn.execute("INSERT INTO sessions (started_at, last_heartbeat_at, status) VALUES (1.0, 1.0, 'running')")
             conn.execute(
                 "INSERT INTO scheduled_jobs "
@@ -116,25 +103,19 @@ class TestFreshMigration:
                 " VALUES ('app', 0, 'my_job', 'do_thing', 'app.py:1', 'scheduled')"
             )
             conn.commit()
-            conn.execute(
-                "INSERT INTO executions "
-                "(kind, job_id, session_id, execution_start_ts, duration_ms, status, source_tier) "
-                "VALUES ('job', 1, 1, 1.0, 0.0, 'skipped', 'app')"
+            insert_execution_row(
+                conn, kind="job", job_id=1, session_id=1, execution_start_ts=1.0, duration_ms=0.0, status="skipped"
             )
             conn.commit()
             row = conn.execute("SELECT status, duration_ms FROM executions WHERE status = 'skipped'").fetchone()
             assert row == ("skipped", 0.0)
-        finally:
-            conn.close()
 
     def test_check_constraints_reject_negative_duration(self, tmp_path: Path) -> None:
         """Executions with negative duration_ms raises IntegrityError."""
         db_path = tmp_path / "test.db"
         run_migrations(db_path)
 
-        conn = sqlite3.connect(db_path)
-        conn.execute("PRAGMA foreign_keys = ON")
-        try:
+        with sqlite_conn(db_path, foreign_keys=True) as conn:
             conn.execute("INSERT INTO sessions (started_at, last_heartbeat_at, status) VALUES (1.0, 1.0, 'running')")
             conn.execute(
                 "INSERT INTO listeners (app_key, instance_index, name, handler_method, topic, source_location)"
@@ -142,22 +123,16 @@ class TestFreshMigration:
             )
             conn.commit()
             with pytest.raises(sqlite3.IntegrityError):
-                conn.execute(
-                    "INSERT INTO executions "
-                    "(kind, listener_id, session_id, execution_start_ts, duration_ms, status, source_tier) "
-                    "VALUES ('handler', 1, 1, 1.0, -1.0, 'success', 'app')"
+                insert_execution_row(
+                    conn, kind="handler", listener_id=1, session_id=1, execution_start_ts=1.0, duration_ms=-1.0
                 )
-        finally:
-            conn.close()
 
     def test_nullable_listener_id_allows_null(self, tmp_path: Path) -> None:
         """Executions must allow NULL listener_id when job_id is set."""
         db_path = tmp_path / "test.db"
         run_migrations(db_path)
 
-        conn = sqlite3.connect(db_path)
-        conn.execute("PRAGMA foreign_keys = ON")
-        try:
+        with sqlite_conn(db_path, foreign_keys=True) as conn:
             conn.execute("INSERT INTO sessions (started_at, last_heartbeat_at, status) VALUES (1.0, 1.0, 'running')")
             conn.execute(
                 "INSERT INTO scheduled_jobs "
@@ -165,25 +140,18 @@ class TestFreshMigration:
                 " VALUES ('app', 0, 'my_job', 'on_x', 'app.py:1', 'app', 'scheduled')"
             )
             conn.commit()
-            conn.execute(
-                "INSERT INTO executions "
-                "(kind, job_id, session_id, execution_start_ts, duration_ms, status, source_tier) "
-                "VALUES ('job', 1, 1, 1.0, 10.0, 'success', 'app')"
-            )
+            insert_execution_row(conn, kind="job", job_id=1, session_id=1, execution_start_ts=1.0, duration_ms=10.0)
             conn.commit()
             cursor = conn.execute("SELECT listener_id FROM executions WHERE id = 1")
             row = cursor.fetchone()
             assert row[0] is None
-        finally:
-            conn.close()
 
     def test_sessions_drop_counters_default_to_zero(self, tmp_path: Path) -> None:
         """Sessions table defaults drop counters to 0."""
         db_path = tmp_path / "test.db"
         run_migrations(db_path)
 
-        conn = sqlite3.connect(db_path)
-        try:
+        with sqlite_conn(db_path) as conn:
             conn.execute("INSERT INTO sessions (started_at, last_heartbeat_at, status) VALUES (1.0, 1.0, 'running')")
             conn.commit()
             cursor = conn.execute(
@@ -191,29 +159,23 @@ class TestFreshMigration:
             )
             row = cursor.fetchone()
             assert row == (0, 0, 0)
-        finally:
-            conn.close()
 
     def test_sessions_has_no_dropped_no_session_column(self, tmp_path: Path) -> None:
         """Sessions table does NOT have dropped_no_session (removed in new schema)."""
         db_path = tmp_path / "test.db"
         run_migrations(db_path)
 
-        conn = sqlite3.connect(db_path)
-        try:
+        with sqlite_conn(db_path) as conn:
             cursor = conn.execute("PRAGMA table_info(sessions)")
             cols = {row[1] for row in cursor.fetchall()}
             assert "dropped_no_session" not in cols
-        finally:
-            conn.close()
 
     def test_views_filter_by_tier(self, tmp_path: Path) -> None:
         """Views active_app_listeners and active_framework_listeners filter by source_tier."""
         db_path = tmp_path / "test.db"
         run_migrations(db_path)
 
-        conn = sqlite3.connect(db_path)
-        try:
+        with sqlite_conn(db_path) as conn:
             conn.execute(
                 "INSERT INTO listeners "
                 "(app_key, instance_index, name, handler_method, topic, source_location, source_tier) "
@@ -237,19 +199,14 @@ class TestFreshMigration:
             cursor = conn.execute("SELECT source_tier FROM active_listeners ORDER BY source_tier")
             tiers = [row[0] for row in cursor.fetchall()]
             assert tiers == ["app", "framework"]
-        finally:
-            conn.close()
 
     def test_user_version_set_after_migration(self, tmp_path: Path) -> None:
         """PRAGMA user_version is LATEST_MIGRATION_VERSION after all migrations run."""
         db_path = tmp_path / "test.db"
         run_migrations(db_path)
 
-        conn = sqlite3.connect(db_path)
-        try:
+        with sqlite_conn(db_path) as conn:
             version = conn.execute("PRAGMA user_version").fetchone()[0]
-        finally:
-            conn.close()
 
         assert version == LATEST_MIGRATION_VERSION
 
@@ -258,8 +215,7 @@ class TestFreshMigration:
         db_path = tmp_path / "test.db"
         run_migrations(db_path)
 
-        conn = sqlite3.connect(db_path)
-        try:
+        with sqlite_conn(db_path) as conn:
             cursor = conn.execute("PRAGMA table_info(listeners)")
             cols = {row[1] for row in cursor.fetchall()}
             assert "mode" in cols
@@ -271,16 +227,13 @@ class TestFreshMigration:
             conn.commit()
             row = conn.execute("SELECT mode FROM listeners WHERE name = 'my_listener'").fetchone()
             assert row[0] == "single"
-        finally:
-            conn.close()
 
     def test_listeners_has_backpressure_column_default_block(self, tmp_path: Path) -> None:
         """008.sql adds a backpressure column to listeners defaulting to 'block'."""
         db_path = tmp_path / "test.db"
         run_migrations(db_path)
 
-        conn = sqlite3.connect(db_path)
-        try:
+        with sqlite_conn(db_path) as conn:
             cursor = conn.execute("PRAGMA table_info(listeners)")
             cols = {row[1] for row in cursor.fetchall()}
             assert "backpressure" in cols
@@ -292,40 +245,31 @@ class TestFreshMigration:
             conn.commit()
             row = conn.execute("SELECT backpressure FROM listeners WHERE name = 'my_listener'").fetchone()
             assert row[0] == "block"
-        finally:
-            conn.close()
 
     def test_listeners_backpressure_backfills_pre_migration_rows(self, tmp_path: Path) -> None:
         """A listener row written before migration 008 reads 'block' after the migration runs."""
         db_path = tmp_path / "test.db"
         run_migrations(db_path, target=7)  # schema before the backpressure column existed
 
-        conn = sqlite3.connect(db_path)
-        try:
+        with sqlite_conn(db_path) as conn:
             conn.execute(
                 "INSERT INTO listeners (app_key, instance_index, name, handler_method, topic, source_location)"
                 " VALUES ('app', 0, 'legacy_listener', 'on_x', 'light.kitchen', 'app.py:1')"
             )
             conn.commit()
-        finally:
-            conn.close()
 
         run_migrations(db_path)  # apply 008 onto the populated table
 
-        conn = sqlite3.connect(db_path)
-        try:
+        with sqlite_conn(db_path) as conn:
             row = conn.execute("SELECT backpressure FROM listeners WHERE name = 'legacy_listener'").fetchone()
             assert row[0] == "block"
-        finally:
-            conn.close()
 
     def test_scheduled_jobs_has_mode_column_default_single(self, tmp_path: Path) -> None:
         """006.sql adds a mode column to scheduled_jobs defaulting to 'single'."""
         db_path = tmp_path / "test.db"
         run_migrations(db_path)
 
-        conn = sqlite3.connect(db_path)
-        try:
+        with sqlite_conn(db_path) as conn:
             cursor = conn.execute("PRAGMA table_info(scheduled_jobs)")
             cols = {row[1] for row in cursor.fetchall()}
             assert "mode" in cols
@@ -338,24 +282,18 @@ class TestFreshMigration:
             conn.commit()
             row = conn.execute("SELECT mode FROM scheduled_jobs WHERE job_name = 'my_job'").fetchone()
             assert row[0] == "single"
-        finally:
-            conn.close()
 
     def test_scheduled_jobs_mode_check_rejects_invalid(self, tmp_path: Path) -> None:
         """scheduled_jobs.mode CHECK constraint rejects invalid values."""
         db_path = tmp_path / "test.db"
         run_migrations(db_path)
 
-        conn = sqlite3.connect(db_path)
-        try:
-            with pytest.raises(sqlite3.IntegrityError):
-                conn.execute(
-                    "INSERT INTO scheduled_jobs "
-                    "(app_key, instance_index, job_name, handler_method, source_location, source_tier, mode)"
-                    " VALUES ('app', 0, 'bad_job', 'on_x', 'app.py:1', 'app', 'invalid')"
-                )
-        finally:
-            conn.close()
+        with sqlite_conn(db_path) as conn, pytest.raises(sqlite3.IntegrityError):
+            conn.execute(
+                "INSERT INTO scheduled_jobs "
+                "(app_key, instance_index, job_name, handler_method, source_location, source_tier, mode)"
+                " VALUES ('app', 0, 'bad_job', 'on_x', 'app.py:1', 'app', 'invalid')"
+            )
 
 
 class TestDbVersionMismatch:
@@ -396,12 +334,9 @@ class TestSchemaUpgradePreservesData:
         db_path = tmp_path / "test.db"
         run_migrations(db_path, target=5)
 
-        conn = sqlite3.connect(db_path)
-        try:
+        with sqlite_conn(db_path) as conn:
             conn.execute("INSERT INTO sessions (started_at, last_heartbeat_at, status) VALUES (1.0, 1.0, 'running')")
             conn.commit()
-        finally:
-            conn.close()
 
         svc = DatabaseService.__new__(DatabaseService)
         svc.logger = MagicMock()
@@ -410,11 +345,8 @@ class TestSchemaUpgradePreservesData:
 
         assert db_path.exists(), "Database file was deleted despite having valid schema version > 0"
 
-        conn = sqlite3.connect(db_path)
-        try:
+        with sqlite_conn(db_path) as conn:
             count = conn.execute("SELECT COUNT(*) FROM sessions").fetchone()[0]
-        finally:
-            conn.close()
         assert count == 1, "Session data was lost during schema version check"
 
 


### PR DESCRIPTION
## Summary

A "clean code sweep" bundling 10 small/medium Code Quality milestone issues into one PR. All findings originated from prior nitpicker/clean-code review passes and were addressed by parallel and sequential subagents, each batch re-reviewed by code-reviewer, integration-reviewer, wtf-reviewer, llm-checker, lazy-checker, and nitpicker before moving on. Every finding from those review passes is folded into the commits below — nothing deferred.

### Codegen test boilerplate
- Deduplicated `HA_CORE_PATH` and `sys.path.insert` setup repeated across `codegen/tests/test_*.py` into a single shared fixture/helper, removing near-identical boilerplate from 8 files.

### Demo stack config single-sourcing
- Introduced `scripts/docker/.env` (committed — fixture-only demo values, not secrets) as the single source of truth for the HA image tag and the two demo auth tokens, which were previously hardcoded independently across `scripts/docker/ha-demo.yml`, `tests/system/docker-compose.yml`, `scripts/capture_screenshots.py`, and `.mise/tasks/demo-verify`. Both compose files now interpolate from this `.env` via Compose's native auto-load; `tests/system/.env` is a symlink to the same file (Compose loads `.env` from the compose file's own directory, not the invoking process's cwd). Updated `ha-version-bump`'s Phase 2 instructions to bump the single `HA_VERSION` line instead of grep-hunting multiple compose files.
- A follow-up review pass caught a 4th hardcoded copy of the HA fixture JWT still living in `tests/system/conftest.py`; it now reads from the same `.env`.

### `app_lifecycle_service.py` reconciliation state
- Consolidated four parallel `_pending_pre_release_*` instance attributes on `AppLifecycleService` into a single `_pending_reconciliation: PendingReconciliation | None` dataclass field, where presence of an instance is the "is one queued?" signal instead of a separate bool flag. Behavior-preserving: the merge logic in `_record_pre_release_reconciliation` (keep first-recorded baseline, union changed paths unless either side degrades to "unknown") and the take-and-clear semantics in `_take_pre_release_reconciliation` are unchanged.

### Test suite dedup and hygiene
- `test_websocket_service.py`: collapsed 7 near-identical `fake_make_connection` closures into one parametrized `FailingConnection` helper, and extracted `apply_early_drop_config()` to patch the 4 early-drop config knobs in one call instead of 4 repeated `monkeypatch.setattr` lines per test. Moved `make_task_bucket_spawn_stub()` into the shared `hassette.test_utils.ws_mocks` module so both call sites reuse it. Centralized early-drop retry/backoff literals as named constants in `test_utils/config.py`.
- `test_state_proxy.py`: extracted `gated_get_states_raw_factory(result, error)` for the entered/release `asyncio.Event` gating pattern repeated across 9 tests.
- `test_auth.py`: extracted a shared trusted-peer request helper, removing repeated setup across that file's test cases.
- Migration/telemetry tests: extracted shared `sqlite_conn`/`insert_execution_row` helpers and a shared row-coherence assertion helper, removing duplicated raw-SQL scaffolding and near-identical job/listener telemetry test bodies.
- Migrated remaining inline `settle()` negative-assertion call sites onto the existing shared `test_utils` helper.
- `test_app_factory_lifecycle.py`: switched 5 test methods off locally-constructed `AppFactory`/`AppLifecycleService` instances (each with a manual `shutdown_all()` teardown call) onto the existing `app_factory`/`app_lifecycle` fixtures, so the fixture's own teardown owns cleanup. One call site keeps its explicit `shutdown_all()` since the test asserts on its effect.
- Naming/literal hygiene: renamed a `message_id`/`msg_id`/`id` mix in `test_websocket_service.py` to the single name (`msg_id`) used everywhere else in the file; renamed `build_watcher_hassette` to `make_watcher_hassette` in `tests/unit/core/conftest.py` to match the `make_*` prefix used by every other test-double factory in that module; extracted repeated route-path string literals (`/api/health`, `/api/ws`, `/api/apps/my_app/*`, etc.) into module-level constants in `test_endpoints.py`/`test_ws_endpoint.py`.

### Housekeeping
- `ws_mocks.py`: fixed a mixed `import typing` / `from typing import ...` split for the same module (`Coroutine` now imports from `collections.abc` per ruff UP035).
- `FailingConnection` now raises in `__init__` if `final_error` is passed without `fail_after`, instead of silently ignoring `final_error` at call time.
- `_request_from_peer`'s `method` param is now typed `Literal["get", "post"]` instead of `str`.
- Marked KI-003/KI-005 resolved in `design/specs/091-web-api-auth/known-issues.md`.

## Testing

Full suite passes except one pre-existing, unrelated failure: `tests/unit/cli/test_client.py::TestCredentialAttachment::test_env_var_populates_config_and_attaches_bearer_header`. This is caused by a `HASSETTE__CLI__AUTH_TOKEN` env var set globally on this dev machine, which leaks into `CLIClientFactory`'s token resolution ahead of the test's monkeypatched `HASSETTE__WEB_API__AUTH_TOKEN`. Confirmed via `git stash` bisection (fails identically with this branch's changes removed) and via `env | grep HASSETTE__` showing the leaking var. Not introduced by this branch and out of scope here.

Closes #1547
Closes #1536
Closes #1523
Closes #1524
Closes #1368
Closes #1494
Closes #1493
Closes #1543
Closes #1501
Closes #1502
