### PR TITLE
chore: clean code sweep — codegen pipeline, drift-check dedup

### DIFF
--- a/.claude/rules/clean-code-findings.md
+++ b/.claude/rules/clean-code-findings.md
@@ -12,6 +12,16 @@ File an issue when a clean-code or nitpicker review surfaces a pre-existing find
 
 Do not file findings introduced by the current branch — fix those in the current PR.
 
+## Code Quality vs. Architecture — mutually exclusive
+
+This file governs `topic:code-quality` + the **Code Quality** milestone only. There is a sibling track, `topic:architecture` + the **Architecture** milestone, for structural/SOLID work — module decomposition, coupling reduction, redesigning an internal boundary. An issue gets exactly one of the two label+milestone pairs, never both. If a finding could plausibly wear either tag, use the diagnostic below rather than applying both "to be safe." Architecture-track issues have no separate shape doc — file them with `/mine-create-issue` using its standard type/area/size labeling, just with `topic:architecture` + the Architecture milestone instead of the Code Quality pairing below.
+
+**`topic:code-quality`** — mechanical, local, low-risk. Fixable as a same-shape find-and-replace without changing how a reader traces control flow through the surrounding code: naming a magic constant, extracting a literally-repeated block, deleting dead code, fixing an import-order nit, deduplicating a copy-pasted test fixture. The kind of thing `/mine-clean-code`'s three checkers (llm-checker, lazy-checker, nitpicker) surface.
+
+**`topic:architecture`** — structural. Splitting an oversized function/module along a genuinely different responsibility boundary, reducing coupling between modules, or any change that needs `refactoring-discipline.md`'s pin-behavior-first treatment (a characterization test before restructuring) because the risk of silently changing behavior is real. If the fix requires re-tracing control flow or re-deriving an invariant to verify correctness, it's architecture, not code-quality — regardless of how small the resulting diff looks.
+
+**Diagnostic:** "Decompose `run_pipeline` into named steps" is architecture (six blended responsibilities, needed a pin test, real risk of reordering side effects). "Name the `d93f0b` literal as `DEFAULT_LABEL_COLOR`" is code-quality (one file, no behavior change, nothing to re-verify). When genuinely unsure, err toward architecture — it carries more scrutiny (pin-behavior-first), and mislabeling a risky change as a quick mechanical one is the more expensive mistake.
+
 ## Issue Shape
 
 **Title:** `Clean up <what> in <where>` — imperative, specific to the affected files or component area. Not the checker name or finding ID.
@@ -19,8 +29,8 @@ Do not file findings introduced by the current branch — fix those in the curre
 **Labels (all required):**
 
 - `type:enhancement`
-- `topic:code-quality`
-- `size:small` (most findings are; use `size:medium` only for multi-file structural changes)
+- `topic:code-quality` — never combine with `topic:architecture`; see above
+- `size:small` (most findings are; use `size:medium` only for coordinated multi-file mechanical changes, e.g. a consistent rename across a package — not for anything that decomposes or restructures)
 - One or more `area:` labels matching the affected code
 
 **Milestone:** `Code Quality`

--- a/.github/workflows/docker-drift-check.yml
+++ b/.github/workflows/docker-drift-check.yml
@@ -14,6 +14,7 @@ jobs:
         runs-on: ubuntu-latest
         timeout-minutes: 5
         permissions:
+            contents: read
             issues: write
             packages: read
         steps:

--- a/.github/workflows/docker-drift-check.yml
+++ b/.github/workflows/docker-drift-check.yml
@@ -37,6 +37,9 @@ jobs:
                   fi
                   GITHUB_VERSION="${GITHUB_TAG#v}"
                   EXPECTED_TAG="${GITHUB_VERSION}-py3.13"
+                  # Plain (not the delimiter-safe form drift_check.py's outputs use below): this
+                  # value comes from this repo's own release tag, not an external registry, so the
+                  # injection risk that motivates the heredoc form there doesn't apply here.
                   echo "version=${GITHUB_VERSION}" >> "$GITHUB_OUTPUT"
 
                   echo "GitHub release: v${GITHUB_VERSION}"

--- a/.github/workflows/docker-drift-check.yml
+++ b/.github/workflows/docker-drift-check.yml
@@ -1,8 +1,9 @@
 name: Docker Drift Check
 
-# Structural sibling of pypi-drift-check.yml (same compare/dedup/file-issue shape, applied
-# to GHCR instead of PyPI) and ha-version-drift.yml. Keep drift-check behavior changes
-# (dedup logic, label creation, exit semantics) in sync across all three.
+# Structural sibling of pypi-drift-check.yml and ha-version-drift.yml — all three share
+# tools/release/drift_check.py for the compare/dedup logic. Each workflow still fetches its own
+# current/latest values (the sources of truth differ too much to share) and keeps its own issue
+# title/body/labels, since those differ per check too.
 on:
     schedule:
         - cron: "0 12 * * *" # daily at noon UTC
@@ -16,7 +17,13 @@ jobs:
             issues: write
             packages: read
         steps:
+            - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+              with:
+                persist-credentials: false
+                sparse-checkout: tools/release/drift_check.py
+
             - name: Compare GitHub release to GHCR image tags
+              id: drift
               env:
                   GH_TOKEN: ${{ github.token }}
               run: |
@@ -46,25 +53,28 @@ jobs:
                   fi
 
                   if echo "$TAGS" | grep -qx "$EXPECTED_TAG"; then
-                      echo "GHCR has ${EXPECTED_TAG} — no drift detected"
-                      exit 0
+                      FOUND_TAG="$EXPECTED_TAG"
+                  else
+                      FOUND_TAG="not-in-registry"
                   fi
 
-                  echo "::error::Docker drift detected! GitHub has v${GITHUB_VERSION} but GHCR has no ${EXPECTED_TAG} image"
+                  uv run ./tools/release/drift_check.py \
+                      --current "$EXPECTED_TAG" \
+                      --latest "$FOUND_TAG" \
+                      --label "docker-drift" \
+                      --label-description "Docker image publish is missing for the latest release"
 
-                  # Check if an issue already exists (label-based dedup, not search-text)
-                  EXISTING=$(gh issue list --repo "$GITHUB_REPOSITORY" --label "docker-drift" --state open --json number -q '.[0].number' 2>/dev/null || echo "")
-                  if [ -n "$EXISTING" ]; then
-                      echo "Issue #${EXISTING} already open for this drift"
-                      exit 0
-                  fi
+            - name: File tracking issue
+              if: steps.drift.outputs.drift == 'true' && steps.drift.outputs.existing-issue == ''
+              env:
+                  GH_TOKEN: ${{ github.token }}
+                  EXPECTED_TAG: ${{ steps.drift.outputs.current }}
+              run: |
+                  set -euo pipefail
 
-                  # Ensure the label exists
-                  gh label create "docker-drift" \
-                      --repo "$GITHUB_REPOSITORY" \
-                      --description "Docker image publish is missing for the latest release" \
-                      --color "d93f0b" \
-                      2>/dev/null || true
+                  # current carries the "-py3.13" suffix (see the compare step above); strip it
+                  # back off for the bare version used in title/body prose.
+                  GITHUB_VERSION="${EXPECTED_TAG%-py3.13}"
 
                   gh issue create --repo "$GITHUB_REPOSITORY" \
                       --title "Docker publish drift: GitHub v${GITHUB_VERSION} missing from GHCR" \
@@ -88,3 +98,7 @@ jobs:
                   - GitHub release: [v${GITHUB_VERSION}](https://github.com/${GITHUB_REPOSITORY}/releases/tag/v${GITHUB_VERSION})
                   - GHCR: https://github.com/${GITHUB_REPOSITORY}/pkgs/container/hassette
                   - Detected by: [docker-drift-check workflow](https://github.com/${GITHUB_REPOSITORY}/actions/workflows/docker-drift-check.yml)"
+
+            - name: Existing drift issue
+              if: steps.drift.outputs.drift == 'true' && steps.drift.outputs.existing-issue != ''
+              run: echo "Issue #${{ steps.drift.outputs.existing-issue }} already open for this drift"

--- a/.github/workflows/docker-drift-check.yml
+++ b/.github/workflows/docker-drift-check.yml
@@ -37,6 +37,7 @@ jobs:
                   fi
                   GITHUB_VERSION="${GITHUB_TAG#v}"
                   EXPECTED_TAG="${GITHUB_VERSION}-py3.13"
+                  echo "version=${GITHUB_VERSION}" >> "$GITHUB_OUTPUT"
 
                   echo "GitHub release: v${GITHUB_VERSION}"
                   echo "Checking GHCR for tag: ${EXPECTED_TAG}"
@@ -68,13 +69,10 @@ jobs:
               if: steps.drift.outputs.drift == 'true' && steps.drift.outputs.existing-issue == ''
               env:
                   GH_TOKEN: ${{ github.token }}
+                  GITHUB_VERSION: ${{ steps.drift.outputs.version }}
                   EXPECTED_TAG: ${{ steps.drift.outputs.current }}
               run: |
                   set -euo pipefail
-
-                  # current carries the "-py3.13" suffix (see the compare step above); strip it
-                  # back off for the bare version used in title/body prose.
-                  GITHUB_VERSION="${EXPECTED_TAG%-py3.13}"
 
                   gh issue create --repo "$GITHUB_REPOSITORY" \
                       --title "Docker publish drift: GitHub v${GITHUB_VERSION} missing from GHCR" \

--- a/.github/workflows/ha-version-drift.yml
+++ b/.github/workflows/ha-version-drift.yml
@@ -11,6 +11,12 @@ concurrency:
 
 # Complements ha-version-staleness in lint.yml (per-PR warning annotation).
 # This workflow files a tracking issue so drift is visible even without PRs.
+#
+# Structural sibling of pypi-drift-check.yml and docker-drift-check.yml — shares
+# tools/release/drift_check.py for the compare/dedup logic. Unlike the other two, this workflow
+# also updates the tracking issue on repeat drift and auto-closes it once the pin catches up
+# (last two steps below) — that behavior is specific to this workflow and isn't part of the
+# shared script (see #1474).
 jobs:
     check-drift:
         runs-on: ubuntu-latest
@@ -22,9 +28,12 @@ jobs:
             - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
               with:
                 persist-credentials: false
-                sparse-checkout: codegen/ha-version.txt
+                sparse-checkout: |
+                    codegen/ha-version.txt
+                    tools/release/drift_check.py
 
             - name: Compare pinned HA version to latest release
+              id: drift
               env:
                   GH_TOKEN: ${{ github.token }}
               run: |
@@ -37,39 +46,20 @@ jobs:
                       exit 0
                   fi
 
-                  echo "Pinned: $PINNED"
-                  echo "Latest: $LATEST"
+                  uv run ./tools/release/drift_check.py \
+                      --current "$PINNED" \
+                      --latest "$LATEST" \
+                      --label "ha-version-drift" \
+                      --label-description "Codegen HA version pin is behind latest release"
 
-                  if [ "$PINNED" = "$LATEST" ]; then
-                      echo "Versions match — no drift"
-
-                      # Close any stale drift issue
-                      EXISTING=$(gh issue list --repo "$GITHUB_REPOSITORY" --label "ha-version-drift" --state open --json number -q '.[0].number' 2>/dev/null || echo "")
-                      if [ -n "$EXISTING" ]; then
-                          gh issue close "$EXISTING" --repo "$GITHUB_REPOSITORY" \
-                              --comment "Pinned version now matches latest HA release ($LATEST). Closing automatically."
-                          echo "Closed stale drift issue #${EXISTING}"
-                      fi
-                      exit 0
-                  fi
-
-                  echo "::warning::Pinned HA version ($PINNED) is behind latest ($LATEST)"
-
-                  # Check for existing open issue (label-based dedup)
-                  EXISTING=$(gh issue list --repo "$GITHUB_REPOSITORY" --label "ha-version-drift" --state open --json number -q '.[0].number' 2>/dev/null || echo "")
-                  if [ -n "$EXISTING" ]; then
-                      gh issue comment "$EXISTING" --repo "$GITHUB_REPOSITORY" \
-                          --body "Still behind: pinned \`$PINNED\`, latest \`$LATEST\` (checked $(date -u +%Y-%m-%d))"
-                      echo "Updated existing issue #${EXISTING}"
-                      exit 0
-                  fi
-
-                  # Ensure the label exists
-                  gh label create "ha-version-drift" \
-                      --repo "$GITHUB_REPOSITORY" \
-                      --description "Codegen HA version pin is behind latest release" \
-                      --color "d93f0b" \
-                      2>/dev/null || true
+            - name: File tracking issue
+              if: steps.drift.outputs.drift == 'true' && steps.drift.outputs.existing-issue == ''
+              env:
+                  GH_TOKEN: ${{ github.token }}
+                  PINNED: ${{ steps.drift.outputs.current }}
+                  LATEST: ${{ steps.drift.outputs.latest }}
+              run: |
+                  set -euo pipefail
 
                   gh issue create --repo "$GITHUB_REPOSITORY" \
                       --title "Codegen HA version drift: pinned $PINNED, latest is $LATEST" \
@@ -98,3 +88,34 @@ jobs:
                   - Detected by: [ha-version-drift workflow](https://github.com/$GITHUB_REPOSITORY/actions/workflows/ha-version-drift.yml)
 
                   This issue will be updated daily until the pin is bumped, and closed automatically when versions match."
+
+            - name: Update existing tracking issue
+              if: steps.drift.outputs.drift == 'true' && steps.drift.outputs.existing-issue != ''
+              env:
+                  GH_TOKEN: ${{ github.token }}
+                  EXISTING: ${{ steps.drift.outputs.existing-issue }}
+                  PINNED: ${{ steps.drift.outputs.current }}
+                  LATEST: ${{ steps.drift.outputs.latest }}
+              run: |
+                  set -euo pipefail
+
+                  gh issue comment "$EXISTING" --repo "$GITHUB_REPOSITORY" \
+                      --body "Still behind: pinned \`$PINNED\`, latest \`$LATEST\` (checked $(date -u +%Y-%m-%d))"
+                  echo "Updated existing issue #${EXISTING}"
+
+            # Not part of the shared script: pypi/docker have no equivalent "auto-close on
+            # resync" branch, so this stays as a documented per-workflow extension (see #1474).
+            # existing-issue is populated by drift_check.py regardless of drift, so no extra
+            # `gh issue list` lookup is needed here.
+            - name: Close stale tracking issue on resync
+              if: steps.drift.outputs.drift == 'false' && steps.drift.outputs.existing-issue != ''
+              env:
+                  GH_TOKEN: ${{ github.token }}
+                  EXISTING: ${{ steps.drift.outputs.existing-issue }}
+                  LATEST: ${{ steps.drift.outputs.latest }}
+              run: |
+                  set -euo pipefail
+
+                  gh issue close "$EXISTING" --repo "$GITHUB_REPOSITORY" \
+                      --comment "Pinned version now matches latest HA release ($LATEST). Closing automatically."
+                  echo "Closed stale drift issue #${EXISTING}"

--- a/.github/workflows/pypi-drift-check.yml
+++ b/.github/workflows/pypi-drift-check.yml
@@ -14,6 +14,7 @@ jobs:
         runs-on: ubuntu-latest
         timeout-minutes: 5
         permissions:
+            contents: read
             issues: write
         steps:
             - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7

--- a/.github/workflows/pypi-drift-check.yml
+++ b/.github/workflows/pypi-drift-check.yml
@@ -1,5 +1,9 @@
 name: PyPI Drift Check
 
+# Structural sibling of docker-drift-check.yml and ha-version-drift.yml — all three share
+# tools/release/drift_check.py for the compare/dedup logic. Each workflow still fetches its own
+# current/latest values (the sources of truth differ too much to share) and keeps its own issue
+# title/body/labels, since those differ per check too.
 on:
     schedule:
         - cron: "0 12 * * *" # daily at noon UTC
@@ -12,7 +16,13 @@ jobs:
         permissions:
             issues: write
         steps:
+            - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+              with:
+                persist-credentials: false
+                sparse-checkout: tools/release/drift_check.py
+
             - name: Compare GitHub release to PyPI
+              id: drift
               env:
                   GH_TOKEN: ${{ github.token }}
               run: |
@@ -37,23 +47,20 @@ jobs:
                       sys.exit(1)
                   ")
 
-                  echo "GitHub release: v${GITHUB_VERSION}"
-                  echo "PyPI latest:    v${PYPI_VERSION}"
+                  uv run ./tools/release/drift_check.py \
+                      --current "$GITHUB_VERSION" \
+                      --latest "$PYPI_VERSION" \
+                      --label "pypi-drift" \
+                      --label-description "Auto-filed by PyPI drift check workflow"
 
-                  if [ "$GITHUB_VERSION" = "$PYPI_VERSION" ]; then
-                      echo "Versions match — no drift detected"
-                      exit 0
-                  fi
-
-                  # Check if the GitHub release is newer (drift) or older (PyPI ahead somehow)
-                  echo "::error::Version drift detected! GitHub has v${GITHUB_VERSION} but PyPI has v${PYPI_VERSION}"
-
-                  # Check if an issue already exists (label-based dedup, not search-text)
-                  EXISTING=$(gh issue list --repo "$GITHUB_REPOSITORY" --label "pypi-drift" --state open --json number -q '.[0].number' 2>/dev/null || echo "")
-                  if [ -n "$EXISTING" ]; then
-                      echo "Issue #${EXISTING} already open for this drift"
-                      exit 0
-                  fi
+            - name: File tracking issue
+              if: steps.drift.outputs.drift == 'true' && steps.drift.outputs.existing-issue == ''
+              env:
+                  GH_TOKEN: ${{ github.token }}
+                  GITHUB_VERSION: ${{ steps.drift.outputs.current }}
+                  PYPI_VERSION: ${{ steps.drift.outputs.latest }}
+              run: |
+                  set -euo pipefail
 
                   gh issue create --repo "$GITHUB_REPOSITORY" \
                       --title "PyPI publish drift: GitHub v${GITHUB_VERSION} vs PyPI v${PYPI_VERSION}" \
@@ -77,3 +84,7 @@ jobs:
                   - GitHub release: [v${GITHUB_VERSION}](https://github.com/${GITHUB_REPOSITORY}/releases/tag/v${GITHUB_VERSION})
                   - PyPI: https://pypi.org/project/hassette/${PYPI_VERSION}/
                   - Detected by: [pypi-drift-check workflow](https://github.com/${GITHUB_REPOSITORY}/actions/workflows/pypi-drift-check.yml)"
+
+            - name: Existing drift issue
+              if: steps.drift.outputs.drift == 'true' && steps.drift.outputs.existing-issue != ''
+              run: echo "Issue #${{ steps.drift.outputs.existing-issue }} already open for this drift"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -374,6 +374,10 @@ YAML form templates in `.github/ISSUE_TEMPLATE/` enforce structure:
 - `task.yml` — internal work items with acceptance criteria
 - `config.yml` — disables blank issues, points questions to Discussions
 
+## Pull Requests
+
+**CodeRabbit reviews are manual.** Auto-review is disabled (`.coderabbit.yaml`, `auto_review.enabled: false`) — a review firing on every push to an already-open PR is noisy and out of sync with the actual review cadence. After the full PR workflow is complete (commit, push, PR created and marked ready), comment `@coderabbitai review` on the PR to trigger a review.
+
 ## Design Artifacts
 
 Internal design documents live in `design/`, not in `docs/` (which is the readthedocs site).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -338,10 +338,11 @@ Apply when clearly warranted:
 
 - **Priority**: `priority:high` (blockers, data loss), `priority:low` (nice-to-haves)
 - **Descriptors**: `good first issue`
-- **Topic labels** — what conceptual concern is involved? Cross-cuts areas. Answers "what kind of problem is this?" (an issue can have multiple):
+- **Topic labels** — what conceptual concern is involved? Cross-cuts areas. Answers "what kind of problem is this?" (an issue can have multiple — except `topic:architecture`/`topic:code-quality`, which are mutually exclusive; see below):
    - `topic:a11y` — Accessibility: focus, keyboard navigation, screen readers
-   - `topic:architecture` — Module decomposition, coupling reduction, internal structure
+   - `topic:architecture` — Module decomposition, coupling reduction, internal structure. Mutually exclusive with `topic:code-quality` — see `.claude/rules/clean-code-findings.md` for the dividing line
    - `topic:cli` — hassette CLI commands (init, build, migrate)
+   - `topic:code-quality` — Pre-existing mechanical/hygiene findings (naming, duplication, dead code) surfaced by `/mine-clean-code`. Mutually exclusive with `topic:architecture` — see `.claude/rules/clean-code-findings.md`
    - `topic:codegen` — Code/type generation pipelines, typed models from HA, schema export
    - `topic:concurrency` — Semaphores, rate limiting, timeouts, task management
    - `topic:design-system` — Visual tokens, theming, color scales, typography, spacing

--- a/codegen/src/hassette_codegen/pipeline.py
+++ b/codegen/src/hassette_codegen/pipeline.py
@@ -1,7 +1,7 @@
 """Main generation pipeline — wires extractors, generators, and output together."""
 
 import sys
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from pathlib import Path
 from typing import NamedTuple
 
@@ -62,17 +62,19 @@ class Rejection(NamedTuple):
     what: str
 
 
-@dataclass
+@dataclass(frozen=True)
 class _DomainOutcome:
     """What generating one domain produced — folded into the run's overall bookkeeping by the caller.
 
     Built via the named constructors below rather than the raw dataclass constructor: each shape
     populates only the fields that are meaningful for that outcome, and the others fall through to
     their defaults implicitly. The constructor name states which shape a given call site returns
-    without the reader having to check what got left out.
+    without the reader having to check what got left out. Frozen because these are handed off as
+    finished results, not further mutated — the constructors take the caller's own working `set`
+    and freeze it on the way in.
     """
 
-    generated_files: set[Path] = field(default_factory=set)
+    generated_files: frozenset[Path] = frozenset()
     skipped: bool = False
     rejection: Rejection | None = None
     any_drift: bool = False
@@ -85,29 +87,29 @@ class _DomainOutcome:
     @classmethod
     def reject(cls, generated_files: set[Path], rejection: Rejection) -> "_DomainOutcome":
         """The entity wrapper was refused; the state model already in `generated_files` still stands."""
-        return cls(generated_files=generated_files, rejection=rejection)
+        return cls(generated_files=frozenset(generated_files), rejection=rejection)
 
     @classmethod
     def ok(cls, generated_files: set[Path], *, any_drift: bool = False) -> "_DomainOutcome":
         """The domain produced usable output, with or without detected drift."""
-        return cls(generated_files=generated_files, any_drift=any_drift)
+        return cls(generated_files=frozenset(generated_files), any_drift=any_drift)
 
 
-@dataclass
+@dataclass(frozen=True)
 class _GenerationResult:
     """Aggregated bookkeeping from generating every domain in the run."""
 
-    generated_files: set[Path]
-    skipped_domains: list[str]
-    rejections: list[Rejection]
+    generated_files: frozenset[Path]
+    skipped_domains: tuple[str, ...]
+    rejections: tuple[Rejection, ...]
     any_drift: bool
 
 
-@dataclass
+@dataclass(frozen=True)
 class _WriteOutput:
     """What a non-domain generation step (constants, package __init__.py files) produced."""
 
-    generated_files: set[Path] = field(default_factory=set)
+    generated_files: frozenset[Path] = frozenset()
     any_drift: bool = False
 
 
@@ -146,7 +148,7 @@ def run_pipeline(
         previous_manifest=previous_manifest,
         manifest_tracked=manifest_tracked,
     )
-    rejections = rejections + domain_result.rejections
+    rejections = rejections + list(domain_result.rejections)
     generated_files = domain_result.generated_files
     skipped_domains = domain_result.skipped_domains
     any_drift = domain_result.any_drift
@@ -161,6 +163,10 @@ def run_pipeline(
     init_output = _generate_package_inits(states_dir, entities_dir, repo_root, check_mode=check_mode)
     generated_files = generated_files | init_output.generated_files
     any_drift = any_drift or init_output.any_drift
+
+    # From here on, generated_files only feeds the pre-existing manifest APIs, which operate on
+    # plain mutable sets — convert once at this boundary rather than widening their signatures.
+    generated_files = set(generated_files)
 
     if not check_mode:
         _finalize_manifest(
@@ -254,7 +260,7 @@ def _generate_domains(
             rejections.append(outcome.rejection)
         any_drift = any_drift or outcome.any_drift
 
-    return _GenerationResult(generated_files, skipped_domains, rejections, any_drift)
+    return _GenerationResult(frozenset(generated_files), tuple(skipped_domains), tuple(rejections), any_drift)
 
 
 def _check_or_write(path: Path, content: str, label: str, *, check_mode: bool) -> tuple[bool, bool]:
@@ -361,7 +367,7 @@ def _generate_constants(ha_source: HASource, const_dir: Path, repo_root: Path, *
     # retained older copy as an orphan on the next full run.
     wrote, drifted = _check_or_write(const_path, const_content, "sensor constants", check_mode=check_mode)
     if wrote:
-        return _WriteOutput(generated_files={rel_const}, any_drift=drifted)
+        return _WriteOutput(generated_files=frozenset({rel_const}), any_drift=drifted)
     return _WriteOutput()
 
 
@@ -405,7 +411,7 @@ def _generate_package_inits(states_dir: Path, entities_dir: Path, repo_root: Pat
         if wrote:
             generated_files.add(rel_init)
 
-    return _WriteOutput(generated_files=generated_files, any_drift=any_drift)
+    return _WriteOutput(generated_files=frozenset(generated_files), any_drift=any_drift)
 
 
 def _finalize_manifest(
@@ -436,7 +442,7 @@ def _finalize_manifest(
 def _report_summary_and_exit_code(
     *,
     domains: list[DiscoveredDomain],
-    skipped_domains: list[str],
+    skipped_domains: tuple[str, ...],
     rejections: list[Rejection],
     any_drift: bool,
     previous_manifest: set[Path],

--- a/codegen/src/hassette_codegen/pipeline.py
+++ b/codegen/src/hassette_codegen/pipeline.py
@@ -64,12 +64,33 @@ class Rejection(NamedTuple):
 
 @dataclass
 class _DomainOutcome:
-    """What generating one domain produced — folded into the run's overall bookkeeping by the caller."""
+    """What generating one domain produced — folded into the run's overall bookkeeping by the caller.
+
+    Built via the named constructors below rather than the raw dataclass constructor: each shape
+    populates only the fields that are meaningful for that outcome, and the others fall through to
+    their defaults implicitly. The constructor name states which shape a given call site returns
+    without the reader having to check what got left out.
+    """
 
     generated_files: set[Path] = field(default_factory=set)
     skipped: bool = False
     rejection: Rejection | None = None
     any_drift: bool = False
+
+    @classmethod
+    def skip(cls) -> "_DomainOutcome":
+        """The domain's extraction or write failed outright — nothing usable was produced."""
+        return cls(skipped=True)
+
+    @classmethod
+    def reject(cls, generated_files: set[Path], rejection: Rejection) -> "_DomainOutcome":
+        """The entity wrapper was refused; the state model already in `generated_files` still stands."""
+        return cls(generated_files=generated_files, rejection=rejection)
+
+    @classmethod
+    def ok(cls, generated_files: set[Path], *, any_drift: bool = False) -> "_DomainOutcome":
+        """The domain produced usable output, with or without detected drift."""
+        return cls(generated_files=generated_files, any_drift=any_drift)
 
 
 @dataclass
@@ -215,7 +236,7 @@ def _generate_domains(
     any_drift = False
 
     for domain_info in domains:
-        outcome = _generate_domain_files(
+        outcome = _generate_files_for_domain(
             domain_info,
             ha_source=ha_source,
             overrides=overrides,
@@ -236,7 +257,7 @@ def _generate_domains(
     return _GenerationResult(generated_files, skipped_domains, rejections, any_drift)
 
 
-def _generate_domain_files(
+def _generate_files_for_domain(
     domain_info: DiscoveredDomain,
     *,
     ha_source: HASource,
@@ -253,7 +274,7 @@ def _generate_domain_files(
         extracted = _extract_domain(ha_source.path, domain_info, overrides)
     except Exception as exc:
         print(f"WARNING: Failed to extract {domain_info.name}: {exc}", file=sys.stderr)
-        return _DomainOutcome(skipped=True)
+        return _DomainOutcome.skip()
 
     state_content = generate_state_model(extracted)
     state_path = states_dir / f"{domain_info.name}.py"
@@ -267,12 +288,12 @@ def _generate_domain_files(
         generated_files.add(rel_state)
     else:
         if not _may_overwrite(state_path, rel_state, previous_manifest, tracked=manifest_tracked):
-            return _DomainOutcome(skipped=True)
+            return _DomainOutcome.skip()
         if atomic_write(state_path, state_content):
             generated_files.add(rel_state)
         else:
             print(f"WARNING: Skipped {rel_state} (validation failed)", file=sys.stderr)
-            return _DomainOutcome(skipped=True)
+            return _DomainOutcome.skip()
 
     try:
         entity_content = generate_entity_wrapper(extracted)
@@ -282,10 +303,10 @@ def _generate_domain_files(
         # still recorded as a rejection: the committed wrapper was never checked against
         # upstream, and --check must not report the tree as current on that basis.
         print(f"WARNING: Rejected {domain_info.name} entity wrapper: {exc}", file=sys.stderr)
-        return _DomainOutcome(generated_files=generated_files, rejection=Rejection(domain_info.name, "entity wrapper"))
+        return _DomainOutcome.reject(generated_files, Rejection(domain_info.name, "entity wrapper"))
 
     if entity_content is None:
-        return _DomainOutcome(generated_files=generated_files, any_drift=any_drift)
+        return _DomainOutcome.ok(generated_files, any_drift=any_drift)
 
     entity_path = entities_dir / f"{domain_info.name}.py"
     rel_entity = entity_path.relative_to(repo_root)
@@ -294,19 +315,19 @@ def _generate_domain_files(
         if not check_drift(entity_path, entity_content, f"{domain_info.name} entity wrapper"):
             any_drift = True
         generated_files.add(rel_entity)
-        return _DomainOutcome(generated_files=generated_files, any_drift=any_drift)
+        return _DomainOutcome.ok(generated_files, any_drift=any_drift)
 
     # Unlike the state model above, the domain is not added to skipped_domains: its state model
     # did generate. The refusal is reported by the warning, matching how an entity wrapper that
     # fails ruff validation is already handled.
     if not _may_overwrite(entity_path, rel_entity, previous_manifest, tracked=manifest_tracked):
-        return _DomainOutcome(generated_files=generated_files, any_drift=any_drift)
+        return _DomainOutcome.ok(generated_files, any_drift=any_drift)
     if atomic_write(entity_path, entity_content):
         generated_files.add(rel_entity)
     else:
         print(f"WARNING: Skipped {rel_entity} (validation failed)", file=sys.stderr)
 
-    return _DomainOutcome(generated_files=generated_files, any_drift=any_drift)
+    return _DomainOutcome.ok(generated_files, any_drift=any_drift)
 
 
 def _generate_constants(ha_source: HASource, const_dir: Path, repo_root: Path, *, check_mode: bool) -> _WriteOutput:

--- a/codegen/src/hassette_codegen/pipeline.py
+++ b/codegen/src/hassette_codegen/pipeline.py
@@ -257,6 +257,25 @@ def _generate_domains(
     return _GenerationResult(generated_files, skipped_domains, rejections, any_drift)
 
 
+def _check_or_write(path: Path, content: str, label: str, *, check_mode: bool) -> tuple[bool, bool]:
+    """Run the check-mode/generate split shared by every generated-file write site.
+
+    Returns ``(wrote, drifted)``. In ``--check`` mode this only compares `content` against the
+    file already on disk and never touches it — ``wrote`` is always True (checked files count as
+    "would be generated") and ``drifted`` reflects whether they differed. Outside ``--check`` mode
+    this performs the write — ``drifted`` is always False and ``wrote`` reflects whether
+    ``atomic_write`` succeeded.
+
+    This wraps only the part that is genuinely identical across call sites: which of
+    ``check_drift``/``atomic_write`` to call, and how to fold the result into ``(wrote,
+    drifted)``. Callers that gate the write behind ``_may_overwrite`` or need custom
+    warning/skip behavior on a failed write still do that themselves — those differ per site.
+    """
+    if check_mode:
+        return True, not check_drift(path, content, label)
+    return atomic_write(path, content), False
+
+
 def _generate_files_for_domain(
     domain_info: DiscoveredDomain,
     *,
@@ -282,18 +301,17 @@ def _generate_files_for_domain(
     generated_files: set[Path] = set()
     any_drift = False
 
-    if check_mode:
-        if not check_drift(state_path, state_content, f"{domain_info.name} state model"):
-            any_drift = True
+    if not check_mode and not _may_overwrite(state_path, rel_state, previous_manifest, tracked=manifest_tracked):
+        return _DomainOutcome.skip()
+    wrote, drifted = _check_or_write(
+        state_path, state_content, f"{domain_info.name} state model", check_mode=check_mode
+    )
+    any_drift = any_drift or drifted
+    if wrote:
         generated_files.add(rel_state)
-    else:
-        if not _may_overwrite(state_path, rel_state, previous_manifest, tracked=manifest_tracked):
-            return _DomainOutcome.skip()
-        if atomic_write(state_path, state_content):
-            generated_files.add(rel_state)
-        else:
-            print(f"WARNING: Skipped {rel_state} (validation failed)", file=sys.stderr)
-            return _DomainOutcome.skip()
+    elif not check_mode:
+        print(f"WARNING: Skipped {rel_state} (validation failed)", file=sys.stderr)
+        return _DomainOutcome.skip()
 
     try:
         entity_content = generate_entity_wrapper(extracted)
@@ -311,20 +329,18 @@ def _generate_files_for_domain(
     entity_path = entities_dir / f"{domain_info.name}.py"
     rel_entity = entity_path.relative_to(repo_root)
 
-    if check_mode:
-        if not check_drift(entity_path, entity_content, f"{domain_info.name} entity wrapper"):
-            any_drift = True
-        generated_files.add(rel_entity)
-        return _DomainOutcome.ok(generated_files, any_drift=any_drift)
-
     # Unlike the state model above, the domain is not added to skipped_domains: its state model
     # did generate. The refusal is reported by the warning, matching how an entity wrapper that
     # fails ruff validation is already handled.
-    if not _may_overwrite(entity_path, rel_entity, previous_manifest, tracked=manifest_tracked):
+    if not check_mode and not _may_overwrite(entity_path, rel_entity, previous_manifest, tracked=manifest_tracked):
         return _DomainOutcome.ok(generated_files, any_drift=any_drift)
-    if atomic_write(entity_path, entity_content):
+    wrote, drifted = _check_or_write(
+        entity_path, entity_content, f"{domain_info.name} entity wrapper", check_mode=check_mode
+    )
+    any_drift = any_drift or drifted
+    if wrote:
         generated_files.add(rel_entity)
-    else:
+    elif not check_mode:
         print(f"WARNING: Skipped {rel_entity} (validation failed)", file=sys.stderr)
 
     return _DomainOutcome.ok(generated_files, any_drift=any_drift)
@@ -340,15 +356,12 @@ def _generate_constants(ha_source: HASource, const_dir: Path, repo_root: Path, *
     const_path = const_dir / "sensor.py"
     rel_const = const_path.relative_to(repo_root)
 
-    if check_mode:
-        any_drift = not check_drift(const_path, const_content, "sensor constants")
-        return _WriteOutput(generated_files={rel_const}, any_drift=any_drift)
-
-    # Ownership is only claimed for output this run actually produced. atomic_write reports its
-    # own failure, and leaving the path out of the manifest surfaces the retained older copy as an
-    # orphan on the next full run.
-    if atomic_write(const_path, const_content):
-        return _WriteOutput(generated_files={rel_const})
+    # Ownership is only claimed for output this run actually produced (outside --check).
+    # atomic_write reports its own failure, and leaving the path out of the manifest surfaces the
+    # retained older copy as an orphan on the next full run.
+    wrote, drifted = _check_or_write(const_path, const_content, "sensor constants", check_mode=check_mode)
+    if wrote:
+        return _WriteOutput(generated_files={rel_const}, any_drift=drifted)
     return _WriteOutput()
 
 
@@ -387,11 +400,9 @@ def _generate_package_inits(states_dir: Path, entities_dir: Path, repo_root: Pat
         init_path = pkg_dir / "__init__.py"
         rel_init = init_path.relative_to(repo_root)
 
-        if check_mode:
-            if not check_drift(init_path, init_content, f"{pkg_dir.name} __init__.py"):
-                any_drift = True
-            generated_files.add(rel_init)
-        elif atomic_write(init_path, init_content):
+        wrote, drifted = _check_or_write(init_path, init_content, f"{pkg_dir.name} __init__.py", check_mode=check_mode)
+        any_drift = any_drift or drifted
+        if wrote:
             generated_files.add(rel_init)
 
     return _WriteOutput(generated_files=generated_files, any_drift=any_drift)

--- a/codegen/src/hassette_codegen/pipeline.py
+++ b/codegen/src/hassette_codegen/pipeline.py
@@ -1,6 +1,7 @@
 """Main generation pipeline — wires extractors, generators, and output together."""
 
 import sys
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import NamedTuple
 
@@ -61,6 +62,34 @@ class Rejection(NamedTuple):
     what: str
 
 
+@dataclass
+class _DomainOutcome:
+    """What generating one domain produced — folded into the run's overall bookkeeping by the caller."""
+
+    generated_files: set[Path] = field(default_factory=set)
+    skipped: bool = False
+    rejection: Rejection | None = None
+    any_drift: bool = False
+
+
+@dataclass
+class _GenerationResult:
+    """Aggregated bookkeeping from generating every domain in the run."""
+
+    generated_files: set[Path]
+    skipped_domains: list[str]
+    rejections: list[Rejection]
+    any_drift: bool
+
+
+@dataclass
+class _WriteOutput:
+    """What a non-domain generation step (constants, package __init__.py files) produced."""
+
+    generated_files: set[Path] = field(default_factory=set)
+    any_drift: bool = False
+
+
 def run_pipeline(
     ha_source: HASource,
     repo_root: Path,
@@ -72,6 +101,74 @@ def run_pipeline(
     check_python_version(ha_source.path)
     check_ruff_available()
 
+    domains, all_domains, rejections, overrides = _discover_domains_for_run(ha_source, domain_filter)
+    if domain_filter and not domains:
+        print(f"WARNING: No domains matched filter: {domain_filter}", file=sys.stderr)
+        return 1
+    validate_overrides(overrides, {d.name for d in all_domains})
+
+    previous_manifest = load_manifest(repo_root)
+    manifest_tracked = manifest_exists(repo_root)
+
+    states_dir = repo_root / "src" / "hassette" / "models" / "states"
+    entities_dir = repo_root / "src" / "hassette" / "models" / "entities"
+    const_dir = repo_root / "src" / "hassette" / "const"
+
+    domain_result = _generate_domains(
+        domains,
+        ha_source=ha_source,
+        overrides=overrides,
+        repo_root=repo_root,
+        states_dir=states_dir,
+        entities_dir=entities_dir,
+        check_mode=check_mode,
+        previous_manifest=previous_manifest,
+        manifest_tracked=manifest_tracked,
+    )
+    rejections = rejections + domain_result.rejections
+    generated_files = domain_result.generated_files
+    skipped_domains = domain_result.skipped_domains
+    any_drift = domain_result.any_drift
+
+    const_output = _generate_constants(ha_source, const_dir, repo_root, check_mode=check_mode)
+    generated_files = generated_files | const_output.generated_files
+    any_drift = any_drift or const_output.any_drift
+
+    if not _predicate_is_fresh(ha_source, repo_root, check_mode=check_mode):
+        any_drift = True
+
+    init_output = _generate_package_inits(states_dir, entities_dir, repo_root, check_mode=check_mode)
+    generated_files = generated_files | init_output.generated_files
+    any_drift = any_drift or init_output.any_drift
+
+    if not check_mode:
+        _finalize_manifest(
+            repo_root, domain_filter, generated_files=generated_files, previous_manifest=previous_manifest
+        )
+
+    return _report_summary_and_exit_code(
+        domains=domains,
+        skipped_domains=skipped_domains,
+        rejections=rejections,
+        any_drift=any_drift,
+        previous_manifest=previous_manifest,
+        generated_files=generated_files,
+        check_mode=check_mode,
+        domain_filter=domain_filter,
+    )
+
+
+def _discover_domains_for_run(
+    ha_source: HASource, domain_filter: set[str] | None
+) -> tuple[list[DiscoveredDomain], list[DiscoveredDomain], list[Rejection], dict[str, DomainOverride]]:
+    """Discover regular + manually-declared domains and apply ``--domain`` filtering.
+
+    Returns ``(domains, all_domains, rejections, overrides)``. ``all_domains`` is the unfiltered
+    set — the caller needs it for override validation, which must see every discovered domain
+    name regardless of ``--domain``. Prints the "Discovered N entity domains" line as a side
+    effect; the caller is responsible for the "no domains matched filter" early-exit, since that
+    has to skip override validation entirely.
+    """
     all_domains, rejections = _reject_unsafe_domain_names(discover_domains(ha_source.path))
     overrides = load_overrides()
 
@@ -87,115 +184,182 @@ def run_pipeline(
         # A rejection outside the requested filter is not this run's concern, and letting it fail
         # --check would make every filtered run answer for the whole of upstream.
         rejections = [r for r in rejections if r.domain in domain_filter]
-        if not domains:
-            print(f"WARNING: No domains matched filter: {domain_filter}", file=sys.stderr)
-            return 1
     else:
         domains = all_domains
 
-    validate_overrides(overrides, {d.name for d in all_domains})
+    return domains, all_domains, rejections, overrides
 
-    previous_manifest = load_manifest(repo_root)
-    manifest_tracked = manifest_exists(repo_root)
+
+def _generate_domains(
+    domains: list[DiscoveredDomain],
+    *,
+    ha_source: HASource,
+    overrides: dict[str, DomainOverride],
+    repo_root: Path,
+    states_dir: Path,
+    entities_dir: Path,
+    check_mode: bool,
+    previous_manifest: set[Path],
+    manifest_tracked: bool,
+) -> _GenerationResult:
+    """Extract and generate state models + entity wrappers for every discovered domain.
+
+    Two ways a domain can come up short, kept apart because they mean different things to the
+    operator: a skip is "the generator tried and could not finish this domain", a rejection is
+    "a name from upstream was not safe to put in generated source, so nothing was attempted".
+    Both fail --check; only skips reduce the generated count in the summary.
+    """
     generated_files: set[Path] = set()
-    # Two ways a domain can come up short, kept apart because they mean different things to the
-    # operator: a skip is "the generator tried and could not finish this domain", a rejection is
-    # "a name from upstream was not safe to put in generated source, so nothing was attempted".
-    # Both fail --check; only skips reduce the generated count in the summary.
     skipped_domains: list[str] = []
+    rejections: list[Rejection] = []
     any_drift = False
 
-    states_dir = repo_root / "src" / "hassette" / "models" / "states"
-    entities_dir = repo_root / "src" / "hassette" / "models" / "entities"
-    const_dir = repo_root / "src" / "hassette" / "const"
-
     for domain_info in domains:
-        try:
-            extracted = _extract_domain(ha_source.path, domain_info, overrides)
-        except Exception as exc:
-            print(f"WARNING: Failed to extract {domain_info.name}: {exc}", file=sys.stderr)
+        outcome = _generate_domain_files(
+            domain_info,
+            ha_source=ha_source,
+            overrides=overrides,
+            repo_root=repo_root,
+            states_dir=states_dir,
+            entities_dir=entities_dir,
+            check_mode=check_mode,
+            previous_manifest=previous_manifest,
+            manifest_tracked=manifest_tracked,
+        )
+        generated_files |= outcome.generated_files
+        if outcome.skipped:
             skipped_domains.append(domain_info.name)
-            continue
+        if outcome.rejection is not None:
+            rejections.append(outcome.rejection)
+        any_drift = any_drift or outcome.any_drift
 
-        state_content = generate_state_model(extracted)
-        state_path = states_dir / f"{domain_info.name}.py"
-        rel_state = state_path.relative_to(repo_root)
+    return _GenerationResult(generated_files, skipped_domains, rejections, any_drift)
 
-        if check_mode:
-            if not check_drift(state_path, state_content, f"{domain_info.name} state model"):
-                any_drift = True
+
+def _generate_domain_files(
+    domain_info: DiscoveredDomain,
+    *,
+    ha_source: HASource,
+    overrides: dict[str, DomainOverride],
+    repo_root: Path,
+    states_dir: Path,
+    entities_dir: Path,
+    check_mode: bool,
+    previous_manifest: set[Path],
+    manifest_tracked: bool,
+) -> _DomainOutcome:
+    """Generate the state model and (if applicable) entity wrapper for a single domain."""
+    try:
+        extracted = _extract_domain(ha_source.path, domain_info, overrides)
+    except Exception as exc:
+        print(f"WARNING: Failed to extract {domain_info.name}: {exc}", file=sys.stderr)
+        return _DomainOutcome(skipped=True)
+
+    state_content = generate_state_model(extracted)
+    state_path = states_dir / f"{domain_info.name}.py"
+    rel_state = state_path.relative_to(repo_root)
+    generated_files: set[Path] = set()
+    any_drift = False
+
+    if check_mode:
+        if not check_drift(state_path, state_content, f"{domain_info.name} state model"):
+            any_drift = True
+        generated_files.add(rel_state)
+    else:
+        if not _may_overwrite(state_path, rel_state, previous_manifest, tracked=manifest_tracked):
+            return _DomainOutcome(skipped=True)
+        if atomic_write(state_path, state_content):
             generated_files.add(rel_state)
         else:
-            if not _may_overwrite(state_path, rel_state, previous_manifest, tracked=manifest_tracked):
-                skipped_domains.append(domain_info.name)
-                continue
-            if atomic_write(state_path, state_content):
-                generated_files.add(rel_state)
-            else:
-                print(f"WARNING: Skipped {rel_state} (validation failed)", file=sys.stderr)
-                skipped_domains.append(domain_info.name)
-                continue
+            print(f"WARNING: Skipped {rel_state} (validation failed)", file=sys.stderr)
+            return _DomainOutcome(skipped=True)
 
-        try:
-            entity_content = generate_entity_wrapper(extracted)
-        except UnsafeGeneratedValueError as exc:
-            # The state model above is unaffected and stays generated — only the service wrappers
-            # depend on the rejected name, so the domain is not added to skipped_domains. It is
-            # still recorded as a rejection: the committed wrapper was never checked against
-            # upstream, and --check must not report the tree as current on that basis.
-            print(f"WARNING: Rejected {domain_info.name} entity wrapper: {exc}", file=sys.stderr)
-            rejections.append(Rejection(domain_info.name, "entity wrapper"))
-            continue
+    try:
+        entity_content = generate_entity_wrapper(extracted)
+    except UnsafeGeneratedValueError as exc:
+        # The state model above is unaffected and stays generated — only the service wrappers
+        # depend on the rejected name, so the domain is not added to skipped_domains. It is
+        # still recorded as a rejection: the committed wrapper was never checked against
+        # upstream, and --check must not report the tree as current on that basis.
+        print(f"WARNING: Rejected {domain_info.name} entity wrapper: {exc}", file=sys.stderr)
+        return _DomainOutcome(generated_files=generated_files, rejection=Rejection(domain_info.name, "entity wrapper"))
 
-        if entity_content is not None:
-            entity_path = entities_dir / f"{domain_info.name}.py"
-            rel_entity = entity_path.relative_to(repo_root)
+    if entity_content is None:
+        return _DomainOutcome(generated_files=generated_files, any_drift=any_drift)
 
-            if check_mode:
-                if not check_drift(entity_path, entity_content, f"{domain_info.name} entity wrapper"):
-                    any_drift = True
-                generated_files.add(rel_entity)
-            else:
-                # Unlike the state model above, the domain is not added to skipped_domains: its
-                # state model did generate. The refusal is reported by the warning, matching how
-                # an entity wrapper that fails ruff validation is already handled.
-                if not _may_overwrite(entity_path, rel_entity, previous_manifest, tracked=manifest_tracked):
-                    continue
-                if atomic_write(entity_path, entity_content):
-                    generated_files.add(rel_entity)
-                else:
-                    print(f"WARNING: Skipped {rel_entity} (validation failed)", file=sys.stderr)
+    entity_path = entities_dir / f"{domain_info.name}.py"
+    rel_entity = entity_path.relative_to(repo_root)
 
-    constants = extract_sensor_constants(ha_source.path)
-    if constants:
-        const_content = generate_sensor_constants(constants)
-        const_path = const_dir / "sensor.py"
-        rel_const = const_path.relative_to(repo_root)
-
-        if check_mode:
-            if not check_drift(const_path, const_content, "sensor constants"):
-                any_drift = True
-            generated_files.add(rel_const)
-        elif atomic_write(const_path, const_content):
-            # Ownership is only claimed for output this run actually produced. atomic_write
-            # reports its own failure, and leaving the path out of the manifest surfaces the
-            # retained older copy as an orphan on the next full run.
-            generated_files.add(rel_const)
-
-    sensor_dir = ha_source.path / "homeassistant" / "components" / "sensor"
-    if check_mode and sensor_dir.is_dir():
-        # Not a generated-file comparison — this guards the *hand-written* port in
-        # sensor_shapes.py against HA changing the logic it was ported from. The fixture test
-        # that pins hassette's own behavior can't see that; this can. Scoped to --check (what CI
-        # runs) so a plain `generate` run is never blocked by unrelated upstream drift, and
-        # scoped to sources that actually have a sensor component so synthetic single-domain
-        # test fixtures elsewhere in this suite are unaffected. Checking the directory rather than
-        # `__init__.py` specifically means a relocated/renamed predicate file still triggers the
-        # freshness check below, which then itself reports the missing predicate as drift instead
-        # of silently skipping the guard.
-        numeric_predicate_snapshot = repo_root / "codegen" / "snapshots" / "numeric_state_expected.py.txt"
-        if not _check_predicate_freshness(ha_source.path, numeric_predicate_snapshot):
+    if check_mode:
+        if not check_drift(entity_path, entity_content, f"{domain_info.name} entity wrapper"):
             any_drift = True
+        generated_files.add(rel_entity)
+        return _DomainOutcome(generated_files=generated_files, any_drift=any_drift)
+
+    # Unlike the state model above, the domain is not added to skipped_domains: its state model
+    # did generate. The refusal is reported by the warning, matching how an entity wrapper that
+    # fails ruff validation is already handled.
+    if not _may_overwrite(entity_path, rel_entity, previous_manifest, tracked=manifest_tracked):
+        return _DomainOutcome(generated_files=generated_files, any_drift=any_drift)
+    if atomic_write(entity_path, entity_content):
+        generated_files.add(rel_entity)
+    else:
+        print(f"WARNING: Skipped {rel_entity} (validation failed)", file=sys.stderr)
+
+    return _DomainOutcome(generated_files=generated_files, any_drift=any_drift)
+
+
+def _generate_constants(ha_source: HASource, const_dir: Path, repo_root: Path, *, check_mode: bool) -> _WriteOutput:
+    """Generate the sensor device-class/unit/state-class constants module, if any exist upstream."""
+    constants = extract_sensor_constants(ha_source.path)
+    if not constants:
+        return _WriteOutput()
+
+    const_content = generate_sensor_constants(constants)
+    const_path = const_dir / "sensor.py"
+    rel_const = const_path.relative_to(repo_root)
+
+    if check_mode:
+        any_drift = not check_drift(const_path, const_content, "sensor constants")
+        return _WriteOutput(generated_files={rel_const}, any_drift=any_drift)
+
+    # Ownership is only claimed for output this run actually produced. atomic_write reports its
+    # own failure, and leaving the path out of the manifest surfaces the retained older copy as an
+    # orphan on the next full run.
+    if atomic_write(const_path, const_content):
+        return _WriteOutput(generated_files={rel_const})
+    return _WriteOutput()
+
+
+def _predicate_is_fresh(ha_source: HASource, repo_root: Path, *, check_mode: bool) -> bool:
+    """Guard against Home Assistant changing the numeric-branch predicate logic hassette ported.
+
+    Not a generated-file comparison — this guards the *hand-written* port in sensor_shapes.py
+    against HA changing the logic it was ported from. The fixture test that pins hassette's own
+    behavior can't see that; this can. Scoped to --check (what CI runs) so a plain `generate` run
+    is never blocked by unrelated upstream drift, and scoped to sources that actually have a
+    sensor component so synthetic single-domain test fixtures elsewhere in this suite are
+    unaffected. Checking the directory rather than `__init__.py` specifically means a
+    relocated/renamed predicate file still triggers the freshness check below, which then itself
+    reports the missing predicate as drift instead of silently skipping the guard.
+
+    Returns whether the predicate is fresh (or the guard doesn't apply to this run) — same
+    True-means-OK polarity as ``check_drift``, so a caller always reads ``if not ...: any_drift =
+    True``. Always True (vacuously) outside --check mode or when the source has no sensor
+    component at all.
+    """
+    sensor_dir = ha_source.path / "homeassistant" / "components" / "sensor"
+    if not (check_mode and sensor_dir.is_dir()):
+        return True
+
+    numeric_predicate_snapshot = repo_root / "codegen" / "snapshots" / "numeric_state_expected.py.txt"
+    return _check_predicate_freshness(ha_source.path, numeric_predicate_snapshot)
+
+
+def _generate_package_inits(states_dir: Path, entities_dir: Path, repo_root: Path, *, check_mode: bool) -> _WriteOutput:
+    """Regenerate the states/ and entities/ package __init__.py files from their sibling modules."""
+    generated_files: set[Path] = set()
+    any_drift = False
 
     for pkg_dir in (states_dir, entities_dir):
         init_content = generate_init_py(pkg_dir)
@@ -209,19 +373,46 @@ def run_pipeline(
         elif atomic_write(init_path, init_content):
             generated_files.add(rel_init)
 
-    if not check_mode:
-        if domain_filter:
-            merged = merge_manifest(repo_root, domain_filter, generated_files)
-            save_manifest(repo_root, merged)
-        else:
-            orphans = detect_orphans(previous_manifest, generated_files)
-            if orphans:
-                print(
-                    f"Orphaned files (no longer generated): {', '.join(str(p) for p in sorted(orphans))}",
-                    file=sys.stderr,
-                )
-            save_manifest(repo_root, generated_files)
+    return _WriteOutput(generated_files=generated_files, any_drift=any_drift)
 
+
+def _finalize_manifest(
+    repo_root: Path,
+    domain_filter: set[str] | None,
+    *,
+    generated_files: set[Path],
+    previous_manifest: set[Path],
+) -> None:
+    """Persist the manifest for this run, warning about any newly-orphaned files.
+
+    Only called for a non-check-mode run — --check never mutates the manifest.
+    """
+    if domain_filter:
+        merged = merge_manifest(repo_root, domain_filter, generated_files)
+        save_manifest(repo_root, merged)
+        return
+
+    orphans = detect_orphans(previous_manifest, generated_files)
+    if orphans:
+        print(
+            f"Orphaned files (no longer generated): {', '.join(str(p) for p in sorted(orphans))}",
+            file=sys.stderr,
+        )
+    save_manifest(repo_root, generated_files)
+
+
+def _report_summary_and_exit_code(
+    *,
+    domains: list[DiscoveredDomain],
+    skipped_domains: list[str],
+    rejections: list[Rejection],
+    any_drift: bool,
+    previous_manifest: set[Path],
+    generated_files: set[Path],
+    check_mode: bool,
+    domain_filter: set[str] | None,
+) -> int:
+    """Print the run summary and, in --check mode, the failure detail. Returns the exit code."""
     generated_count = len(domains) - len(skipped_domains)
     print(
         f"Summary: {generated_count} domains generated, {len(skipped_domains)} skipped"
@@ -237,14 +428,14 @@ def run_pipeline(
         file=sys.stderr,
     )
 
-    if check_mode and (any_drift or skipped_domains or rejections):
-        if skipped_domains:
-            print(f"Skipped domains: {', '.join(skipped_domains)}", file=sys.stderr)
-        if rejections:
-            print(f"Rejected: {', '.join(f'{r.domain} ({r.what})' for r in rejections)}", file=sys.stderr)
-        return 1
+    if not (check_mode and (any_drift or skipped_domains or rejections)):
+        return 0
 
-    return 0
+    if skipped_domains:
+        print(f"Skipped domains: {', '.join(skipped_domains)}", file=sys.stderr)
+    if rejections:
+        print(f"Rejected: {', '.join(f'{r.domain} ({r.what})' for r in rejections)}", file=sys.stderr)
+    return 1
 
 
 def _reject_unsafe_domain_names(domains: list[DiscoveredDomain]) -> tuple[list[DiscoveredDomain], list[Rejection]]:

--- a/codegen/tests/test_pipeline_characterization.py
+++ b/codegen/tests/test_pipeline_characterization.py
@@ -1,0 +1,219 @@
+"""End-to-end characterization test for ``run_pipeline``.
+
+``run_pipeline`` (see ``pipeline.py``) blends six responsibilities in one ~180-line function:
+domain discovery/rejection, override loading/validation, per-domain state and entity generation,
+sensor-constants generation, the predicate-freshness drift guard, and manifest/summary
+bookkeeping. Splitting it risks silently reordering its interleaved stderr diagnostics or
+dropping one of the ``generated_files``/``skipped_domains``/``rejections`` bookkeeping updates
+threaded through every stage.
+
+This test pins the current behavior — the *relative order* of every diagnostic line, the exact
+manifest contents, the summary line, and the exit code — for one scenario that exercises all six
+responsibilities in a single run:
+
+- a normal domain that generates both a state model and an entity wrapper (``widget``)
+- a domain whose entity wrapper is rejected for an unsafe service name, but whose state model
+  still generates (``badservice``)
+- a domain whose extraction raises and is skipped entirely (``flaky``)
+- a reserved domain name rejected before generation ever starts (``base``)
+- a manually-discovered override domain with no upstream component directory (``myintegration``)
+- an override that matches no discovered domain, to pin the validation-warning path
+  (``ghostdomain``)
+- a synthetic ``sensor`` component (not itself a discovered entity domain) whose ``const.py`` and
+  ``__init__.py`` drive sensor-constants generation and the predicate-freshness guard
+- a stale manifest entry that becomes an orphan once this run's generated set excludes it
+
+A later decomposition of ``run_pipeline`` into named steps must leave this test's assertions
+unchanged.
+
+Real override files bundled in ``hassette_codegen/overrides/`` are bypassed by monkeypatching
+``pipeline.load_overrides`` — this scenario's domain names deliberately collide with none of them,
+but patching keeps the scenario independent of whatever overrides the project happens to ship.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from hassette_codegen import pipeline
+from hassette_codegen.extractors.properties import ExtractedProperty
+from hassette_codegen.ha_source import HASource
+from hassette_codegen.manifest import load_manifest, save_manifest
+from hassette_codegen.overrides import DomainOverride
+
+from .test_pipeline_guards import STATES, UNSAFE_SERVICE_YAML, make_ha_core
+
+ENTITIES = Path("src/hassette/models/entities")
+CONST = Path("src/hassette/const")
+
+SAFE_SERVICE_YAML = "turn_on:\n  fields: {}\n"
+
+# The exact source segment `ast.get_source_segment` will extract for the FunctionDef below —
+# `extract_numeric_state_expected_source` returns this verbatim, and the freshness guard compares
+# it (stripped) against the committed snapshot.
+NUMERIC_STATE_EXPECTED_SOURCE = (
+    'def _numeric_state_expected(state: str) -> bool:\n    return state not in ("unknown", "unavailable")'
+)
+
+SENSOR_INIT_PY = f'''"""Synthetic HA sensor component for predicate freshness testing."""
+
+
+{NUMERIC_STATE_EXPECTED_SOURCE}
+
+
+class _Marker:
+    pass
+'''
+
+SENSOR_CONST_PY = """class SensorDeviceClass:
+    TEMPERATURE = "temperature"
+    HUMIDITY = "humidity"
+
+
+NON_NUMERIC_DEVICE_CLASSES = {SensorDeviceClass.TEMPERATURE}
+
+
+class SensorStateClass:
+    MEASUREMENT = "measurement"
+"""
+
+
+def assert_in_order(text: str, *markers: str) -> None:
+    """Assert each marker appears in ``text``, in the given order, without needing exact equality.
+
+    Substring search rather than full-text equality on purpose: the noise-free scenario built
+    below is already deterministic, so this only needs to prove the *relative order* of the
+    diagnostics that matter, not forbid any other line from existing.
+    """
+    cursor = 0
+    for marker in markers:
+        idx = text.find(marker, cursor)
+        assert idx != -1, f"expected {marker!r} to appear at or after position {cursor} in:\n{text}"
+        cursor = idx + len(marker)
+
+
+@pytest.fixture
+def scenario(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> tuple[HASource, Path]:
+    """Build the full six-responsibility scenario described in the module docstring."""
+    ha_source = make_ha_core(
+        tmp_path / "core",
+        ["base", "badservice", "flaky", "widget"],
+        services={"badservice": UNSAFE_SERVICE_YAML, "widget": SAFE_SERVICE_YAML},
+    )
+
+    # A manually-discovered domain: an empty component directory (no __init__.py, so ordinary
+    # discovery never sees it) plus an override that supplies its properties directly.
+    (ha_source.path / "homeassistant" / "components" / "myintegration").mkdir()
+
+    # A synthetic sensor component: no CACHED_PROPERTIES_WITH_ATTR_ marker, so it is never a
+    # discovered entity domain — it exists only to drive sensor-constants generation and the
+    # predicate-freshness guard, both of which read straight from this path.
+    sensor_dir = ha_source.path / "homeassistant" / "components" / "sensor"
+    sensor_dir.mkdir()
+    (sensor_dir / "__init__.py").write_text(SENSOR_INIT_PY, encoding="utf-8")
+    (sensor_dir / "const.py").write_text(SENSOR_CONST_PY, encoding="utf-8")
+
+    overrides = {
+        "myintegration": DomainOverride(
+            domain="myintegration",
+            discovery="manual",
+            state_base_class="StringBaseState",
+            properties=[ExtractedProperty(name="value", python_type="str", has_default=True)],
+        ),
+        # Matches no discovered domain — pins the validate_overrides mismatch warning.
+        "ghostdomain": DomainOverride(domain="ghostdomain"),
+    }
+    monkeypatch.setattr(pipeline, "load_overrides", lambda: overrides)
+
+    # Force one domain's extraction to fail, deterministically, without touching real extractor
+    # internals — mirrors the monkeypatch pattern already used in test_pipeline_guards.py.
+    real_extract_domain = pipeline._extract_domain
+
+    def flaky_extract_domain(ha_core_path, domain_info, domain_overrides):
+        if domain_info.name == "flaky":
+            raise ValueError("synthetic extraction failure")
+        return real_extract_domain(ha_core_path, domain_info, domain_overrides)
+
+    monkeypatch.setattr(pipeline, "_extract_domain", flaky_extract_domain)
+
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    (repo_root / "codegen" / "snapshots").mkdir(parents=True)
+    (repo_root / "codegen" / "snapshots" / "numeric_state_expected.py.txt").write_text(
+        NUMERIC_STATE_EXPECTED_SOURCE, encoding="utf-8"
+    )
+
+    # A stale manifest entry with no corresponding domain in this run — becomes an orphan.
+    save_manifest(repo_root, {Path(STATES / "ghostfile.py")})
+
+    return ha_source, repo_root
+
+
+class TestRunPipelineCharacterization:
+    def test_generate_run_pins_ordering_bookkeeping_and_exit_code(
+        self, scenario: tuple[HASource, Path], capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        ha_source, repo_root = scenario
+
+        exit_code = pipeline.run_pipeline(ha_source, repo_root, check_mode=False)
+        err = capsys.readouterr().err
+
+        assert exit_code == 0
+
+        assert_in_order(
+            err,
+            "WARNING: Rejected domain 'base': reserved for hand-written files",
+            "Discovered 4 entity domains (1 manual)",
+            "WARNING: Override file for 'ghostdomain' does not match any discovered domain",
+            "WARNING: Rejected badservice entity wrapper:",
+            "WARNING: Failed to extract flaky: synthetic extraction failure",
+            "Orphaned files (no longer generated): src/hassette/models/states/ghostfile.py",
+            "Summary: 3 domains generated, 1 skipped, 2 rejected, 1 orphans",
+        )
+
+        expected_manifest = {
+            STATES / "badservice.py",
+            STATES / "widget.py",
+            STATES / "myintegration.py",
+            STATES / "__init__.py",
+            ENTITIES / "widget.py",
+            ENTITIES / "__init__.py",
+            CONST / "sensor.py",
+        }
+        assert load_manifest(repo_root) == expected_manifest, (
+            "generated_files bookkeeping must match exactly — the manifest is what the next run's "
+            "ownership and orphan checks consult"
+        )
+
+        assert not (repo_root / STATES / "flaky.py").exists()
+        assert not (repo_root / ENTITIES / "badservice.py").exists()
+
+    def test_check_run_pins_drift_free_pass_through_and_exit_code(
+        self, scenario: tuple[HASource, Path], capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        ha_source, repo_root = scenario
+        pipeline.run_pipeline(ha_source, repo_root, check_mode=False)
+        capsys.readouterr()  # drop the generate run's output — only the check run is asserted on
+
+        exit_code = pipeline.run_pipeline(ha_source, repo_root, check_mode=True)
+        err = capsys.readouterr().err
+
+        assert exit_code == 1
+
+        assert_in_order(
+            err,
+            "WARNING: Rejected domain 'base': reserved for hand-written files",
+            "Discovered 4 entity domains (1 manual)",
+            "WARNING: Override file for 'ghostdomain' does not match any discovered domain",
+            "WARNING: Rejected badservice entity wrapper:",
+            "WARNING: Failed to extract flaky: synthetic extraction failure",
+            "Summary: 3 domains generated, 1 skipped, 2 rejected",
+            "Skipped domains: flaky",
+            "Rejected: base (domain name), badservice (entity wrapper)",
+        )
+
+        # A freshly-generated tree must be drift-free — every check_drift call (state models,
+        # entity wrappers, sensor constants, both __init__.py files) and the predicate-freshness
+        # guard all silently pass. Orphan detection is also write-mode-only.
+        assert "is out of date" not in err
+        assert "orphan" not in err.lower()

--- a/codegen/tests/test_pipeline_characterization.py
+++ b/codegen/tests/test_pipeline_characterization.py
@@ -48,6 +48,12 @@ CONST = Path("src/hassette/const")
 
 SAFE_SERVICE_YAML = "turn_on:\n  fields: {}\n"
 
+# A non-string top-level key is valid YAML but not a valid service name: extract_services'
+# unqualified `service_name.startswith(".")` check has no int/str guard, so this raises a real
+# AttributeError instead of the yaml.YAMLError the parser already handles. Used to force a
+# genuine extraction failure for the "flaky" domain below, without touching pipeline internals.
+MALFORMED_SERVICE_YAML = "123:\n  fields: {}\n"
+
 # The exact source segment `ast.get_source_segment` will extract for the FunctionDef below —
 # `extract_numeric_state_expected_source` returns this verbatim, and the freshness guard compares
 # it (stripped) against the committed snapshot.
@@ -98,7 +104,11 @@ def scenario(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> tuple[HASource,
     ha_source = make_ha_core(
         tmp_path / "core",
         ["base", "badservice", "flaky", "widget"],
-        services={"badservice": UNSAFE_SERVICE_YAML, "widget": SAFE_SERVICE_YAML},
+        services={
+            "badservice": UNSAFE_SERVICE_YAML,
+            "flaky": MALFORMED_SERVICE_YAML,
+            "widget": SAFE_SERVICE_YAML,
+        },
     )
 
     # A manually-discovered domain: an empty component directory (no __init__.py, so ordinary
@@ -124,17 +134,6 @@ def scenario(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> tuple[HASource,
         "ghostdomain": DomainOverride(domain="ghostdomain"),
     }
     monkeypatch.setattr(pipeline, "load_overrides", lambda: overrides)
-
-    # Force one domain's extraction to fail, deterministically, without touching real extractor
-    # internals — mirrors the monkeypatch pattern already used in test_pipeline_guards.py.
-    real_extract_domain = pipeline._extract_domain
-
-    def flaky_extract_domain(ha_core_path, domain_info, domain_overrides):
-        if domain_info.name == "flaky":
-            raise ValueError("synthetic extraction failure")
-        return real_extract_domain(ha_core_path, domain_info, domain_overrides)
-
-    monkeypatch.setattr(pipeline, "_extract_domain", flaky_extract_domain)
 
     repo_root = tmp_path / "repo"
     repo_root.mkdir()
@@ -166,7 +165,7 @@ class TestRunPipelineCharacterization:
             "Discovered 4 entity domains (1 manual)",
             "WARNING: Override file for 'ghostdomain' does not match any discovered domain",
             "WARNING: Rejected badservice entity wrapper:",
-            "WARNING: Failed to extract flaky: synthetic extraction failure",
+            "WARNING: Failed to extract flaky: 'int' object has no attribute 'startswith'",
             "Orphaned files (no longer generated): src/hassette/models/states/ghostfile.py",
             "Summary: 3 domains generated, 1 skipped, 2 rejected, 1 orphans",
         )
@@ -206,7 +205,7 @@ class TestRunPipelineCharacterization:
             "Discovered 4 entity domains (1 manual)",
             "WARNING: Override file for 'ghostdomain' does not match any discovered domain",
             "WARNING: Rejected badservice entity wrapper:",
-            "WARNING: Failed to extract flaky: synthetic extraction failure",
+            "WARNING: Failed to extract flaky: 'int' object has no attribute 'startswith'",
             "Summary: 3 domains generated, 1 skipped, 2 rejected",
             "Skipped domains: flaky",
             "Rejected: base (domain name), badservice (entity wrapper)",

--- a/tests/integration/test_drift_check.py
+++ b/tests/integration/test_drift_check.py
@@ -36,7 +36,7 @@ esac
 class DriftCheckResult:
     returncode: int
     stderr: str
-    github_output: str
+    fields: dict[str, str]
 
 
 @pytest.fixture
@@ -50,6 +50,31 @@ def stub_gh_path(tmp_path: Path) -> Path:
     gh.write_text(STUB_GH)
     gh.chmod(0o755)
     return bin_dir
+
+
+def parse_github_output(text: str) -> dict[str, str]:
+    r"""Parse GITHUB_OUTPUT's `key<<DELIM\nvalue\nDELIM\n` heredoc format into a dict.
+
+    drift_check.py writes this form (a random per-field delimiter) rather than plain `key=value`
+    lines so a value containing a newline can never terminate its own field early — see
+    write_github_output's docstring in tools/release/drift_check.py.
+    """
+    fields: dict[str, str] = {}
+    lines = text.splitlines()
+    i = 0
+    while i < len(lines):
+        key, sep, delimiter = lines[i].partition("<<")
+        if not sep:
+            i += 1
+            continue
+        i += 1
+        value_lines: list[str] = []
+        while lines[i] != delimiter:
+            value_lines.append(lines[i])
+            i += 1
+        fields[key] = "\n".join(value_lines)
+        i += 1
+    return fields
 
 
 def run_drift_check(bin_dir: Path, *, existing_issue: str = "", **extra_args: str) -> DriftCheckResult:
@@ -66,7 +91,9 @@ def run_drift_check(bin_dir: Path, *, existing_issue: str = "", **extra_args: st
         args += [f"--{key.replace('_', '-')}", value]
 
     result = subprocess.run(args, cwd=str(PROJECT_ROOT), capture_output=True, text=True, timeout=30, env=env)
-    return DriftCheckResult(returncode=result.returncode, stderr=result.stderr, github_output=output_file.read_text())
+    return DriftCheckResult(
+        returncode=result.returncode, stderr=result.stderr, fields=parse_github_output(output_file.read_text())
+    )
 
 
 @pytest.mark.integration
@@ -76,10 +103,10 @@ def test_no_drift_reports_drift_false(stub_gh_path: Path) -> None:
     )
 
     assert result.returncode == 0, result.stderr
-    assert "drift=false" in result.github_output
-    assert "current=1.2.3" in result.github_output
-    assert "latest=1.2.3" in result.github_output
-    assert "existing-issue=" in result.github_output
+    assert result.fields["drift"] == "false"
+    assert result.fields["current"] == "1.2.3"
+    assert result.fields["latest"] == "1.2.3"
+    assert result.fields["existing-issue"] == ""
 
 
 @pytest.mark.integration
@@ -89,8 +116,8 @@ def test_drift_with_no_existing_issue(stub_gh_path: Path) -> None:
     )
 
     assert result.returncode == 0, result.stderr
-    assert "drift=true" in result.github_output
-    assert "existing-issue=\n" in result.github_output
+    assert result.fields["drift"] == "true"
+    assert result.fields["existing-issue"] == ""
 
 
 @pytest.mark.integration
@@ -105,8 +132,8 @@ def test_drift_with_existing_issue_is_deduped(stub_gh_path: Path) -> None:
     )
 
     assert result.returncode == 0, result.stderr
-    assert "drift=true" in result.github_output
-    assert "existing-issue=42" in result.github_output
+    assert result.fields["drift"] == "true"
+    assert result.fields["existing-issue"] == "42"
 
 
 @pytest.mark.integration
@@ -124,5 +151,5 @@ def test_no_drift_still_reports_existing_issue_for_resync_close(stub_gh_path: Pa
     )
 
     assert result.returncode == 0, result.stderr
-    assert "drift=false" in result.github_output
-    assert "existing-issue=7" in result.github_output
+    assert result.fields["drift"] == "false"
+    assert result.fields["existing-issue"] == "7"

--- a/tests/integration/test_drift_check.py
+++ b/tests/integration/test_drift_check.py
@@ -22,6 +22,10 @@ case "$1 $2" in
         exit 0
         ;;
     "issue list")
+        if [ -n "${STUB_ISSUE_LIST_FAIL:-}" ]; then
+            echo "stub gh: simulated issue list failure" >&2
+            exit 1
+        fi
         echo "${STUB_EXISTING_ISSUE:-}"
         exit 0
         ;;
@@ -78,13 +82,16 @@ def parse_github_output(text: str) -> dict[str, str]:
     return fields
 
 
-def run_drift_check(bin_dir: Path, *, existing_issue: str = "", **extra_args: str) -> DriftCheckResult:
+def run_drift_check(
+    bin_dir: Path, *, existing_issue: str = "", fail_issue_list: bool = False, **extra_args: str
+) -> DriftCheckResult:
     output_file = bin_dir.parent / "github_output"
     output_file.write_text("")
 
     env = dict(os.environ)
     env["PATH"] = f"{bin_dir}:{env['PATH']}"
     env["STUB_EXISTING_ISSUE"] = existing_issue
+    env["STUB_ISSUE_LIST_FAIL"] = "1" if fail_issue_list else ""
     env["GITHUB_OUTPUT"] = str(output_file)
 
     args = ["uv", "run", str(SCRIPT)]
@@ -156,3 +163,45 @@ def test_no_drift_still_reports_existing_issue_for_resync_close(stub_gh_path: Pa
     assert result.returncode == 0, result.stderr
     assert result.fields["drift"] == "false"
     assert result.fields["existing-issue"] == "7"
+
+
+@pytest.mark.integration
+def test_embedded_newline_cannot_smuggle_a_second_output_field(stub_gh_path: Path) -> None:
+    r"""A value containing a newline must not forge a separate GITHUB_OUTPUT field.
+
+    ``--latest`` is untrusted (it comes from an external registry) — see write_github_output's
+    docstring in drift_check.py. If the script wrote plain ``key=value`` lines instead of the
+    heredoc-with-random-delimiter form, a value like ``"1.2.3\ninjected=true"`` would terminate
+    the ``latest`` field early and inject a bogus ``injected`` field.
+    """
+    result = run_drift_check(
+        stub_gh_path,
+        current="1.2.3",
+        latest="1.2.3\ninjected=true",
+        label="pypi-drift",
+        label_description="desc",
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert result.fields["latest"] == "1.2.3\ninjected=true"
+    assert "injected" not in result.fields
+
+
+@pytest.mark.integration
+def test_failed_issue_lookup_fails_loud_instead_of_filing_a_duplicate(stub_gh_path: Path) -> None:
+    """A failed `gh issue list` (auth, rate limit, network) must not be swallowed as "no existing
+    issue" — that would let a scheduled run file a duplicate tracking issue instead of surfacing
+    the real failure. See find_existing_issue's docstring in drift_check.py.
+    """
+    result = run_drift_check(
+        stub_gh_path,
+        fail_issue_list=True,
+        current="1.2.3",
+        latest="1.2.4",
+        label="pypi-drift",
+        label_description="desc",
+    )
+
+    assert result.returncode != 0
+    assert "gh issue list failed" in result.stderr
+    assert result.fields == {}

--- a/tests/integration/test_drift_check.py
+++ b/tests/integration/test_drift_check.py
@@ -15,6 +15,7 @@ import pytest
 
 PROJECT_ROOT = Path(__file__).resolve().parents[2]
 SCRIPT = PROJECT_ROOT / "tools" / "release" / "drift_check.py"
+SUBPROCESS_TIMEOUT_SECONDS = 30
 STUB_GH = """#!/usr/bin/env bash
 case "$1 $2" in
     "label create")
@@ -90,7 +91,9 @@ def run_drift_check(bin_dir: Path, *, existing_issue: str = "", **extra_args: st
     for key, value in extra_args.items():
         args += [f"--{key.replace('_', '-')}", value]
 
-    result = subprocess.run(args, cwd=str(PROJECT_ROOT), capture_output=True, text=True, timeout=30, env=env)
+    result = subprocess.run(
+        args, cwd=str(PROJECT_ROOT), capture_output=True, text=True, timeout=SUBPROCESS_TIMEOUT_SECONDS, env=env
+    )
     return DriftCheckResult(
         returncode=result.returncode, stderr=result.stderr, fields=parse_github_output(output_file.read_text())
     )

--- a/tests/integration/test_drift_check.py
+++ b/tests/integration/test_drift_check.py
@@ -1,0 +1,128 @@
+"""Verify tools/release/drift_check.py — the shared compare/dedup logic used by
+pypi-drift-check.yml, docker-drift-check.yml, and ha-version-drift.yml.
+
+Runs the script as a subprocess (it's a standalone `uv run --script`, not an importable module —
+see tools/release/check_wheel_spa.py and test_packaging.py for the established pattern) against
+a stub `gh` binary placed first on PATH, so no real GitHub API calls happen.
+"""
+
+import os
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+
+import pytest
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = PROJECT_ROOT / "tools" / "release" / "drift_check.py"
+STUB_GH = """#!/usr/bin/env bash
+case "$1 $2" in
+    "label create")
+        exit 0
+        ;;
+    "issue list")
+        echo "${STUB_EXISTING_ISSUE:-}"
+        exit 0
+        ;;
+    *)
+        echo "stub gh: unhandled args: $*" >&2
+        exit 1
+        ;;
+esac
+"""
+
+
+@dataclass(frozen=True)
+class DriftCheckResult:
+    returncode: int
+    stderr: str
+    github_output: str
+
+
+@pytest.fixture
+def stub_gh_path(tmp_path: Path) -> Path:
+    """Put a fake `gh` binary first on PATH so the script's `gh label create` /
+    `gh issue list` calls resolve to a controllable stub instead of the real CLI.
+    """
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    gh = bin_dir / "gh"
+    gh.write_text(STUB_GH)
+    gh.chmod(0o755)
+    return bin_dir
+
+
+def run_drift_check(bin_dir: Path, *, existing_issue: str = "", **extra_args: str) -> DriftCheckResult:
+    output_file = bin_dir.parent / "github_output"
+    output_file.write_text("")
+
+    env = dict(os.environ)
+    env["PATH"] = f"{bin_dir}:{env['PATH']}"
+    env["STUB_EXISTING_ISSUE"] = existing_issue
+    env["GITHUB_OUTPUT"] = str(output_file)
+
+    args = ["uv", "run", str(SCRIPT)]
+    for key, value in extra_args.items():
+        args += [f"--{key.replace('_', '-')}", value]
+
+    result = subprocess.run(args, cwd=str(PROJECT_ROOT), capture_output=True, text=True, timeout=30, env=env)
+    return DriftCheckResult(returncode=result.returncode, stderr=result.stderr, github_output=output_file.read_text())
+
+
+@pytest.mark.integration
+def test_no_drift_reports_drift_false(stub_gh_path: Path) -> None:
+    result = run_drift_check(
+        stub_gh_path, current="1.2.3", latest="1.2.3", label="pypi-drift", label_description="desc"
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "drift=false" in result.github_output
+    assert "current=1.2.3" in result.github_output
+    assert "latest=1.2.3" in result.github_output
+    assert "existing-issue=" in result.github_output
+
+
+@pytest.mark.integration
+def test_drift_with_no_existing_issue(stub_gh_path: Path) -> None:
+    result = run_drift_check(
+        stub_gh_path, current="1.2.3", latest="1.2.4", label="pypi-drift", label_description="desc"
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "drift=true" in result.github_output
+    assert "existing-issue=\n" in result.github_output
+
+
+@pytest.mark.integration
+def test_drift_with_existing_issue_is_deduped(stub_gh_path: Path) -> None:
+    result = run_drift_check(
+        stub_gh_path,
+        existing_issue="42",
+        current="1.2.3",
+        latest="1.2.4",
+        label="pypi-drift",
+        label_description="desc",
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "drift=true" in result.github_output
+    assert "existing-issue=42" in result.github_output
+
+
+@pytest.mark.integration
+def test_no_drift_still_reports_existing_issue_for_resync_close(stub_gh_path: Path) -> None:
+    """ha-version-drift.yml's auto-close-on-resync step relies on existing-issue being
+    populated even when there's no drift, so it doesn't need its own separate dedup lookup.
+    """
+    result = run_drift_check(
+        stub_gh_path,
+        existing_issue="7",
+        current="2024.1.0",
+        latest="2024.1.0",
+        label="ha-version-drift",
+        label_description="desc",
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "drift=false" in result.github_output
+    assert "existing-issue=7" in result.github_output

--- a/tests/unit/tools/conftest.py
+++ b/tests/unit/tools/conftest.py
@@ -3,6 +3,7 @@
 import textwrap
 from collections.abc import Callable
 from pathlib import Path
+from types import ModuleType
 
 import pytest
 
@@ -17,3 +18,17 @@ def write_sample(tmp_path: Path) -> Callable[[str], Path]:
         return target
 
     return _write
+
+
+def make_frontend_src(tmp_path: Path, monkeypatch: pytest.MonkeyPatch, module: ModuleType) -> Path:
+    """Point `module`'s REPO_ROOT/FRONTEND_SRC constants at an isolated tmp_path frontend tree.
+
+    Shared by the tools/frontend/check_*.py test files' own `frontend_env` fixtures, which each
+    extend this for whatever additional path constants (GLOBAL_CSS, MEDIA_QUERY_TS, EXEMPTIONS,
+    ...) their own module reads, and create any subdirectories their own tests need.
+    """
+    src = tmp_path / "frontend" / "src"
+    src.mkdir(parents=True)
+    monkeypatch.setattr(module, "REPO_ROOT", tmp_path)
+    monkeypatch.setattr(module, "FRONTEND_SRC", src)
+    return src

--- a/tests/unit/tools/conftest.py
+++ b/tests/unit/tools/conftest.py
@@ -26,6 +26,15 @@ def make_frontend_src(tmp_path: Path, monkeypatch: pytest.MonkeyPatch, module: M
     Shared by the tools/frontend/check_*.py test files' own `frontend_env` fixtures, which each
     extend this for whatever additional path constants (GLOBAL_CSS, MEDIA_QUERY_TS, EXEMPTIONS,
     ...) their own module reads, and create any subdirectories their own tests need.
+
+    Args:
+        tmp_path: Pytest's per-test temp directory, used as the isolated repo root.
+        monkeypatch: Used to patch `module`'s path constants for the duration of the test.
+        module: The `tools/frontend/check_*.py` module under test, whose `REPO_ROOT` and
+            `FRONTEND_SRC` constants get pointed at the isolated tree.
+
+    Returns:
+        The isolated `frontend/src` path, so callers can populate it with test fixtures.
     """
     src = tmp_path / "frontend" / "src"
     src.mkdir(parents=True)

--- a/tests/unit/tools/test_check_breakpoint_drift.py
+++ b/tests/unit/tools/test_check_breakpoint_drift.py
@@ -1,0 +1,233 @@
+"""Characterization tests for tools/frontend/check_breakpoint_drift.py.
+
+Pin the extraction logic for each of the four breakpoint sources (JS constants,
+Tailwind `@theme` registrations, CSS `@media` queries, Tailwind responsive
+utility prefixes) and the drift detection that compares them, using an
+isolated tmp_path frontend tree so nothing depends on the real frontend/src
+contents.
+"""
+
+import sys
+from pathlib import Path
+
+import check_breakpoint_drift
+import pytest
+from check_breakpoint_drift import (
+    extract_css_breakpoints,
+    extract_js_breakpoints,
+    extract_tailwind_utility_breakpoints,
+    extract_theme_breakpoints,
+    find_frontend_source_files,
+    find_missing_constants,
+    main,
+    theme_breakpoints_by_value,
+)
+
+# Each case: (id, js constants, css breakpoints, expected missing values).
+FIND_MISSING_CASES: list[tuple[str, dict[int, str], dict[int, list[Path]], set[int]]] = [
+    (
+        "all_covered",
+        {768: "BREAKPOINT_MOBILE"},
+        {768: [Path("a.css")]},
+        set(),
+    ),
+    (
+        "one_missing",
+        {768: "BREAKPOINT_MOBILE"},
+        {768: [Path("a.css")], 600: [Path("b.css")]},
+        {600},
+    ),
+    (
+        "no_css_breakpoints",
+        {768: "BREAKPOINT_MOBILE"},
+        {},
+        set(),
+    ),
+]
+
+
+@pytest.fixture
+def frontend_env(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Point the module's path constants at an isolated tmp_path frontend tree."""
+    src = tmp_path / "frontend" / "src"
+    (src / "hooks").mkdir(parents=True)
+    monkeypatch.setattr(check_breakpoint_drift, "REPO_ROOT", tmp_path)
+    monkeypatch.setattr(check_breakpoint_drift, "FRONTEND_SRC", src)
+    monkeypatch.setattr(check_breakpoint_drift, "MEDIA_QUERY_TS", src / "hooks" / "use-media-query.ts")
+    monkeypatch.setattr(check_breakpoint_drift, "GLOBAL_CSS", src / "global.css")
+    return src
+
+
+@pytest.mark.parametrize(
+    ("js", "css", "expected"),
+    [(c[1], c[2], c[3]) for c in FIND_MISSING_CASES],
+    ids=[c[0] for c in FIND_MISSING_CASES],
+)
+def test_find_missing_constants(js: dict[int, str], css: dict[int, list[Path]], expected: set[int]) -> None:
+    assert find_missing_constants(js, css) == expected
+
+
+def test_theme_breakpoints_by_value_groups_by_pixel_value(frontend_env: Path) -> None:
+    result = theme_breakpoints_by_value({"mobile": 768, "tablet": 1024})
+    assert result == {
+        768: [frontend_env / "global.css"],
+        1024: [frontend_env / "global.css"],
+    }
+
+
+def test_extract_js_breakpoints_parses_exported_constants(frontend_env: Path) -> None:
+    (frontend_env / "hooks" / "use-media-query.ts").write_text(
+        "export const BREAKPOINT_MOBILE = 768;\nexport const BREAKPOINT_TABLET = 1024;\n"
+    )
+    assert extract_js_breakpoints() == {768: "BREAKPOINT_MOBILE", 1024: "BREAKPOINT_TABLET"}
+
+
+@pytest.mark.usefixtures("frontend_env")
+def test_extract_js_breakpoints_missing_file_returns_empty() -> None:
+    assert extract_js_breakpoints() == {}
+
+
+def test_extract_css_breakpoints_finds_media_queries_across_files(frontend_env: Path) -> None:
+    (frontend_env / "a.css").write_text("@media (max-width: 768px) { .x { color: red; } }\n")
+    (frontend_env / "b.css").write_text("@media screen and (max-width: 900px) { .y {} }\n")
+    result = extract_css_breakpoints()
+    assert set(result) == {768, 900}
+
+
+def test_extract_css_breakpoints_ignores_commented_out_media(frontend_env: Path) -> None:
+    (frontend_env / "a.css").write_text("/* @media (max-width: 768px) { .x {} } */\n")
+    assert extract_css_breakpoints() == {}
+
+
+def test_extract_css_breakpoints_dedupes_same_file(frontend_env: Path) -> None:
+    (frontend_env / "a.css").write_text("@media (max-width: 768px) { .x {} }\n@media (max-width: 768px) { .y {} }\n")
+    result = extract_css_breakpoints()
+    assert len(result[768]) == 1
+
+
+def test_extract_theme_breakpoints_parses_registrations(frontend_env: Path) -> None:
+    (frontend_env / "global.css").write_text("--breakpoint-mobile: 768px;\n--breakpoint-tablet: 1024px;\n")
+    assert extract_theme_breakpoints() == {"mobile": 768, "tablet": 1024}
+
+
+@pytest.mark.usefixtures("frontend_env")
+def test_extract_theme_breakpoints_missing_file_returns_empty() -> None:
+    assert extract_theme_breakpoints() == {}
+
+
+def test_find_frontend_source_files_excludes_declaration_files(frontend_env: Path) -> None:
+    (frontend_env / "App.tsx").write_text("export const App = () => null;\n")
+    (frontend_env / "util.ts").write_text("export const x = 1;\n")
+    (frontend_env / "types.d.ts").write_text("declare module 'x';\n")
+    names = {p.name for p in find_frontend_source_files()}
+    assert names == {"App.tsx", "util.ts"}
+
+
+def test_extract_tailwind_utility_breakpoints_registered_screen(frontend_env: Path) -> None:
+    target = frontend_env / "App.tsx"
+    target.write_text('<div className="mobile:hidden" />\n')
+    found, unknown = extract_tailwind_utility_breakpoints({"mobile": 768}, {768: "BREAKPOINT_MOBILE"})
+    assert found == {768: [target]}
+    assert unknown == {}
+
+
+def test_extract_tailwind_utility_breakpoints_unknown_max_screen(frontend_env: Path) -> None:
+    target = frontend_env / "App.tsx"
+    target.write_text('<div className="max-widescreen:flex" />\n')
+    found, unknown = extract_tailwind_utility_breakpoints({"mobile": 768}, {768: "BREAKPOINT_MOBILE"})
+    assert found == {}
+    assert unknown == {"widescreen": [target]}
+
+
+def test_extract_tailwind_utility_breakpoints_arbitrary_max_px(frontend_env: Path) -> None:
+    target = frontend_env / "App.tsx"
+    target.write_text('<div className="max-[768px]:hidden" />\n')
+    found, unknown = extract_tailwind_utility_breakpoints({}, {})
+    assert found == {768: [target]}
+    assert unknown == {}
+
+
+def test_extract_tailwind_utility_breakpoints_min_arbitrary_folds_to_known_max(frontend_env: Path) -> None:
+    # min-[769px] with 768 already a known JS breakpoint is the inclusive complement
+    # of max-768 and folds into the existing bucket instead of reporting a new one.
+    target = frontend_env / "App.tsx"
+    target.write_text('<div className="min-[769px]:flex" />\n')
+    found, unknown = extract_tailwind_utility_breakpoints({}, {768: "BREAKPOINT_MOBILE"})
+    assert found == {768: [target]}
+    assert unknown == {}
+
+
+def test_main_ok_when_all_breakpoints_covered(frontend_env: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    (frontend_env / "hooks" / "use-media-query.ts").write_text("export const BREAKPOINT_MOBILE = 768;\n")
+    (frontend_env / "global.css").write_text("--breakpoint-mobile: 768px;\n")
+    (frontend_env / "a.css").write_text("@media (max-width: 768px) { .x {} }\n")
+    monkeypatch.setattr(sys, "argv", ["check_breakpoint_drift.py"])
+    assert main() == 0
+
+
+def test_main_ok_prints_covered_breakpoints(
+    frontend_env: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    (frontend_env / "hooks" / "use-media-query.ts").write_text("export const BREAKPOINT_MOBILE = 768;\n")
+    (frontend_env / "global.css").write_text("--breakpoint-mobile: 768px;\n")
+    (frontend_env / "a.css").write_text("@media (max-width: 768px) { .x {} }\n")
+    monkeypatch.setattr(sys, "argv", ["check_breakpoint_drift.py"])
+    main()
+    assert "OK" in capsys.readouterr().out
+
+
+def test_main_fails_when_css_breakpoint_has_no_js_constant(
+    frontend_env: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    (frontend_env / "hooks" / "use-media-query.ts").write_text("export const BREAKPOINT_MOBILE = 768;\n")
+    (frontend_env / "global.css").write_text("--breakpoint-mobile: 768px;\n")
+    (frontend_env / "a.css").write_text("@media (max-width: 768px) { .x {} }\n@media (max-width: 600px) { .y {} }\n")
+    monkeypatch.setattr(sys, "argv", ["check_breakpoint_drift.py"])
+    assert main() == 1
+    assert "600px" in capsys.readouterr().out
+
+
+def test_main_fails_on_unregistered_tailwind_screen(
+    frontend_env: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    (frontend_env / "hooks" / "use-media-query.ts").write_text("export const BREAKPOINT_MOBILE = 768;\n")
+    (frontend_env / "global.css").write_text("--breakpoint-mobile: 768px;\n")
+    (frontend_env / "a.css").write_text("@media (max-width: 768px) { .x {} }\n")
+    (frontend_env / "App.tsx").write_text('<div className="max-widescreen:flex" />\n')
+    monkeypatch.setattr(sys, "argv", ["check_breakpoint_drift.py"])
+    assert main() == 1
+    assert "widescreen" in capsys.readouterr().out
+
+
+@pytest.mark.usefixtures("frontend_env")
+def test_main_errors_when_no_js_constants_file(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.setattr(sys, "argv", ["check_breakpoint_drift.py"])
+    assert main() == 1
+    assert "no BREAKPOINT_* constants" in capsys.readouterr().err
+
+
+def test_main_errors_when_no_theme_registrations(
+    frontend_env: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    (frontend_env / "hooks" / "use-media-query.ts").write_text("export const BREAKPOINT_MOBILE = 768;\n")
+    monkeypatch.setattr(sys, "argv", ["check_breakpoint_drift.py"])
+    assert main() == 1
+    assert "no Tailwind @theme breakpoint registrations" in capsys.readouterr().err
+
+
+def test_main_errors_when_no_media_queries(
+    frontend_env: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    (frontend_env / "hooks" / "use-media-query.ts").write_text("export const BREAKPOINT_MOBILE = 768;\n")
+    (frontend_env / "global.css").write_text("--breakpoint-mobile: 768px;\n")
+    monkeypatch.setattr(sys, "argv", ["check_breakpoint_drift.py"])
+    assert main() == 1
+    assert "no @media (max-width: Npx) queries" in capsys.readouterr().err
+
+
+def test_main_smoke_test_flag_passes(monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]) -> None:
+    monkeypatch.setattr(sys, "argv", ["check_breakpoint_drift.py", "--smoke-test"])
+    assert main() == 0
+    assert "Smoke test passed." in capsys.readouterr().out

--- a/tests/unit/tools/test_check_breakpoint_drift.py
+++ b/tests/unit/tools/test_check_breakpoint_drift.py
@@ -23,6 +23,8 @@ from check_breakpoint_drift import (
     theme_breakpoints_by_value,
 )
 
+from tests.unit.tools.conftest import make_frontend_src
+
 # Each case: (id, js constants, css breakpoints, expected missing values).
 FIND_MISSING_CASES: list[tuple[str, dict[int, str], dict[int, list[Path]], set[int]]] = [
     (
@@ -49,10 +51,8 @@ FIND_MISSING_CASES: list[tuple[str, dict[int, str], dict[int, list[Path]], set[i
 @pytest.fixture
 def frontend_env(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
     """Point the module's path constants at an isolated tmp_path frontend tree."""
-    src = tmp_path / "frontend" / "src"
-    (src / "hooks").mkdir(parents=True)
-    monkeypatch.setattr(check_breakpoint_drift, "REPO_ROOT", tmp_path)
-    monkeypatch.setattr(check_breakpoint_drift, "FRONTEND_SRC", src)
+    src = make_frontend_src(tmp_path, monkeypatch, check_breakpoint_drift)
+    (src / "hooks").mkdir()
     monkeypatch.setattr(check_breakpoint_drift, "MEDIA_QUERY_TS", src / "hooks" / "use-media-query.ts")
     monkeypatch.setattr(check_breakpoint_drift, "GLOBAL_CSS", src / "global.css")
     return src

--- a/tests/unit/tools/test_check_dead_tokens.py
+++ b/tests/unit/tools/test_check_dead_tokens.py
@@ -1,0 +1,212 @@
+"""Characterization tests for tools/frontend/check_dead_tokens.py.
+
+Pin the token-extraction logic (source tokens under `:root` and
+`[data-theme="dark"]`, stopping before the shadcn alias block), the
+reference-scanning logic (word-boundary matching so `--accent` isn't counted
+referenced by `--accent-hover`), and the pass/fail/warning outcomes of
+`main()`, using an isolated tmp_path frontend tree.
+"""
+
+import textwrap
+from pathlib import Path
+
+import check_dead_tokens
+import pytest
+from check_dead_tokens import (
+    build_corpus,
+    extract_block,
+    extract_token_definitions,
+    find_frontend_files,
+    is_referenced,
+    main,
+)
+
+# Each case: (id, css_text, selector, expected block body).
+EXTRACT_BLOCK_CASES: list[tuple[str, str, str, str]] = [
+    (
+        "root_block_found",
+        ":root {\n  --a: 1;\n}\n",
+        ":root",
+        "\n  --a: 1;\n",
+    ),
+    (
+        "nested_braces_stay_balanced",
+        ":root {\n  --a: var(--b);\n}\n",
+        ":root",
+        "\n  --a: var(--b);\n",
+    ),
+    (
+        "selector_missing_returns_empty",
+        ":root {\n  --a: 1;\n}\n",
+        '[data-theme="dark"]',
+        "",
+    ),
+    (
+        "unbalanced_braces_returns_empty",
+        ":root {\n  --a: 1;\n",
+        ":root",
+        "",
+    ),
+]
+
+
+# Each case: (id, token, corpus, expected is_referenced).
+IS_REFERENCED_CASES: list[tuple[str, str, str, bool]] = [
+    ("referenced_elsewhere", "--accent", "color: var(--accent);", True),
+    ("not_referenced_at_all", "--accent", "color: red;", False),
+    ("prefix_collision_not_counted", "--accent", "color: var(--accent-hover);", False),
+    ("only_in_own_definition_line_not_referenced", "--accent", "  --accent: #fff;", False),
+]
+
+
+@pytest.mark.parametrize(
+    ("css_text", "selector", "expected"),
+    [(c[1], c[2], c[3]) for c in EXTRACT_BLOCK_CASES],
+    ids=[c[0] for c in EXTRACT_BLOCK_CASES],
+)
+def test_extract_block(css_text: str, selector: str, expected: str) -> None:
+    assert extract_block(css_text, selector) == expected
+
+
+def test_extract_token_definitions_stops_before_shadcn_aliases() -> None:
+    css_text = textwrap.dedent(
+        """\
+        :root {
+          --bg-page: #fff;
+          --ink-1: #000;
+          --background: var(--bg-page);
+        }
+        """
+    )
+    assert extract_token_definitions(css_text) == ["--bg-page", "--ink-1"]
+
+
+def test_extract_token_definitions_includes_dark_theme_block() -> None:
+    css_text = textwrap.dedent(
+        """\
+        :root {
+          --bg-page: #fff;
+          --background: var(--bg-page);
+        }
+        [data-theme="dark"] {
+          --bg-page-dark: #000;
+          --primary: oklch(0.5 0 0);
+        }
+        """
+    )
+    assert extract_token_definitions(css_text) == ["--bg-page", "--bg-page-dark"]
+
+
+def test_extract_token_definitions_dedupes_repeated_names() -> None:
+    css_text = textwrap.dedent(
+        """\
+        :root {
+          --bg-page: #fff;
+          --bg-page: #eee;
+          --background: var(--bg-page);
+        }
+        """
+    )
+    assert extract_token_definitions(css_text) == ["--bg-page"]
+
+
+@pytest.mark.parametrize(
+    ("token", "corpus", "expected"),
+    [(c[1], c[2], c[3]) for c in IS_REFERENCED_CASES],
+    ids=[c[0] for c in IS_REFERENCED_CASES],
+)
+def test_is_referenced(token: str, corpus: str, expected: bool) -> None:
+    assert is_referenced(token, corpus) == expected
+
+
+@pytest.fixture
+def frontend_env(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Point the module's path constants at an isolated tmp_path frontend tree."""
+    src = tmp_path / "frontend" / "src"
+    src.mkdir(parents=True)
+    monkeypatch.setattr(check_dead_tokens, "REPO_ROOT", tmp_path)
+    monkeypatch.setattr(check_dead_tokens, "FRONTEND_SRC", src)
+    monkeypatch.setattr(check_dead_tokens, "GLOBAL_CSS", src / "global.css")
+    return src
+
+
+def test_find_frontend_files_excludes_declaration_files(frontend_env: Path) -> None:
+    (frontend_env / "global.css").write_text("body {}\n")
+    (frontend_env / "App.tsx").write_text("export {};\n")
+    (frontend_env / "types.d.ts").write_text("declare module 'x';\n")
+    names = {p.name for p in find_frontend_files()}
+    assert names == {"global.css", "App.tsx"}
+
+
+def test_build_corpus_concatenates_file_contents(tmp_path: Path) -> None:
+    a = tmp_path / "a.css"
+    b = tmp_path / "b.tsx"
+    a.write_text("body { color: red; }")
+    b.write_text("export const x = 1;")
+    corpus = build_corpus([a, b])
+    assert "color: red" in corpus
+    assert "export const x" in corpus
+
+
+def test_main_ok_when_all_tokens_referenced(frontend_env: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    (frontend_env / "global.css").write_text(
+        textwrap.dedent(
+            """\
+            :root {
+              --bg-page: #fff;
+              --background: var(--bg-page);
+            }
+            """
+        )
+    )
+    (frontend_env / "App.tsx").write_text("const x = 'var(--bg-page)';\n")
+    assert main() == 0
+    assert "OK" in capsys.readouterr().out
+
+
+def test_main_fails_on_unreferenced_token(frontend_env: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    (frontend_env / "global.css").write_text(
+        textwrap.dedent(
+            """\
+            :root {
+              --bg-page: #fff;
+              --ink-1: #000;
+              --background: var(--bg-page);
+            }
+            """
+        )
+    )
+    (frontend_env / "App.tsx").write_text("const x = 'var(--bg-page)';\n")
+    assert main() == 1
+    assert "--ink-1" in capsys.readouterr().out
+
+
+@pytest.mark.usefixtures("frontend_env")
+def test_main_missing_global_css_errors(capsys: pytest.CaptureFixture[str]) -> None:
+    assert main() == 1
+    assert "not found" in capsys.readouterr().err
+
+
+def test_main_warns_when_no_source_files_found(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    # GLOBAL_CSS deliberately lives outside FRONTEND_SRC so the source-file glob
+    # comes back empty even though the token file itself exists and parses fine.
+    outside_css = tmp_path / "outside" / "global.css"
+    outside_css.parent.mkdir(parents=True)
+    outside_css.write_text(
+        textwrap.dedent(
+            """\
+            :root {
+              --bg-page: #fff;
+              --background: var(--bg-page);
+            }
+            """
+        )
+    )
+    empty_src = tmp_path / "frontend" / "src"
+    empty_src.mkdir(parents=True)
+    monkeypatch.setattr(check_dead_tokens, "GLOBAL_CSS", outside_css)
+    monkeypatch.setattr(check_dead_tokens, "FRONTEND_SRC", empty_src)
+    assert main() == 0
+    assert "No .css/.ts/.tsx files" in capsys.readouterr().err

--- a/tests/unit/tools/test_check_dead_tokens.py
+++ b/tests/unit/tools/test_check_dead_tokens.py
@@ -33,9 +33,9 @@ EXTRACT_BLOCK_CASES: list[tuple[str, str, str, str]] = [
     ),
     (
         "nested_braces_stay_balanced",
-        ":root {\n  --a: var(--b);\n}\n",
+        ":root {\n  @media (min-width: 1px) {\n    --a: 1;\n  }\n}\n",
         ":root",
-        "\n  --a: var(--b);\n",
+        "\n  @media (min-width: 1px) {\n    --a: 1;\n  }\n",
     ),
     (
         "selector_missing_returns_empty",

--- a/tests/unit/tools/test_check_dead_tokens.py
+++ b/tests/unit/tools/test_check_dead_tokens.py
@@ -21,6 +21,8 @@ from check_dead_tokens import (
     main,
 )
 
+from tests.unit.tools.conftest import make_frontend_src
+
 # Each case: (id, css_text, selector, expected block body).
 EXTRACT_BLOCK_CASES: list[tuple[str, str, str, str]] = [
     (
@@ -122,10 +124,7 @@ def test_is_referenced(token: str, corpus: str, expected: bool) -> None:
 @pytest.fixture
 def frontend_env(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
     """Point the module's path constants at an isolated tmp_path frontend tree."""
-    src = tmp_path / "frontend" / "src"
-    src.mkdir(parents=True)
-    monkeypatch.setattr(check_dead_tokens, "REPO_ROOT", tmp_path)
-    monkeypatch.setattr(check_dead_tokens, "FRONTEND_SRC", src)
+    src = make_frontend_src(tmp_path, monkeypatch, check_dead_tokens)
     monkeypatch.setattr(check_dead_tokens, "GLOBAL_CSS", src / "global.css")
     return src
 

--- a/tests/unit/tools/test_check_internal_anchor_links.py
+++ b/tests/unit/tools/test_check_internal_anchor_links.py
@@ -1,0 +1,114 @@
+"""Characterization tests for tools/frontend/check_internal_anchor_links.py.
+
+Pin which native `<a href=...>` usages the guard flags as internal-route
+navigation that should use wouter's `<Link>` instead — literal internal hrefs,
+dynamic expression hrefs, multi-line opening tags — and which it leaves alone
+(external URLs, mailto/tel/fragment links, `.test.tsx` files, EXEMPTIONS
+entries), using an isolated tmp_path frontend tree.
+"""
+
+from pathlib import Path
+
+import check_internal_anchor_links
+import pytest
+from check_internal_anchor_links import _check_tag, is_exempt, main, scan_file
+
+# Each case: (id, opening-tag text, expected reported href or None).
+CHECK_TAG_CASES: list[tuple[str, str, str | None]] = [
+    ("internal_literal_href_flagged", '<a href="/settings">', '"/settings"'),
+    ("external_https_not_flagged", '<a href="https://example.com">', None),
+    ("external_http_not_flagged", '<a href="http://example.com">', None),
+    ("mailto_not_flagged", '<a href="mailto:a@b.com">', None),
+    ("tel_not_flagged", '<a href="tel:12345">', None),
+    ("hash_fragment_not_flagged", '<a href="#top">', None),
+    ("dynamic_expr_flagged", "<a href={appUrl}>", "{appUrl}"),
+    ("dynamic_expr_external_template_not_flagged", "<a href={`https://x.com/${id}`}>", None),
+    ("dynamic_expr_external_string_not_flagged", '<a href={"https://x.com"}>', None),
+]
+
+
+def check_tag_href(tag: str) -> str | None:
+    """Return just the reported href text (or None) for a given opening-tag string."""
+    result = _check_tag(tag, Path("x.tsx"), 1)
+    return None if result is None else result[2]
+
+
+@pytest.mark.parametrize(
+    ("tag", "expected"), [(c[1], c[2]) for c in CHECK_TAG_CASES], ids=[c[0] for c in CHECK_TAG_CASES]
+)
+def test_check_tag(tag: str, expected: str | None) -> None:
+    assert check_tag_href(tag) == expected
+
+
+def test_is_exempt_matches_configured_entry(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(check_internal_anchor_links, "EXEMPTIONS", {"frontend/src/App.tsx:10": "reason"})
+    assert is_exempt("frontend/src/App.tsx", 10) is True
+
+
+def test_is_exempt_no_match(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(check_internal_anchor_links, "EXEMPTIONS", {})
+    assert is_exempt("frontend/src/App.tsx", 10) is False
+
+
+def test_scan_file_flags_internal_href(tmp_path: Path) -> None:
+    f = tmp_path / "Page.tsx"
+    f.write_text('export const Page = () => <a href="/apps">Apps</a>;\n')
+    assert scan_file(f) == [(f, 1, '"/apps"')]
+
+
+def test_scan_file_ignores_external_href(tmp_path: Path) -> None:
+    f = tmp_path / "Page.tsx"
+    f.write_text('export const Page = () => <a href="https://x.com">X</a>;\n')
+    assert scan_file(f) == []
+
+
+def test_scan_file_ignores_non_anchor_tags(tmp_path: Path) -> None:
+    f = tmp_path / "Page.tsx"
+    f.write_text('export const Page = () => <Link href="/apps">Apps</Link>;\n')
+    assert scan_file(f) == []
+
+
+def test_scan_file_handles_multiline_opening_tag(tmp_path: Path) -> None:
+    f = tmp_path / "Page.tsx"
+    f.write_text(
+        'export const Page = () => (\n  <a\n    href="/apps"\n    className="link"\n  >\n    Apps\n  </a>\n);\n'
+    )
+    assert scan_file(f) == [(f, 2, '"/apps"')]
+
+
+@pytest.fixture
+def frontend_env(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Point the module's path constants at an isolated tmp_path frontend tree."""
+    src = tmp_path / "frontend" / "src"
+    src.mkdir(parents=True)
+    monkeypatch.setattr(check_internal_anchor_links, "REPO_ROOT", tmp_path)
+    monkeypatch.setattr(check_internal_anchor_links, "FRONTEND_SRC", src)
+    monkeypatch.setattr(check_internal_anchor_links, "EXEMPTIONS", {})
+    return src
+
+
+def test_main_ok_when_no_native_internal_anchors(frontend_env: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    (frontend_env / "Page.tsx").write_text('<Link href="/apps">Apps</Link>\n')
+    assert main() == 0
+    assert "OK" in capsys.readouterr().out
+
+
+def test_main_fails_on_native_internal_anchor(frontend_env: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    (frontend_env / "Page.tsx").write_text('<a href="/apps">Apps</a>\n')
+    assert main() == 1
+    assert "Page.tsx:1" in capsys.readouterr().out
+
+
+def test_main_skips_test_files(frontend_env: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    (frontend_env / "Page.test.tsx").write_text('<a href="/apps">Apps</a>\n')
+    assert main() == 0
+    assert "OK" in capsys.readouterr().out
+
+
+def test_main_respects_exemptions(
+    frontend_env: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    (frontend_env / "Page.tsx").write_text('<a href="/apps">Apps</a>\n')
+    monkeypatch.setattr(check_internal_anchor_links, "EXEMPTIONS", {"frontend/src/Page.tsx:1": "legacy redirect page"})
+    assert main() == 0
+    assert "1 exempted" in capsys.readouterr().out

--- a/tests/unit/tools/test_check_internal_anchor_links.py
+++ b/tests/unit/tools/test_check_internal_anchor_links.py
@@ -13,6 +13,8 @@ import check_internal_anchor_links
 import pytest
 from check_internal_anchor_links import _check_tag, is_exempt, main, scan_file
 
+from tests.unit.tools.conftest import make_frontend_src
+
 # Each case: (id, opening-tag text, expected reported href or None).
 CHECK_TAG_CASES: list[tuple[str, str, str | None]] = [
     ("internal_literal_href_flagged", '<a href="/settings">', '"/settings"'),
@@ -79,10 +81,7 @@ def test_scan_file_handles_multiline_opening_tag(tmp_path: Path) -> None:
 @pytest.fixture
 def frontend_env(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
     """Point the module's path constants at an isolated tmp_path frontend tree."""
-    src = tmp_path / "frontend" / "src"
-    src.mkdir(parents=True)
-    monkeypatch.setattr(check_internal_anchor_links, "REPO_ROOT", tmp_path)
-    monkeypatch.setattr(check_internal_anchor_links, "FRONTEND_SRC", src)
+    src = make_frontend_src(tmp_path, monkeypatch, check_internal_anchor_links)
     monkeypatch.setattr(check_internal_anchor_links, "EXEMPTIONS", {})
     return src
 

--- a/tools/release/drift_check.py
+++ b/tools/release/drift_check.py
@@ -15,7 +15,7 @@ tracking issue itself stays in each workflow, since title/body/labels differ per
 
 Usage:
     uv run ./tools/release/drift_check.py --current "$CURRENT" --latest "$LATEST" \
-        --label "pypi-drift" --label-description "..." [--label-color d93f0b]
+        --label "pypi-drift" --label-description "..." [--label-color HEXCOLOR]
 
 Writes to $GITHUB_OUTPUT (or stdout, for local runs): current, latest, drift (true/false), and
 existing-issue (the number of an already-open issue with `label`, or empty). existing-issue is
@@ -28,6 +28,8 @@ import os
 import subprocess
 import sys
 import uuid
+
+DEFAULT_LABEL_COLOR = "d93f0b"
 
 
 def ensure_label(label: str, description: str, color: str) -> None:
@@ -83,7 +85,7 @@ def main(argv: list[str]) -> int:
         "--label", required=True, help="Dedup label — an open issue with this label is treated as 'already tracked'."
     )
     p.add_argument("--label-description", required=True, help="Used when creating the label, if it's missing.")
-    p.add_argument("--label-color", default="d93f0b", help="Used when creating the label, if it's missing.")
+    p.add_argument("--label-color", default=DEFAULT_LABEL_COLOR, help="Used when creating the label, if it's missing.")
     args = p.parse_args(argv)
 
     drift = args.current != args.latest

--- a/tools/release/drift_check.py
+++ b/tools/release/drift_check.py
@@ -24,6 +24,7 @@ resync (see ha-version-drift.yml) doesn't need its own separate lookup.
 """
 
 import argparse
+import contextlib
 import os
 import subprocess
 import sys
@@ -37,24 +38,52 @@ def ensure_label(label: str, description: str, color: str) -> None:
 
     Best-effort: a failure here (e.g. the label already exists) is ignored, since
     `gh issue create --label` will raise its own clear error if the label is somehow still
-    missing.
+    missing. Bounded by a timeout so a hung `gh` call can't stall the job past its own
+    best-effort intent.
+
+    Args:
+        label: The label name to create.
+        description: The label's description, shown in the GitHub UI.
+        color: The label's hex color, without a leading `#`.
     """
-    subprocess.run(
-        ["gh", "label", "create", label, "--description", description, "--color", color],
-        stdout=subprocess.DEVNULL,
-        stderr=subprocess.DEVNULL,
-        check=False,
-    )
+    with contextlib.suppress(subprocess.TimeoutExpired):
+        subprocess.run(
+            ["gh", "label", "create", label, "--description", description, "--color", color],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            check=False,
+            timeout=30,
+        )
 
 
 def find_existing_issue(label: str) -> str:
-    """Return the number of an open issue carrying `label`, or "" if none exists."""
-    result = subprocess.run(
-        ["gh", "issue", "list", "--label", label, "--state", "open", "--json", "number", "-q", ".[0].number"],
-        capture_output=True,
-        text=True,
-        check=False,
-    )
+    """Return the number of an open issue carrying `label`, or "" if none exists.
+
+    Unlike `ensure_label`, a failed lookup here is not best-effort: it raises. Swallowing a
+    failed `gh issue list` (auth, rate limit, network) would return "" indistinguishably from
+    "no existing issue," letting the caller file a duplicate tracking issue instead of
+    surfacing the real failure.
+
+    Args:
+        label: The label to search open issues for.
+
+    Returns:
+        The issue number as a string, or "" if no open issue carries the label.
+    """
+    try:
+        result = subprocess.run(
+            ["gh", "issue", "list", "--label", label, "--state", "open", "--json", "number", "-q", ".[0].number"],
+            capture_output=True,
+            text=True,
+            check=True,
+            timeout=30,
+        )
+    except subprocess.CalledProcessError as exc:
+        # check=True gives an uncaught traceback that shows only the command and exit code —
+        # print gh's own stderr first so the operator sees *why* the lookup failed (auth,
+        # rate limit, bad label) instead of having to reproduce it locally.
+        print(f"::error::gh issue list failed: {exc.stderr}", file=sys.stderr)
+        raise
     return result.stdout.strip()
 
 
@@ -64,6 +93,10 @@ def write_github_output(**fields: str) -> None:
     Values come from external registries (PyPI, GHCR, GitHub releases) — untrusted enough that a
     plain `key=value` line could be spoofed by an embedded newline. Use GITHUB_OUTPUT's heredoc
     form with a random delimiter instead, so a value can never terminate its own field early.
+
+    Args:
+        **fields: Output name/value pairs to write. Falls back to printing `key=value` lines to
+            stdout when `$GITHUB_OUTPUT` is unset, for local runs.
     """
     output_path = os.getenv("GITHUB_OUTPUT")
     if not output_path:
@@ -78,6 +111,15 @@ def write_github_output(**fields: str) -> None:
 
 
 def main(argv: list[str]) -> int:
+    """Compare `--current` against `--latest` and report drift plus any existing tracking issue.
+
+    Args:
+        argv: Command-line arguments, excluding the program name.
+
+    Returns:
+        Exit code — always 0; a genuine failure (e.g. the issue lookup failing) raises instead
+        of returning a nonzero code.
+    """
     p = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
     p.add_argument("--current", required=True, help="The resolved current/local value.")
     p.add_argument("--latest", required=True, help="The resolved latest/external value to compare against.")

--- a/tools/release/drift_check.py
+++ b/tools/release/drift_check.py
@@ -27,6 +27,7 @@ import argparse
 import os
 import subprocess
 import sys
+import uuid
 
 
 def ensure_label(label: str, description: str, color: str) -> None:
@@ -56,13 +57,22 @@ def find_existing_issue(label: str) -> str:
 
 
 def write_github_output(**fields: str) -> None:
+    """Write step outputs, one per field.
+
+    Values come from external registries (PyPI, GHCR, GitHub releases) — untrusted enough that a
+    plain `key=value` line could be spoofed by an embedded newline. Use GITHUB_OUTPUT's heredoc
+    form with a random delimiter instead, so a value can never terminate its own field early.
+    """
     output_path = os.getenv("GITHUB_OUTPUT")
-    lines = [f"{key}={value}" for key, value in fields.items()]
-    if output_path:
-        with open(output_path, "a", encoding="utf-8") as f:
-            f.write("\n".join(lines) + "\n")
-    else:
-        print("\n".join(lines))
+    if not output_path:
+        for key, value in fields.items():
+            print(f"{key}={value}")
+        return
+
+    with open(output_path, "a", encoding="utf-8") as f:
+        for key, value in fields.items():
+            delimiter = uuid.uuid4().hex
+            f.write(f"{key}<<{delimiter}\n{value}\n{delimiter}\n")
 
 
 def main(argv: list[str]) -> int:

--- a/tools/release/drift_check.py
+++ b/tools/release/drift_check.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.11"
+# ///
+r"""Shared compare/dedup logic for pypi-drift-check.yml, docker-drift-check.yml, and
+ha-version-drift.yml.
+
+Each of those workflows fetches its own "current" and "latest" values before calling this
+script — the sources of truth differ too much to share (this repo's GitHub release, a PyPI/GHCR
+query, another repo's release) and so does fetch-failure handling (some treat a failed query as
+a soft warning, some let it fail the job). This script owns only the part that's genuinely
+identical across all three: comparing the two values, making sure the dedup label exists, and
+looking up an already-open tracking issue by that label. Filing, commenting on, or closing the
+tracking issue itself stays in each workflow, since title/body/labels differ per check.
+
+Usage:
+    uv run ./tools/release/drift_check.py --current "$CURRENT" --latest "$LATEST" \
+        --label "pypi-drift" --label-description "..." [--label-color d93f0b]
+
+Writes to $GITHUB_OUTPUT (or stdout, for local runs): current, latest, drift (true/false), and
+existing-issue (the number of an already-open issue with `label`, or empty). existing-issue is
+always computed, drift or not, so a workflow that wants to auto-close a stale tracking issue on
+resync (see ha-version-drift.yml) doesn't need its own separate lookup.
+"""
+
+import argparse
+import os
+import subprocess
+import sys
+
+
+def ensure_label(label: str, description: str, color: str) -> None:
+    """Create the dedup label if it doesn't already exist yet.
+
+    Best-effort: a failure here (e.g. the label already exists) is ignored, since
+    `gh issue create --label` will raise its own clear error if the label is somehow still
+    missing.
+    """
+    subprocess.run(
+        ["gh", "label", "create", label, "--description", description, "--color", color],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        check=False,
+    )
+
+
+def find_existing_issue(label: str) -> str:
+    """Return the number of an open issue carrying `label`, or "" if none exists."""
+    result = subprocess.run(
+        ["gh", "issue", "list", "--label", label, "--state", "open", "--json", "number", "-q", ".[0].number"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    return result.stdout.strip()
+
+
+def write_github_output(**fields: str) -> None:
+    output_path = os.getenv("GITHUB_OUTPUT")
+    lines = [f"{key}={value}" for key, value in fields.items()]
+    if output_path:
+        with open(output_path, "a", encoding="utf-8") as f:
+            f.write("\n".join(lines) + "\n")
+    else:
+        print("\n".join(lines))
+
+
+def main(argv: list[str]) -> int:
+    p = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    p.add_argument("--current", required=True, help="The resolved current/local value.")
+    p.add_argument("--latest", required=True, help="The resolved latest/external value to compare against.")
+    p.add_argument(
+        "--label", required=True, help="Dedup label — an open issue with this label is treated as 'already tracked'."
+    )
+    p.add_argument("--label-description", required=True, help="Used when creating the label, if it's missing.")
+    p.add_argument("--label-color", default="d93f0b", help="Used when creating the label, if it's missing.")
+    args = p.parse_args(argv)
+
+    drift = args.current != args.latest
+    print(f"Current: {args.current}")
+    print(f"Latest:  {args.latest}")
+    if drift:
+        print(f"::error::Drift detected! current={args.current} latest={args.latest}")
+    else:
+        print("Versions match — no drift detected")
+
+    ensure_label(args.label, args.label_description, args.label_color)
+    existing_issue = find_existing_issue(args.label)
+
+    write_github_output(
+        current=args.current,
+        latest=args.latest,
+        drift="true" if drift else "false",
+        **{"existing-issue": existing_issue},
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))


### PR DESCRIPTION
### Notable Changes
- Fixed a `GITHUB_OUTPUT` injection risk in the new shared drift-check script: version strings pulled from external registries (PyPI, GHCR, GitHub releases) are untrusted enough that a plain `key=value` output line could be spoofed by an embedded newline, so `write_github_output` now uses `GITHUB_OUTPUT`'s heredoc form with a random per-field delimiter instead.

### Codegen pipeline decomposition
- `run_pipeline` in `codegen/src/hassette_codegen/pipeline.py` blended six responsibilities in one ~180-line function (domain discovery/rejection, override validation, per-domain generation, sensor-constants generation, the predicate-freshness drift guard, and manifest/summary bookkeeping). Split it into named steps (`_discover_domains_for_run`, `_generate_domains`, `_generate_files_for_domain`, `_generate_constants`, `_predicate_is_fresh`, `_generate_package_inits`, `_finalize_manifest`, `_report_summary_and_exit_code`) so each stage is independently readable and testable.
- Added `_DomainOutcome`/`_GenerationResult`/`_WriteOutput` dataclasses with named constructors (`.skip()`, `.reject()`, `.ok()`) so a call site's return value states which shape it produced without the reader inferring it from which fields got left out.
- Collapsed the repeated check-mode/write branching (compare-only under `--check` vs. actually write) that was duplicated at every generated-file site into one `_check_or_write` helper.
- Landed a characterization test (`codegen/tests/test_pipeline_characterization.py`) that pins the exact diagnostic ordering, manifest contents, summary line, and exit code across all six responsibilities in one scenario *before* the decomposition, so the refactor has a behavioral pin rather than relying on "it still compiles."

### Drift-check workflow deduplication
- `pypi-drift-check.yml`, `docker-drift-check.yml`, and `ha-version-drift.yml` each hand-rolled the same compare/label/dedup-lookup logic. Extracted the identical part into `tools/release/drift_check.py` (a standalone `uv run --script`), while each workflow keeps fetching its own current/latest values and its own issue title/body/labels, since those genuinely differ per check.
- `ha-version-drift.yml` keeps its workflow-specific extensions (updating an existing tracking issue on repeat drift, auto-closing it on resync) since pypi/docker have no equivalent behavior — `drift_check.py` always reports `existing-issue` regardless of drift so that auto-close path doesn't need its own separate lookup.
- Added `tests/integration/test_drift_check.py`, which runs the script as a subprocess against a stub `gh` binary on `PATH` so the compare/dedup logic is verified without hitting the real GitHub API.

### Housekeeping
- Named the drift-check label-color default (`DEFAULT_LABEL_COLOR`) and test subprocess timeout (`SUBPROCESS_TIMEOUT_SECONDS`) instead of restating bare literals inline.
- Commented `docker-drift-check.yml`'s plain (non-heredoc) version output, clarifying it's sourced from this repo's own release tag rather than an external registry, unlike `drift_check.py`'s fields.
- Extracted a shared `make_frontend_src` fixture helper (`tests/unit/tools/conftest.py`) for the frontend linter characterization tests, and added missing characterization coverage for `check_breakpoint_drift.py`, `check_dead_tokens.py`, and `check_internal_anchor_links.py`.

Closes #1474
Closes #1546
Closes #1309

