### PR TITLE
test: pin nox test sessions to an explicit xdist worker count

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -18,6 +18,19 @@ nox.options.reuse_existing_virtualenvs = True
 
 _SPA_INDEX = Path("src/hassette/web/static/spa/index.html")
 
+# Explicit xdist worker count for every parallel test session, rather than ``-n auto``.
+#
+# ``-n auto`` resolves to the CPU count, which is 4 on CI's ubuntu-latest runners but 12+ on a
+# developer box. Worker count decides how the suite is partitioned, so that gap makes reproducing
+# a CI-only failure locally largely a matter of luck. Pinning the number also stops a many-core
+# box from spawning one heavy worker per core.
+#
+# The trade: ``-n auto`` tracked the runner's core count by itself, and this constant does not.
+# It currently equals what CI resolves to, so it changes nothing today — but if GitHub resizes the
+# ubuntu-latest runner, nothing here fails loudly; the suite just runs under- or over-subscribed
+# until someone updates this line. Re-check against a CI run's ``created: N/N workers`` line.
+XDIST_WORKERS = "4"
+
 
 @nox.session(python=False)
 def frontend(session: "Session"):
@@ -37,11 +50,8 @@ def dev(session: "Session"):
         "pytest",
         "-m",
         "not docker and not e2e and not system and not system_destructive",
-        # Explicit worker count, not -n auto: bounds local parallelism so a many-core box
-        # doesn't spawn one heavy worker per core. The CI matrix sessions keep -n auto,
-        # which is right for their small dedicated runners.
         "-n",
-        "4",
+        XDIST_WORKERS,
         "--dist",
         "loadscope",
         "-v",
@@ -62,7 +72,7 @@ def tests(session: "Session"):
         "-m",
         "not docker and not e2e and not system and not system_destructive",
         "-n",
-        "auto",
+        XDIST_WORKERS,
         "--dist",
         "loadscope",
         "--tb=line",
@@ -226,7 +236,7 @@ def tests_with_coverage(session: "Session"):
         "-m",
         "not docker and not e2e and not system and not system_destructive",
         "-n",
-        "auto",
+        XDIST_WORKERS,
         "--dist",
         "loadscope",
         "--tb=line",


### PR DESCRIPTION
## Summary

`tests` and `tests_with_coverage` ran under `-n auto`, which resolves to the CPU count — 4 on CI's
`ubuntu-latest` runners, 12+ on a developer box. Worker count decides how xdist partitions the
suite, so the same command produced a different partition locally than on CI, which makes
reproducing a CI-only failure locally largely a matter of luck.

All three parallel sessions now share one `XDIST_WORKERS` constant. `dev` already used `4`, so this
is a no-op there, and `4` is what CI already resolves to — so nothing about CI's behaviour changes
today. The `system` session's deliberate `-n 0` (serial) is untouched, as is `e2e`, which has no
nox-level `-n` flag.

## Why this came up

While investigating #1558 (coverage data silently lost from an xdist worker), the drop was only
reproducible locally once the run used CI's worker topology. Under 12 workers the partition differs
enough that the failure behaves differently. Matching CI's worker count is a prerequisite for
reproducing that class of bug at all, and #1571 tracks four-plus timing-fragile tests whose
failures are similarly partition- and contention-sensitive.

## The trade-off, stated plainly

`-n auto` tracked the runner's core count automatically; a pinned constant does not. If GitHub
resizes the `ubuntu-latest` runner, nothing fails loudly — the suite just runs under- or
over-subscribed until someone updates the constant. That trade is called out in the comment above
the constant, along with how to re-check it (a CI run's `created: N/N workers` line). Reviewers
flagged this as the one real cost of the change and it is deliberate: a partition that matches CI
is worth more than one that silently drifts with the runner spec.

## Verification

- `uv run nox -l` lists all sessions (noxfile parses, no session broken)
- `prek run --files noxfile.py` — clean
- CI worker count confirmed from run 31288084374: `created: 4/4 workers`, `4 workers [9207 items]`
- Test behaviour is unchanged by construction: only the `-n` value passed to pytest differs, and
  only for the two sessions that previously computed it from the local CPU count

No changelog entry — `test:` is excluded from release-please's changelog sections.
