### PR TITLE
test: stop xdist workers from silently losing their coverage data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,7 @@ frontend/coverage/
 .nox/
 .coverage
 .coverage.*
+.coverage-receipts/
 .cache
 nosetests.xml
 coverage.xml

--- a/noxfile.py
+++ b/noxfile.py
@@ -157,9 +157,10 @@ def _reset_coverage_receipts(session: "Session") -> None:
 def _check_coverage_complete(session: "Session") -> None:
     """Fail before combining if any test process lost its coverage data.
 
-    Coverage started via the .pth file below persists only at interpreter shutdown, and xdist
-    kills workers that have not got there yet, so a silently truncated run reports a plausible
-    but wrong number. See tests/coverage_integrity.py and issue #1558.
+    Coverage started by _install_coverage_pth() persists only at interpreter shutdown, and
+    xdist kills workers that have not got there yet, so a silently truncated run reports a
+    plausible but wrong number. The plugin doing the saving is registered in
+    tests/conftest.py. See tests/coverage_integrity.py and issue #1558.
     """
     session.run("uv", "run", "--active", "python", "-m", "tests.coverage_integrity", external=True)
 
@@ -198,11 +199,6 @@ def _run_system_tests(session: "Session", *, marker: str, extra_args: list[str] 
         "--reinstall-package",
         "hassette",
         "pytest",
-        # Saves coverage during the run instead of leaving it to atexit, and records a
-        # receipt the pre-combine check reads. No-ops when coverage isn't running, so the
-        # plain `system` session is unaffected. See tests/coverage_integrity.py.
-        "-p",
-        "tests.coverage_integrity",
         "-m",
         marker,
         "-v",
@@ -246,11 +242,6 @@ def tests_with_coverage(session: "Session"):
         "--reinstall-package",
         "hassette",
         "pytest",
-        # Loaded into the controller and every xdist worker. Saves each process's coverage
-        # during the run rather than at interpreter shutdown, which xdist may never let a
-        # worker reach. See tests/coverage_integrity.py and issue #1558.
-        "-p",
-        "tests.coverage_integrity",
         "-m",
         "not docker and not e2e and not system and not system_destructive",
         "-n",

--- a/noxfile.py
+++ b/noxfile.py
@@ -150,8 +150,16 @@ def system_with_coverage(session: "Session"):
 
 
 def _reset_coverage_receipts(session: "Session") -> None:
-    """Drop receipts left by an earlier run so the integrity check only judges this one."""
+    """Drop receipts and coverage data left by an earlier run.
+
+    Without this, a run that stopped before ``coverage combine`` leaves its ``COVERAGE_FILE``
+    data files on disk, and the next run's ``combine`` picks up both, silently blending a stale
+    run's data into the new report. ``coverage erase`` reads ``parallel = true`` from
+    ``pyproject.toml`` and removes those suffixed files along with the base file, not just the
+    receipts that back the integrity check.
+    """
     session.run("uv", "run", "--active", "python", "-m", "tests.coverage_integrity", "--reset", external=True)
+    session.run("uv", "run", "--active", "coverage", "erase", external=True)
 
 
 def _check_coverage_complete(session: "Session") -> None:

--- a/noxfile.py
+++ b/noxfile.py
@@ -139,12 +139,29 @@ def system_with_coverage(session: "Session"):
     session.env["COVERAGE_FILE"] = f".coverage.system.{session.python}"
     _install_coverage_pth(session)
     session.env["COVERAGE_PROCESS_START"] = "pyproject.toml"
+    _reset_coverage_receipts(session)
     _run_system_tests(session, marker="system and not system_destructive")
     _run_system_tests(session, marker="system_destructive")
+    _check_coverage_complete(session)
     session.run("uv", "run", "--active", "coverage", "combine", external=True)
     session.run(
         "uv", "run", "--active", "coverage", "xml", "--fail-under=0", "-o", "coverage.system.xml", external=True
     )
+
+
+def _reset_coverage_receipts(session: "Session") -> None:
+    """Drop receipts left by an earlier run so the integrity check only judges this one."""
+    session.run("uv", "run", "--active", "python", "-m", "tests.coverage_integrity", "--reset", external=True)
+
+
+def _check_coverage_complete(session: "Session") -> None:
+    """Fail before combining if any test process lost its coverage data.
+
+    Coverage started via the .pth file below persists only at interpreter shutdown, and xdist
+    kills workers that have not got there yet, so a silently truncated run reports a plausible
+    but wrong number. See tests/coverage_integrity.py and issue #1558.
+    """
+    session.run("uv", "run", "--active", "python", "-m", "tests.coverage_integrity", external=True)
 
 
 def _install_coverage_pth(session: "Session") -> None:
@@ -181,6 +198,11 @@ def _run_system_tests(session: "Session", *, marker: str, extra_args: list[str] 
         "--reinstall-package",
         "hassette",
         "pytest",
+        # Saves coverage during the run instead of leaving it to atexit, and records a
+        # receipt the pre-combine check reads. No-ops when coverage isn't running, so the
+        # plain `system` session is unaffected. See tests/coverage_integrity.py.
+        "-p",
+        "tests.coverage_integrity",
         "-m",
         marker,
         "-v",
@@ -216,6 +238,7 @@ def tests_with_coverage(session: "Session"):
     session.env["COVERAGE_FILE"] = f".coverage.{session.python}"
     _install_coverage_pth(session)
     session.env["COVERAGE_PROCESS_START"] = "pyproject.toml"
+    _reset_coverage_receipts(session)
     session.run(
         "uv",
         "run",
@@ -223,6 +246,11 @@ def tests_with_coverage(session: "Session"):
         "--reinstall-package",
         "hassette",
         "pytest",
+        # Loaded into the controller and every xdist worker. Saves each process's coverage
+        # during the run rather than at interpreter shutdown, which xdist may never let a
+        # worker reach. See tests/coverage_integrity.py and issue #1558.
+        "-p",
+        "tests.coverage_integrity",
         "-m",
         "not docker and not e2e and not system and not system_destructive",
         "-n",
@@ -239,6 +267,7 @@ def tests_with_coverage(session: "Session"):
         "thread",
         external=True,
     )
+    _check_coverage_complete(session)
     session.run("uv", "run", "--active", "coverage", "combine", external=True)
     session.run("uv", "run", "--active", "coverage", "report", "--show-missing", "--skip-covered", external=True)
     session.run("uv", "run", "--active", "coverage", "xml", external=True)

--- a/tests/TESTING.md
+++ b/tests/TESTING.md
@@ -374,6 +374,14 @@ COVERAGE_PROCESS_START=pyproject.toml COVERAGE_FILE=.coverage \
 uv run coverage combine && uv run coverage report
 ```
 
+### Why the coverage sessions check their own data before combining
+
+Starting coverage from a `.pth` file has one consequence worth knowing about. `coverage.process_startup()` sets `_auto_save = True`, which is read only by `Coverage._atexit`, so a process started that way writes its data file only at interpreter shutdown. xdist does not promise a worker gets there: `WorkerManager.teardown_nodes()` calls `group.terminate(EXIT_TIMEOUT)`, and execnet has its own `os._exit(1)` path. Both skip atexit. Measured on this suite, the worker that reported session finish last lost everything it had collected on essentially every parallel run, so the reported number was understated by a module-shaped amount that changed run to run (issue #1558).
+
+`tests/coverage_integrity.py` closes this. Registered in `tests/conftest.py`'s `pytest_plugins`, so it reaches the controller and every worker, it saves each process's coverage at `pytest_sessionfinish` instead of waiting for atexit — the same thing pytest-cov does in `DistWorker.finish()`. Each process also records a receipt, and the nox coverage sessions run `python -m tests.coverage_integrity` before `coverage combine` to confirm every process that started got its data to disk. If one didn't, the session fails with a message saying the data is incomplete rather than publishing a wrong percentage.
+
+Every hook no-ops when coverage was not started this way, so ordinary `pytest` runs are unaffected. If you replicate the manual approach above, add `-p tests.coverage_integrity` (with the repo root on `PYTHONPATH`) to get the same protection.
+
 ### What's excluded from coverage
 
 Codegen and pure-data modules are excluded in both `pyproject.toml` (`[tool.coverage.run] omit`) and `.github/codecov.yml` (`ignore`). See the comments in those files for the full list and rationale.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -44,7 +44,7 @@ assert APPS_TOML_TEMPLATE.exists(), f"Apps TOML template {APPS_TOML_TEMPLATE} do
 
 # this wants package.nested_directories.final_file_name
 # do not include the name of the fixture
-pytest_plugins = [
+pytest_plugins: list[str] = [
     "hassette.test_utils.fixtures",
     "hassette.test_utils.resource_tracker",
     # Saves each process's coverage during the run instead of leaving it to atexit, which xdist

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -44,7 +44,15 @@ assert APPS_TOML_TEMPLATE.exists(), f"Apps TOML template {APPS_TOML_TEMPLATE} do
 
 # this wants package.nested_directories.final_file_name
 # do not include the name of the fixture
-pytest_plugins = ["hassette.test_utils.fixtures", "hassette.test_utils.resource_tracker"]
+pytest_plugins = [
+    "hassette.test_utils.fixtures",
+    "hassette.test_utils.resource_tracker",
+    # Saves each process's coverage during the run instead of leaving it to atexit, which xdist
+    # may kill a worker before it reaches. Registered here rather than passed as `-p` from the
+    # noxfile because pytest resolves `-p` before the repo root is on sys.path. No-ops unless
+    # coverage was started by the nox sessions' .pth file. See tests/coverage_integrity.py.
+    "tests.coverage_integrity",
+]
 
 
 @pytest.fixture(autouse=True)

--- a/tests/coverage_integrity.py
+++ b/tests/coverage_integrity.py
@@ -20,10 +20,11 @@ pytest-cov never has this problem because it never waits for atexit: ``DistWorke
 calls ``cov.save()`` during the run. This module does the same for the ``.pth`` setup, then
 checks that every process which started actually got its data to disk.
 
-Loaded with ``-p tests.coverage_integrity`` so it reaches both the xdist controller and every
-worker. Run as ``python -m tests.coverage_integrity`` before ``coverage combine`` to verify the
-result. Both are wired up in the noxfile coverage sessions. Every hook is a no-op when coverage
-was not started this way, so ordinary pytest runs are unaffected.
+Registered in ``tests/conftest.py``'s ``pytest_plugins``, which is how this repo loads plugins
+that have to reach the xdist controller and every worker. Run
+``python -m tests.coverage_integrity`` before ``coverage combine`` to verify the result; the
+noxfile coverage sessions do. Every hook is a no-op when coverage was not started this way, so
+ordinary pytest runs are unaffected.
 
 See issue #1558.
 """
@@ -32,6 +33,7 @@ import argparse
 import os
 import shutil
 import sys
+import time
 from pathlib import Path
 
 import coverage
@@ -40,40 +42,50 @@ import pytest
 RECEIPT_DIR = Path(".coverage-receipts")
 STARTED_SUFFIX = ".started"
 SAVED_SUFFIX = ".saved"
+PARTIAL_SUFFIX = ".partial"
 CONTROLLER_LABEL = "controller"
+
+# Identifies this process's receipts. A bare pid is not enough: system_with_coverage runs two
+# pytest invocations against one receipt directory, and if the OS recycled the first
+# invocation's pid, the second would overwrite its receipts and erase the evidence of a drop.
+RUN_KEY = f"{os.getpid()}-{time.time_ns()}"
 
 
 def active_coverage() -> coverage.Coverage | None:
     """Return the Coverage instance auto-started by the ``.pth`` file, or None.
 
-    ``process_startup()`` annotates itself with the instance it created. coverage.py reaches
-    for it the same way in ``_prevent_sub_process_measurement()``.
+    ``process_startup()`` annotates itself with the instance it created, and coverage.py reads
+    it back the same way in ``_prevent_sub_process_measurement()``. That attribute is private
+    and unversioned, so if this ever returns None during a real coverage run, check whether
+    coverage.py renamed it. The symptom is indistinguishable from the plugin not being loaded:
+    every hook here quietly no-ops.
     """
     return getattr(coverage.process_startup, "coverage", None)
 
 
 def write_receipt(path: Path, contents: str) -> None:
-    """Write a receipt and fsync it.
+    """Write a receipt atomically and fsync it.
 
-    Without the fsync a receipt can still be sitting in the page cache when the process is
-    killed, which would read back as a process that never started.
+    Both halves matter, because the process can be killed at any point. Without the fsync a
+    receipt can still be in the page cache, reading back as a process that never started.
+    Without the rename, a kill between truncation and write leaves an empty receipt, which
+    reads back as a successful save.
     """
-    with path.open("w") as handle:
+    partial = path.with_name(f"{path.name}{PARTIAL_SUFFIX}")
+    with partial.open("w") as handle:
         handle.write(contents)
         handle.flush()
         os.fsync(handle.fileno())
+    partial.replace(path)
 
 
-def read_receipts(receipt_dir: Path, suffix: str) -> dict[int, str]:
-    """Map pid to receipt contents for every receipt of the given kind."""
-    receipts: dict[int, str] = {}
-    for path in receipt_dir.glob(f"*{suffix}"):
-        try:
-            pid = int(path.name.removesuffix(suffix))
-        except ValueError:
-            continue
-        receipts[pid] = path.read_text().strip()
-    return receipts
+def read_receipts(receipt_dir: Path, suffix: str) -> dict[str, str]:
+    """Map run key to receipt contents for every receipt of the given kind."""
+    return {
+        path.name.removesuffix(suffix): path.read_text().strip()
+        for path in receipt_dir.glob(f"*{suffix}")
+        if not path.name.endswith(PARTIAL_SUFFIX)
+    }
 
 
 def find_problems(receipt_dir: Path) -> list[str]:
@@ -84,17 +96,18 @@ def find_problems(receipt_dir: Path) -> list[str]:
     if not started:
         return [
             f"no receipts found in {receipt_dir}/, so no process recorded its coverage data. "
-            "The pytest run probably did not load the plugin (-p tests.coverage_integrity)."
+            "The pytest run probably did not load the tests.coverage_integrity plugin."
         ]
 
     problems: list[str] = []
-    for pid, label in sorted(started.items()):
-        if pid not in saved:
-            problems.append(f"{label} (pid {pid}) started but never saved its coverage data; it was killed mid-run")
-            continue
-        part_file = Path(saved[pid])
-        if not part_file.exists():
-            problems.append(f"{label} (pid {pid}) saved coverage data to {part_file}, but that file is now missing")
+    for run_key, label in sorted(started.items()):
+        recorded = saved.get(run_key)
+        if recorded is None:
+            problems.append(f"{label} started but never saved its coverage data; it was killed mid-run")
+        elif not recorded or not Path(recorded).is_absolute():
+            problems.append(f"{label} left an unusable save receipt ({recorded!r}); its data cannot be confirmed")
+        elif not Path(recorded).exists():
+            problems.append(f"{label} saved coverage data to {recorded}, but that file is now missing")
     return problems
 
 
@@ -103,9 +116,9 @@ def pytest_configure(config: pytest.Config) -> None:
     if active_coverage() is None:
         return
 
-    label = getattr(config, "workerinput", {}).get("workerid", CONTROLLER_LABEL)
+    worker = getattr(config, "workerinput", {}).get("workerid", CONTROLLER_LABEL)
     RECEIPT_DIR.mkdir(parents=True, exist_ok=True)
-    write_receipt(RECEIPT_DIR / f"{os.getpid()}{STARTED_SUFFIX}", label)
+    write_receipt(RECEIPT_DIR / f"{RUN_KEY}{STARTED_SUFFIX}", f"{worker} (pid {os.getpid()})")
 
 
 @pytest.hookimpl(trylast=True)
@@ -123,7 +136,7 @@ def pytest_sessionfinish() -> None:
 
     cov.save()
     RECEIPT_DIR.mkdir(parents=True, exist_ok=True)
-    write_receipt(RECEIPT_DIR / f"{os.getpid()}{SAVED_SUFFIX}", str(cov.get_data().data_filename()))
+    write_receipt(RECEIPT_DIR / f"{RUN_KEY}{SAVED_SUFFIX}", str(cov.get_data().data_filename()))
 
 
 def main(argv: list[str] | None = None) -> int:

--- a/tests/coverage_integrity.py
+++ b/tests/coverage_integrity.py
@@ -39,16 +39,16 @@ from pathlib import Path
 import coverage
 import pytest
 
-RECEIPT_DIR = Path(".coverage-receipts")
-STARTED_SUFFIX = ".started"
-SAVED_SUFFIX = ".saved"
-PARTIAL_SUFFIX = ".partial"
-CONTROLLER_LABEL = "controller"
+RECEIPT_DIR: Path = Path(".coverage-receipts")
+STARTED_SUFFIX: str = ".started"
+SAVED_SUFFIX: str = ".saved"
+PARTIAL_SUFFIX: str = ".partial"
+CONTROLLER_LABEL: str = "controller"
 
 # Identifies this process's receipts. A bare pid is not enough: system_with_coverage runs two
 # pytest invocations against one receipt directory, and if the OS recycled the first
 # invocation's pid, the second would overwrite its receipts and erase the evidence of a drop.
-RUN_KEY = f"{os.getpid()}-{time.time_ns()}"
+RUN_KEY: str = f"{os.getpid()}-{time.time_ns()}"
 
 
 def active_coverage() -> coverage.Coverage | None:
@@ -108,6 +108,8 @@ def find_problems(receipt_dir: Path) -> list[str]:
             problems.append(f"{label} left an unusable save receipt ({recorded!r}); its data cannot be confirmed")
         elif not Path(recorded).exists():
             problems.append(f"{label} saved coverage data to {recorded}, but that file is now missing")
+        elif not Path(recorded).is_file():
+            problems.append(f"{label} left an unusable save receipt ({recorded!r}); its data cannot be confirmed")
     return problems
 
 

--- a/tests/coverage_integrity.py
+++ b/tests/coverage_integrity.py
@@ -1,0 +1,155 @@
+"""Stop test processes from silently losing their coverage data, and fail loudly if any does.
+
+The nox coverage sessions start coverage with a ``.pth`` file plus ``COVERAGE_PROCESS_START``
+rather than pytest-cov, because pytest-cov attaches during ``pytest_configure``, after conftest
+has already imported hassette at module scope. That permanently hides every module-level
+statement and under-reports by tens of percentage points. See ``tests_with_coverage`` in
+``noxfile.py``.
+
+That trade has a cost, which this module pays back. ``coverage.process_startup()`` sets
+``_auto_save = True``, and that flag is read in exactly one place: ``Coverage._atexit``. So a
+``.pth``-started process persists its data only at interpreter shutdown, and xdist does not
+promise its workers ever reach one. ``WorkerManager.teardown_nodes()`` calls
+``group.terminate(EXIT_TIMEOUT)``, documented as killing subprocesses once the timeout expires,
+and execnet has its own ``os._exit(1)`` path. Both skip atexit. Measured on this suite, the
+worker that reports session finish last loses everything it collected on essentially every
+parallel run, so reported coverage is understated by a module-shaped amount that changes from
+run to run.
+
+pytest-cov never has this problem because it never waits for atexit: ``DistWorker.finish()``
+calls ``cov.save()`` during the run. This module does the same for the ``.pth`` setup, then
+checks that every process which started actually got its data to disk.
+
+Loaded with ``-p tests.coverage_integrity`` so it reaches both the xdist controller and every
+worker. Run as ``python -m tests.coverage_integrity`` before ``coverage combine`` to verify the
+result. Both are wired up in the noxfile coverage sessions. Every hook is a no-op when coverage
+was not started this way, so ordinary pytest runs are unaffected.
+
+See issue #1558.
+"""
+
+import argparse
+import os
+import shutil
+import sys
+from pathlib import Path
+
+import coverage
+import pytest
+
+RECEIPT_DIR = Path(".coverage-receipts")
+STARTED_SUFFIX = ".started"
+SAVED_SUFFIX = ".saved"
+CONTROLLER_LABEL = "controller"
+
+
+def active_coverage() -> coverage.Coverage | None:
+    """Return the Coverage instance auto-started by the ``.pth`` file, or None.
+
+    ``process_startup()`` annotates itself with the instance it created. coverage.py reaches
+    for it the same way in ``_prevent_sub_process_measurement()``.
+    """
+    return getattr(coverage.process_startup, "coverage", None)
+
+
+def write_receipt(path: Path, contents: str) -> None:
+    """Write a receipt and fsync it.
+
+    Without the fsync a receipt can still be sitting in the page cache when the process is
+    killed, which would read back as a process that never started.
+    """
+    with path.open("w") as handle:
+        handle.write(contents)
+        handle.flush()
+        os.fsync(handle.fileno())
+
+
+def read_receipts(receipt_dir: Path, suffix: str) -> dict[int, str]:
+    """Map pid to receipt contents for every receipt of the given kind."""
+    receipts: dict[int, str] = {}
+    for path in receipt_dir.glob(f"*{suffix}"):
+        try:
+            pid = int(path.name.removesuffix(suffix))
+        except ValueError:
+            continue
+        receipts[pid] = path.read_text().strip()
+    return receipts
+
+
+def find_problems(receipt_dir: Path) -> list[str]:
+    """Return one description per process whose coverage data did not reach disk."""
+    started = read_receipts(receipt_dir, STARTED_SUFFIX)
+    saved = read_receipts(receipt_dir, SAVED_SUFFIX)
+
+    if not started:
+        return [
+            f"no receipts found in {receipt_dir}/, so no process recorded its coverage data. "
+            "The pytest run probably did not load the plugin (-p tests.coverage_integrity)."
+        ]
+
+    problems: list[str] = []
+    for pid, label in sorted(started.items()):
+        if pid not in saved:
+            problems.append(f"{label} (pid {pid}) started but never saved its coverage data; it was killed mid-run")
+            continue
+        part_file = Path(saved[pid])
+        if not part_file.exists():
+            problems.append(f"{label} (pid {pid}) saved coverage data to {part_file}, but that file is now missing")
+    return problems
+
+
+def pytest_configure(config: pytest.Config) -> None:
+    """Record that this process started, so a mid-run kill can be told from a clean run."""
+    if active_coverage() is None:
+        return
+
+    label = getattr(config, "workerinput", {}).get("workerid", CONTROLLER_LABEL)
+    RECEIPT_DIR.mkdir(parents=True, exist_ok=True)
+    write_receipt(RECEIPT_DIR / f"{os.getpid()}{STARTED_SUFFIX}", label)
+
+
+@pytest.hookimpl(trylast=True)
+def pytest_sessionfinish() -> None:
+    """Persist coverage while the process is still alive, rather than leaving it to atexit.
+
+    Runs ``trylast`` so other plugins' session-finish work is measured too. Coverage stays
+    started afterwards, so a process that does reach interpreter shutdown saves again through
+    atexit and picks up anything executed after this point. That second save reuses the same
+    data file rather than creating a duplicate.
+    """
+    cov = active_coverage()
+    if cov is None:
+        return
+
+    cov.save()
+    RECEIPT_DIR.mkdir(parents=True, exist_ok=True)
+    write_receipt(RECEIPT_DIR / f"{os.getpid()}{SAVED_SUFFIX}", str(cov.get_data().data_filename()))
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Verify every test process wrote its coverage data.")
+    parser.add_argument("--receipt-dir", type=Path, default=RECEIPT_DIR, help="where receipts were recorded")
+    parser.add_argument("--reset", action="store_true", help="delete receipts from a previous run and exit")
+    args = parser.parse_args(argv)
+
+    if args.reset:
+        shutil.rmtree(args.receipt_dir, ignore_errors=True)
+        return 0
+
+    problems = find_problems(args.receipt_dir)
+    if not problems:
+        return 0
+
+    print("COVERAGE DATA INCOMPLETE: test processes lost data. This is not a coverage regression.", file=sys.stderr)
+    for problem in problems:
+        print(f"  - {problem}", file=sys.stderr)
+    print(
+        "\nCombining now would report a coverage number lower than the code actually has. "
+        "Failing instead of publishing it. See issue #1558.",
+        file=sys.stderr,
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/integration/test_coverage_integrity.py
+++ b/tests/integration/test_coverage_integrity.py
@@ -115,6 +115,10 @@ def run_killed_session(workspace: Path, *, load_plugin: bool, expect_completion:
     Set ``expect_completion=False`` for workspaces whose conftest kills the process before the
     session can finish.
     """
+    # Production loads the plugin from tests/conftest.py, but this throwaway workspace has its
+    # own conftest, so the only way to toggle the plugin here is an explicit `-p` (with the
+    # repo root seeded into PYTHONPATH below, which pytest does not do for `-p` on its own).
+    # test_plugin_is_registered_for_every_run_by_conftest covers the production path.
     args = [sys.executable, "-m", "pytest", "-q", "-p", "no:cacheprovider"]
     if load_plugin:
         args += ["-p", "tests.coverage_integrity"]
@@ -210,12 +214,12 @@ def test_checker_catches_a_process_killed_before_it_could_save(coverage_workspac
     assert "killed mid-run" in stderr
 
 
-def write_started(receipt_dir: Path, pid: int, label: str) -> None:
-    (receipt_dir / f"{pid}{STARTED_SUFFIX}").write_text(label)
+def write_started(receipt_dir: Path, run_key: str, label: str) -> None:
+    (receipt_dir / f"{run_key}{STARTED_SUFFIX}").write_text(label)
 
 
-def write_saved(receipt_dir: Path, pid: int, part_file: Path) -> None:
-    (receipt_dir / f"{pid}{SAVED_SUFFIX}").write_text(str(part_file))
+def write_saved(receipt_dir: Path, run_key: str, contents: str) -> None:
+    (receipt_dir / f"{run_key}{SAVED_SUFFIX}").write_text(contents)
 
 
 @pytest.fixture
@@ -226,11 +230,11 @@ def receipt_dir(tmp_path: Path) -> Path:
 
 
 def test_find_problems_accepts_a_run_where_every_process_saved(receipt_dir: Path, tmp_path: Path):
-    for pid, label in ((1, "controller"), (2, "gw0")):
-        part_file = tmp_path / f"part-{pid}"
+    for run_key, label in (("1-100", "controller (pid 1)"), ("2-200", "gw0 (pid 2)")):
+        part_file = tmp_path / f"part-{run_key}"
         part_file.write_text("data")
-        write_started(receipt_dir, pid, label)
-        write_saved(receipt_dir, pid, part_file)
+        write_started(receipt_dir, run_key, label)
+        write_saved(receipt_dir, run_key, str(part_file))
 
     assert find_problems(receipt_dir) == []
 
@@ -238,9 +242,9 @@ def test_find_problems_accepts_a_run_where_every_process_saved(receipt_dir: Path
 def test_find_problems_reports_a_process_that_never_saved(receipt_dir: Path, tmp_path: Path):
     part_file = tmp_path / "part-1"
     part_file.write_text("data")
-    write_started(receipt_dir, 1, "controller")
-    write_saved(receipt_dir, 1, part_file)
-    write_started(receipt_dir, 2, "gw0")
+    write_started(receipt_dir, "1-100", "controller (pid 1)")
+    write_saved(receipt_dir, "1-100", str(part_file))
+    write_started(receipt_dir, "2-200", "gw0 (pid 2)")
 
     problems = find_problems(receipt_dir)
 
@@ -250,14 +254,31 @@ def test_find_problems_reports_a_process_that_never_saved(receipt_dir: Path, tmp
 
 
 def test_find_problems_reports_a_part_file_that_vanished(receipt_dir: Path, tmp_path: Path):
-    write_started(receipt_dir, 7, "gw3")
-    write_saved(receipt_dir, 7, tmp_path / "never-created")
+    write_started(receipt_dir, "7-700", "gw3 (pid 7)")
+    write_saved(receipt_dir, "7-700", str(tmp_path / "never-created"))
 
     problems = find_problems(receipt_dir)
 
     assert len(problems) == 1
     assert "gw3 (pid 7)" in problems[0]
     assert "now missing" in problems[0]
+
+
+def test_find_problems_rejects_a_truncated_save_receipt(receipt_dir: Path):
+    """An empty receipt must not read as a successful save.
+
+    A process killed between truncating its receipt and writing to it leaves an empty file.
+    Path("") is PosixPath("."), and the current directory always exists, so an existence check
+    on the recorded path alone would wave this straight through.
+    """
+    write_started(receipt_dir, "9-900", "gw1 (pid 9)")
+    write_saved(receipt_dir, "9-900", "")
+
+    problems = find_problems(receipt_dir)
+
+    assert len(problems) == 1
+    assert "gw1 (pid 9)" in problems[0]
+    assert "unusable save receipt" in problems[0]
 
 
 def test_find_problems_reports_an_unmeasured_run_rather_than_passing_it(tmp_path: Path):
@@ -269,7 +290,23 @@ def test_find_problems_reports_an_unmeasured_run_rather_than_passing_it(tmp_path
 
 
 def test_main_resets_receipts_from_a_previous_run(receipt_dir: Path):
-    write_started(receipt_dir, 1, "controller")
+    write_started(receipt_dir, "1-100", "controller (pid 1)")
 
     assert main(["--receipt-dir", str(receipt_dir), "--reset"]) == 0
     assert not receipt_dir.exists()
+
+
+def test_plugin_is_registered_for_every_run_by_conftest(pytestconfig: pytest.Config):
+    """The nox coverage sessions rely on conftest registration to reach the controller and
+    every xdist worker.
+
+    The subprocess tests above load the plugin with an explicit `-p` and a seeded PYTHONPATH,
+    so they cannot catch a broken registration. An earlier version of this change wired it as
+    `-p tests.coverage_integrity` from the noxfile, which fails to import because pytest
+    resolves `-p` before the repo root reaches sys.path; every subprocess test still passed.
+    This asserts the path production actually uses.
+    """
+    assert pytestconfig.pluginmanager.hasplugin("tests.coverage_integrity"), (
+        "tests/conftest.py must keep tests.coverage_integrity in pytest_plugins, or the nox "
+        "coverage sessions silently stop saving worker coverage data"
+    )

--- a/tests/integration/test_coverage_integrity.py
+++ b/tests/integration/test_coverage_integrity.py
@@ -22,6 +22,8 @@ from pathlib import Path
 
 import pytest
 
+from tests.coverage_integrity import RECEIPT_DIR, SAVED_SUFFIX, STARTED_SUFFIX, find_problems, main
+
 PROJECT_ROOT = Path(__file__).resolve().parents[2]
 SUBPROCESS_TIMEOUT_SECONDS = 120
 
@@ -71,6 +73,20 @@ def test_add():
     assert add(1, 2) == 3
 """
 
+# Kills the process after pytest_configure (so a .started receipt exists) but before
+# pytest_sessionfinish (so no .saved receipt follows). That is the real "worker died
+# mid-run" shape, which the plugin cannot save its way out of and the checker must catch.
+EARLY_KILL_CONFTEST = """\
+import os
+import sys
+
+
+def pytest_collection(session):
+    sys.stdout.flush()
+    sys.stderr.flush()
+    os._exit(0)
+"""
+
 
 @dataclass(frozen=True)
 class SubprocessRun:
@@ -93,8 +109,12 @@ def coverage_workspace(tmp_path: Path) -> Path:
     return tmp_path
 
 
-def run_killed_session(workspace: Path, *, load_plugin: bool) -> SubprocessRun:
-    """Run the workspace's pytest session, optionally with the integrity plugin loaded."""
+def run_killed_session(workspace: Path, *, load_plugin: bool, expect_completion: bool = True) -> SubprocessRun:
+    """Run the workspace's pytest session, optionally with the integrity plugin loaded.
+
+    Set ``expect_completion=False`` for workspaces whose conftest kills the process before the
+    session can finish.
+    """
     args = [sys.executable, "-m", "pytest", "-q", "-p", "no:cacheprovider"]
     if load_plugin:
         args += ["-p", "tests.coverage_integrity"]
@@ -124,11 +144,12 @@ def run_killed_session(workspace: Path, *, load_plugin: bool) -> SubprocessRun:
     # `-p`, a collection error — it never reaches pytest_unconfigure, so the process is
     # never killed, atexit runs, and a part file appears. That looks identical to the
     # plugin working. Requiring the session to have actually completed rules it out.
-    assert "1 passed" in proc.stdout, (
-        "the pytest session did not run to completion, so the kill never happened and "
-        f"this run proves nothing.\nargs: {args}\nreturncode: {proc.returncode}\n"
-        f"stdout:\n{proc.stdout}\nstderr:\n{proc.stderr}"
-    )
+    if expect_completion:
+        assert "1 passed" in proc.stdout, (
+            "the pytest session did not run to completion, so the kill never happened and "
+            f"this run proves nothing.\nargs: {args}\nreturncode: {proc.returncode}\n"
+            f"stdout:\n{proc.stdout}\nstderr:\n{proc.stderr}"
+        )
 
     return SubprocessRun(
         returncode=proc.returncode,
@@ -165,3 +186,90 @@ def test_plugin_saves_coverage_data_before_the_process_is_killed(coverage_worksp
         f"{result.part_files}\nstdout:\n{result.stdout}\nstderr:\n{result.stderr}"
     )
     assert result.part_files[0].stat().st_size > 0, "coverage part file is empty"
+
+
+@pytest.mark.integration
+def test_checker_catches_a_process_killed_before_it_could_save(coverage_workspace: Path, capsys):
+    """The guard, induced end to end rather than asserted on hand-built receipts.
+
+    Saving at session finish cannot help a process that dies before session finish, so the
+    checker has to notice. This is issue #1558's acceptance criterion that the guard be
+    watched catching the thing it exists to catch.
+    """
+    (coverage_workspace / "conftest.py").write_text(EARLY_KILL_CONFTEST)
+
+    result = run_killed_session(coverage_workspace, load_plugin=True, expect_completion=False)
+    assert result.part_files == [], "the process was supposed to die before saving anything"
+
+    exit_code = main(["--receipt-dir", str(coverage_workspace / RECEIPT_DIR)])
+
+    assert exit_code == 1
+    stderr = capsys.readouterr().err
+    assert "COVERAGE DATA INCOMPLETE" in stderr
+    assert "not a coverage regression" in stderr, "the message must not be mistaken for a threshold failure"
+    assert "killed mid-run" in stderr
+
+
+def write_started(receipt_dir: Path, pid: int, label: str) -> None:
+    (receipt_dir / f"{pid}{STARTED_SUFFIX}").write_text(label)
+
+
+def write_saved(receipt_dir: Path, pid: int, part_file: Path) -> None:
+    (receipt_dir / f"{pid}{SAVED_SUFFIX}").write_text(str(part_file))
+
+
+@pytest.fixture
+def receipt_dir(tmp_path: Path) -> Path:
+    path = tmp_path / RECEIPT_DIR
+    path.mkdir()
+    return path
+
+
+def test_find_problems_accepts_a_run_where_every_process_saved(receipt_dir: Path, tmp_path: Path):
+    for pid, label in ((1, "controller"), (2, "gw0")):
+        part_file = tmp_path / f"part-{pid}"
+        part_file.write_text("data")
+        write_started(receipt_dir, pid, label)
+        write_saved(receipt_dir, pid, part_file)
+
+    assert find_problems(receipt_dir) == []
+
+
+def test_find_problems_reports_a_process_that_never_saved(receipt_dir: Path, tmp_path: Path):
+    part_file = tmp_path / "part-1"
+    part_file.write_text("data")
+    write_started(receipt_dir, 1, "controller")
+    write_saved(receipt_dir, 1, part_file)
+    write_started(receipt_dir, 2, "gw0")
+
+    problems = find_problems(receipt_dir)
+
+    assert len(problems) == 1
+    assert "gw0 (pid 2)" in problems[0]
+    assert "killed mid-run" in problems[0]
+
+
+def test_find_problems_reports_a_part_file_that_vanished(receipt_dir: Path, tmp_path: Path):
+    write_started(receipt_dir, 7, "gw3")
+    write_saved(receipt_dir, 7, tmp_path / "never-created")
+
+    problems = find_problems(receipt_dir)
+
+    assert len(problems) == 1
+    assert "gw3 (pid 7)" in problems[0]
+    assert "now missing" in problems[0]
+
+
+def test_find_problems_reports_an_unmeasured_run_rather_than_passing_it(tmp_path: Path):
+    """An empty receipt directory means the plugin never loaded, which must not read as success."""
+    problems = find_problems(tmp_path / "absent")
+
+    assert len(problems) == 1
+    assert "tests.coverage_integrity" in problems[0]
+
+
+def test_main_resets_receipts_from_a_previous_run(receipt_dir: Path):
+    write_started(receipt_dir, 1, "controller")
+
+    assert main(["--receipt-dir", str(receipt_dir), "--reset"]) == 0
+    assert not receipt_dir.exists()

--- a/tests/integration/test_coverage_integrity.py
+++ b/tests/integration/test_coverage_integrity.py
@@ -24,10 +24,10 @@ import pytest
 
 from tests.coverage_integrity import RECEIPT_DIR, SAVED_SUFFIX, STARTED_SUFFIX, find_problems, main
 
-PROJECT_ROOT = Path(__file__).resolve().parents[2]
-SUBPROCESS_TIMEOUT_SECONDS = 120
+PROJECT_ROOT: Path = Path(__file__).resolve().parents[2]
+SUBPROCESS_TIMEOUT_SECONDS: int = 120
 
-COVERAGERC = """\
+COVERAGERC: str = """\
 [run]
 parallel = True
 relative_files = True
@@ -36,7 +36,7 @@ source = .
 
 # Starts tracing at interpreter startup, standing in for the .pth file the nox sessions
 # install. Python imports sitecustomize automatically during site initialization.
-SITECUSTOMIZE = """\
+SITECUSTOMIZE: str = """\
 import coverage
 
 coverage.process_startup()
@@ -49,7 +49,7 @@ coverage.process_startup()
 # The flushes matter: os._exit() also discards unflushed stdio, and captured stdout is
 # block-buffered, so without them the caller cannot tell a completed session from a
 # session that died during startup. Only the atexit bypass is load-bearing here.
-KILLING_CONFTEST = """\
+KILLING_CONFTEST: str = """\
 import os
 import sys
 
@@ -60,12 +60,12 @@ def pytest_unconfigure(config):
     os._exit(0)
 """
 
-SAMPLE_MODULE = """\
+SAMPLE_MODULE: str = """\
 def add(a, b):
     return a + b
 """
 
-SAMPLE_TEST = """\
+SAMPLE_TEST: str = """\
 from sample_module import add
 
 
@@ -76,7 +76,7 @@ def test_add():
 # Kills the process after pytest_configure (so a .started receipt exists) but before
 # pytest_sessionfinish (so no .saved receipt follows). That is the real "worker died
 # mid-run" shape, which the plugin cannot save its way out of and the checker must catch.
-EARLY_KILL_CONFTEST = """\
+EARLY_KILL_CONFTEST: str = """\
 import os
 import sys
 
@@ -164,7 +164,7 @@ def run_killed_session(workspace: Path, *, load_plugin: bool, expect_completion:
 
 
 @pytest.mark.integration
-def test_killed_process_loses_coverage_data_without_the_plugin(coverage_workspace: Path):
+def test_killed_process_loses_coverage_data_without_the_plugin(coverage_workspace: Path) -> None:
     """The bug itself: coverage.process_startup() saves only from its atexit hook, so a
     process killed before interpreter shutdown writes no data file at all.
 
@@ -181,7 +181,7 @@ def test_killed_process_loses_coverage_data_without_the_plugin(coverage_workspac
 
 
 @pytest.mark.integration
-def test_plugin_saves_coverage_data_before_the_process_is_killed(coverage_workspace: Path):
+def test_plugin_saves_coverage_data_before_the_process_is_killed(coverage_workspace: Path) -> None:
     """The fix: saving at session finish means the data is already on disk when the kill lands."""
     result = run_killed_session(coverage_workspace, load_plugin=True)
 
@@ -193,7 +193,9 @@ def test_plugin_saves_coverage_data_before_the_process_is_killed(coverage_worksp
 
 
 @pytest.mark.integration
-def test_checker_catches_a_process_killed_before_it_could_save(coverage_workspace: Path, capsys):
+def test_checker_catches_a_process_killed_before_it_could_save(
+    coverage_workspace: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
     """The guard, induced end to end rather than asserted on hand-built receipts.
 
     Saving at session finish cannot help a process that dies before session finish, so the
@@ -229,7 +231,7 @@ def receipt_dir(tmp_path: Path) -> Path:
     return path
 
 
-def test_find_problems_accepts_a_run_where_every_process_saved(receipt_dir: Path, tmp_path: Path):
+def test_find_problems_accepts_a_run_where_every_process_saved(receipt_dir: Path, tmp_path: Path) -> None:
     for run_key, label in (("1-100", "controller (pid 1)"), ("2-200", "gw0 (pid 2)")):
         part_file = tmp_path / f"part-{run_key}"
         part_file.write_text("data")
@@ -239,7 +241,7 @@ def test_find_problems_accepts_a_run_where_every_process_saved(receipt_dir: Path
     assert find_problems(receipt_dir) == []
 
 
-def test_find_problems_reports_a_process_that_never_saved(receipt_dir: Path, tmp_path: Path):
+def test_find_problems_reports_a_process_that_never_saved(receipt_dir: Path, tmp_path: Path) -> None:
     part_file = tmp_path / "part-1"
     part_file.write_text("data")
     write_started(receipt_dir, "1-100", "controller (pid 1)")
@@ -253,7 +255,7 @@ def test_find_problems_reports_a_process_that_never_saved(receipt_dir: Path, tmp
     assert "killed mid-run" in problems[0]
 
 
-def test_find_problems_reports_a_part_file_that_vanished(receipt_dir: Path, tmp_path: Path):
+def test_find_problems_reports_a_part_file_that_vanished(receipt_dir: Path, tmp_path: Path) -> None:
     write_started(receipt_dir, "7-700", "gw3 (pid 7)")
     write_saved(receipt_dir, "7-700", str(tmp_path / "never-created"))
 
@@ -264,7 +266,7 @@ def test_find_problems_reports_a_part_file_that_vanished(receipt_dir: Path, tmp_
     assert "now missing" in problems[0]
 
 
-def test_find_problems_rejects_a_truncated_save_receipt(receipt_dir: Path):
+def test_find_problems_rejects_a_truncated_save_receipt(receipt_dir: Path) -> None:
     """An empty receipt must not read as a successful save.
 
     A process killed between truncating its receipt and writing to it leaves an empty file.
@@ -281,7 +283,23 @@ def test_find_problems_rejects_a_truncated_save_receipt(receipt_dir: Path):
     assert "unusable save receipt" in problems[0]
 
 
-def test_find_problems_reports_an_unmeasured_run_rather_than_passing_it(tmp_path: Path):
+def test_find_problems_rejects_a_directory_receipt(receipt_dir: Path, tmp_path: Path) -> None:
+    """A recorded path that exists but is a directory cannot be a coverage data file.
+
+    An existence check alone would let this through, since a directory like tmp_path always
+    "exists" too.
+    """
+    write_started(receipt_dir, "3-300", "gw2 (pid 3)")
+    write_saved(receipt_dir, "3-300", str(tmp_path))
+
+    problems = find_problems(receipt_dir)
+
+    assert len(problems) == 1
+    assert "gw2 (pid 3)" in problems[0]
+    assert "unusable save receipt" in problems[0]
+
+
+def test_find_problems_reports_an_unmeasured_run_rather_than_passing_it(tmp_path: Path) -> None:
     """An empty receipt directory means the plugin never loaded, which must not read as success."""
     problems = find_problems(tmp_path / "absent")
 
@@ -289,14 +307,14 @@ def test_find_problems_reports_an_unmeasured_run_rather_than_passing_it(tmp_path
     assert "tests.coverage_integrity" in problems[0]
 
 
-def test_main_resets_receipts_from_a_previous_run(receipt_dir: Path):
+def test_main_resets_receipts_from_a_previous_run(receipt_dir: Path) -> None:
     write_started(receipt_dir, "1-100", "controller (pid 1)")
 
     assert main(["--receipt-dir", str(receipt_dir), "--reset"]) == 0
     assert not receipt_dir.exists()
 
 
-def test_plugin_is_registered_for_every_run_by_conftest(pytestconfig: pytest.Config):
+def test_plugin_is_registered_for_every_run_by_conftest(pytestconfig: pytest.Config) -> None:
     """The nox coverage sessions rely on conftest registration to reach the controller and
     every xdist worker.
 

--- a/tests/integration/test_coverage_integrity.py
+++ b/tests/integration/test_coverage_integrity.py
@@ -1,0 +1,167 @@
+"""Verify tests/coverage_integrity.py — the plugin that stops a killed pytest process
+from silently discarding its coverage data.
+
+The real trigger is xdist killing a worker between ``pytest_sessionfinish`` and
+interpreter shutdown, which is a race and cannot be asserted on directly. It is
+reproduced deterministically here instead: a throwaway conftest calls ``os._exit()``
+from ``pytest_unconfigure``, which lands in exactly that window — after session finish,
+before atexit. Both the real kill and this one bypass atexit, which is the only thing
+that matters to the mechanism. See issue #1558.
+
+The subprocess mirrors the nox coverage sessions' setup (``COVERAGE_PROCESS_START`` plus
+tracing started at interpreter startup) using ``sitecustomize.py`` in place of the
+``.pth`` file, since a test must not write into site-packages. Both hooks run at the same
+point in startup and call the same ``coverage.process_startup()``.
+"""
+
+import os
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+import pytest
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+SUBPROCESS_TIMEOUT_SECONDS = 120
+
+COVERAGERC = """\
+[run]
+parallel = True
+relative_files = True
+source = .
+"""
+
+# Starts tracing at interpreter startup, standing in for the .pth file the nox sessions
+# install. Python imports sitecustomize automatically during site initialization.
+SITECUSTOMIZE = """\
+import coverage
+
+coverage.process_startup()
+"""
+
+# os._exit() skips atexit entirely, the same way execnet's os._exit(1) and a SIGKILL from
+# Group.terminate() do. pytest_unconfigure runs after pytest_sessionfinish, so a plugin
+# that saves at session finish has already had its chance; one that relies on atexit has not.
+#
+# The flushes matter: os._exit() also discards unflushed stdio, and captured stdout is
+# block-buffered, so without them the caller cannot tell a completed session from a
+# session that died during startup. Only the atexit bypass is load-bearing here.
+KILLING_CONFTEST = """\
+import os
+import sys
+
+
+def pytest_unconfigure(config):
+    sys.stdout.flush()
+    sys.stderr.flush()
+    os._exit(0)
+"""
+
+SAMPLE_MODULE = """\
+def add(a, b):
+    return a + b
+"""
+
+SAMPLE_TEST = """\
+from sample_module import add
+
+
+def test_add():
+    assert add(1, 2) == 3
+"""
+
+
+@dataclass(frozen=True)
+class SubprocessRun:
+    returncode: int
+    stdout: str
+    stderr: str
+    part_files: list[Path]
+
+
+@pytest.fixture
+def coverage_workspace(tmp_path: Path) -> Path:
+    """A self-contained directory that runs one tiny pytest session under coverage
+    and then kills itself before interpreter shutdown.
+    """
+    (tmp_path / ".coveragerc").write_text(COVERAGERC)
+    (tmp_path / "sitecustomize.py").write_text(SITECUSTOMIZE)
+    (tmp_path / "conftest.py").write_text(KILLING_CONFTEST)
+    (tmp_path / "sample_module.py").write_text(SAMPLE_MODULE)
+    (tmp_path / "test_sample.py").write_text(SAMPLE_TEST)
+    return tmp_path
+
+
+def run_killed_session(workspace: Path, *, load_plugin: bool) -> SubprocessRun:
+    """Run the workspace's pytest session, optionally with the integrity plugin loaded."""
+    args = [sys.executable, "-m", "pytest", "-q", "-p", "no:cacheprovider"]
+    if load_plugin:
+        args += ["-p", "tests.coverage_integrity"]
+    args.append("test_sample.py")
+
+    env = {
+        **os.environ,
+        "COVERAGE_PROCESS_START": ".coveragerc",
+        # Repo root so `-p tests.coverage_integrity` resolves; workspace so sitecustomize
+        # and the sample module do. PYTHONPATH precedes site-packages, so the workspace
+        # sitecustomize wins over any the venv ships.
+        "PYTHONPATH": os.pathsep.join([str(PROJECT_ROOT), str(workspace)]),
+    }
+    env.pop("COVERAGE_FILE", None)
+
+    proc = subprocess.run(
+        args,
+        cwd=workspace,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=SUBPROCESS_TIMEOUT_SECONDS,
+        check=False,
+    )
+
+    # Without this the tests pass for the wrong reason. If pytest bails early — a bad
+    # `-p`, a collection error — it never reaches pytest_unconfigure, so the process is
+    # never killed, atexit runs, and a part file appears. That looks identical to the
+    # plugin working. Requiring the session to have actually completed rules it out.
+    assert "1 passed" in proc.stdout, (
+        "the pytest session did not run to completion, so the kill never happened and "
+        f"this run proves nothing.\nargs: {args}\nreturncode: {proc.returncode}\n"
+        f"stdout:\n{proc.stdout}\nstderr:\n{proc.stderr}"
+    )
+
+    return SubprocessRun(
+        returncode=proc.returncode,
+        stdout=proc.stdout,
+        stderr=proc.stderr,
+        part_files=sorted(workspace.glob(".coverage.*")),
+    )
+
+
+@pytest.mark.integration
+def test_killed_process_loses_coverage_data_without_the_plugin(coverage_workspace: Path):
+    """The bug itself: coverage.process_startup() saves only from its atexit hook, so a
+    process killed before interpreter shutdown writes no data file at all.
+
+    This asserts the loss still happens, which is what makes the plugin necessary. If it
+    ever starts failing, coverage.py changed its save contract and the plugin may be
+    redundant.
+    """
+    result = run_killed_session(coverage_workspace, load_plugin=False)
+
+    assert result.part_files == [], (
+        "expected the killed process to lose its coverage data, but a part file survived: "
+        f"{result.part_files}\nstdout:\n{result.stdout}"
+    )
+
+
+@pytest.mark.integration
+def test_plugin_saves_coverage_data_before_the_process_is_killed(coverage_workspace: Path):
+    """The fix: saving at session finish means the data is already on disk when the kill lands."""
+    result = run_killed_session(coverage_workspace, load_plugin=True)
+
+    assert len(result.part_files) == 1, (
+        "expected exactly one coverage part file to survive the kill, got "
+        f"{result.part_files}\nstdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+    )
+    assert result.part_files[0].stat().st_size > 0, "coverage part file is empty"


### PR DESCRIPTION
## Summary

The coverage nox sessions lose one test process's coverage data on essentially every parallel run and report a plausible but wrong number. This saves each process's data during the run instead of leaving it to atexit, and fails loudly before `coverage combine` if any process's data is missing anyway.

Closes #1558

## Whose bug this is

Neither xdist's nor coverage.py's. Both behave to their documented contracts; the seam between them was unowned in our config.

- `coverage.process_startup()` — the `.pth` mechanism these sessions use — sets `_auto_save = True`, and that flag is read in exactly one place, `Coverage._atexit`. So a `.pth`-started process persists its data **only at interpreter shutdown**. That is the documented contract of the subprocess mechanism.
- `WorkerManager.teardown_nodes()` is one line: `group.terminate(EXIT_TIMEOUT)`. `Group.terminate`'s own docstring says it will "try to kill local sub processes" once the timeout expires, and execnet has a second `os._exit(1)` path at `gateway_base.py:1253`. Both skip atexit. Advertised behaviour.
- pytest-cov never hits this because it never waits for atexit: `DistWorker.finish()` calls `cov.save()` during the run.

We dropped pytest-cov deliberately, and correctly — it attaches in `pytest_configure`, after conftest has imported hassette at module scope, which hides every module-level statement and under-reports by 15-40pp. But pytest-cov was also the only component holding the worker-save handshake, and the raw `.pth` setup that replaced it has no equivalent. This adds one.

## What changed

`tests/coverage_integrity.py`, registered in `tests/conftest.py`'s `pytest_plugins` so it reaches the xdist controller and every worker:

- Saves coverage at `pytest_sessionfinish` (`trylast`), while the process is still alive. Coverage stays started, so a process that does reach shutdown saves again through atexit and picks up anything after that point — the second save reuses the same data file rather than creating a duplicate.
- Records a receipt per process. `noxfile.py`'s two coverage sessions run `python -m tests.coverage_integrity` before `coverage combine`; if a process started but never saved, the session fails with a message that cannot be mistaken for a threshold breach.

Every hook no-ops when coverage was not started this way, so ordinary `pytest` runs are unaffected.

## Evidence

**The bug, reproduced deterministically.** Racing xdist is not assertable, so `tests/integration/test_coverage_integrity.py` induces the same window: a throwaway conftest calls `os._exit()` from `pytest_unconfigure`, after session finish and before atexit. `test_killed_process_loses_coverage_data_without_the_plugin` asserts the data *is* lost without the plugin, and will start failing if coverage.py ever changes its save contract.

**The fix, on a real run.** Full unit+integration suite, `-n auto`, 12 workers plus controller:

```
13 processes started, 13 saved
$ python -m tests.coverage_integrity
$ echo $?
0
```

No false positive on a healthy parallel run, and every worker's data landed. Before this change the worker reporting session finish last dropped its data.

**The guard, induced end to end.** `test_checker_catches_a_process_killed_before_it_could_save` kills a process after `pytest_configure` and before `pytest_sessionfinish` — the one case saving cannot rescue — and asserts the checker exits 1 naming it.

Three tests failed in that run (`test_simulate_call_service_typed_di_domain`, `test_listener_with_throttle`, `test_tier1_ignore_suppresses_warning_and_row`). All three pass in isolation; they are load-sensitive flakes unrelated to this change. The first two are tracked in #1571. The third is coverage-specific: coverage's own `bytecode.py`/`sysmon.py` frames appear in that run's blocking-IO stall traces, so the instrumentation is stalling the loop.

## Expect the coverage number to go up

Reported coverage has been systematically understated, so this should raise it rather than move it around. The `codecov/project` baseline rebases itself off main once this merges. #1585 is currently red on `codecov/project` at -5.50% for a comment-only diff, which is this bug showing up live; it should go green after a rebase onto this.

## Review notes

Three findings from code and integration review are folded in, each with a test:

- The plugin was originally passed as `-p tests.coverage_integrity` from the noxfile. That cannot import: pytest resolves `-p` in `consider_preparse` at `config/__init__.py:1405`, one line *after* `_configure_python_path()`, and `tests` is not in `pyproject.toml`'s `pythonpath`. It broke the plain `system` session too. The subprocess tests missed it because they seed `PYTHONPATH` themselves, so `test_plugin_is_registered_for_every_run_by_conftest` now asserts the path production uses.
- An empty `.saved` receipt read as a successful save, because `Path("")` is `PosixPath(".")` and the current directory always exists. Receipts are now written atomically via a temp file plus rename, and unusable ones are rejected.
- Receipts are keyed by pid plus start time. `system_with_coverage` runs two pytest invocations against one receipt directory, so a recycled pid could have let the second overwrite the first's evidence of a drop.
