### PR TITLE
chore: discover autofix PRs by source:autofix label instead of text search

### DIFF
--- a/.claude/skills/review-autofixes/SKILL.md
+++ b/.claude/skills/review-autofixes/SKILL.md
@@ -15,10 +15,10 @@ Daily review of auto-generated PRs on `autofix/*` branches. For each open PR: tr
 
 ## Phase 1: Discover
 
-Find open autofix PRs:
+Find open autofix PRs by label (autofix PR creation attaches `source:autofix`):
 
 ```bash
-gh pr list --search "autofix" --state open --json number,title,headRefName --jq '.[] | "\(.number) | \(.title) | \(.headRefName)"'
+gh pr list --label "source:autofix" --state open --json number,title,headRefName --jq '.[] | "\(.number) | \(.title) | \(.headRefName)"'
 ```
 
 Present the list to the user. If no open PRs, report that and stop.


### PR DESCRIPTION
## Summary

The `review-autofixes` skill discovered open autofix PRs via `gh pr list --search "autofix"`, a fuzzy full-text search over PR title/body. It doesn't reliably match on the branch name — confirmed it silently returned zero open PRs while a real, non-draft, open autofix PR (#1587, `autofix/issue-1511`) existed, because its title never contained the literal word "autofix".

Switches discovery to `gh pr list --label "source:autofix"`. The `source:autofix` label already exists in the repo (created this session) but nothing attaches it to PRs yet — that requires a separate change in the external process that opens these PRs, which does not live in this repo.

## Changes

- `.claude/skills/review-autofixes/SKILL.md`: Phase 1 discovery now filters by `--label "source:autofix"` instead of `--search "autofix"`.

## Follow-up required

The autofix PR-creation process (external to this repo) needs to attach the `source:autofix` label when it opens a PR. Until that ships, this skill's discovery step will find nothing.