### PR TITLE
chore(frontend): extract duplicated JSON content-type literal in API client

### DIFF
--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -1,6 +1,7 @@
 /** Base API client for fetching JSON from the Hassette backend. */
 
 const BASE_URL = "/api";
+const JSON_CONTENT_TYPE = "application/json";
 
 export class ApiError extends Error {
   constructor(
@@ -30,7 +31,7 @@ export async function apiFetch<T>(path: string, init?: RequestInit): Promise<T> 
     ...init,
     credentials: "same-origin",
     headers: {
-      Accept: "application/json",
+      Accept: JSON_CONTENT_TYPE,
       ...init?.headers,
     },
   });
@@ -46,7 +47,7 @@ export async function apiFetch<T>(path: string, init?: RequestInit): Promise<T> 
 function apiWrite<T>(method: "POST" | "PUT", path: string, body?: unknown): Promise<T> {
   return apiFetch<T>(path, {
     method,
-    headers: { "Content-Type": "application/json" },
+    headers: { "Content-Type": JSON_CONTENT_TYPE },
     body: body ? JSON.stringify(body) : undefined,
   });
 }
@@ -70,7 +71,7 @@ export async function postSession(token: string): Promise<PostSessionResult> {
     response = await fetch(`${BASE_URL}/auth/session`, {
       method: "POST",
       credentials: "same-origin",
-      headers: { "Content-Type": "application/json" },
+      headers: { "Content-Type": JSON_CONTENT_TYPE },
       body: JSON.stringify({ token }),
     });
   } catch {


### PR DESCRIPTION
## What changed

`frontend/src/api/client.ts` hand-wrote the `"application/json"` MIME-type string in three places. It is now a single module-level constant, `JSON_CONTENT_TYPE`, declared next to the existing `BASE_URL` constant and referenced at every call site:

- `apiFetch` — the `Accept` header
- `apiWrite` — the `Content-Type` header
- `postSession` — the `Content-Type` header (this third occurrence was not listed in the issue, but is the same literal and was folded in)

No behavior change: the emitted header values are byte-for-byte identical.

## Why

Pre-existing code-quality finding from the automated quality scanner. `BASE_URL` directly above was already hoisted as a named constant, so the duplicated literal was inconsistent with the file's own convention.

## Testing

All green on this branch:

- `uv run nox -s dev` — 9221 passed, 1 skipped, 2 xfailed
- `cd frontend && npm run test` — 1488 passed across 101 files
- `prek -a` — all hooks passed (ruff, eslint, prettier, stylelint, tsc, and the repo's custom checks)
- `prek pyright -a --stage pre-push` — passed

## Draft status

Opened as a draft because the change arrived uncommitted in the worktree and was committed as `wip:` by an automated shipping pass rather than being finished and committed deliberately. The content itself is complete — it satisfies the issue's acceptance criterion and all checks pass — so this can most likely be marked ready as-is after a glance at the diff.

Closes #1514