### PR TITLE
fix: clean up unused exports, naming inconsistencies, and orphaned mocks in frontend API

### DIFF
--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -44,16 +44,13 @@ export async function apiFetch<T>(path: string, init?: RequestInit): Promise<T> 
   return response.json() as Promise<T>;
 }
 
-function apiWrite<T>(method: "POST" | "PUT", path: string, body?: unknown): Promise<T> {
+export function apiPost<T>(path: string, body?: unknown): Promise<T> {
   return apiFetch<T>(path, {
-    method,
+    method: "POST",
     headers: { "Content-Type": JSON_CONTENT_TYPE },
     body: body ? JSON.stringify(body) : undefined,
   });
 }
-
-export const apiPost = <T>(path: string, body?: unknown) => apiWrite<T>("POST", path, body);
-export const apiPut = <T>(path: string, body?: unknown) => apiWrite<T>("PUT", path, body);
 
 export type PostSessionResult = { ok: true } | { ok: false; message: string };
 

--- a/frontend/src/api/endpoints.ts
+++ b/frontend/src/api/endpoints.ts
@@ -2,14 +2,13 @@
 /** Typed API endpoint functions for all Hassette REST endpoints. */
 
 import { DETAIL_FETCH_LIMIT } from "../utils/constants";
-import { apiFetch, apiPost, apiPut } from "./client";
+import { apiFetch, apiPost } from "./client";
 import type { ConfigRecord, SchemaNode } from "./config-view-types";
 import type { components } from "./generated-types";
 
 export type AppManifest = components["schemas"]["AppManifestResponse"];
 export type AppInstance = components["schemas"]["AppInstanceResponse"];
 export type ManifestListResponse = components["schemas"]["AppManifestListResponse"];
-export type AppHealthData = components["schemas"]["AppHealthResponse"];
 export type ListenerData = components["schemas"]["ListenerWithSummary"];
 export type DashboardAppGridEntry = components["schemas"]["DashboardAppGridEntry"];
 export type JobData = components["schemas"]["JobSummary"];
@@ -26,6 +25,12 @@ export type AppSourceData = components["schemas"]["AppSourceResponse"];
 export type ActivityFeedEntryData = components["schemas"]["ActivityFeedEntry"];
 export type ActionResponse = components["schemas"]["ActionResponse"];
 export type JobTriggerResponse = components["schemas"]["JobTriggerResponse"];
+export type SystemConfig = Omit<components["schemas"]["ConfigSchemaResponse"], "config_schema" | "config_values"> & {
+  config_schema: SchemaNode;
+  config_values: ConfigRecord;
+};
+export type SystemStatus = components["schemas"]["SystemStatusResponse"];
+export type BootIssue = components["schemas"]["BootIssueResponse"];
 
 export const WS_PATH = "/api/ws";
 
@@ -52,11 +57,6 @@ export const getAppConfig = (appKey: string, signal?: AbortSignal) =>
 export const getAppSource = (appKey: string, signal?: AbortSignal) =>
   apiFetch<AppSourceData>(`/apps/${encodeURIComponent(appKey)}/source`, { signal });
 
-export const getAppHealth = (appKey: string, instanceIndex = 0, since?: number | null) =>
-  apiFetch<AppHealthData>(
-    buildUrl(`/telemetry/app/${encodeURIComponent(appKey)}/health`, { instance_index: instanceIndex, since }),
-  );
-
 export const getAppListeners = (appKey: string, instanceIndex = 0, since?: number | null, signal?: AbortSignal) =>
   apiFetch<ListenerData[]>(
     buildUrl(`/telemetry/app/${encodeURIComponent(appKey)}/listeners`, { instance_index: instanceIndex, since }),
@@ -71,7 +71,7 @@ export const getAppJobs = (appKey: string, instanceIndex = 0, since?: number | n
 
 export const getAppActivity = (
   appKey: string,
-  instanceIndex?: number | null,
+  instanceIndex = 0,
   limit = DETAIL_FETCH_LIMIT,
   since?: number | null,
   signal?: AbortSignal,
@@ -101,62 +101,35 @@ export const getJobExecutions = (
 export const getExecutionById = (executionId: string, signal?: AbortSignal) =>
   apiFetch<ExecutionData | null>(`/telemetry/execution/${executionId}`, { signal });
 
-export const getExecutions = (
-  params?: {
-    kind?: "handler" | "job" | null;
-    limit?: number | null;
-    since?: number | null;
-  },
-  signal?: AbortSignal,
-) =>
-  apiFetch<ExecutionData[]>(
-    buildUrl("/telemetry/executions", { kind: params?.kind, limit: params?.limit, since: params?.since }),
-    { signal },
-  );
-
 export const getDashboardAppGrid = (since?: number | null, signal?: AbortSignal) =>
   apiFetch<{ apps: DashboardAppGridEntry[] }>(buildUrl("/telemetry/dashboard/app-grid", { since }), { signal });
 
 export const getTelemetryStatus = (signal?: AbortSignal) => apiFetch<TelemetryStatus>("/telemetry/status", { signal });
 
-export type SystemConfig = Omit<components["schemas"]["ConfigSchemaResponse"], "config_schema" | "config_values"> & {
-  config_schema: SchemaNode;
-  config_values: ConfigRecord;
-};
-
 export const getConfig = () => apiFetch<SystemConfig>("/config");
-
-export type LogsByExecutionResponse = components["schemas"]["LogsByExecutionResponse"];
-export type LogLevelResponse = components["schemas"]["LogLevelResponse"];
 
 export const getRecentLogs = (
   params?: {
     level?: string;
-    app_key?: string;
+    appKey?: string;
     limit?: number;
     since?: number | null;
-    execution_id?: string | null;
-    source_tier?: string | null;
+    executionId?: string | null;
+    sourceTier?: string | null;
   },
   signal?: AbortSignal,
 ) =>
   apiFetch<LogEntry[]>(
     buildUrl("/logs/recent", {
       level: params?.level,
-      app_key: params?.app_key,
+      app_key: params?.appKey,
       limit: params?.limit,
       since: params?.since,
-      execution_id: params?.execution_id,
-      source_tier: params?.source_tier,
+      execution_id: params?.executionId,
+      source_tier: params?.sourceTier,
     }),
     { signal },
   );
-
-export const getLogsByExecution = (executionId: string, limit?: number) =>
-  apiFetch<LogsByExecutionResponse>(buildUrl(`/executions/${encodeURIComponent(executionId)}`, { limit }));
-
-export const setLogLevel = (logger: string, level: string) =>
-  apiPut<LogLevelResponse>("/logs/level", { logger, level });
 
 export const getAllListeners = (since?: number | null, signal?: AbortSignal) =>
   apiFetch<ListenerData[]>(buildUrl("/bus/listeners", { since }), { signal });
@@ -165,8 +138,5 @@ export const getAllJobs = (since?: number | null, signal?: AbortSignal) =>
   apiFetch<JobData[]>(buildUrl("/scheduler/jobs", { since }), { signal });
 
 export const triggerJob = (jobId: number) => apiPost<JobTriggerResponse>(`/scheduler/jobs/${jobId}/trigger`);
-
-export type SystemStatus = components["schemas"]["SystemStatusResponse"];
-export type BootIssue = components["schemas"]["BootIssueResponse"];
 
 export const getSystemStatus = (signal?: AbortSignal) => apiFetch<SystemStatus>("/health", { signal });

--- a/frontend/src/components/shared/log-table/use-log-data.ts
+++ b/frontend/src/components/shared/log-table/use-log-data.ts
@@ -57,8 +57,7 @@ export function useLogData({ appKey, executionId }: UseLogDataParams): UseLogDat
 
   const { data, isPending, isError, error } = useScopedQuery(
     queryKeys.recentLogs(appKey, executionId),
-    (since, signal) =>
-      getRecentLogs({ app_key: appKey, limit: REST_FETCH_LIMIT, execution_id: executionId, since }, signal),
+    (since, signal) => getRecentLogs({ appKey, limit: REST_FETCH_LIMIT, executionId, since }, signal),
   );
 
   useEffect(() => {

--- a/frontend/src/test/factories.ts
+++ b/frontend/src/test/factories.ts
@@ -19,7 +19,6 @@ type AppManifestListResponse = components["schemas"]["AppManifestListResponse"];
 type DashboardAppGridEntry = components["schemas"]["DashboardAppGridEntry"];
 type ListenerWithSummary = components["schemas"]["ListenerWithSummary"];
 type JobSummary = components["schemas"]["JobSummary"];
-type AppHealthResponse = components["schemas"]["AppHealthResponse"];
 type LogEntryResponse = components["schemas"]["LogEntryResponse"];
 type TelemetryStatusResponse = components["schemas"]["TelemetryStatusResponse"];
 type AppInstanceResponse = components["schemas"]["AppInstanceResponse"];
@@ -222,18 +221,6 @@ export function createJob(overrides: Partial<JobSummary> = {}): JobSummary {
     dropped_count: 0,
     ...overrides,
   } satisfies JobSummary;
-}
-
-export function createHealthData(overrides: Partial<AppHealthResponse> = {}): AppHealthResponse {
-  return {
-    error_rate: 0,
-    error_rate_class: "good",
-    handler_avg_duration: 0,
-    job_avg_duration: 0,
-    last_activity_ts: null,
-    health_status: "good",
-    ...overrides,
-  } satisfies AppHealthResponse;
 }
 
 export function createLogEntry(overrides: Partial<LogEntryResponse> = {}): LogEntryResponse {

--- a/frontend/src/test/handlers.ts
+++ b/frontend/src/test/handlers.ts
@@ -18,14 +18,12 @@ import { createSystemConfig } from "./factories";
 type SystemStatusResponse = components["schemas"]["SystemStatusResponse"];
 type ManifestListResponse = components["schemas"]["AppManifestListResponse"];
 type ConfigSchemaResponse = components["schemas"]["ConfigSchemaResponse"];
-type AppHealthResponse = components["schemas"]["AppHealthResponse"];
 type ListenerWithSummary = components["schemas"]["ListenerWithSummary"];
 type JobSummary = components["schemas"]["JobSummary"];
 type Execution = components["schemas"]["Execution"];
 type DashboardAppGridResponse = components["schemas"]["DashboardAppGridResponse"];
 type TelemetryStatusResponse = components["schemas"]["TelemetryStatusResponse"];
 type LogEntryResponse = components["schemas"]["LogEntryResponse"];
-type LogsByExecutionResponse = components["schemas"]["LogsByExecutionResponse"];
 type ActionResponse = components["schemas"]["ActionResponse"];
 type ActivityFeedEntry = components["schemas"]["ActivityFeedEntry"];
 type JobTriggerResponse = components["schemas"]["JobTriggerResponse"];
@@ -90,18 +88,6 @@ export const handlers = [
     });
   }),
 
-  // GET /api/telemetry/app/:app_key/health
-  http.get("/api/telemetry/app/:app_key/health", () => {
-    return HttpResponse.json<AppHealthResponse>({
-      error_rate: 0,
-      error_rate_class: "good",
-      handler_avg_duration: 0,
-      job_avg_duration: 0,
-      last_activity_ts: null,
-      health_status: "good",
-    });
-  }),
-
   // GET /api/telemetry/app/:app_key/listeners
   http.get("/api/telemetry/app/:app_key/listeners", () => {
     return HttpResponse.json<ListenerWithSummary[]>([]);
@@ -163,15 +149,6 @@ export const handlers = [
   // GET /api/logs/recent
   http.get("/api/logs/recent", () => {
     return HttpResponse.json<LogEntryResponse[]>([]);
-  }),
-
-  // GET /api/executions/:execution_id
-  http.get("/api/executions/:execution_id", () => {
-    return HttpResponse.json<LogsByExecutionResponse>({
-      records: [],
-      truncated: false,
-      retention_expired: false,
-    });
   }),
 
   // GET /api/apps/:app_key/source


### PR DESCRIPTION
## Summary

Remove dead frontend API bindings, fix naming inconsistencies, and clean up orphaned MSW mock handlers — all pre-existing code-quality findings in `frontend/src/api/endpoints.ts`.

## Changes

**Unused exports removed** — `getAppHealth`, `getExecutions`, `getLogsByExecution`, and `setLogLevel` had zero callers (verified by grep). Their orphaned type aliases (`AppHealthData`, `LogsByExecutionResponse`, `LogLevelResponse`) and the now-unused `apiPut` import were also removed. The corresponding backend routes still exist, so these can be re-added from the OpenAPI types when a UI is built for them.

**Snake-case params renamed** — `getRecentLogs` exposed `app_key`, `execution_id`, `source_tier` in its public params while every sibling function used camelCase. Renamed to `appKey`/`executionId`/`sourceTier`, keeping snake_case only inside the `buildUrl` call where they are actual query-string parameter names. Updated the single call site in `use-log-data.ts`.

**Instance index contract unified** — `getAppActivity` declared `instanceIndex?: number | null` (optional, nullable) while `getAppListeners` and `getAppJobs` used `instanceIndex = 0` (required with default). Changed `getAppActivity` to match — all callers already resolve to a concrete number before passing.

**Type alias placement consolidated** — Moved `SystemConfig`, `SystemStatus`, and `BootIssue` from mid-file declarations to the top-of-file type alias block.

**Orphaned MSW handlers removed** — Deleted the `/api/telemetry/app/:app_key/health` and `/api/executions/:execution_id` mock handlers from `test/handlers.ts`, along with their now-unused type aliases.

## Testing

- All prek hooks pass (`prek -a` + `prek pyright`)
- `tsc` frontend type check passes
- Backend dev suite: 9223 passed, 2 failed (both pre-existing on main, in untouched files: `test_human_mode_renders_table` and `test_root_reachable_with_no_credential`)

Closes #1519