### PR TITLE
perf(ui): scope execution-completion subscriptions in app-detail children

### DIFF
--- a/frontend/src/components/app-detail/job-detail.tsx
+++ b/frontend/src/components/app-detail/job-detail.tsx
@@ -9,7 +9,7 @@ import { getJobExecutions, triggerJob } from "../../api/endpoints";
 import { useAsyncAction } from "../../hooks/use-async-action";
 import { useQueryInvalidator } from "../../hooks/use-query-invalidator";
 import { useRelativeTime } from "../../hooks/use-relative-time";
-import { useJobExecution } from "../../hooks/use-scoped-execution";
+import { isExecutionDefined, useJobExecution } from "../../hooks/use-scoped-execution";
 import { useScopedQuery } from "../../hooks/use-scoped-query";
 import { queryKeys } from "../../lib/query-keys";
 import { DETAIL_FETCH_LIMIT } from "../../utils/constants";
@@ -195,7 +195,7 @@ export function JobDetail({ job, appKey, instanceQs, onSwitchToCode }: Props) {
   const nextRunLabel = useRelativeTime(job.next_run ?? null);
   const fireAtLabel = useRelativeTime(job.fire_at ?? null);
 
-  useQueryInvalidator(execution, (exec) => exec !== undefined, queryKeys.jobExecutions(job.job_id));
+  useQueryInvalidator(execution, isExecutionDefined, queryKeys.jobExecutions(job.job_id));
 
   const kindLabel = handlerKindLabel("job", null, job.trigger_type);
   const jobKind = jobHealthKind(job);

--- a/frontend/src/components/app-detail/job-detail.tsx
+++ b/frontend/src/components/app-detail/job-detail.tsx
@@ -9,9 +9,9 @@ import { getJobExecutions, triggerJob } from "../../api/endpoints";
 import { useAsyncAction } from "../../hooks/use-async-action";
 import { useQueryInvalidator } from "../../hooks/use-query-invalidator";
 import { useRelativeTime } from "../../hooks/use-relative-time";
+import { useJobExecution } from "../../hooks/use-scoped-execution";
 import { useScopedQuery } from "../../hooks/use-scoped-query";
 import { queryKeys } from "../../lib/query-keys";
-import { useAppStore } from "../../state/store";
 import { DETAIL_FETCH_LIMIT } from "../../utils/constants";
 import { formatTriggerDetail } from "../../utils/format";
 import { scheduleStatusDisplay } from "../../utils/schedule-status";
@@ -64,18 +64,17 @@ interface RunNowFeedback {
 }
 
 function useRunNowFeedback(jobId: number): RunNowFeedback {
-  const executionCompleted = useAppStore((s) => s.executionCompleted);
+  const execution = useJobExecution(jobId);
   const watchingRef = useRef(false);
   const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   useEffect(() => {
     if (!watchingRef.current) return;
-    const matched = executionCompleted?.some((e) => e.kind === "job" && e.job_id === jobId);
-    if (!matched) return;
+    if (execution === undefined) return;
     watchingRef.current = false;
     if (timeoutRef.current) clearTimeout(timeoutRef.current);
     toast.success("Execution recorded");
-  }, [executionCompleted, jobId]);
+  }, [execution]);
 
   useEffect(
     () => () => {
@@ -191,16 +190,12 @@ export function JobDetail({ job, appKey, instanceQs, onSwitchToCode }: Props) {
     (since, signal) => getJobExecutions(job.job_id, DETAIL_FETCH_LIMIT, since, signal),
   );
 
-  const executionCompleted = useAppStore((s) => s.executionCompleted);
+  const execution = useJobExecution(job.job_id);
   const lastExecutedLabel = useRelativeTime(job.last_executed_at);
   const nextRunLabel = useRelativeTime(job.next_run ?? null);
   const fireAtLabel = useRelativeTime(job.fire_at ?? null);
 
-  useQueryInvalidator(
-    executionCompleted,
-    (events) => events?.some((e) => e.kind === "job" && e.job_id === job.job_id) ?? false,
-    queryKeys.jobExecutions(job.job_id),
-  );
+  useQueryInvalidator(execution, (exec) => exec !== undefined, queryKeys.jobExecutions(job.job_id));
 
   const kindLabel = handlerKindLabel("job", null, job.trigger_type);
   const jobKind = jobHealthKind(job);

--- a/frontend/src/components/app-detail/listener-detail.tsx
+++ b/frontend/src/components/app-detail/listener-detail.tsx
@@ -4,7 +4,7 @@ import type { ListenerData } from "../../api/endpoints";
 import { getListenerExecutions } from "../../api/endpoints";
 import { useQueryInvalidator } from "../../hooks/use-query-invalidator";
 import { useRelativeTime } from "../../hooks/use-relative-time";
-import { useListenerExecution } from "../../hooks/use-scoped-execution";
+import { isExecutionDefined, useListenerExecution } from "../../hooks/use-scoped-execution";
 import { useScopedQuery } from "../../hooks/use-scoped-query";
 import { queryKeys } from "../../lib/query-keys";
 import { DETAIL_FETCH_LIMIT } from "../../utils/constants";
@@ -83,7 +83,7 @@ export function ListenerDetail({ listener, appKey, instanceQs, onSwitchToCode }:
   const execution = useListenerExecution(listener.listener_id);
   const lastInvokedLabel = useRelativeTime(listener.last_invoked_at ?? null);
 
-  useQueryInvalidator(execution, (exec) => exec !== undefined, queryKeys.listenerExecutions(listener.listener_id));
+  useQueryInvalidator(execution, isExecutionDefined, queryKeys.listenerExecutions(listener.listener_id));
 
   const kindLabel = handlerKindLabel("listener", listener.listener_kind, null);
   const listenerKind = listenerHealthKind(listener);

--- a/frontend/src/components/app-detail/listener-detail.tsx
+++ b/frontend/src/components/app-detail/listener-detail.tsx
@@ -4,9 +4,9 @@ import type { ListenerData } from "../../api/endpoints";
 import { getListenerExecutions } from "../../api/endpoints";
 import { useQueryInvalidator } from "../../hooks/use-query-invalidator";
 import { useRelativeTime } from "../../hooks/use-relative-time";
+import { useListenerExecution } from "../../hooks/use-scoped-execution";
 import { useScopedQuery } from "../../hooks/use-scoped-query";
 import { queryKeys } from "../../lib/query-keys";
-import { useAppStore } from "../../state/store";
 import { DETAIL_FETCH_LIMIT } from "../../utils/constants";
 import { lastDotSegment, MS_PER_SECOND } from "../../utils/format";
 import { handlerKindLabel } from "../../utils/status";
@@ -80,14 +80,10 @@ export function ListenerDetail({ listener, appKey, instanceQs, onSwitchToCode }:
     (since, signal) => getListenerExecutions(listener.listener_id, DETAIL_FETCH_LIMIT, since, signal),
   );
 
-  const executionCompleted = useAppStore((s) => s.executionCompleted);
+  const execution = useListenerExecution(listener.listener_id);
   const lastInvokedLabel = useRelativeTime(listener.last_invoked_at ?? null);
 
-  useQueryInvalidator(
-    executionCompleted,
-    (events) => events?.some((e) => e.kind === "handler" && e.listener_id === listener.listener_id) ?? false,
-    queryKeys.listenerExecutions(listener.listener_id),
-  );
+  useQueryInvalidator(execution, (exec) => exec !== undefined, queryKeys.listenerExecutions(listener.listener_id));
 
   const kindLabel = handlerKindLabel("listener", listener.listener_kind, null);
   const listenerKind = listenerHealthKind(listener);

--- a/frontend/src/components/app-detail/recent-activity-section.rerender.test.tsx
+++ b/frontend/src/components/app-detail/recent-activity-section.rerender.test.tsx
@@ -6,6 +6,7 @@ import { describe, expect, it } from "vitest";
 import type { components } from "../../api/generated-types";
 import type { WsExecutionCompletedPayload } from "../../api/ws-types";
 import { useAppStore } from "../../state/store";
+import { createExecutionCompletedPayload } from "../../test/factories";
 import { renderWithAppState } from "../../test/render-helpers";
 import { server } from "../../test/server";
 import { RecentActivitySection } from "./recent-activity-section";
@@ -13,7 +14,7 @@ import { RecentActivitySection } from "./recent-activity-section";
 type ActivityFeedEntry = components["schemas"]["ActivityFeedEntry"];
 
 function makeExecution(appKey: string, kind: "handler" | "job"): WsExecutionCompletedPayload {
-  return { kind, app_key: appKey, instance_index: 0, status: "success", duration_ms: 5 };
+  return createExecutionCompletedPayload({ kind, app_key: appKey });
 }
 
 /**

--- a/frontend/src/components/app-detail/recent-activity-section.rerender.test.tsx
+++ b/frontend/src/components/app-detail/recent-activity-section.rerender.test.tsx
@@ -1,0 +1,68 @@
+import { act, waitFor } from "@testing-library/react";
+import { http, HttpResponse } from "msw";
+import { Profiler } from "react";
+import { describe, expect, it } from "vitest";
+
+import type { components } from "../../api/generated-types";
+import type { WsExecutionCompletedPayload } from "../../api/ws-types";
+import { useAppStore } from "../../state/store";
+import { renderWithAppState } from "../../test/render-helpers";
+import { server } from "../../test/server";
+import { RecentActivitySection } from "./recent-activity-section";
+
+type ActivityFeedEntry = components["schemas"]["ActivityFeedEntry"];
+
+function makeExecution(appKey: string, kind: "handler" | "job"): WsExecutionCompletedPayload {
+  return { kind, app_key: appKey, instance_index: 0, status: "success", duration_ms: 5 };
+}
+
+/**
+ * Renders the section under a Profiler and waits for the initial fetch to commit.
+ *
+ * The Profiler counts commits of the subtree, so a store write that the section's selector
+ * filters out produces no re-render and no count change — the seam these assertions need.
+ */
+async function renderSettled() {
+  server.use(http.get("/api/telemetry/app/:app_key/activity", () => HttpResponse.json<ActivityFeedEntry[]>([])));
+  const counter = { renders: 0 };
+  const view = renderWithAppState(
+    <Profiler
+      id="recent-activity"
+      onRender={() => {
+        counter.renders += 1;
+      }}
+    >
+      <RecentActivitySection appKey="test_app" resolvedInstanceIndex={0} />
+    </Profiler>,
+    { storeOverrides: { uptimeSeconds: 120 } },
+  );
+  await view.findByTestId("overview-activity-empty");
+  await act(async () => {});
+  return { ...view, counter };
+}
+
+describe("RecentActivitySection store subscriptions", () => {
+  it("does not re-render on an unrelated app's execution completions", async () => {
+    const { counter } = await renderSettled();
+    const before = counter.renders;
+
+    act(() => {
+      useAppStore
+        .getState()
+        .setExecutionCompleted([makeExecution("other_app", "handler"), makeExecution("other_app", "job")]);
+    });
+
+    expect(counter.renders).toBe(before);
+  });
+
+  it.each(["handler", "job"] as const)("re-renders on its own app's %s execution completion", async (kind) => {
+    const { counter } = await renderSettled();
+    const before = counter.renders;
+
+    act(() => {
+      useAppStore.getState().setExecutionCompleted([makeExecution("test_app", kind)]);
+    });
+
+    await waitFor(() => expect(counter.renders).toBeGreaterThan(before));
+  });
+});

--- a/frontend/src/components/app-detail/recent-activity-section.tsx
+++ b/frontend/src/components/app-detail/recent-activity-section.tsx
@@ -5,7 +5,7 @@ import { cn } from "@/lib/utils";
 import type { ActivityFeedEntryData } from "../../api/endpoints";
 import { getAppActivity } from "../../api/endpoints";
 import { useQueryInvalidator } from "../../hooks/use-query-invalidator";
-import { useAppExecution } from "../../hooks/use-scoped-execution";
+import { isExecutionDefined, useAppExecution } from "../../hooks/use-scoped-execution";
 import { useScopedQuery } from "../../hooks/use-scoped-query";
 import { queryKeys } from "../../lib/query-keys";
 import { useAppStore } from "../../state/store";
@@ -130,7 +130,7 @@ export function RecentActivitySection({
   // which recomputes the relative-time labels rendered by ActivityGroupRow below.
   useAppStore((s) => s.tick);
 
-  useQueryInvalidator(execution, (exec) => exec !== undefined, queryKeys.appActivity.prefix(appKey));
+  useQueryInvalidator(execution, isExecutionDefined, queryKeys.appActivity.prefix(appKey));
 
   const groups = useMemo(() => summarizeActivityByHandler(activity ?? []).slice(0, ACTIVITY_ROW_LIMIT), [activity]);
 

--- a/frontend/src/components/app-detail/recent-activity-section.tsx
+++ b/frontend/src/components/app-detail/recent-activity-section.tsx
@@ -5,6 +5,7 @@ import { cn } from "@/lib/utils";
 import type { ActivityFeedEntryData } from "../../api/endpoints";
 import { getAppActivity } from "../../api/endpoints";
 import { useQueryInvalidator } from "../../hooks/use-query-invalidator";
+import { useAppExecution } from "../../hooks/use-scoped-execution";
 import { useScopedQuery } from "../../hooks/use-scoped-query";
 import { queryKeys } from "../../lib/query-keys";
 import { useAppStore } from "../../state/store";
@@ -124,16 +125,12 @@ export function RecentActivitySection({
     getAppActivity(appKey, resolvedInstanceIndex, ACTIVITY_FETCH_LIMIT, since, signal),
   );
 
-  const executionCompleted = useAppStore((s) => s.executionCompleted);
+  const execution = useAppExecution(appKey);
   // Selecting tick (unused otherwise) subscribes this component to re-render on every tick,
   // which recomputes the relative-time labels rendered by ActivityGroupRow below.
   useAppStore((s) => s.tick);
 
-  useQueryInvalidator(
-    executionCompleted,
-    (events) => events?.some((e: { app_key: string }) => e.app_key === appKey) ?? false,
-    queryKeys.appActivity.prefix(appKey),
-  );
+  useQueryInvalidator(execution, (exec) => exec !== undefined, queryKeys.appActivity.prefix(appKey));
 
   const groups = useMemo(() => summarizeActivityByHandler(activity ?? []).slice(0, ACTIVITY_ROW_LIMIT), [activity]);
 

--- a/frontend/src/hooks/use-scoped-execution.test.ts
+++ b/frontend/src/hooks/use-scoped-execution.test.ts
@@ -3,21 +3,15 @@ import { describe, expect, it } from "vitest";
 
 import type { WsExecutionCompletedPayload } from "../api/ws-types";
 import { useAppStore } from "../state/store";
+import { createExecutionCompletedPayload } from "../test/factories";
 import { useAppExecution, useJobExecution, useListenerExecution } from "./use-scoped-execution";
 
 function handlerCompletion(appKey: string, listenerId: number): WsExecutionCompletedPayload {
-  return {
-    kind: "handler",
-    app_key: appKey,
-    instance_index: 0,
-    status: "success",
-    duration_ms: 5,
-    listener_id: listenerId,
-  };
+  return createExecutionCompletedPayload({ kind: "handler", app_key: appKey, listener_id: listenerId, job_id: null });
 }
 
 function jobCompletion(appKey: string, jobId: number): WsExecutionCompletedPayload {
-  return { kind: "job", app_key: appKey, instance_index: 0, status: "success", duration_ms: 5, job_id: jobId };
+  return createExecutionCompletedPayload({ kind: "job", app_key: appKey, job_id: jobId });
 }
 
 /** Renders `hook` while counting how many times it re-ran — the seam for the scoping assertions. */

--- a/frontend/src/hooks/use-scoped-execution.test.ts
+++ b/frontend/src/hooks/use-scoped-execution.test.ts
@@ -1,0 +1,126 @@
+import { act, renderHook } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import type { WsExecutionCompletedPayload } from "../api/ws-types";
+import { useAppStore } from "../state/store";
+import { useAppExecution, useJobExecution, useListenerExecution } from "./use-scoped-execution";
+
+function handlerCompletion(appKey: string, listenerId: number): WsExecutionCompletedPayload {
+  return {
+    kind: "handler",
+    app_key: appKey,
+    instance_index: 0,
+    status: "success",
+    duration_ms: 5,
+    listener_id: listenerId,
+  };
+}
+
+function jobCompletion(appKey: string, jobId: number): WsExecutionCompletedPayload {
+  return { kind: "job", app_key: appKey, instance_index: 0, status: "success", duration_ms: 5, job_id: jobId };
+}
+
+/** Renders `hook` while counting how many times it re-ran — the seam for the scoping assertions. */
+function renderCounted<T>(hook: () => T) {
+  const counter = { renders: 0 };
+  const view = renderHook(() => {
+    counter.renders += 1;
+    return hook();
+  });
+  return { ...view, counter };
+}
+
+function publish(...events: WsExecutionCompletedPayload[]) {
+  act(() => {
+    useAppStore.getState().setExecutionCompleted(events);
+  });
+}
+
+describe("useAppExecution", () => {
+  it("does not re-render on another app's completions", () => {
+    const { result, counter } = renderCounted(() => useAppExecution("test_app"));
+    const before = counter.renders;
+
+    publish(handlerCompletion("other_app", 1), jobCompletion("other_app", 2));
+
+    expect(counter.renders).toBe(before);
+    expect(result.current).toBeUndefined();
+  });
+
+  it("returns this app's matching record", () => {
+    const { result, counter } = renderCounted(() => useAppExecution("test_app"));
+    const before = counter.renders;
+    const own = handlerCompletion("test_app", 1);
+
+    publish(handlerCompletion("other_app", 9), own);
+
+    expect(counter.renders).toBeGreaterThan(before);
+    expect(result.current).toBe(own);
+  });
+
+  it("ignores this app's completions of the other kind when narrowed", () => {
+    const { result, counter } = renderCounted(() => useAppExecution("test_app", "handler"));
+    const before = counter.renders;
+
+    publish(jobCompletion("test_app", 3));
+
+    expect(counter.renders).toBe(before);
+    expect(result.current).toBeUndefined();
+  });
+
+  it("re-renders on each consecutive own completion", () => {
+    const { counter } = renderCounted(() => useAppExecution("test_app"));
+
+    publish(handlerCompletion("test_app", 1));
+    const afterFirst = counter.renders;
+    publish(handlerCompletion("test_app", 1));
+
+    expect(counter.renders).toBeGreaterThan(afterFirst);
+  });
+});
+
+describe("useJobExecution", () => {
+  it("does not re-render on another job's completions", () => {
+    const { result, counter } = renderCounted(() => useJobExecution(7));
+    const before = counter.renders;
+
+    publish(jobCompletion("test_app", 8), handlerCompletion("test_app", 7));
+
+    expect(counter.renders).toBe(before);
+    expect(result.current).toBeUndefined();
+  });
+
+  it("returns this job's matching record", () => {
+    const { result, counter } = renderCounted(() => useJobExecution(7));
+    const before = counter.renders;
+    const own = jobCompletion("test_app", 7);
+
+    publish(jobCompletion("test_app", 8), own);
+
+    expect(counter.renders).toBeGreaterThan(before);
+    expect(result.current).toBe(own);
+  });
+});
+
+describe("useListenerExecution", () => {
+  it("does not re-render on another listener's completions", () => {
+    const { result, counter } = renderCounted(() => useListenerExecution(4));
+    const before = counter.renders;
+
+    publish(handlerCompletion("test_app", 5), jobCompletion("test_app", 4));
+
+    expect(counter.renders).toBe(before);
+    expect(result.current).toBeUndefined();
+  });
+
+  it("returns this listener's matching record", () => {
+    const { result, counter } = renderCounted(() => useListenerExecution(4));
+    const before = counter.renders;
+    const own = handlerCompletion("test_app", 4);
+
+    publish(handlerCompletion("test_app", 5), own);
+
+    expect(counter.renders).toBeGreaterThan(before);
+    expect(result.current).toBe(own);
+  });
+});

--- a/frontend/src/hooks/use-scoped-execution.ts
+++ b/frontend/src/hooks/use-scoped-execution.ts
@@ -15,7 +15,7 @@ import { useAppStore } from "../state/store";
  * fires even if that next batch is unrelated. Bounded to exactly one render per matching
  * completion — steady-state unrelated activity stays undefined-to-undefined.
  *
- * Callers pair the result with `useQueryInvalidator(execution, (e) => e !== undefined, key)`: the
+ * Callers pair the result with `useQueryInvalidator(execution, isExecutionDefined, key)`: the
  * scoping already happened in the selector, so the filter only checks definedness.
  */
 function useScopedExecution(
@@ -24,7 +24,12 @@ function useScopedExecution(
   return useAppStore((s) => s.executionCompleted?.find(match));
 }
 
-/** This app's first completion in the latest batch, optionally narrowed to one handler kind. */
+/** Shared `useQueryInvalidator` filter for the scoped-execution hooks below — see their docstrings. */
+export function isExecutionDefined(execution: WsExecutionCompletedPayload | undefined): boolean {
+  return execution !== undefined;
+}
+
+/** This app's first completion in the latest batch, optionally narrowed to one completion kind. */
 export function useAppExecution(appKey: string, kind?: "handler" | "job"): WsExecutionCompletedPayload | undefined {
   return useScopedExecution((e) => e.app_key === appKey && (kind === undefined || e.kind === kind));
 }

--- a/frontend/src/hooks/use-scoped-execution.ts
+++ b/frontend/src/hooks/use-scoped-execution.ts
@@ -1,0 +1,40 @@
+import type { WsExecutionCompletedPayload } from "../api/ws-types";
+import { useAppStore } from "../state/store";
+
+/**
+ * Pick the first execution completion matching `match` out of the latest fleet-wide WS batch.
+ *
+ * Selecting the matching record rather than the whole `executionCompleted` batch is what keeps a
+ * component off the fleet-wide render path: a batch carrying only other apps' executions selects
+ * to `undefined`, which is `Object.is`-equal to the previous `undefined`, so the store never
+ * notifies. The record itself is a fresh object per batch, so consecutive matching completions do
+ * each register as a change.
+ *
+ * One case still costs a render: the batch immediately after a matching completion selects back to
+ * `undefined`, which is *not* `Object.is`-equal to the previous matched record, so one extra render
+ * fires even if that next batch is unrelated. Bounded to exactly one render per matching
+ * completion — steady-state unrelated activity stays undefined-to-undefined.
+ *
+ * Callers pair the result with `useQueryInvalidator(execution, (e) => e !== undefined, key)`: the
+ * scoping already happened in the selector, so the filter only checks definedness.
+ */
+function useScopedExecution(
+  match: (event: WsExecutionCompletedPayload) => boolean,
+): WsExecutionCompletedPayload | undefined {
+  return useAppStore((s) => s.executionCompleted?.find(match));
+}
+
+/** This app's first completion in the latest batch, optionally narrowed to one handler kind. */
+export function useAppExecution(appKey: string, kind?: "handler" | "job"): WsExecutionCompletedPayload | undefined {
+  return useScopedExecution((e) => e.app_key === appKey && (kind === undefined || e.kind === kind));
+}
+
+/** This job's first completion in the latest batch. */
+export function useJobExecution(jobId: number): WsExecutionCompletedPayload | undefined {
+  return useScopedExecution((e) => e.kind === "job" && e.job_id === jobId);
+}
+
+/** This listener's first completion in the latest batch. */
+export function useListenerExecution(listenerId: number): WsExecutionCompletedPayload | undefined {
+  return useScopedExecution((e) => e.kind === "handler" && e.listener_id === listenerId);
+}

--- a/frontend/src/pages/app-detail.tsx
+++ b/frontend/src/pages/app-detail.tsx
@@ -19,7 +19,7 @@ import { useDocumentTitle } from "../hooks/use-document-title";
 import { useManifest } from "../hooks/use-manifest";
 import { useQueryInvalidator } from "../hooks/use-query-invalidator";
 import { useQueryParams } from "../hooks/use-query-params";
-import { useAppExecution } from "../hooks/use-scoped-execution";
+import { isExecutionDefined, useAppExecution } from "../hooks/use-scoped-execution";
 import { useScopedQuery } from "../hooks/use-scoped-query";
 import { queryKeys } from "../lib/query-keys";
 import { appStatusKey, useAppStore } from "../state/store";
@@ -132,8 +132,8 @@ export function AppDetailPage({ params }: Props) {
     { placeholderData: keepPreviousData },
   );
 
-  useQueryInvalidator(handlerExecution, (exec) => exec !== undefined, queryKeys.appListeners.prefix(appKey));
-  useQueryInvalidator(jobExecution, (exec) => exec !== undefined, queryKeys.appJobs.prefix(appKey));
+  useQueryInvalidator(handlerExecution, isExecutionDefined, queryKeys.appListeners.prefix(appKey));
+  useQueryInvalidator(jobExecution, isExecutionDefined, queryKeys.appJobs.prefix(appKey));
 
   const displayListeners = listenersData ?? [];
   const displayJobs = jobsData ?? [];

--- a/frontend/src/pages/app-detail.tsx
+++ b/frontend/src/pages/app-detail.tsx
@@ -6,7 +6,6 @@ import { Link, useLocation } from "wouter";
 import { cn } from "@/lib/utils";
 
 import { getAppJobs, getAppListeners } from "../api/endpoints";
-import type { WsExecutionCompletedPayload } from "../api/ws-types";
 import { AppDetailHeader } from "../components/app-detail/app-detail-header";
 import { AppLogsPanel } from "../components/app-detail/app-logs-panel";
 import { CodeTab } from "../components/app-detail/code-tab";
@@ -20,6 +19,7 @@ import { useDocumentTitle } from "../hooks/use-document-title";
 import { useManifest } from "../hooks/use-manifest";
 import { useQueryInvalidator } from "../hooks/use-query-invalidator";
 import { useQueryParams } from "../hooks/use-query-params";
+import { useAppExecution } from "../hooks/use-scoped-execution";
 import { useScopedQuery } from "../hooks/use-scoped-query";
 import { queryKeys } from "../lib/query-keys";
 import { appStatusKey, useAppStore } from "../state/store";
@@ -87,28 +87,6 @@ function TabPanel({ id, children, className }: { id: TabId; children: ReactNode;
   );
 }
 
-/**
- * Pick this app's first execution completion of `kind` out of the latest WS batch.
- *
- * Selecting the matching record rather than the whole `executionCompleted` batch is what keeps
- * this page off the fleet-wide render path: a batch carrying only other apps' executions selects
- * to `undefined`, which is `Object.is`-equal to the previous `undefined`, so the store never
- * notifies. The record itself is a fresh object per batch, so consecutive own-app completions do
- * each register as a change.
- *
- * One case still costs a render: the batch immediately after this app's own completion selects
- * back to `undefined`, which is *not* `Object.is`-equal to the previous matched record, so one
- * extra render fires even if that next batch has nothing to do with this app. Bounded to exactly
- * one render per own completion — steady-state unrelated activity stays undefined-to-undefined.
- */
-function findExecution(
-  events: WsExecutionCompletedPayload[] | null,
-  appKey: string,
-  kind: "handler" | "job",
-): WsExecutionCompletedPayload | undefined {
-  return events?.find((e) => e.kind === kind && e.app_key === appKey);
-}
-
 function handleTabKeyDown(e: ReactKeyboardEvent) {
   if (e.key !== "ArrowRight" && e.key !== "ArrowLeft") return;
   e.preventDefault();
@@ -122,8 +100,8 @@ function handleTabKeyDown(e: ReactKeyboardEvent) {
 export function AppDetailPage({ params }: Props) {
   const appKey = params.key;
   const activeTab: TabId = params.tab ?? "overview";
-  const handlerExecution = useAppStore((s) => findExecution(s.executionCompleted, appKey, "handler"));
-  const jobExecution = useAppStore((s) => findExecution(s.executionCompleted, appKey, "job"));
+  const handlerExecution = useAppExecution(appKey, "handler");
+  const jobExecution = useAppExecution(appKey, "job");
   const { data: manifest, isPending: manifestLoading, error: manifestError } = useManifest(appKey);
   const [, navigate] = useLocation();
   const queryParams = useQueryParams();
@@ -154,9 +132,6 @@ export function AppDetailPage({ params }: Props) {
     { placeholderData: keepPreviousData },
   );
 
-  // Sibling call sites filter the raw fleet-wide batch with `events?.some(...)`; findExecution
-  // above already reduced this to a single matched-or-undefined record, so the filter here only
-  // needs to check definedness.
   useQueryInvalidator(handlerExecution, (exec) => exec !== undefined, queryKeys.appListeners.prefix(appKey));
   useQueryInvalidator(jobExecution, (exec) => exec !== undefined, queryKeys.appJobs.prefix(appKey));
 


### PR DESCRIPTION
## Summary

`AppDetailPage` already scoped its own `executionCompleted` store subscription (PR #1528, issue #1465) so it selects only its app's matching record out of the fleet-wide WS batch instead of subscribing to the whole array. Three components mounted *inside* that same page still used the old broad-subscribe-then-filter pattern, so the page-level fix didn't actually hold — a child re-rendered on every unrelated app's execution completion regardless.

This scopes those children and consolidates the matching logic in one place.

## What changed

- **New `frontend/src/hooks/use-scoped-execution.ts`** — holds the previously-inline `findExecution` logic from `app-detail.tsx`, exposed as `useAppExecution(appKey, kind?)`, `useJobExecution(jobId)`, and `useListenerExecution(listenerId)`. Selecting the *matching record* rather than the batch is what keeps a component off the fleet-wide render path: a batch of only other apps' executions selects to `undefined`, which is `Object.is`-equal to the previous `undefined`, so the store never notifies.
- **`recent-activity-section.tsx`, `job-detail.tsx`, `listener-detail.tsx`** — replaced `useAppStore((s) => s.executionCompleted)` + `events?.some(...)` inside the `useQueryInvalidator` callback with the corresponding scoped hook. The invalidator filter is now just a definedness check, since scoping already happened in the selector.
- **`app-detail.tsx`** — dropped its local `findExecution` and routes through the shared hook, so all four consumers share one implementation of the matching semantics. A future change (e.g. adding instance-index matching) now lands in one place instead of four.

The one remaining render cost is documented on the hook: the batch immediately following a matching completion selects back to `undefined`, which is not `Object.is`-equal to the previously matched record, so exactly one extra render fires per matching completion. Steady-state unrelated activity stays undefined-to-undefined.

## Testing

- New `frontend/src/hooks/use-scoped-execution.test.ts` — render-count assertions per hook: no re-render on another app's/job's/listener's completions, re-render plus correct record on its own, kind narrowing, and consecutive own completions each registering.
- New `frontend/src/components/app-detail/recent-activity-section.rerender.test.tsx` — `Profiler`-based commit-count regression test analogous to the existing `app-detail.rerender.test.tsx`, covering both the unrelated-app and own-app cases.
- Full frontend suite green: 1499 tests across 103 files.
- `prek -a` and `prek pyright -a --stage pre-push` clean; backend suite (`nox -s dev`) green apart from one pre-existing, console-width-dependent CLI table failure (`test_commands_app.py::TestCmdAppActivity::test_human_mode_renders_table`) that reproduces identically on a clean `main` and is untouched by this branch.

No rendered output changes — this only affects when components re-render, hence the `no-visual-change` label.

Closes #1542
