### PR TITLE
test: add regression test for concurrent reload_app locking

### DIFF
--- a/tests/unit/core/test_app_lifecycle_service_coverage.py
+++ b/tests/unit/core/test_app_lifecycle_service_coverage.py
@@ -406,6 +406,67 @@ class TestReplayPreReleaseReconciliationSerialization:
         assert call_count == 2
 
 
+class TestReloadAppFullSerialization:
+    async def test_concurrent_reload_app_calls_serialize_the_whole_stop_and_start_pair(
+        self,
+        lifecycle_service: AppLifecycleService,
+        mock_registry: MagicMock,
+        mock_manifest: MagicMock,
+    ) -> None:
+        """Two concurrent reload_app("x") calls -- e.g. a UI reload racing a file-watcher
+        reload for the same app_key (issue #1227) -- must run each call's full stop+start
+        sequence as one atomic unit. `test_reload_app_acquires_app_key_lock_once` proves a
+        single reload_app acquires the lock once; this proves a *second*, concurrent
+        reload_app for the same key is genuinely blocked until the first's entire
+        stop+start pair has completed -- not just serialized within start_app's own
+        internals, which is the gap #1227 originally described (the second racer's
+        create_instances() overwriting the registry entry the first racer just created,
+        orphaning a live, already-initialized instance set).
+        """
+        mock_registry.get_manifest = Mock(return_value=mock_manifest)
+
+        gate = asyncio.Event()
+        first_entered = asyncio.Event()
+        call_order: list[str] = []
+
+        async def gated_stop_unlocked(_app_key: str) -> None:
+            call_order.append("stop_start")
+            if call_order.count("stop_start") == 1:
+                first_entered.set()
+                await gate.wait()
+            call_order.append("stop_end")
+
+        async def recording_start_unlocked(_app_key: str, _app_manifest: MagicMock, _force_reload: bool) -> None:
+            call_order.append("start")
+
+        lifecycle_service._admit_start = AsyncMock()  # pyright: ignore[reportAttributeAccessIssue]
+        lifecycle_service._stop_app_unlocked = gated_stop_unlocked  # pyright: ignore[reportAttributeAccessIssue]
+        lifecycle_service._start_app_unlocked = recording_start_unlocked  # pyright: ignore[reportAttributeAccessIssue]
+
+        task1 = asyncio.create_task(lifecycle_service.reload_app("test_app"))
+        await asyncio.wait_for(first_entered.wait(), timeout=1.0)
+
+        task2 = asyncio.create_task(lifecycle_service.reload_app("test_app"))
+        lock = lifecycle_service._get_app_key_lock("test_app")
+        await wait_for(lambda: bool(lock._waiters), desc="task2 queued on the app-key lock")
+
+        # task2 must be blocked acquiring the lock -- it must not have entered its own
+        # stop phase while task1's stop+start pair is still mid-flight.
+        assert lock.locked()
+        assert call_order.count("stop_start") == 1
+        assert not task2.done()
+
+        gate.set()
+        await asyncio.wait_for(task1, timeout=1.0)
+        await asyncio.wait_for(task2, timeout=1.0)
+
+        # Each reload's stop and start run back-to-back, and the second reload's stop
+        # only starts after the first reload's start has finished -- proving the lock
+        # covers the entire pair, not just one half of it.
+        assert call_order == ["stop_start", "stop_end", "start", "stop_start", "stop_end", "start"]
+        assert not lock.locked()
+
+
 class TestTakePreReleaseReconciliation:
     def test_returns_all_none_when_nothing_is_queued(self, lifecycle_service: AppLifecycleService) -> None:
         """With no pending reconciliation, take() returns (None, None, None) rather than raising --

--- a/tests/unit/core/test_app_lifecycle_service_coverage.py
+++ b/tests/unit/core/test_app_lifecycle_service_coverage.py
@@ -406,67 +406,6 @@ class TestReplayPreReleaseReconciliationSerialization:
         assert call_count == 2
 
 
-class TestReloadAppFullSerialization:
-    async def test_concurrent_reload_app_calls_serialize_the_whole_stop_and_start_pair(
-        self,
-        lifecycle_service: AppLifecycleService,
-        mock_registry: MagicMock,
-        mock_manifest: MagicMock,
-    ) -> None:
-        """Two concurrent reload_app("x") calls -- e.g. a UI reload racing a file-watcher
-        reload for the same app_key (issue #1227) -- must run each call's full stop+start
-        sequence as one atomic unit. `test_reload_app_acquires_app_key_lock_once` proves a
-        single reload_app acquires the lock once; this proves a *second*, concurrent
-        reload_app for the same key is genuinely blocked until the first's entire
-        stop+start pair has completed -- not just serialized within start_app's own
-        internals, which is the gap #1227 originally described (the second racer's
-        create_instances() overwriting the registry entry the first racer just created,
-        orphaning a live, already-initialized instance set).
-        """
-        mock_registry.get_manifest = Mock(return_value=mock_manifest)
-
-        gate = asyncio.Event()
-        first_entered = asyncio.Event()
-        call_order: list[str] = []
-
-        async def gated_stop_unlocked(_app_key: str) -> None:
-            call_order.append("stop_start")
-            if call_order.count("stop_start") == 1:
-                first_entered.set()
-                await gate.wait()
-            call_order.append("stop_end")
-
-        async def recording_start_unlocked(_app_key: str, _app_manifest: MagicMock, _force_reload: bool) -> None:
-            call_order.append("start")
-
-        lifecycle_service._admit_start = AsyncMock()  # pyright: ignore[reportAttributeAccessIssue]
-        lifecycle_service._stop_app_unlocked = gated_stop_unlocked  # pyright: ignore[reportAttributeAccessIssue]
-        lifecycle_service._start_app_unlocked = recording_start_unlocked  # pyright: ignore[reportAttributeAccessIssue]
-
-        task1 = asyncio.create_task(lifecycle_service.reload_app("test_app"))
-        await asyncio.wait_for(first_entered.wait(), timeout=1.0)
-
-        task2 = asyncio.create_task(lifecycle_service.reload_app("test_app"))
-        lock = lifecycle_service._get_app_key_lock("test_app")
-        await wait_for(lambda: bool(lock._waiters), desc="task2 queued on the app-key lock")
-
-        # task2 must be blocked acquiring the lock -- it must not have entered its own
-        # stop phase while task1's stop+start pair is still mid-flight.
-        assert lock.locked()
-        assert call_order.count("stop_start") == 1
-        assert not task2.done()
-
-        gate.set()
-        await asyncio.wait_for(task1, timeout=1.0)
-        await asyncio.wait_for(task2, timeout=1.0)
-
-        # Each reload's stop and start run back-to-back, and the second reload's stop
-        # only starts after the first reload's start has finished -- proving the lock
-        # covers the entire pair, not just one half of it.
-        assert call_order == ["stop_start", "stop_end", "start", "stop_start", "stop_end", "start"]
-        assert not lock.locked()
-
-
 class TestTakePreReleaseReconciliation:
     def test_returns_all_none_when_nothing_is_queued(self, lifecycle_service: AppLifecycleService) -> None:
         """With no pending reconciliation, take() returns (None, None, None) rather than raising --

--- a/tests/unit/core/test_app_lifecycle_service_operations.py
+++ b/tests/unit/core/test_app_lifecycle_service_operations.py
@@ -537,12 +537,12 @@ class TestReloadAppLocking:
         mock_registry: MagicMock,
         mock_manifest: MagicMock,
     ) -> None:
-        """Two concurrent reload_app("x") calls -- e.g. a UI reload racing a file-watcher
-        reload for the same app_key (issue #1227) -- must run each call's full stop+start
+        """Two concurrent reload_app("x") calls — e.g. a UI reload racing a file-watcher
+        reload for the same app_key (issue #1227) — must run each call's full stop+start
         sequence as one atomic unit. `test_reload_app_acquires_app_key_lock_once` proves a
         single reload_app acquires the lock once; this proves a *second*, concurrent
         reload_app for the same key is genuinely blocked until the first's entire
-        stop+start pair has completed -- not just serialized within start_app's own
+        stop+start pair has completed — not just serialized within start_app's own
         internals, which is the gap #1227 originally described (the second racer's
         create_instances() overwriting the registry entry the first racer just created,
         orphaning a live, already-initialized instance set).
@@ -569,24 +569,24 @@ class TestReloadAppLocking:
         lifecycle_service._start_app_unlocked = recording_start_unlocked  # pyright: ignore[reportAttributeAccessIssue]
 
         task1 = asyncio.create_task(lifecycle_service.reload_app("test_app"))
-        await asyncio.wait_for(first_entered.wait(), timeout=1.0)
+        await asyncio.wait_for(first_entered.wait(), timeout=1)
 
         task2 = asyncio.create_task(lifecycle_service.reload_app("test_app"))
         lock = lifecycle_service._get_app_key_lock("test_app")
         await wait_for(lambda: bool(lock._waiters), desc="task2 queued on the app-key lock")
 
-        # task2 must be blocked acquiring the lock -- it must not have entered its own
+        # task2 must be blocked acquiring the lock — it must not have entered its own
         # stop phase while task1's stop+start pair is still mid-flight.
         assert lock.locked()
         assert call_order.count("stop_start") == 1
         assert not task2.done()
 
         gate.set()
-        await asyncio.wait_for(task1, timeout=1.0)
-        await asyncio.wait_for(task2, timeout=1.0)
+        await asyncio.wait_for(task1, timeout=1)
+        await asyncio.wait_for(task2, timeout=1)
 
         # Each reload's stop and start run back-to-back, and the second reload's stop
-        # only starts after the first reload's start has finished -- proving the lock
+        # only starts after the first reload's start has finished — proving the lock
         # covers the entire pair, not just one half of it.
         assert call_order == ["stop_start", "stop_end", "start", "stop_start", "stop_end", "start"]
         assert not lock.locked()

--- a/tests/unit/core/test_app_lifecycle_service_operations.py
+++ b/tests/unit/core/test_app_lifecycle_service_operations.py
@@ -9,7 +9,7 @@ from hassette.core.app_change_detector import ChangeSet
 from hassette.core.app_lifecycle_service import AppAdmissionMode, AppLifecycleService
 from hassette.exceptions import AppBootstrapNotReleasedError
 from hassette.schemas.app_snapshots import AppInstanceInfo
-from hassette.test_utils import EventCapture
+from hassette.test_utils import EventCapture, wait_for
 from hassette.types import Topic
 from hassette.types.enums import BlockReason, ResourceStatus
 
@@ -529,6 +529,66 @@ class TestReloadAppLocking:
         await asyncio.wait_for(lifecycle_service.reload_app("test_app"), timeout=1)
 
         assert lock.acquire.call_count == 1
+        assert not lock.locked()
+
+    async def test_concurrent_reload_app_calls_serialize_the_whole_stop_and_start_pair(
+        self,
+        lifecycle_service: AppLifecycleService,
+        mock_registry: MagicMock,
+        mock_manifest: MagicMock,
+    ) -> None:
+        """Two concurrent reload_app("x") calls -- e.g. a UI reload racing a file-watcher
+        reload for the same app_key (issue #1227) -- must run each call's full stop+start
+        sequence as one atomic unit. `test_reload_app_acquires_app_key_lock_once` proves a
+        single reload_app acquires the lock once; this proves a *second*, concurrent
+        reload_app for the same key is genuinely blocked until the first's entire
+        stop+start pair has completed -- not just serialized within start_app's own
+        internals, which is the gap #1227 originally described (the second racer's
+        create_instances() overwriting the registry entry the first racer just created,
+        orphaning a live, already-initialized instance set).
+        """
+        mock_registry.get_manifest = Mock(return_value=mock_manifest)
+
+        gate = asyncio.Event()
+        first_entered = asyncio.Event()
+        call_order: list[str] = []
+
+        async def gated_stop_unlocked(_app_key: str) -> None:
+            call_order.append("stop_start")
+            if call_order.count("stop_start") == 1:
+                first_entered.set()
+                await gate.wait()
+            call_order.append("stop_end")
+
+        async def recording_start_unlocked(_app_key: str, _app_manifest: MagicMock, _force_reload: bool) -> None:
+            await asyncio.sleep(0)
+            call_order.append("start")
+
+        lifecycle_service._admit_start = AsyncMock()  # pyright: ignore[reportAttributeAccessIssue]
+        lifecycle_service._stop_app_unlocked = gated_stop_unlocked  # pyright: ignore[reportAttributeAccessIssue]
+        lifecycle_service._start_app_unlocked = recording_start_unlocked  # pyright: ignore[reportAttributeAccessIssue]
+
+        task1 = asyncio.create_task(lifecycle_service.reload_app("test_app"))
+        await asyncio.wait_for(first_entered.wait(), timeout=1.0)
+
+        task2 = asyncio.create_task(lifecycle_service.reload_app("test_app"))
+        lock = lifecycle_service._get_app_key_lock("test_app")
+        await wait_for(lambda: bool(lock._waiters), desc="task2 queued on the app-key lock")
+
+        # task2 must be blocked acquiring the lock -- it must not have entered its own
+        # stop phase while task1's stop+start pair is still mid-flight.
+        assert lock.locked()
+        assert call_order.count("stop_start") == 1
+        assert not task2.done()
+
+        gate.set()
+        await asyncio.wait_for(task1, timeout=1.0)
+        await asyncio.wait_for(task2, timeout=1.0)
+
+        # Each reload's stop and start run back-to-back, and the second reload's stop
+        # only starts after the first reload's start has finished -- proving the lock
+        # covers the entire pair, not just one half of it.
+        assert call_order == ["stop_start", "stop_end", "start", "stop_start", "stop_end", "start"]
         assert not lock.locked()
 
 


### PR DESCRIPTION
### Regression test for issue #1227

- Adds `test_concurrent_reload_app_calls_serialize_the_whole_stop_and_start_pair` to `TestReloadAppLocking`, proving two concurrent `reload_app("x")` calls — e.g. a UI reload racing a file-watcher reload for the same `app_key` — fully serialize their stop+start sequence as one atomic unit. This is the last open acceptance criterion on #1227: the locking mechanism itself already shipped in #1605 (the app-key lock is now acquired once in `reload_app` and held across `_stop_app_unlocked` + `_start_app_unlocked`), but nothing proved the lock actually covered the whole pair rather than just `start_app`'s own internals. Verified RED against the old partial-lock behavior before confirming GREEN against the current fix.
- The test lives next to its sibling, `test_reload_app_acquires_app_key_lock_once`, in `test_app_lifecycle_service_operations.py` rather than `test_app_lifecycle_service_coverage.py` (which is scoped to branch-coverage gap-filling, a different concern).
- The mocked start-phase callback includes a yield point (`await asyncio.sleep(0)`) — without it, the event loop never gets a chance to interleave a second `reload_app` call during the first's start phase, so the test would pass even against a reintroduced bug that narrows the lock scope back to only the stop phase. This closes a false-pass gap that existed in an earlier draft of the test.

Closes #1227
