### PR TITLE
test: name the repeated timestamp fixture literal in ws-validator tests

### DIFF
--- a/frontend/src/api/ws-validator.test.ts
+++ b/frontend/src/api/ws-validator.test.ts
@@ -2,12 +2,14 @@ import { describe, expect, it } from "vitest";
 
 import { validateWsMessage, WsValidationError } from "./ws-validator";
 
+const FIXTURE_TIMESTAMP = 1700000000;
+
 describe("validateWsMessage", () => {
   it("validates a connected message", () => {
     const msg = {
       type: "connected",
       data: { uptime_seconds: 123.4, entity_count: 50, app_count: 3, version: "0.25.0" },
-      timestamp: 1700000000,
+      timestamp: FIXTURE_TIMESTAMP,
     };
     expect(validateWsMessage(msg)).toEqual(msg);
   });
@@ -26,7 +28,7 @@ describe("validateWsMessage", () => {
           error_type: null,
         },
       ],
-      timestamp: 1700000000,
+      timestamp: FIXTURE_TIMESTAMP,
     };
     expect(validateWsMessage(msg)).toEqual(msg);
   });
@@ -36,7 +38,7 @@ describe("validateWsMessage", () => {
       type: "log",
       data: {
         seq: 1,
-        timestamp: 1700000000,
+        timestamp: FIXTURE_TIMESTAMP,
         level: "INFO",
         logger_name: "hassette.test",
         func_name: null,
@@ -49,7 +51,7 @@ describe("validateWsMessage", () => {
         instance_index: null,
         source_tier: null,
       },
-      timestamp: 1700000000,
+      timestamp: FIXTURE_TIMESTAMP,
     };
     expect(validateWsMessage(msg)).toEqual(msg);
   });
@@ -66,7 +68,7 @@ describe("validateWsMessage", () => {
     const msg = {
       type: "unknown_type",
       data: {},
-      timestamp: 1700000000,
+      timestamp: FIXTURE_TIMESTAMP,
     };
     expect(() => validateWsMessage(msg)).toThrow(WsValidationError);
   });

--- a/frontend/src/api/ws-validator.test.ts
+++ b/frontend/src/api/ws-validator.test.ts
@@ -2,14 +2,14 @@ import { describe, expect, it } from "vitest";
 
 import { validateWsMessage, WsValidationError } from "./ws-validator";
 
-const FIXTURE_TIMESTAMP = 1700000000;
+const BASE_TIME_S = 1_700_000_000; // arbitrary fixed epoch in seconds
 
 describe("validateWsMessage", () => {
   it("validates a connected message", () => {
     const msg = {
       type: "connected",
       data: { uptime_seconds: 123.4, entity_count: 50, app_count: 3, version: "0.25.0" },
-      timestamp: FIXTURE_TIMESTAMP,
+      timestamp: BASE_TIME_S,
     };
     expect(validateWsMessage(msg)).toEqual(msg);
   });
@@ -28,7 +28,7 @@ describe("validateWsMessage", () => {
           error_type: null,
         },
       ],
-      timestamp: FIXTURE_TIMESTAMP,
+      timestamp: BASE_TIME_S,
     };
     expect(validateWsMessage(msg)).toEqual(msg);
   });
@@ -38,7 +38,7 @@ describe("validateWsMessage", () => {
       type: "log",
       data: {
         seq: 1,
-        timestamp: FIXTURE_TIMESTAMP,
+        timestamp: BASE_TIME_S,
         level: "INFO",
         logger_name: "hassette.test",
         func_name: null,
@@ -51,7 +51,7 @@ describe("validateWsMessage", () => {
         instance_index: null,
         source_tier: null,
       },
-      timestamp: FIXTURE_TIMESTAMP,
+      timestamp: BASE_TIME_S,
     };
     expect(validateWsMessage(msg)).toEqual(msg);
   });
@@ -68,7 +68,7 @@ describe("validateWsMessage", () => {
     const msg = {
       type: "unknown_type",
       data: {},
-      timestamp: FIXTURE_TIMESTAMP,
+      timestamp: BASE_TIME_S,
     };
     expect(() => validateWsMessage(msg)).toThrow(WsValidationError);
   });


### PR DESCRIPTION
## What changed

`frontend/src/api/ws-validator.test.ts` hardcoded the arbitrary epoch value `1700000000` at five sites across four test cases. This replaces all five with a single module-level `FIXTURE_TIMESTAMP` constant.

## Why

The timestamp carries no wire-protocol meaning, unlike the `type` discriminators in the same file — those stay literal on purpose, so a backend rename fails the test rather than silently tracking along. The timestamp is pure fixture noise, and repeating it invited drift: editing one occurrence would leave the others quietly inconsistent.

It also makes one relationship explicit. The `log` test case carries two timestamps — the inner log-record field and the outer envelope field — and as two independent magic numbers a reader had no way to tell whether they were intentionally equal or coincidentally so. Both now reference the same named value.

Scope is deliberately narrow: no test logic, assertions, or fixture shapes changed, and the substituted value is identical at every site.

## Testing

- `npm run test -- --run src/api/ws-validator.test.ts` — 7 passed
- `uv run nox -s dev` — 9269 passed, 1 skipped, 2 xfailed
- `prek -a` and the `pre-push` hook stage (including `pyright`) — all hooks pass

Closes #1551