### PR TITLE
test: deduplicate repeated bus predicate and scheduler error-handler test scaffolding

### DIFF
--- a/src/hassette/test_utils/__init__.py
+++ b/src/hassette/test_utils/__init__.py
@@ -44,6 +44,7 @@ from .harness import preserve_config as preserve_config
 from .harness import wait_for as wait_for
 from .helpers import FakeStateReader as FakeStateReader
 from .helpers import create_app_manifest as create_app_manifest
+from .helpers import create_attr_change_event as create_attr_change_event
 from .helpers import (
     create_call_service_event,
     create_state_change_event,

--- a/src/hassette/test_utils/helpers.py
+++ b/src/hassette/test_utils/helpers.py
@@ -130,6 +130,32 @@ def create_state_change_event(
     return event
 
 
+def create_attr_change_event(
+    old_attr_value: Any,
+    new_attr_value: Any,
+    *,
+    attr_name: str = "brightness",
+    entity_id: str = "light.office",
+    old_value: str = "on",
+    new_value: str = "on",
+) -> RawStateChangeEvent:
+    """Create a state-change event where a single attribute changes and the state itself doesn't.
+
+    Collapses the dominant shape used across attribute-predicate tests (AttrFrom/AttrTo/
+    AttrDidChange/AttrComparison/DidChange-with-attr-source): the entity's state stays "on",
+    and only one attribute (brightness by default) moves from ``old_attr_value`` to
+    ``new_attr_value``. Override ``entity_id``/``old_value``/``new_value`` for the handful of
+    cases that vary the base state as well.
+    """
+    return create_state_change_event(
+        entity_id=entity_id,
+        old_value=old_value,
+        new_value=new_value,
+        old_attrs={attr_name: old_attr_value},
+        new_attrs={attr_name: new_attr_value},
+    )
+
+
 def create_call_service_event(
     *,
     domain: str,

--- a/tests/integration/test_scheduler_error_handler.py
+++ b/tests/integration/test_scheduler_error_handler.py
@@ -39,6 +39,14 @@ class _SchedulerErrorCollector:
         assert isinstance(self.contexts[0].exception, exc_type)
         return self.contexts[0]
 
+    async def wait_and_assert_single(
+        self, exc_type: type[Exception], timeout: float = ERROR_TIMEOUT
+    ) -> SchedulerErrorContext:
+        """Wait for the error, let the loop settle, then assert and return its context."""
+        await self.wait(timeout)
+        await settle()
+        return self.single(exc_type)
+
 
 @pytest.fixture
 def scheduler(hassette_with_scheduler: "HassetteHarness") -> "Scheduler":
@@ -59,10 +67,7 @@ async def test_app_level_error_handler_called_on_job_failure(hassette_with_sched
     scheduler.on_error(errors.record)
     await scheduler.run_in(bad_job, delay=0.01, name="app_level_error_handler_called_on_job_fa_run_in")
 
-    await errors.wait()
-    await settle()
-
-    ctx = errors.single(ValueError)
+    ctx = await errors.wait_and_assert_single(ValueError)
     assert str(ctx.exception) == "job failed"
 
 
@@ -80,10 +85,7 @@ async def test_per_job_error_handler_wins(hassette_with_scheduler: "HassetteHarn
     scheduler.on_error(app_level.record)
     await scheduler.run_in(bad_job, delay=0.01, on_error=per_job.record, name="per_job_error_handler_wins_run_in")
 
-    await per_job.wait()
-    await settle()
-
-    per_job.single(RuntimeError)
+    await per_job.wait_and_assert_single(RuntimeError)
     assert not app_level.contexts, "App-level handler should not be called when per-job handler wins"
 
 
@@ -124,9 +126,6 @@ async def test_error_context_contains_args_kwargs(hassette_with_scheduler: "Hass
         name="error_context_contains_args_kwargs_run_in",
     )
 
-    await errors.wait()
-    await settle()
-
-    ctx = errors.single(ValueError)
+    ctx = await errors.wait_and_assert_single(ValueError)
     assert ctx.args == ("sensor.kitchen",)
     assert ctx.kwargs == {"count": 3}

--- a/tests/unit/bus/CLAUDE.md
+++ b/tests/unit/bus/CLAUDE.md
@@ -8,6 +8,7 @@
 ## Shared helpers
 
 - `from hassette.test_utils.factories import make_mock_parent` — owning-App stand-in, used to set `bus.parent`
+- `from hassette.test_utils import create_attr_change_event` — builds a state-change event where a single attribute moves and the state itself doesn't (`entity_id="light.office"`, state `"on"` → `"on"` by default, `attr_name="brightness"` by default). Collapses the repeated `create_state_change_event(entity_id=..., old_attrs={"brightness": X}, new_attrs={"brightness": Y})` shape used across `test_accessors.py`, `test_predicates.py`, and `test_predicate_details.py`'s attribute-predicate tests. Override `entity_id`/`old_value`/`new_value`/`attr_name` for the few cases that vary the base state or attribute.
 - `mock_add_listener(bus)` (local contextmanager) — swaps `bus.bus_service.add_listener` for an `AsyncMock`, restores on exit
 
 ## Key conventions

--- a/tests/unit/bus/test_accessors.py
+++ b/tests/unit/bus/test_accessors.py
@@ -9,20 +9,14 @@ from types import SimpleNamespace
 
 from hassette.const import MISSING_VALUE
 from hassette.event_handling import accessors as A
-from hassette.test_utils import create_call_service_event, create_state_change_event
+from hassette.test_utils import create_attr_change_event, create_call_service_event, create_state_change_event
 from hassette.test_utils.helpers import create_component_loaded_event, create_hass_event
 
 
 # get_state_object_* accessors
 def test_get_state_object_old_and_new_return_full_dicts() -> None:
     """get_state_object_old/new return the full state dict, not just the value."""
-    event = create_state_change_event(
-        entity_id="light.kitchen",
-        old_value="off",
-        new_value="on",
-        old_attrs={"brightness": 100},
-        new_attrs={"brightness": 200},
-    )
+    event = create_attr_change_event(100, 200, entity_id="light.kitchen", old_value="off", new_value="on")
 
     old_obj = A.get_state_object_old(event)
     new_obj = A.get_state_object_new(event)
@@ -119,13 +113,7 @@ def test_get_attrs_new_when_new_state_is_none() -> None:
 
 def test_get_attrs_old_new_returns_tuple_of_dicts() -> None:
     """get_attrs_old_new returns (old_attrs_dict, new_attrs_dict) for the requested keys."""
-    event = create_state_change_event(
-        entity_id="light.office",
-        old_value="on",
-        new_value="on",
-        old_attrs={"brightness": 100},
-        new_attrs={"brightness": 200},
-    )
+    event = create_attr_change_event(100, 200)
 
     accessor = A.get_attrs_old_new(["brightness"])
     old_attrs, new_attrs = accessor(event)
@@ -313,13 +301,7 @@ def test_get_all_changes_excludes_default_noisy_fields() -> None:
 
 def test_get_all_changes_respects_custom_exclude() -> None:
     """get_all_changes with a narrower exclude list surfaces fields the default would hide."""
-    event = create_state_change_event(
-        entity_id="light.office",
-        old_value="off",
-        new_value="on",
-        old_attrs={"brightness": 100},
-        new_attrs={"brightness": 200},
-    )
+    event = create_attr_change_event(100, 200, old_value="off", new_value="on")
 
     # Exclude nothing this time, but only inspect the attributes key for a clean assertion
     changes = A.get_all_changes(exclude=())(event)

--- a/tests/unit/bus/test_predicate_details.py
+++ b/tests/unit/bus/test_predicate_details.py
@@ -32,7 +32,7 @@ from hassette.event_handling.predicates import (
     _summarize_predicate,
     compare_value,
 )
-from hassette.test_utils import create_state_change_event
+from hassette.test_utils import create_attr_change_event, create_state_change_event
 
 if typing.TYPE_CHECKING:
     from hassette.events import Event
@@ -128,13 +128,7 @@ def test_did_change_false_when_values_equal() -> None:
 def test_did_change_with_attr_source() -> None:
     """DidChange works with any (old, new) tuple source, e.g. get_attr_old_new."""
     predicate = DidChange(source=get_attr_old_new("brightness"))
-    event = create_state_change_event(
-        entity_id="light.office",
-        old_value="on",
-        new_value="on",
-        old_attrs={"brightness": 100},
-        new_attrs={"brightness": 200},
-    )
+    event = create_attr_change_event(100, 200)
 
     assert predicate(event) is True
 
@@ -201,13 +195,7 @@ def test_state_comparison_warns_and_instantiates_when_passed_a_class(caplog: pyt
 def test_attr_comparison_calls_condition_with_old_and_new_attr() -> None:
     """AttrComparison passes (old_attr, new_attr) to the comparison condition."""
     predicate = AttrComparison(attr_name="brightness", condition=Increased())
-    event = create_state_change_event(
-        entity_id="light.office",
-        old_value="on",
-        new_value="on",
-        old_attrs={"brightness": 100},
-        new_attrs={"brightness": 200},
-    )
+    event = create_attr_change_event(100, 200)
 
     assert predicate(event) is True
 
@@ -215,13 +203,7 @@ def test_attr_comparison_calls_condition_with_old_and_new_attr() -> None:
 def test_attr_comparison_false_when_condition_fails() -> None:
     """AttrComparison returns False when the new attribute value fails the comparison."""
     predicate = AttrComparison(attr_name="brightness", condition=Decreased())
-    event = create_state_change_event(
-        entity_id="light.office",
-        old_value="on",
-        new_value="on",
-        old_attrs={"brightness": 100},
-        new_attrs={"brightness": 200},
-    )
+    event = create_attr_change_event(100, 200)
 
     assert predicate(event) is False
 

--- a/tests/unit/bus/test_predicates.py
+++ b/tests/unit/bus/test_predicates.py
@@ -38,7 +38,7 @@ from hassette.event_handling.predicates import (
     ValueIs,
     summarize_top_level,
 )
-from hassette.test_utils import create_call_service_event, create_state_change_event
+from hassette.test_utils import create_attr_change_event, create_call_service_event, create_state_change_event
 
 
 # ValueIs tests
@@ -101,13 +101,7 @@ def test_state_to_predicate() -> None:
 
 def test_attr_from_predicate() -> None:
     """Test AttrFrom predicate for old attribute values."""
-    event = create_state_change_event(
-        entity_id="light.office",
-        old_value="on",
-        new_value="on",
-        old_attrs={"brightness": 100},
-        new_attrs={"brightness": 200},
-    )
+    event = create_attr_change_event(100, 200)
 
     assert P.AttrFrom("brightness", 100)(event) is True
     assert P.AttrFrom("brightness", 200)(event) is False
@@ -115,13 +109,7 @@ def test_attr_from_predicate() -> None:
 
 def test_attr_to_predicate() -> None:
     """Test AttrTo predicate for new attribute values."""
-    event = create_state_change_event(
-        entity_id="light.office",
-        old_value="on",
-        new_value="on",
-        old_attrs={"brightness": 100},
-        new_attrs={"brightness": 200},
-    )
+    event = create_attr_change_event(100, 200)
 
     assert P.AttrTo("brightness", 200)(event) is True
     assert P.AttrTo("brightness", 100)(event) is False
@@ -129,13 +117,7 @@ def test_attr_to_predicate() -> None:
 
 def test_attr_from_to_predicates_apply_conditions() -> None:
     """Test that AttrFrom and AttrTo predicates correctly match old and new attribute values."""
-    event = create_state_change_event(
-        entity_id="light.office",
-        old_value="on",
-        new_value="on",
-        old_attrs={"brightness": 100},
-        new_attrs={"brightness": 150},
-    )
+    event = create_attr_change_event(100, 150)
 
     attr_from = P.AttrFrom("brightness", 100)
     attr_to = P.AttrTo("brightness", 150)
@@ -162,26 +144,14 @@ def test_state_did_change_false_when_unchanged() -> None:
 def test_attr_did_change_detects_attribute_modifications() -> None:
     """Test that AttrDidChange predicate detects when specified attributes change."""
     predicate = P.AttrDidChange("brightness")
-    event = create_state_change_event(
-        entity_id="light.office",
-        old_value="on",
-        new_value="on",
-        old_attrs={"brightness": 100},
-        new_attrs={"brightness": 150},
-    )
+    event = create_attr_change_event(100, 150)
     assert predicate(event) is True
 
 
 def test_attr_did_change_false_when_unchanged() -> None:
     """Test that AttrDidChange returns False when specified attribute is unchanged."""
     predicate = P.AttrDidChange("brightness")
-    event = create_state_change_event(
-        entity_id="light.office",
-        old_value="on",
-        new_value="on",
-        old_attrs={"brightness": 100},
-        new_attrs={"brightness": 100},
-    )
+    event = create_attr_change_event(100, 100)
     assert predicate(event) is False
 
 


### PR DESCRIPTION
### Notable Changes
- Add `create_attr_change_event()` to `hassette.test_utils.helpers` — collapses the dominant `light.office` brightness-change event shape (state unchanged, one attribute moves) that was hand-built via `create_state_change_event(...)` in nearly every attribute-predicate test across `test_accessors.py`, `test_predicates.py`, and `test_predicate_details.py`. Callers that vary the base state or entity still override `entity_id`/`old_value`/`new_value`.
- Add `wait_and_assert_single()` to `_SchedulerErrorCollector` in `test_scheduler_error_handler.py` — collapses the repeated `await errors.wait()` / `await settle()` / `errors.single(exc_type)` tail used by all three scheduler error-handler tests into one call.
- Document the new `create_attr_change_event` helper in `tests/unit/bus/CLAUDE.md` so it's discoverable before a future test reintroduces the same inline event construction.

Closes #1622
