### PR TITLE
test: deduplicate tests/unit/resources test patterns

### DIFF
--- a/src/hassette/test_utils/helpers.py
+++ b/src/hassette/test_utils/helpers.py
@@ -77,6 +77,15 @@ async def async_noop() -> None:
     """Async no-op — call it to get a coroutine object (e.g. bucket.spawn(async_noop()))."""
 
 
+async def block_until_cancelled(_self: Any) -> None:
+    """Service.serve() body: blocks until the task is cancelled.
+
+    Assign as ``serve = block_until_cancelled`` on a test Service subclass — the function
+    is bound as an instance method via the normal descriptor protocol.
+    """
+    await asyncio.Event().wait()
+
+
 async def settle(seconds: float = SETTLE_SECONDS) -> None:
     """Give a stray extra handler call time to land before a negative assertion."""
     # negative-assertion: no event-driven alternative

--- a/tests/unit/core/conftest.py
+++ b/tests/unit/core/conftest.py
@@ -24,6 +24,7 @@ from hassette.core.service_watcher import ServiceWatcher
 from hassette.core.telemetry.repository import TelemetryRepository
 from hassette.resources.restart import RestartSpec
 from hassette.resources.service import Service
+from hassette.test_utils.helpers import block_until_cancelled
 from hassette.test_utils.mock_hassette import make_mock_hassette
 from hassette.types.enums import BlockingIOBehavior, ResourceStatus, RestartType
 
@@ -326,11 +327,7 @@ class DummyService(Service):
 
     restart_spec: RestartSpec = RestartSpec(restart_type=RestartType.TRANSIENT)
 
-    async def serve(self) -> None:
-        try:
-            await asyncio.Event().wait()
-        except asyncio.CancelledError:
-            raise
+    serve = block_until_cancelled  # bound as instance method via the descriptor protocol
 
 
 class TempService(Service):
@@ -338,11 +335,7 @@ class TempService(Service):
 
     restart_spec: RestartSpec = RestartSpec(restart_type=RestartType.TEMPORARY)
 
-    async def serve(self) -> None:
-        try:
-            await asyncio.Event().wait()
-        except asyncio.CancelledError:
-            raise
+    serve = block_until_cancelled  # bound as instance method via the descriptor protocol
 
 
 def make_watcher_hassette(*, strict_lifecycle: bool = False) -> AsyncMock:

--- a/tests/unit/resources/lifecycle/conftest.py
+++ b/tests/unit/resources/lifecycle/conftest.py
@@ -1,11 +1,13 @@
 """Shared helpers for lifecycle propagation tests."""
 
 import asyncio
+from unittest.mock import AsyncMock
 
 from hassette.resources.base import Resource
 from hassette.resources.restart import RestartSpec
 from hassette.resources.service import Service
-from tests.unit.resources.conftest import ConcreteResource
+from hassette.test_utils import make_mock_hassette
+from tests.unit.resources.conftest import ConcreteResource, wait_for_running
 
 __all__ = [
     "ConcreteResource",
@@ -15,6 +17,9 @@ __all__ = [
     "ShutdownCounter",
     "SimpleParent",
     "SimpleService",
+    "make_initialized_shutdown_counter",
+    "make_parent_with_child",
+    "make_running_simple_service",
 ]
 
 
@@ -66,3 +71,35 @@ class SimpleService(Service):
 
     async def serve(self) -> None:
         await asyncio.Event().wait()  # block forever
+
+
+def make_parent_with_child(
+    order_list: list, child_cls: type[Resource], hassette: AsyncMock | None = None
+) -> tuple[SimpleParent, Resource]:
+    """Clear `order_list`, build a `SimpleParent`, and attach one `child_cls` child.
+
+    Callers needing more than one child add the rest with `parent.add_child(...)` after.
+    The mock hassette is reachable as `parent.hassette` if needed.
+    """
+    order_list.clear()
+    hassette = hassette or make_mock_hassette(sealed=False)
+    parent = SimpleParent(hassette)
+    child = parent.add_child(child_cls)
+    return parent, child
+
+
+async def make_running_simple_service(hassette: AsyncMock | None = None) -> SimpleService:
+    """Build a `SimpleService`, initialize it, and wait for it to reach RUNNING."""
+    hassette = hassette or make_mock_hassette(sealed=False)
+    svc = SimpleService(hassette)
+    await svc.initialize()
+    await wait_for_running(svc)
+    return svc
+
+
+async def make_initialized_shutdown_counter(hassette: AsyncMock | None = None) -> ShutdownCounter:
+    """Build a `ShutdownCounter` and initialize it."""
+    hassette = hassette or make_mock_hassette(sealed=False)
+    resource = ShutdownCounter(hassette)
+    await resource.initialize()
+    return resource

--- a/tests/unit/resources/lifecycle/test_force_terminal.py
+++ b/tests/unit/resources/lifecycle/test_force_terminal.py
@@ -24,9 +24,8 @@ from hassette.scheduler.scheduler import Scheduler
 from hassette.test_utils import make_mock_hassette
 from hassette.test_utils.factories import make_scheduled_job
 from hassette.types.enums import ResourceStatus
-from tests.unit.resources.conftest import wait_for_running
 
-from .conftest import HangingChild, ShutdownCounter, SimpleParent, SimpleService
+from .conftest import HangingChild, ShutdownCounter, SimpleParent, make_running_simple_service
 
 
 async def test_scheduler_on_shutdown_dequeues_all_jobs():
@@ -150,11 +149,7 @@ async def test_force_terminal_skips_completed_children():
 
 async def test_service_force_terminal_cancels_serve_task():
     """Service._force_terminal() cancels the _serve_task before calling super()."""
-    hassette = make_mock_hassette(sealed=False)
-    svc = SimpleService(hassette)
-
-    await svc.initialize()
-    await wait_for_running(svc)
+    svc = await make_running_simple_service()
 
     assert svc._serve_task is not None
     assert not svc._serve_task.done()

--- a/tests/unit/resources/lifecycle/test_init.py
+++ b/tests/unit/resources/lifecycle/test_init.py
@@ -32,7 +32,7 @@ from hassette.test_utils import make_mock_hassette
 from hassette.types.enums import ResourceStatus
 from tests.unit.resources.conftest import wait_for_running
 
-from .conftest import SimpleParent
+from .conftest import SimpleParent, make_parent_with_child
 
 # Shared list to record init order across multiple children
 _init_order: list[str] = []
@@ -84,11 +84,7 @@ class ServiceInitTrackingChild(Resource):
 
 async def test_init_propagates_to_children_in_insertion_order():
     """Parent with 3 children: init propagates in insertion order."""
-    _init_order.clear()
-    hassette = make_mock_hassette(sealed=False)
-    parent = SimpleParent(hassette)
-
-    child_a = parent.add_child(InitTrackingChild)
+    parent, child_a = make_parent_with_child(_init_order, InitTrackingChild)
     child_b = parent.add_child(InitTrackingChild)
     child_c = parent.add_child(InitTrackingChild)
 
@@ -106,11 +102,7 @@ async def test_init_propagates_to_children_in_insertion_order():
 
 async def test_init_skips_running_children():
     """Pre-initialized (RUNNING) children are not re-initialized."""
-    _init_order.clear()
-    hassette = make_mock_hassette(sealed=False)
-    parent = SimpleParent(hassette)
-
-    child_a = parent.add_child(InitTrackingChild)
+    parent, child_a = make_parent_with_child(_init_order, InitTrackingChild)
     child_b = parent.add_child(InitTrackingChild)
 
     # Pre-initialize child_a so it reaches RUNNING
@@ -128,11 +120,7 @@ async def test_init_skips_running_children():
 
 async def test_init_skips_starting_children():
     """Children in STARTING status are skipped during propagation."""
-    _init_order.clear()
-    hassette = make_mock_hassette(sealed=False)
-    parent = SimpleParent(hassette)
-
-    child = parent.add_child(InitTrackingChild)
+    parent, child = make_parent_with_child(_init_order, InitTrackingChild)
 
     # Force child into STARTING status
     await handle_starting(child)
@@ -147,11 +135,7 @@ async def test_init_skips_starting_children():
 
 async def test_init_reinitializes_stopped_children():
     """Stopped children are re-initialized when parent initializes."""
-    _init_order.clear()
-    hassette = make_mock_hassette(sealed=False)
-    parent = SimpleParent(hassette)
-
-    child = parent.add_child(InitTrackingChild)
+    parent, child = make_parent_with_child(_init_order, InitTrackingChild)
 
     # Initialize then shut down to reach STOPPED
     await child.initialize()
@@ -167,11 +151,7 @@ async def test_init_reinitializes_stopped_children():
 
 async def test_init_reinitializes_failed_children():
     """Failed children are re-initialized when parent initializes."""
-    _init_order.clear()
-    hassette = make_mock_hassette(sealed=False)
-    parent = SimpleParent(hassette)
-
-    child = parent.add_child(InitTrackingChild)
+    parent, child = make_parent_with_child(_init_order, InitTrackingChild)
 
     # Force child into FAILED status
     await handle_failed(child, RuntimeError("test failure"))

--- a/tests/unit/resources/lifecycle/test_shutdown.py
+++ b/tests/unit/resources/lifecycle/test_shutdown.py
@@ -24,16 +24,16 @@ from .conftest import (
     ShutdownCounter,
     SimpleParent,
     SimpleService,
+    make_initialized_shutdown_counter,
+    make_parent_with_child,
     shutdown_order,
 )
 
 
 async def test_shutdown_completed_prevents_double_shutdown():
     """Calling shutdown() twice only runs on_shutdown once."""
-    hassette = make_mock_hassette(sealed=False)
-    resource = ShutdownCounter(hassette)
+    resource = await make_initialized_shutdown_counter()
 
-    await resource.initialize()
     await resource.shutdown()
     await resource.shutdown()  # second call should be a no-op
 
@@ -42,10 +42,8 @@ async def test_shutdown_completed_prevents_double_shutdown():
 
 async def test_shutdown_completed_reset_by_initialize():
     """After shutdown then initialize, shutdown() works again."""
-    hassette = make_mock_hassette(sealed=False)
-    resource = ShutdownCounter(hassette)
+    resource = await make_initialized_shutdown_counter()
 
-    await resource.initialize()
     await resource.shutdown()
     assert resource.shutdown_count == 1
 
@@ -56,10 +54,8 @@ async def test_shutdown_completed_reset_by_initialize():
 
 async def test_shutdown_event_cleared_by_initialize():
     """initialize() clears shutdown_event so it is not set."""
-    hassette = make_mock_hassette(sealed=False)
-    resource = ShutdownCounter(hassette)
+    resource = await make_initialized_shutdown_counter()
 
-    await resource.initialize()
     await resource.shutdown()
     assert resource.shutdown_event.is_set(), "shutdown_event should be set after shutdown"
 
@@ -69,10 +65,8 @@ async def test_shutdown_event_cleared_by_initialize():
 
 async def test_start_resets_shutdown_completed():
     """start() resets shutdown_completed so the init task is spawned."""
-    hassette = make_mock_hassette(sealed=False)
-    resource = ShutdownCounter(hassette)
+    resource = await make_initialized_shutdown_counter()
 
-    await resource.initialize()
     await resource.shutdown()
     assert resource.shutdown_completed is True
 
@@ -101,11 +95,7 @@ async def test_ordered_children_for_shutdown_returns_reversed():
 
 async def test_shutdown_propagates_to_children_in_reverse_order():
     """Parent with 3 children: shutdown propagates in reverse insertion order."""
-    shutdown_order.clear()
-    hassette = make_mock_hassette(sealed=False)
-    parent = SimpleParent(hassette)
-
-    child_a = parent.add_child(OrderTrackingChild)
+    parent, child_a = make_parent_with_child(shutdown_order, OrderTrackingChild)
     child_b = parent.add_child(OrderTrackingChild)
     child_c = parent.add_child(OrderTrackingChild)
 
@@ -126,11 +116,7 @@ async def test_shutdown_propagates_to_children_in_reverse_order():
 
 async def test_shutdown_propagation_error_tolerance():
     """Middle child raises during shutdown; other children still shut down."""
-    shutdown_order.clear()
-    hassette = make_mock_hassette(sealed=False)
-    parent = SimpleParent(hassette)
-
-    child_a = parent.add_child(OrderTrackingChild)
+    parent, child_a = make_parent_with_child(shutdown_order, OrderTrackingChild)
     child_b = parent.add_child(ErrorChild)  # will raise
     child_c = parent.add_child(OrderTrackingChild)
 

--- a/tests/unit/resources/lifecycle/test_total_timeout.py
+++ b/tests/unit/resources/lifecycle/test_total_timeout.py
@@ -72,13 +72,18 @@ class TotalTimeoutRoot(Resource):
             mark_not_ready(self, "shutdown complete")
 
 
+def make_total_timeout_root(total_timeout: float = 0.1, resource_timeout: float = 5) -> TotalTimeoutRoot:
+    """Build a `TotalTimeoutRoot` with the lifecycle timeout config set."""
+    hassette = make_mock_hassette(sealed=False)
+    hassette.config.lifecycle.total_shutdown_timeout_seconds = total_timeout
+    hassette.config.lifecycle.resource_shutdown_timeout_seconds = resource_timeout
+    return TotalTimeoutRoot(hassette)
+
+
 async def test_total_shutdown_timeout_caps_wall_clock():
     """Hassette-style total timeout ensures shutdown completes within budget even when a child hangs."""
-    hassette = make_mock_hassette(sealed=False)
-    hassette.config.lifecycle.total_shutdown_timeout_seconds = 0.2
-    hassette.config.lifecycle.resource_shutdown_timeout_seconds = 5  # per-level timeout is much larger
+    root = make_total_timeout_root(total_timeout=0.2)
 
-    root = TotalTimeoutRoot(hassette)
     hanging = root.add_child(HangingChild)
     normal = root.add_child(ShutdownCounter)
 
@@ -100,11 +105,8 @@ async def test_total_shutdown_timeout_caps_wall_clock():
 
 async def test_total_timeout_force_patches_all_descendants():
     """On total timeout, _force_terminal() is called recursively on all descendants."""
-    hassette = make_mock_hassette(sealed=False)
-    hassette.config.lifecycle.total_shutdown_timeout_seconds = 0.1
-    hassette.config.lifecycle.resource_shutdown_timeout_seconds = 5
+    root = make_total_timeout_root()
 
-    root = TotalTimeoutRoot(hassette)
     hanging = root.add_child(HangingChild)
     grandchild = hanging.add_child(SimpleParent)
 
@@ -123,11 +125,7 @@ async def test_total_timeout_force_patches_all_descendants():
 
 async def test_total_timeout_finally_always_closes_streams():
     """close_streams() equivalent is called even when the total timeout fires."""
-    hassette = make_mock_hassette(sealed=False)
-    hassette.config.lifecycle.total_shutdown_timeout_seconds = 0.1
-    hassette.config.lifecycle.resource_shutdown_timeout_seconds = 5
-
-    root = TotalTimeoutRoot(hassette)
+    root = make_total_timeout_root()
     root.add_child(HangingChild)
 
     await root.initialize()
@@ -139,11 +137,7 @@ async def test_total_timeout_finally_always_closes_streams():
 
 async def test_total_timeout_sets_shutdown_completed_first():
     """shutdown_completed=True is set before handle_stop() and close_streams() in the finally block."""
-    hassette = make_mock_hassette(sealed=False)
-    hassette.config.lifecycle.total_shutdown_timeout_seconds = 0.1
-    hassette.config.lifecycle.resource_shutdown_timeout_seconds = 5
-
-    root = TotalTimeoutRoot(hassette)
+    root = make_total_timeout_root()
     root.add_child(HangingChild)
 
     await root.initialize()

--- a/tests/unit/resources/test_lifecycle_transitions.py
+++ b/tests/unit/resources/test_lifecycle_transitions.py
@@ -39,8 +39,16 @@ from hassette.resources.lifecycle import (
 from hassette.resources.mixins import LifecycleMixin
 from hassette.test_utils import make_mock_hassette
 from hassette.types.enums import ResourceStatus
-from tests.unit.resources.conftest import ConcreteResource, wait_for_running
-from tests.unit.resources.lifecycle.conftest import SimpleService
+from tests.unit.resources.conftest import ConcreteResource
+from tests.unit.resources.lifecycle.conftest import make_running_simple_service
+
+
+def make_strict_running_resource(strict_lifecycle: bool = True) -> ConcreteResource:
+    """Build a `ConcreteResource` with `_status` set directly to RUNNING, bypassing the setter."""
+    hassette = make_mock_hassette(strict_lifecycle=strict_lifecycle, sealed=False)
+    resource = ConcreteResource(hassette)
+    resource._status = ResourceStatus.RUNNING
+    return resource
 
 
 async def test_valid_transition_sequence():
@@ -91,11 +99,7 @@ async def test_invalid_transition_warns_nonstrict():
 
 async def test_force_terminal_bypasses_validation():
     """In strict mode, _force_terminal() on a RUNNING resource succeeds with STOPPED and no error."""
-    hassette = make_mock_hassette(strict_lifecycle=True, sealed=False)
-    resource = ConcreteResource(hassette)
-
-    # Manually set to RUNNING bypassing the setter so we can test _force_terminal
-    resource._status = ResourceStatus.RUNNING
+    resource = make_strict_running_resource()
 
     # _force_terminal() must NOT raise even in strict mode
     resource._force_terminal()
@@ -175,10 +179,7 @@ async def test_hasattr_guard_no_hassette():
 
 async def test_same_state_no_transition():
     """handle_running() when already RUNNING returns early — idempotency preserved, previous_status unchanged."""
-    hassette = make_mock_hassette(strict_lifecycle=True, sealed=False)
-    resource = ConcreteResource(hassette)
-
-    resource._status = ResourceStatus.RUNNING
+    resource = make_strict_running_resource()
     resource._previous_status = ResourceStatus.STARTING
 
     await handle_running(resource)
@@ -255,11 +256,7 @@ async def test_service_shutdown_sets_stopping_before_hooks():
     handle_stop → STOPPING→STOPPED). The observable STOPPING point is before_shutdown,
     which fires before the serve task is cancelled.
     """
-    hassette = make_mock_hassette(sealed=False)
-    svc = SimpleService(hassette)
-
-    await svc.initialize()
-    await wait_for_running(svc)
+    svc = await make_running_simple_service()
 
     status_in_hook: list[ResourceStatus] = []
 
@@ -308,9 +305,7 @@ async def test_shutdown_stopping_then_stopped_sequence():
 
 async def test_running_to_stopped_direct_is_valid():
     """RUNNING → STOPPED is valid for natural service completion (_serve_wrapper normal return)."""
-    hassette = make_mock_hassette(strict_lifecycle=True, sealed=False)
-    resource = ConcreteResource(hassette)
-    resource._status = ResourceStatus.RUNNING
+    resource = make_strict_running_resource()
 
     resource.status = ResourceStatus.STOPPED
     assert resource.status == ResourceStatus.STOPPED

--- a/tests/unit/resources/test_service_lifecycle.py
+++ b/tests/unit/resources/test_service_lifecycle.py
@@ -12,8 +12,9 @@ from hassette.resources.base import FinalMeta
 from hassette.resources.restart import RestartSpec
 from hassette.resources.service import Service
 from hassette.test_utils import make_mock_hassette, wait_for
+from hassette.test_utils.helpers import block_until_cancelled
 from tests.unit.resources.conftest import wait_for_running
-from tests.unit.resources.lifecycle.conftest import SimpleService
+from tests.unit.resources.lifecycle.conftest import make_running_simple_service
 
 
 class ServiceWithCustomHooks(Service):
@@ -23,11 +24,7 @@ class ServiceWithCustomHooks(Service):
     init_called: bool = False
     shutdown_called: bool = False
 
-    async def serve(self) -> None:
-        try:
-            await asyncio.Event().wait()
-        except asyncio.CancelledError:
-            raise
+    serve = block_until_cancelled  # bound as instance method via the descriptor protocol
 
     async def on_initialize(self) -> None:
         # Deliberately does NOT call super() — the old bug
@@ -167,11 +164,7 @@ def test_finalmeta_blocks_service_subclass_from_overriding_shutdown():
 
 async def test_simple_service_completes_full_lifecycle():
     """A simple service can initialize and shut down cleanly."""
-    hassette = make_mock_hassette(sealed=False)
-    svc = SimpleService(hassette)
-
-    await svc.initialize()
-    await wait_for_running(svc)
+    svc = await make_running_simple_service()
 
     assert svc._serve_task is not None
     assert not svc._serve_task.done()


### PR DESCRIPTION
### Test deduplication

`tools/check_duplicate_code.py` (PMD CPD) flagged 7 duplicate-code clusters in `tests/unit/resources/`. This extracts the shared setup boilerplate into helper functions so each pattern has one definition instead of several identical inline copies:

- `block_until_cancelled` (`src/hassette/test_utils/helpers.py`) — the `Service.serve()` body used via `serve = block_until_cancelled` in three test `Service` subclasses, replacing an identical `try/await/except CancelledError: raise` block that was copy-pasted in each.
- `make_parent_with_child`, `make_running_simple_service`, `make_initialized_shutdown_counter` (`tests/unit/resources/lifecycle/conftest.py`) — shared construction/initialization sequences reused across `test_init.py`, `test_shutdown.py`, `test_force_terminal.py`, `test_total_timeout.py`, and `test_lifecycle_transitions.py`.
- `make_total_timeout_root` (local to `test_total_timeout.py`) and `make_strict_running_resource` (local to `test_lifecycle_transitions.py`) — kept file-local since their config-timeout and strict-lifecycle-status setup isn't reused elsewhere.

No behavior change — this only consolidates repeated setup, the tests being deduplicated still exercise the same lifecycle paths. Split off from #1569 to keep that PR's diff focused.

Closes #1620
