### PR TITLE
test: deduplicate telemetry integration test patterns

### DIFF
--- a/tests/integration/telemetry/CLAUDE.md
+++ b/tests/integration/telemetry/CLAUDE.md
@@ -19,6 +19,7 @@ Everything else lives in this directory's `helpers.py`. Check it before writing 
 - `only_row(query)` — await a query and return its one row, asserting there is exactly one.
 - `recent_activity(query_service, ...)` — `get_app_recent_activity()` with defaults for the four arguments a given test usually doesn't vary.
 - `error_row(...)` / `SINCE_WINDOW_ERROR_ROWS` / `assert_last_error_row_coherence(...)` / `assert_no_last_error(row)` — building and asserting `last_error_*` data.
+- `fetch_blocking_events(db_svc)` / `drain_db_writes(db_svc)` — read all `blocking_events` rows, and block until the DB write queue has drained a just-recorded event, for the blocking-IO detection tests.
 
 ## Key conventions
 

--- a/tests/integration/telemetry/CLAUDE.md
+++ b/tests/integration/telemetry/CLAUDE.md
@@ -10,6 +10,17 @@
 
 - `from hassette.test_utils.mock_hassette import make_mock_hassette` — base builder this directory's `db_hassette` wraps
 
+Everything else lives in this directory's `helpers.py`. Check it before writing a local helper:
+
+- `DbFixture` — the `db` fixture's type, `tuple[DatabaseService, int]`. Annotate `db:` parameters with this, not the raw tuple.
+- `open_db_with_session(hassette)` / `running_command_executor(hassette)` — DB + seeded session, and an initialized `CommandExecutor` as an async context manager. Both are for fixtures that need their own instance instead of the shared `db` fixture.
+- `insert_listener` / `insert_job` / `insert_invocation` / `insert_execution` — single-row inserts.
+- `insert_listener_and_job` / `insert_tiered_listeners` / `insert_app_listener_pair` — the three multi-row setups the UNION and tier-scoping tests share.
+- `only_row(query)` — await a query and return its one row, asserting there is exactly one.
+- `recent_activity(query_service, ...)` — `get_app_recent_activity()` with defaults for the four arguments a given test usually doesn't vary.
+- `error_row(...)` / `SINCE_WINDOW_ERROR_ROWS` / `assert_last_error_row_coherence(...)` / `assert_no_last_error(row)` — building and asserting `last_error_*` data.
+
 ## Key conventions
 
 - Always override `db_hassette` locally when a test needs the web API reachable — don't set `web_api.run` on the shared `integration/conftest.py` version.
+- `tools/check_duplicate_code.py` scans this directory. Where repetition is genuinely parallel test structure — the same setup varying only the data each case probes — wrap **every** occurrence in `# dup-ignore-start: <specific reason>` / `# dup-ignore-end`; partial annotation does not suppress the finding.

--- a/tests/integration/telemetry/conftest.py
+++ b/tests/integration/telemetry/conftest.py
@@ -1,16 +1,16 @@
 """Shared fixtures for telemetry integration tests."""
 
 import asyncio
-import time
 from collections.abc import AsyncIterator
 from pathlib import Path
 from unittest.mock import MagicMock
 
 import pytest
 
-from hassette.core.database_service import DatabaseService
 from hassette.core.telemetry.query_service import TelemetryQueryService
 from hassette.test_utils.mock_hassette import make_mock_hassette
+
+from .helpers import DbFixture, open_db_with_session
 
 
 @pytest.fixture
@@ -26,20 +26,13 @@ def db_hassette(premigrated_db_path: Path) -> MagicMock:
 
 
 @pytest.fixture
-async def db(db_hassette: MagicMock) -> AsyncIterator[tuple[DatabaseService, int]]:
+async def db(db_hassette: MagicMock) -> AsyncIterator[DbFixture]:
     """Initialize a DatabaseService with a seeded session row.
 
     Yields:
         Tuple of (DatabaseService instance, session_id).
     """
-    db_service = DatabaseService(db_hassette, parent=None)
-    await db_service.on_initialize()
-    cursor = await db_service.db.execute(
-        "INSERT INTO sessions (started_at, last_heartbeat_at, status) VALUES (?, ?, 'running')",
-        (time.time(), time.time()),
-    )
-    session_id = cursor.lastrowid
-    await db_service.db.commit()
+    db_service, session_id = await open_db_with_session(db_hassette)
     db_hassette.session_id = session_id
     db_hassette.try_session_id.return_value = session_id
     db_hassette.database_service = db_service
@@ -48,7 +41,7 @@ async def db(db_hassette: MagicMock) -> AsyncIterator[tuple[DatabaseService, int
 
 
 @pytest.fixture
-def query_service(db_hassette: MagicMock, db: tuple[DatabaseService, int]) -> TelemetryQueryService:  # noqa: ARG001
+def query_service(db_hassette: MagicMock, db: DbFixture) -> TelemetryQueryService:  # noqa: ARG001
     """Create a TelemetryQueryService with DatabaseService already wired.
 
     Skips on_initialize (which waits on DatabaseService) since the fixture

--- a/tests/integration/telemetry/helpers.py
+++ b/tests/integration/telemetry/helpers.py
@@ -30,7 +30,7 @@ async def commit_returning_id(db_svc: DatabaseService, cursor: aiosqlite.Cursor)
     return cursor.lastrowid
 
 
-async def open_db_with_session(hassette: Any) -> tuple[DatabaseService, int]:
+async def open_db_with_session(hassette: Any) -> DbFixture:
     """Initialize a ``DatabaseService`` against ``hassette`` and seed one running session row.
 
     Returns:
@@ -254,9 +254,7 @@ async def assert_last_error_row_coherence(
     if trailing_success_ts is not None:
         await insert_row(status="success", execution_start_ts=trailing_success_ts)
 
-    results = await query_fn()
-    assert len(results) == 1
-    row = results[0]
+    row = await only_row(query_fn())
     newest = error_rows[-1]
     assert row.last_error_type == newest["error_type"]
     assert row.last_error_message == newest["error_message"]
@@ -305,6 +303,28 @@ async def insert_execution(
         ),
     )
     return await commit_returning_id(db_svc, cursor)
+
+
+async def fetch_blocking_events(db_svc: DatabaseService) -> list[dict[str, Any]]:
+    """Return all rows from blocking_events as plain dicts."""
+    cursor = await db_svc.db.execute("SELECT * FROM blocking_events ORDER BY id")
+    rows = await cursor.fetchall()
+    return [dict(row) for row in rows]
+
+
+async def drain_db_writes(db_svc: DatabaseService) -> None:
+    """Block until every previously enqueued DB write has been processed.
+
+    Writes go through database_service.enqueue()/submit(), which places the coroutine on the DB
+    write queue for the single-writer worker. The worker drains the queue in FIFO order, so
+    submitting a sentinel coroutine and awaiting it guarantees every write enqueued before it has
+    finished — deterministic where a fixed sleep would race the worker on slow CI.
+    """
+
+    async def _sentinel() -> None:
+        return None
+
+    await db_svc.submit(_sentinel())
 
 
 async def recent_activity(

--- a/tests/integration/telemetry/helpers.py
+++ b/tests/integration/telemetry/helpers.py
@@ -1,15 +1,73 @@
 """Insert helpers for telemetry integration tests."""
 
 import time
-from collections.abc import Awaitable, Callable, Sequence
-from typing import Any
+from collections.abc import AsyncIterator, Awaitable, Callable, Sequence
+from contextlib import asynccontextmanager
+from typing import Any, TypeVar
 
+import aiosqlite
 import pytest
 
+from hassette.core.command_executor import CommandExecutor
 from hassette.core.database_service import DatabaseService
+from hassette.core.telemetry.query_service import TelemetryQueryService
+from hassette.schemas.execution_models import ActivityFeedEntry
 from hassette.test_utils.config import TEST_SOURCE_LOCATION
+from hassette.types.types import QuerySourceTier
 
 BASE_TS = 1_000_000.0
+
+DbFixture = tuple[DatabaseService, int]
+"""What the ``db`` fixture yields: an initialized ``DatabaseService`` and its seeded session id."""
+
+RowT = TypeVar("RowT")
+
+
+async def commit_returning_id(db_svc: DatabaseService, cursor: aiosqlite.Cursor) -> int:
+    """Commit ``cursor``'s pending INSERT and return the row id it produced."""
+    await db_svc.db.commit()
+    assert cursor.lastrowid is not None
+    return cursor.lastrowid
+
+
+async def open_db_with_session(hassette: Any) -> tuple[DatabaseService, int]:
+    """Initialize a ``DatabaseService`` against ``hassette`` and seed one running session row.
+
+    Returns:
+        Tuple of (DatabaseService instance, session_id). The caller owns shutdown.
+    """
+    db_service = DatabaseService(hassette, parent=None)
+    await db_service.on_initialize()
+    cursor = await db_service.db.execute(
+        "INSERT INTO sessions (started_at, last_heartbeat_at, status) VALUES (?, ?, 'running')",
+        (time.time(), time.time()),
+    )
+    session_id = cursor.lastrowid
+    await db_service.db.commit()
+    assert session_id is not None
+    return db_service, session_id
+
+
+@asynccontextmanager
+async def running_command_executor(hassette: Any) -> AsyncIterator[CommandExecutor]:
+    """Yield an initialized ``CommandExecutor``, shutting it down on exit.
+
+    ``parent=None`` matches how the telemetry conftest wires ``DatabaseService``, avoiding the
+    sealed-mock ``unique_name`` issue.
+    """
+    exc = CommandExecutor(hassette, parent=None)
+    await exc.on_initialize()
+    try:
+        yield exc
+    finally:
+        await exc.on_shutdown()
+
+
+async def only_row(query: Awaitable[Sequence[RowT]]) -> RowT:
+    """Await ``query`` and return its single row, asserting there is exactly one."""
+    rows = await query
+    assert len(rows) == 1, f"expected exactly 1 row, got {len(rows)}"
+    return rows[0]
 
 
 async def insert_listener(
@@ -34,9 +92,7 @@ async def insert_listener(
            VALUES (?, ?, ?, ?, ?, NULL, NULL, 0, 0, ?, ?)""",
         (app_key, instance_index, name, handler_method, topic, TEST_SOURCE_LOCATION, source_tier),
     )
-    await db_svc.db.commit()
-    assert cursor.lastrowid is not None
-    return cursor.lastrowid
+    return await commit_returning_id(db_svc, cursor)
 
 
 async def insert_job(
@@ -57,9 +113,7 @@ async def insert_job(
            VALUES (?, ?, ?, ?, 'interval', 1, ?, ?, ?)""",
         (app_key, instance_index, job_name, handler_method, TEST_SOURCE_LOCATION, source_tier, schedule_status),
     )
-    await db_svc.db.commit()
-    assert cursor.lastrowid is not None
-    return cursor.lastrowid
+    return await commit_returning_id(db_svc, cursor)
 
 
 async def insert_invocation(
@@ -98,9 +152,72 @@ async def insert_invocation(
             thread_leaked,
         ),
     )
-    await db_svc.db.commit()
-    assert cursor.lastrowid is not None
-    return cursor.lastrowid
+    return await commit_returning_id(db_svc, cursor)
+
+
+async def insert_listener_and_job(db_svc: DatabaseService, *, app_key: str = "test_app") -> tuple[int, int]:
+    """Insert one listener and one job for ``app_key`` — the two arms every UNION query merges.
+
+    Returns:
+        Tuple of (listener_id, job_id).
+    """
+    listener_id = await insert_listener(db_svc, app_key=app_key, handler_method="on_event")
+    job_id = await insert_job(db_svc, app_key=app_key, job_name="my_job", handler_method="run_job")
+    return listener_id, job_id
+
+
+async def insert_tiered_listeners(db_svc: DatabaseService, *, app_key: str = "test_app") -> tuple[int, int]:
+    """Insert an app-tier and a framework-tier listener under the same ``app_key``.
+
+    Returns:
+        Tuple of (app_tier_listener_id, framework_tier_listener_id).
+    """
+    app_listener = await insert_listener(db_svc, app_key=app_key, handler_method="on_app", source_tier="app")
+    fw_listener = await insert_listener(db_svc, app_key=app_key, handler_method="on_fw", source_tier="framework")
+    return app_listener, fw_listener
+
+
+def error_row(
+    error_type: str, error_message: str, error_traceback: str | None, execution_start_ts: float
+) -> dict[str, Any]:
+    """Build one entry for ``assert_last_error_row_coherence``'s ``error_rows`` argument."""
+    return {
+        "error_type": error_type,
+        "error_message": error_message,
+        "error_traceback": error_traceback,
+        "execution_start_ts": execution_start_ts,
+    }
+
+
+SINCE_WINDOW_ERROR_ROWS: tuple[dict[str, Any], ...] = (
+    error_row("OldError", "before window", "old tb", BASE_TS + 1.0),
+    error_row("NewError", "inside window", "new tb", BASE_TS + 100.0),
+)
+"""One error either side of a ``since=BASE_TS + 50.0`` window, for the ``since``-scoping tests."""
+
+
+def assert_no_last_error(row: Any) -> None:
+    """Assert every ``last_error_*`` field the row exposes is None.
+
+    ``JobSummary`` exposes ``last_error_ts`` and ``ListenerSummary`` doesn't, so this checks that
+    one only when present — same accommodation ``assert_last_error_row_coherence`` makes.
+    """
+    assert row.last_error_type is None
+    assert row.last_error_message is None
+    assert row.last_error_traceback is None
+    if hasattr(row, "last_error_ts"):
+        assert row.last_error_ts is None
+
+
+async def insert_app_listener_pair(db_svc: DatabaseService) -> tuple[int, int]:
+    """Insert one app-tier listener each under ``app_a`` and ``app_b``, for cross-app isolation tests.
+
+    Returns:
+        Tuple of (app_a_listener_id, app_b_listener_id).
+    """
+    listener_a = await insert_listener(db_svc, app_key="app_a", handler_method="on_a")
+    listener_b = await insert_listener(db_svc, app_key="app_b", handler_method="on_b")
+    return listener_a, listener_b
 
 
 async def assert_last_error_row_coherence(
@@ -187,6 +304,23 @@ async def insert_execution(
             thread_leaked,
         ),
     )
-    await db_svc.db.commit()
-    assert cursor.lastrowid is not None
-    return cursor.lastrowid
+    return await commit_returning_id(db_svc, cursor)
+
+
+async def recent_activity(
+    query_service: TelemetryQueryService,
+    *,
+    app_key: str = "test_app",
+    instance_index: int | None = None,
+    limit: int = 50,
+    since: float | None = None,
+    source_tier: QuerySourceTier = "app",
+) -> list[ActivityFeedEntry]:
+    """Call ``get_app_recent_activity`` with the defaults the union tests share.
+
+    Every argument on the real method is required, so spelling all five out at each call site
+    buried the one or two that a given test actually varies.
+    """
+    return await query_service.get_app_recent_activity(
+        app_key=app_key, instance_index=instance_index, limit=limit, since=since, source_tier=source_tier
+    )

--- a/tests/integration/telemetry/test_blocking_events_persistence.py
+++ b/tests/integration/telemetry/test_blocking_events_persistence.py
@@ -21,7 +21,7 @@ from hassette.core.command_executor import CommandExecutor
 from hassette.core.database_service import DatabaseService
 from hassette.core.loop_watchdog import WatchdogEvent
 
-from .helpers import DbFixture, running_command_executor
+from .helpers import DbFixture, drain_db_writes, fetch_blocking_events, running_command_executor
 
 
 @pytest.fixture
@@ -64,35 +64,13 @@ def _make_monkeypatch_event(*, app_key: str | None = "my_app") -> MonkeypatchEve
     )
 
 
-async def _drain_tasks(db_svc: DatabaseService) -> None:
-    """Block until every enqueued record_blocking_event DB write has been processed.
-
-    record_blocking_event() calls database_service.enqueue(), which places the INSERT coroutine
-    on the DB write queue for the single-writer worker. The worker drains the queue in FIFO order,
-    so submitting a sentinel coroutine and awaiting it guarantees that every write enqueued before
-    it has finished — deterministic where a fixed sleep would race the worker on slow CI.
-    """
-
-    async def _sentinel() -> None:
-        return None
-
-    await db_svc.submit(_sentinel())
-
-
-async def _fetch_blocking_events(db_svc: DatabaseService) -> list[dict]:
-    """Fetch all rows from blocking_events as plain dicts."""
-    cursor = await db_svc.db.execute("SELECT * FROM blocking_events ORDER BY id")
-    rows = await cursor.fetchall()
-    return [dict(row) for row in rows]
-
-
 async def _record_and_fetch(
     executor: CommandExecutor, db_svc: DatabaseService, event: WatchdogEvent | MonkeypatchEvent
 ) -> list[dict]:
     """Record one blocking event, wait for its DB write to drain, and return all persisted rows."""
     executor.record_blocking_event(event)
-    await _drain_tasks(db_svc)
-    return await _fetch_blocking_events(db_svc)
+    await drain_db_writes(db_svc)
+    return await fetch_blocking_events(db_svc)
 
 
 class TestTier1Persistence:
@@ -179,9 +157,9 @@ class TestTier2Persistence:
 
         executor.record_blocking_event(_make_watchdog_event(stall_ms=100.0))
         executor.record_blocking_event(_make_monkeypatch_event())
-        await _drain_tasks(db_svc)
+        await drain_db_writes(db_svc)
 
-        rows = await _fetch_blocking_events(db_svc)
+        rows = await fetch_blocking_events(db_svc)
         assert len(rows) == 2
         tiers = {r["tier"] for r in rows}
         assert tiers == {"watchdog", "monkeypatch"}
@@ -232,9 +210,9 @@ class TestUnresolvedOwnerPersistence:
 
         executor.record_blocking_event(_make_watchdog_event(app_key=None))
         executor.record_blocking_event(_make_monkeypatch_event(app_key=None))
-        await _drain_tasks(db_svc)
+        await drain_db_writes(db_svc)
 
-        rows = await _fetch_blocking_events(db_svc)
+        rows = await fetch_blocking_events(db_svc)
         assert len(rows) == 2
         assert all(r["source_tier"] == "framework" for r in rows)
         assert all(r["app_key"] is None for r in rows)

--- a/tests/integration/telemetry/test_blocking_events_persistence.py
+++ b/tests/integration/telemetry/test_blocking_events_persistence.py
@@ -21,24 +21,19 @@ from hassette.core.command_executor import CommandExecutor
 from hassette.core.database_service import DatabaseService
 from hassette.core.loop_watchdog import WatchdogEvent
 
+from .helpers import DbFixture, running_command_executor
+
 
 @pytest.fixture
-async def executor(
-    db_hassette: MagicMock,
-    db: tuple[DatabaseService, int],
-) -> AsyncIterator[CommandExecutor]:
+async def executor(db_hassette: MagicMock, db: DbFixture) -> AsyncIterator[CommandExecutor]:
     """CommandExecutor wired with the telemetry conftest's real DB and session.
 
     Uses parent=None to match how the telemetry conftest wires DatabaseService,
     avoiding the sealed-mock unique_name issue.
     """
     _db_service, _session_id = db
-    exc = CommandExecutor(db_hassette, parent=None)
-    await exc.on_initialize()
-    try:
+    async with running_command_executor(db_hassette) as exc:
         yield exc
-    finally:
-        await exc.on_shutdown()
 
 
 def _make_watchdog_event(*, app_key: str | None = "my_app", stall_ms: float = 250.0) -> WatchdogEvent:
@@ -91,20 +86,22 @@ async def _fetch_blocking_events(db_svc: DatabaseService) -> list[dict]:
     return [dict(row) for row in rows]
 
 
+async def _record_and_fetch(
+    executor: CommandExecutor, db_svc: DatabaseService, event: WatchdogEvent | MonkeypatchEvent
+) -> list[dict]:
+    """Record one blocking event, wait for its DB write to drain, and return all persisted rows."""
+    executor.record_blocking_event(event)
+    await _drain_tasks(db_svc)
+    return await _fetch_blocking_events(db_svc)
+
+
 class TestTier1Persistence:
-    async def test_watchdog_event_inserts_one_row(
-        self,
-        executor: CommandExecutor,
-        db: tuple[DatabaseService, int],
-    ) -> None:
+    async def test_watchdog_event_inserts_one_row(self, executor: CommandExecutor, db: DbFixture) -> None:
         """One WatchdogEvent → exactly one blocking_events row."""
         db_svc, session_id = db
         event = _make_watchdog_event(stall_ms=300.0)
 
-        executor.record_blocking_event(event)
-        await _drain_tasks(db_svc)
-
-        rows = await _fetch_blocking_events(db_svc)
+        rows = await _record_and_fetch(executor, db_svc, event)
         assert len(rows) == 1
 
         row = rows[0]
@@ -117,11 +114,7 @@ class TestTier1Persistence:
         assert row["execution_id"] == "exec-uuid-watchdog"
         assert row["reason"] == "attributed"
 
-    async def test_watchdog_stack_stored_in_source_location(
-        self,
-        executor: CommandExecutor,
-        db: tuple[DatabaseService, int],
-    ) -> None:
+    async def test_watchdog_stack_stored_in_source_location(self, executor: CommandExecutor, db: DbFixture) -> None:
         """Tier 1 stack text is stored in source_location column."""
         db_svc, _ = db
         stack = '  File "my_app.py", line 42, in on_event (my_app)'
@@ -137,18 +130,11 @@ class TestTier1Persistence:
             reason="attributed",
         )
 
-        executor.record_blocking_event(event)
-        await _drain_tasks(db_svc)
-
-        rows = await _fetch_blocking_events(db_svc)
+        rows = await _record_and_fetch(executor, db_svc, event)
         assert len(rows) == 1
         assert rows[0]["source_location"] == stack
 
-    async def test_watchdog_no_stack_source_location_is_null(
-        self,
-        executor: CommandExecutor,
-        db: tuple[DatabaseService, int],
-    ) -> None:
+    async def test_watchdog_no_stack_source_location_is_null(self, executor: CommandExecutor, db: DbFixture) -> None:
         """Tier 1 with no stack → source_location is NULL."""
         db_svc, _ = db
         event = WatchdogEvent(
@@ -163,27 +149,17 @@ class TestTier1Persistence:
             reason="attributed",
         )
 
-        executor.record_blocking_event(event)
-        await _drain_tasks(db_svc)
-
-        rows = await _fetch_blocking_events(db_svc)
+        rows = await _record_and_fetch(executor, db_svc, event)
         assert rows[0]["source_location"] is None
 
 
 class TestTier2Persistence:
-    async def test_monkeypatch_event_inserts_one_row(
-        self,
-        executor: CommandExecutor,
-        db: tuple[DatabaseService, int],
-    ) -> None:
+    async def test_monkeypatch_event_inserts_one_row(self, executor: CommandExecutor, db: DbFixture) -> None:
         """One MonkeypatchEvent → exactly one blocking_events row."""
         db_svc, session_id = db
         event = _make_monkeypatch_event()
 
-        executor.record_blocking_event(event)
-        await _drain_tasks(db_svc)
-
-        rows = await _fetch_blocking_events(db_svc)
+        rows = await _record_and_fetch(executor, db_svc, event)
         assert len(rows) == 1
 
         row = rows[0]
@@ -197,11 +173,7 @@ class TestTier2Persistence:
         assert row["execution_id"] == "exec-uuid-monkeypatch"
         assert row["reason"] == "attributed"
 
-    async def test_two_events_two_rows(
-        self,
-        executor: CommandExecutor,
-        db: tuple[DatabaseService, int],
-    ) -> None:
+    async def test_two_events_two_rows(self, executor: CommandExecutor, db: DbFixture) -> None:
         """Two separate events produce two separate rows."""
         db_svc, _ = db
 
@@ -217,18 +189,13 @@ class TestTier2Persistence:
 
 class TestUnresolvedOwnerPersistence:
     async def test_watchdog_unresolved_owner_recorded_as_framework(
-        self,
-        executor: CommandExecutor,
-        db: tuple[DatabaseService, int],
+        self, executor: CommandExecutor, db: DbFixture
     ) -> None:
         """WatchdogEvent with app_key=None → row with source_tier='framework', NOT dropped."""
         db_svc, _ = db
         event = _make_watchdog_event(app_key=None)
 
-        executor.record_blocking_event(event)
-        await _drain_tasks(db_svc)
-
-        rows = await _fetch_blocking_events(db_svc)
+        rows = await _record_and_fetch(executor, db_svc, event)
         assert len(rows) == 1, "Unresolved owner must NOT be dropped"
 
         row = rows[0]
@@ -240,18 +207,13 @@ class TestUnresolvedOwnerPersistence:
         assert row["reason"] == "framework"
 
     async def test_monkeypatch_unresolved_owner_recorded_as_framework(
-        self,
-        executor: CommandExecutor,
-        db: tuple[DatabaseService, int],
+        self, executor: CommandExecutor, db: DbFixture
     ) -> None:
         """MonkeypatchEvent with app_key=None → row with source_tier='framework', NOT dropped."""
         db_svc, _ = db
         event = _make_monkeypatch_event(app_key=None)
 
-        executor.record_blocking_event(event)
-        await _drain_tasks(db_svc)
-
-        rows = await _fetch_blocking_events(db_svc)
+        rows = await _record_and_fetch(executor, db_svc, event)
         assert len(rows) == 1, "Unresolved owner must NOT be dropped"
 
         row = rows[0]
@@ -263,9 +225,7 @@ class TestUnresolvedOwnerPersistence:
         assert row["reason"] == "framework"
 
     async def test_both_unresolved_events_are_framework_attributed(
-        self,
-        executor: CommandExecutor,
-        db: tuple[DatabaseService, int],
+        self, executor: CommandExecutor, db: DbFixture
     ) -> None:
         """Both tier flavors with app_key=None produce framework-attributed rows."""
         db_svc, _ = db

--- a/tests/integration/telemetry/test_blocking_io_executor_offload.py
+++ b/tests/integration/telemetry/test_blocking_io_executor_offload.py
@@ -49,6 +49,8 @@ from hassette.exceptions import HassetteBlockingIOWarning
 from hassette.test_utils.config import make_test_config
 from hassette.types.enums import BlockingIOBehavior
 
+from .helpers import DbFixture, open_db_with_session, running_command_executor
+
 
 async def _fetch_blocking_events(db_svc: DatabaseService) -> list[dict]:
     """Return all rows from blocking_events as plain dicts."""
@@ -121,32 +123,18 @@ def loop_thread_id() -> int:
 
 
 @pytest.fixture
-async def executor(
-    db_hassette: MagicMock,
-    db: tuple[DatabaseService, int],
-) -> AsyncIterator[CommandExecutor]:
+async def executor(db_hassette: MagicMock, db: DbFixture) -> AsyncIterator[CommandExecutor]:
     """CommandExecutor wired to the real DB via the telemetry conftest's ``db`` fixture."""
     _db_service, _session_id = db
-    exc = CommandExecutor(db_hassette, parent=None)
-    await exc.on_initialize()
-    try:
+    async with running_command_executor(db_hassette) as exc:
         yield exc
-    finally:
-        await exc.on_shutdown()
 
 
 @pytest.fixture
 async def ignore_db(premigrated_db_path: Path) -> AsyncIterator[tuple[DatabaseService, "MagicMock", int]]:
     """DatabaseService + unsealed hassette mock + session_id for ignore-behavior tests."""
     mock_hassette = _make_ignore_hassette(premigrated_db_path)
-    db_service = DatabaseService(mock_hassette, parent=None)
-    await db_service.on_initialize()
-    cursor = await db_service.db.execute(
-        "INSERT INTO sessions (started_at, last_heartbeat_at, status) VALUES (?, ?, 'running')",
-        (time.time(), time.time()),
-    )
-    session_id = cursor.lastrowid
-    await db_service.db.commit()
+    db_service, session_id = await open_db_with_session(mock_hassette)
     mock_hassette.session_id = session_id
     mock_hassette.try_session_id.return_value = session_id
     mock_hassette.database_service = db_service
@@ -157,17 +145,11 @@ async def ignore_db(premigrated_db_path: Path) -> AsyncIterator[tuple[DatabaseSe
 
 
 @pytest.fixture
-async def ignore_executor(
-    ignore_db: tuple[DatabaseService, "MagicMock", int],
-) -> AsyncIterator[CommandExecutor]:
+async def ignore_executor(ignore_db: tuple[DatabaseService, "MagicMock", int]) -> AsyncIterator[CommandExecutor]:
     """CommandExecutor wired to the ignore_db hassette and session."""
     _db_service, mock_hassette, _session_id = ignore_db
-    exc = CommandExecutor(mock_hassette, parent=None)
-    await exc.on_initialize()
-    try:
+    async with running_command_executor(mock_hassette) as exc:
         yield exc
-    finally:
-        await exc.on_shutdown()
 
 
 class TestExecutorOffloadProducesNoBlocking:
@@ -179,10 +161,7 @@ class TestExecutorOffloadProducesNoBlocking:
     """
 
     async def test_tier2_does_not_flag_worker_thread_sleep(
-        self,
-        executor: CommandExecutor,
-        db: tuple[DatabaseService, int],
-        loop_thread_id: int,
+        self, executor: CommandExecutor, db: DbFixture, loop_thread_id: int
     ) -> None:
         """time.sleep on a WORKER thread produces zero warnings and zero DB rows.
 
@@ -242,10 +221,7 @@ class TestExecutorOffloadProducesNoBlocking:
         )
 
     async def test_tier1_watchdog_does_not_flag_worker_thread_sleep(
-        self,
-        executor: CommandExecutor,
-        db: tuple[DatabaseService, int],
-        loop_thread_id: int,
+        self, executor: CommandExecutor, db: DbFixture, loop_thread_id: int
     ) -> None:
         """Worker-thread sleep keeps the loop responsive — Tier 1 never fires.
 
@@ -350,10 +326,7 @@ class TestIgnoreBehaviorSuppressesRowAndWarning:
     """
 
     async def test_tier2_ignore_suppresses_warning_and_row(
-        self,
-        ignore_executor: CommandExecutor,
-        ignore_db: tuple[DatabaseService, "MagicMock", int],
-        loop_thread_id: int,
+        self, ignore_executor: CommandExecutor, ignore_db: tuple[DatabaseService, "MagicMock", int], loop_thread_id: int
     ) -> None:
         """Tier 2 with ignore behavior: time.sleep on loop thread → no warning, no row.
 
@@ -406,10 +379,7 @@ class TestIgnoreBehaviorSuppressesRowAndWarning:
         assert len(rows) == 0, f"ignore behavior must suppress blocking_events row, got {len(rows)}: {rows}"
 
     async def test_tier1_ignore_suppresses_warning_and_row(
-        self,
-        ignore_executor: CommandExecutor,
-        ignore_db: tuple[DatabaseService, "MagicMock", int],
-        loop_thread_id: int,
+        self, ignore_executor: CommandExecutor, ignore_db: tuple[DatabaseService, "MagicMock", int], loop_thread_id: int
     ) -> None:
         """Tier 1 with ignore behavior: loop stall → no warning, no row.
 

--- a/tests/integration/telemetry/test_blocking_io_executor_offload.py
+++ b/tests/integration/telemetry/test_blocking_io_executor_offload.py
@@ -49,28 +49,7 @@ from hassette.exceptions import HassetteBlockingIOWarning
 from hassette.test_utils.config import make_test_config
 from hassette.types.enums import BlockingIOBehavior
 
-from .helpers import DbFixture, open_db_with_session, running_command_executor
-
-
-async def _fetch_blocking_events(db_svc: DatabaseService) -> list[dict]:
-    """Return all rows from blocking_events as plain dicts."""
-    cursor = await db_svc.db.execute("SELECT * FROM blocking_events ORDER BY id")
-    rows = await cursor.fetchall()
-    return [dict(row) for row in rows]
-
-
-async def _drain(db_svc: DatabaseService) -> None:
-    """Block until every enqueued record_blocking_event DB write has been processed.
-
-    The single-writer DB worker drains its queue in FIFO order, so submitting a sentinel coroutine
-    and awaiting it guarantees that all writes enqueued before it have finished — deterministic
-    where a fixed sleep would race the worker on slow CI.
-    """
-
-    async def _sentinel() -> None:
-        return None
-
-    await db_svc.submit(_sentinel())
+from .helpers import DbFixture, drain_db_writes, fetch_blocking_events, open_db_with_session, running_command_executor
 
 
 def _make_ignore_hassette(premigrated_db_path: Path) -> MagicMock:
@@ -204,7 +183,7 @@ class TestExecutorOffloadProducesNoBlocking:
                 )
 
                 # Drain so any (unexpected) record_blocking_event tasks would have persisted.
-                await _drain(db_svc)
+                await drain_db_writes(db_svc)
         finally:
             uninstall()
             mock_hassette.config.blocking_io.deep_detection_enabled = None
@@ -215,7 +194,7 @@ class TestExecutorOffloadProducesNoBlocking:
             f"got: {[str(w.message) for w in blocking_warnings]}"
         )
 
-        rows = await _fetch_blocking_events(db_svc)
+        rows = await fetch_blocking_events(db_svc)
         assert len(rows) == 0, (
             f"Expected zero blocking_events rows for executor-offloaded sync handler, got {len(rows)}: {rows}"
         )
@@ -293,7 +272,7 @@ class TestExecutorOffloadProducesNoBlocking:
 
                         # Give the watchdog multiple poll cycles to notice if it wrongly flags.
                         await asyncio.sleep(0.3)
-                        await _drain(db_svc)
+                        await drain_db_writes(db_svc)
                     finally:
                         executor.unbind_execution_context(token)
             finally:
@@ -309,7 +288,7 @@ class TestExecutorOffloadProducesNoBlocking:
         )
         assert stall_events == [], f"Tier 1 on_stall must not fire for a worker-thread sleep, got: {stall_events}"
 
-        rows = await _fetch_blocking_events(db_svc)
+        rows = await fetch_blocking_events(db_svc)
         assert len(rows) == 0, f"Expected zero blocking_events rows for worker-thread sleep, got {len(rows)}: {rows}"
 
 
@@ -361,7 +340,7 @@ class TestIgnoreBehaviorSuppressesRowAndWarning:
                     # Call time.sleep on the LOOP thread — Tier 2 fires unless behavior is IGNORE.
                     time.sleep(0.01)  # noqa: ASYNC251
 
-                    await _drain(db_svc)
+                    await drain_db_writes(db_svc)
             finally:
                 uninstall()
                 ignore_executor.unbind_execution_context(token)
@@ -375,7 +354,7 @@ class TestIgnoreBehaviorSuppressesRowAndWarning:
             f"got: {[str(w.message) for w in blocking_warnings]}"
         )
 
-        rows = await _fetch_blocking_events(db_svc)
+        rows = await fetch_blocking_events(db_svc)
         assert len(rows) == 0, f"ignore behavior must suppress blocking_events row, got {len(rows)}: {rows}"
 
     async def test_tier1_ignore_suppresses_warning_and_row(
@@ -436,7 +415,7 @@ class TestIgnoreBehaviorSuppressesRowAndWarning:
 
                     # Let the watchdog recover and process the (suppressed) episode.
                     await asyncio.sleep(0.4)
-                    await _drain(db_svc)
+                    await drain_db_writes(db_svc)
             finally:
                 watchdog.stop()
 
@@ -450,5 +429,5 @@ class TestIgnoreBehaviorSuppressesRowAndWarning:
         # IGNORE short-circuits in _emit BEFORE on_stall, so persistence never fires.
         assert stall_events == [], f"IGNORE must short-circuit before on_stall, got: {stall_events}"
 
-        rows = await _fetch_blocking_events(db_svc)
+        rows = await fetch_blocking_events(db_svc)
         assert len(rows) == 0, f"Tier 1 with ignore behavior must produce no DB rows, got {len(rows)}: {rows}"

--- a/tests/integration/telemetry/test_execution_queries.py
+++ b/tests/integration/telemetry/test_execution_queries.py
@@ -7,19 +7,14 @@ import time
 
 import pytest
 
-from hassette.core.database_service import DatabaseService
 from hassette.core.telemetry.query_service import TelemetryQueryService
 from hassette.schemas.execution_models import Execution
 
-from .helpers import insert_execution, insert_invocation, insert_job, insert_listener
+from .helpers import DbFixture, insert_execution, insert_invocation, insert_job, insert_listener
 
 
 class TestGetExecutionsForListener:
-    async def test_get_executions_handler_ordered(
-        self,
-        query_service: TelemetryQueryService,
-        db: tuple[DatabaseService, int],
-    ) -> None:
+    async def test_get_executions_handler_ordered(self, query_service: TelemetryQueryService, db: DbFixture) -> None:
         """5 invocations at different timestamps — most recent first, limit respected."""
         db_svc, session_id = db
         listener_id = await insert_listener(db_svc)
@@ -38,11 +33,7 @@ class TestGetExecutionsForListener:
 
 
 class TestGetExecutionsForJob:
-    async def test_get_executions_job_ordered(
-        self,
-        query_service: TelemetryQueryService,
-        db: tuple[DatabaseService, int],
-    ) -> None:
+    async def test_get_executions_job_ordered(self, query_service: TelemetryQueryService, db: DbFixture) -> None:
         """3 executions — ordered DESC, respects limit."""
         db_svc, session_id = db
         job_id = await insert_job(db_svc)
@@ -59,11 +50,7 @@ class TestGetExecutionsForJob:
 
 
 class TestGetSlowHandlers:
-    async def test_get_slow_handlers(
-        self,
-        query_service: TelemetryQueryService,
-        db: tuple[DatabaseService, int],
-    ) -> None:
+    async def test_get_slow_handlers(self, query_service: TelemetryQueryService, db: DbFixture) -> None:
         """Mix of fast + slow invocations — only above threshold returned, ordered by duration."""
         db_svc, session_id = db
         listener_id = await insert_listener(db_svc)

--- a/tests/integration/telemetry/test_global_jobs_and_service_info.py
+++ b/tests/integration/telemetry/test_global_jobs_and_service_info.py
@@ -243,6 +243,10 @@ class TestGlobalJobsEndpointMultipleApps:
 
 
 class TestGlobalJobsEndpointEnrichesWithLiveData:
+    # dup-ignore-start: parallel "register a live job, wire get_all_jobs, fetch the one row, assert its
+    # fields" test shape shared with the sibling test in this class and with
+    # TestGlobalJobsEndpointLegacyUnknown — each varies only the live-job shape and the fields it
+    # asserts on.
     async def test_enriches_with_live_heap_data(self, scheduler_client, mock_hassette_scheduler) -> None:
         """Global jobs endpoint enriches DB rows with live next_run, fire_at, jitter."""
         db_summary = make_job_summary(job_id=42, app_key="my_app", next_run=None)
@@ -262,6 +266,8 @@ class TestGlobalJobsEndpointEnrichesWithLiveData:
         assert row["fire_at"] is not None
         assert row["schedule_status"] == "scheduled"
 
+    # dup-ignore-end
+
     @pytest.mark.parametrize(
         ("status", "reason"),
         [
@@ -271,6 +277,10 @@ class TestGlobalJobsEndpointEnrichesWithLiveData:
             (ScheduleStatus.MANUAL, None),
         ],
     )
+    # dup-ignore-start: parallel "register a live job, wire get_all_jobs, fetch the one row, assert its
+    # fields" test shape shared with the sibling test in this class and with
+    # TestGlobalJobsEndpointLegacyUnknown — each varies only the live-job shape and the fields it
+    # asserts on.
     async def test_enriches_non_scheduled_statuses_with_null_timing(
         self, scheduler_client, mock_hassette_scheduler, status: ScheduleStatus, reason: ScheduleStatusReason | None
     ) -> None:
@@ -289,6 +299,8 @@ class TestGlobalJobsEndpointEnrichesWithLiveData:
         assert row["fire_at"] is None
         assert row["schedule_status"] == status.value
         assert row["schedule_status_reason"] == (reason.value if reason is not None else None)
+
+    # dup-ignore-end
 
 
 class TestGlobalJobsEndpointLegacyUnknown:
@@ -311,6 +323,9 @@ class TestGlobalJobsEndpointLegacyUnknown:
         assert row["schedule_status_reason"] == "legacy_unknown"
         assert row["next_run"] is None
 
+    # dup-ignore-start: parallel "register a live job, wire get_all_jobs, fetch the one row, assert its
+    # fields" test shape shared with the sibling tests in TestGlobalJobsEndpointEnrichesWithLiveData —
+    # each varies only the live-job shape and the fields it asserts on.
     async def test_live_reregistration_clears_legacy_placeholder(
         self, scheduler_client, mock_hassette_scheduler
     ) -> None:
@@ -334,6 +349,8 @@ class TestGlobalJobsEndpointLegacyUnknown:
         assert row["schedule_status"] == "scheduled"
         assert row["schedule_status_reason"] is None
         assert row["next_run"] is not None
+
+    # dup-ignore-end
 
 
 class TestGlobalJobsEndpointDegradedOnHeapFailure:

--- a/tests/integration/telemetry/test_global_jobs_and_service_info.py
+++ b/tests/integration/telemetry/test_global_jobs_and_service_info.py
@@ -329,8 +329,7 @@ class TestGlobalJobsEndpointLegacyUnknown:
         live_job.mark_registered(77)
         mock_hassette_scheduler.scheduler_service.get_all_jobs = AsyncMock(return_value=[live_job])
 
-        data = await get_jobs(scheduler_client)
-        row = data[0]
+        row = await get_only_job(scheduler_client)
 
         assert row["schedule_status"] == "scheduled"
         assert row["schedule_status_reason"] is None

--- a/tests/integration/telemetry/test_global_jobs_and_service_info.py
+++ b/tests/integration/telemetry/test_global_jobs_and_service_info.py
@@ -13,7 +13,6 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 from httpx2 import ASGITransport, AsyncClient
 
-from hassette.core.database_service import DatabaseService
 from hassette.core.runtime_query_service import RuntimeQueryService
 from hassette.core.telemetry.query_service import TelemetryQueryService
 from hassette.exceptions import TelemetryUnavailableError
@@ -29,20 +28,20 @@ from hassette.web.mappers import system_status_response_from
 from hassette.web.models import ServiceInfoResponse
 
 from .helpers import (
+    SINCE_WINDOW_ERROR_ROWS,
+    DbFixture,
     assert_last_error_row_coherence,
+    error_row,
     insert_execution,
     insert_job,
+    only_row,
 )
 
 STUB_TIMESTAMP = 1_700_000_000.0
 
 
 class TestGetJobSummaryGlobal:
-    async def test_returns_jobs_from_multiple_apps(
-        self,
-        query_service: TelemetryQueryService,
-        db: tuple[DatabaseService, int],
-    ) -> None:
+    async def test_returns_jobs_from_multiple_apps(self, query_service: TelemetryQueryService, db: DbFixture) -> None:
         """get_job_summary() aggregates jobs from multiple apps without app_key filter."""
         db_svc, session_id = db
 
@@ -59,11 +58,7 @@ class TestGetJobSummaryGlobal:
         assert app_keys == {"app_alpha", "app_beta"}
         assert all(isinstance(r, JobSummary) for r in results)
 
-    async def test_no_app_key_filter_returns_all(
-        self,
-        query_service: TelemetryQueryService,
-        db: tuple[DatabaseService, int],
-    ) -> None:
+    async def test_no_app_key_filter_returns_all(self, query_service: TelemetryQueryService, db: DbFixture) -> None:
         """All jobs are returned regardless of app_key when no filter is applied."""
         db_svc, _ = db
 
@@ -73,11 +68,7 @@ class TestGetJobSummaryGlobal:
         results = await query_service.get_job_summary()
         assert len(results) == 5
 
-    async def test_includes_error_fields(
-        self,
-        query_service: TelemetryQueryService,
-        db: tuple[DatabaseService, int],
-    ) -> None:
+    async def test_includes_error_fields(self, query_service: TelemetryQueryService, db: DbFixture) -> None:
         """Jobs with failed executions have last_error_type, last_error_message populated."""
         db_svc, session_id = db
 
@@ -92,17 +83,11 @@ class TestGetJobSummaryGlobal:
             error_message="something went wrong",
         )
 
-        results = await query_service.get_job_summary()
-        assert len(results) == 1
-        row = results[0]
+        row = await only_row(query_service.get_job_summary())
         assert row.last_error_type == "RuntimeError"
         assert row.last_error_message == "something went wrong"
 
-    async def test_includes_min_max_duration(
-        self,
-        query_service: TelemetryQueryService,
-        db: tuple[DatabaseService, int],
-    ) -> None:
+    async def test_includes_min_max_duration(self, query_service: TelemetryQueryService, db: DbFixture) -> None:
         """min_duration_ms and max_duration_ms are populated from executions."""
         db_svc, session_id = db
 
@@ -111,32 +96,22 @@ class TestGetJobSummaryGlobal:
         await insert_execution(db_svc, j1, session_id, status="success", duration_ms=100.0)
         await insert_execution(db_svc, j1, session_id, status="success", duration_ms=50.0)
 
-        results = await query_service.get_job_summary()
-        assert len(results) == 1
-        row = results[0]
+        row = await only_row(query_service.get_job_summary())
         assert row.min_duration_ms == pytest.approx(5.0)
         assert row.max_duration_ms == pytest.approx(100.0)
 
-    async def test_no_executions_has_none_min_max(
-        self,
-        query_service: TelemetryQueryService,
-        db: tuple[DatabaseService, int],
-    ) -> None:
+    async def test_no_executions_has_none_min_max(self, query_service: TelemetryQueryService, db: DbFixture) -> None:
         """Jobs with no executions have min/max duration as None (never executed)."""
         db_svc, _ = db
 
         await insert_job(db_svc, app_key="my_app", job_name="idle_job")
 
-        results = await query_service.get_job_summary()
-        assert len(results) == 1
-        row = results[0]
+        row = await only_row(query_service.get_job_summary())
         assert row.min_duration_ms is None
         assert row.max_duration_ms is None
 
     async def test_since_filter_restricts_by_timestamp(
-        self,
-        query_service: TelemetryQueryService,
-        db: tuple[DatabaseService, int],
+        self, query_service: TelemetryQueryService, db: DbFixture
     ) -> None:
         """Since parameter filters executions by timestamp."""
         db_svc, session_id = db
@@ -150,15 +125,11 @@ class TestGetJobSummaryGlobal:
         # After since: should count
         await insert_execution(db_svc, j1, session_id, status="success", execution_start_ts=base_ts + 10.0)
 
-        results = await query_service.get_job_summary(since=since_ts)
-        assert len(results) == 1
-        row = results[0]
+        row = await only_row(query_service.get_job_summary(since=since_ts))
         assert row.total_executions == 1
 
     async def test_source_tier_app_excludes_framework(
-        self,
-        query_service: TelemetryQueryService,
-        db: tuple[DatabaseService, int],
+        self, query_service: TelemetryQueryService, db: DbFixture
     ) -> None:
         """source_tier='app' excludes framework-tier jobs."""
         db_svc, _ = db
@@ -171,9 +142,7 @@ class TestGetJobSummaryGlobal:
         assert results[0].source_tier == "app"
 
     async def test_source_tier_all_includes_both_tiers(
-        self,
-        query_service: TelemetryQueryService,
-        db: tuple[DatabaseService, int],
+        self, query_service: TelemetryQueryService, db: DbFixture
     ) -> None:
         """source_tier='all' returns both app and framework tier jobs."""
         db_svc, _ = db
@@ -184,11 +153,7 @@ class TestGetJobSummaryGlobal:
         results = await query_service.get_job_summary(source_tier="all")
         assert len(results) == 2
 
-    async def test_last_error_row_coherence(
-        self,
-        query_service: TelemetryQueryService,
-        db: tuple[DatabaseService, int],
-    ) -> None:
+    async def test_last_error_row_coherence(self, query_service: TelemetryQueryService, db: DbFixture) -> None:
         """Multiple errors — all last_error_* columns come from the most recent error row."""
         db_svc, session_id = db
         base_ts = 1_000_000.0
@@ -199,26 +164,12 @@ class TestGetJobSummaryGlobal:
             lambda **kw: insert_execution(db_svc, j1, session_id, **kw),
             lambda: query_service.get_job_summary(),
             [
-                {
-                    "error_type": "OldError",
-                    "error_message": "old message",
-                    "error_traceback": "old traceback",
-                    "execution_start_ts": base_ts + 1.0,
-                },
-                {
-                    "error_type": "NewError",
-                    "error_message": "new message",
-                    "error_traceback": "new traceback",
-                    "execution_start_ts": base_ts + 10.0,
-                },
+                error_row("OldError", "old message", "old traceback", base_ts + 1.0),
+                error_row("NewError", "new message", "new traceback", base_ts + 10.0),
             ],
         )
 
-    async def test_since_filter_scopes_error_cte(
-        self,
-        query_service: TelemetryQueryService,
-        db: tuple[DatabaseService, int],
-    ) -> None:
+    async def test_since_filter_scopes_error_cte(self, query_service: TelemetryQueryService, db: DbFixture) -> None:
         """Error before the since window is excluded from last_error_* in get_job_summary."""
         db_svc, session_id = db
         base_ts = 1_000_000.0
@@ -229,20 +180,7 @@ class TestGetJobSummaryGlobal:
         await assert_last_error_row_coherence(
             lambda **kw: insert_execution(db_svc, j1, session_id, **kw),
             lambda: query_service.get_job_summary(since=since_ts),
-            [
-                {
-                    "error_type": "OldError",
-                    "error_message": "before window",
-                    "error_traceback": "old tb",
-                    "execution_start_ts": base_ts + 1.0,
-                },
-                {
-                    "error_type": "NewError",
-                    "error_message": "inside window",
-                    "error_traceback": "new tb",
-                    "execution_start_ts": base_ts + 100.0,
-                },
-            ],
+            SINCE_WINDOW_ERROR_ROWS,
         )
 
 
@@ -261,15 +199,32 @@ async def scheduler_client(mock_hassette_scheduler):
         yield ac
 
 
+async def get_jobs(client: AsyncClient, *, expect_status: int = 200) -> list[dict]:
+    """GET /api/scheduler/jobs, assert the status code, and return the decoded body."""
+    response = await client.get("/api/scheduler/jobs")
+    assert response.status_code == expect_status
+    return response.json()
+
+
+async def get_only_job(client: AsyncClient) -> dict:
+    """GET /api/scheduler/jobs, assert exactly one row came back, and return it."""
+    data = await get_jobs(client)
+    assert len(data) == 1
+    return data[0]
+
+
+def stub_job_sources(hassette: MagicMock, *, db_rows: list, live_jobs: list | None = None) -> None:
+    """Point the endpoint's two data sources at fixed rows: the telemetry DB and the live heap."""
+    hassette.telemetry_query_service.get_job_summary = AsyncMock(return_value=db_rows)
+    hassette.scheduler_service.get_all_jobs = AsyncMock(return_value=live_jobs if live_jobs is not None else [])
+
+
 class TestGlobalJobsEndpointExists:
     async def test_endpoint_returns_200(self, scheduler_client, mock_hassette_scheduler) -> None:
         """GET /api/scheduler/jobs returns 200 and a list."""
-        mock_hassette_scheduler.telemetry_query_service.get_job_summary = AsyncMock(return_value=[])
-        mock_hassette_scheduler.scheduler_service.get_all_jobs = AsyncMock(return_value=[])
+        stub_job_sources(mock_hassette_scheduler, db_rows=[])
 
-        response = await scheduler_client.get("/api/scheduler/jobs")
-        assert response.status_code == 200
-        assert response.json() == []
+        assert await get_jobs(scheduler_client) == []
 
 
 class TestGlobalJobsEndpointMultipleApps:
@@ -279,12 +234,9 @@ class TestGlobalJobsEndpointMultipleApps:
             make_job_summary(job_id=1, app_key="app_alpha", next_run=None),
             make_job_summary(job_id=2, app_key="app_beta", next_run=None),
         ]
-        mock_hassette_scheduler.telemetry_query_service.get_job_summary = AsyncMock(return_value=db_jobs)
-        mock_hassette_scheduler.scheduler_service.get_all_jobs = AsyncMock(return_value=[])
+        stub_job_sources(mock_hassette_scheduler, db_rows=db_jobs)
 
-        response = await scheduler_client.get("/api/scheduler/jobs")
-        assert response.status_code == 200
-        data = response.json()
+        data = await get_jobs(scheduler_client)
         assert len(data) == 2
         app_keys = {row["app_key"] for row in data}
         assert app_keys == {"app_alpha", "app_beta"}
@@ -302,11 +254,7 @@ class TestGlobalJobsEndpointEnrichesWithLiveData:
         live_job.fire_at = live_job.next_run.add(seconds=5.0)
         mock_hassette_scheduler.scheduler_service.get_all_jobs = AsyncMock(return_value=[live_job])
 
-        response = await scheduler_client.get("/api/scheduler/jobs")
-        assert response.status_code == 200
-        data = response.json()
-        assert len(data) == 1
-        row = data[0]
+        row = await get_only_job(scheduler_client)
 
         assert row["next_run"] is not None
         assert isinstance(row["next_run"], float)
@@ -335,11 +283,7 @@ class TestGlobalJobsEndpointEnrichesWithLiveData:
         live_job.transition_to(status, reason=reason)
         mock_hassette_scheduler.scheduler_service.get_all_jobs = AsyncMock(return_value=[live_job])
 
-        response = await scheduler_client.get("/api/scheduler/jobs")
-        assert response.status_code == 200
-        data = response.json()
-        assert len(data) == 1
-        row = data[0]
+        row = await get_only_job(scheduler_client)
 
         assert row["next_run"] is None
         assert row["fire_at"] is None
@@ -359,14 +303,9 @@ class TestGlobalJobsEndpointLegacyUnknown:
             schedule_status="scheduled",
             schedule_status_reason="legacy_unknown",
         )
-        mock_hassette_scheduler.telemetry_query_service.get_job_summary = AsyncMock(return_value=[db_summary])
-        mock_hassette_scheduler.scheduler_service.get_all_jobs = AsyncMock(return_value=[])
+        stub_job_sources(mock_hassette_scheduler, db_rows=[db_summary])
 
-        response = await scheduler_client.get("/api/scheduler/jobs")
-        assert response.status_code == 200
-        data = response.json()
-        assert len(data) == 1
-        row = data[0]
+        row = await get_only_job(scheduler_client)
 
         assert row["schedule_status"] == "scheduled"
         assert row["schedule_status_reason"] == "legacy_unknown"
@@ -390,9 +329,7 @@ class TestGlobalJobsEndpointLegacyUnknown:
         live_job.mark_registered(77)
         mock_hassette_scheduler.scheduler_service.get_all_jobs = AsyncMock(return_value=[live_job])
 
-        response = await scheduler_client.get("/api/scheduler/jobs")
-        assert response.status_code == 200
-        data = response.json()
+        data = await get_jobs(scheduler_client)
         row = data[0]
 
         assert row["schedule_status"] == "scheduled"
@@ -407,9 +344,7 @@ class TestGlobalJobsEndpointDegradedOnHeapFailure:
         mock_hassette_scheduler.telemetry_query_service.get_job_summary = AsyncMock(return_value=[db_summary])
         mock_hassette_scheduler.scheduler_service.get_all_jobs = AsyncMock(side_effect=RuntimeError("heap unavailable"))
 
-        response = await scheduler_client.get("/api/scheduler/jobs")
-        assert response.status_code == 200
-        data = response.json()
+        data = await get_jobs(scheduler_client)
         assert len(data) == 1
         assert data[0]["next_run"] is None
         assert data[0]["fire_at"] is None
@@ -420,9 +355,7 @@ class TestGlobalJobsEndpointDegradedOnHeapFailure:
             side_effect=TelemetryUnavailableError("disk I/O error")
         )
 
-        response = await scheduler_client.get("/api/scheduler/jobs")
-        assert response.status_code == 503
-        assert response.json() == []
+        assert await get_jobs(scheduler_client, expect_status=503) == []
 
     async def test_trigger_error_reason_survives_degraded_fallback(
         self, scheduler_client, mock_hassette_scheduler
@@ -437,9 +370,7 @@ class TestGlobalJobsEndpointDegradedOnHeapFailure:
         mock_hassette_scheduler.telemetry_query_service.get_job_summary = AsyncMock(return_value=[db_summary])
         mock_hassette_scheduler.scheduler_service.get_all_jobs = AsyncMock(side_effect=RuntimeError("heap unavailable"))
 
-        response = await scheduler_client.get("/api/scheduler/jobs")
-        assert response.status_code == 200
-        data = response.json()
+        data = await get_jobs(scheduler_client)
         assert len(data) == 1
         assert data[0]["schedule_status"] == "completed"
         assert data[0]["schedule_status_reason"] == "trigger_error"

--- a/tests/integration/telemetry/test_health_aggregates_and_global_listeners.py
+++ b/tests/integration/telemetry/test_health_aggregates_and_global_listeners.py
@@ -11,13 +11,14 @@ Covers:
 
 import pytest
 
-from hassette.core.database_service import DatabaseService
 from hassette.core.telemetry.query_service import AppHealthAggregates, TelemetryQueryService
 from hassette.schemas.listener_models import ListenerSummary
 
 from .helpers import (
     BASE_TS,
+    DbFixture,
     assert_last_error_row_coherence,
+    error_row,
     insert_execution,
     insert_invocation,
     insert_job,
@@ -27,9 +28,7 @@ from .helpers import (
 
 class TestGetAppHealthAggregates:
     async def test_returns_correct_totals_matching_per_item_sums(
-        self,
-        query_service: TelemetryQueryService,
-        db: tuple[DatabaseService, int],
+        self, query_service: TelemetryQueryService, db: DbFixture
     ) -> None:
         """Totals from get_app_health_aggregates() match sum of per-listener/per-job detail queries."""
         db_svc, session_id = db
@@ -69,9 +68,7 @@ class TestGetAppHealthAggregates:
         assert agg.last_activity_ts is not None
 
     async def test_excludes_cancelled_listener_invocations(
-        self,
-        query_service: TelemetryQueryService,
-        db: tuple[DatabaseService, int],
+        self, query_service: TelemetryQueryService, db: DbFixture
     ) -> None:
         """A cancelled listener's invocations are excluded from handler aggregates."""
         db_svc, session_id = db
@@ -90,9 +87,7 @@ class TestGetAppHealthAggregates:
         assert agg.handler_errors == 0
 
     async def test_zero_invocations_returns_zero_values(
-        self,
-        query_service: TelemetryQueryService,
-        db: tuple[DatabaseService, int],
+        self, query_service: TelemetryQueryService, db: DbFixture
     ) -> None:
         """App with no invocations or executions returns all-zero aggregates, None last_activity_ts."""
         result = await query_service.get_app_health_aggregates(app_key="no_such_app", instance_index=0)
@@ -108,11 +103,7 @@ class TestGetAppHealthAggregates:
         assert result.job_avg_duration_ms == 0.0
         assert result.last_activity_ts is None
 
-    async def test_listeners_only_no_jobs(
-        self,
-        query_service: TelemetryQueryService,
-        db: tuple[DatabaseService, int],
-    ) -> None:
+    async def test_listeners_only_no_jobs(self, query_service: TelemetryQueryService, db: DbFixture) -> None:
         """App with handlers but no jobs returns correct handler totals, zero job totals."""
         db_svc, session_id = db
 
@@ -130,11 +121,7 @@ class TestGetAppHealthAggregates:
         assert agg.job_errors == 0
         assert agg.job_avg_duration_ms == 0.0
 
-    async def test_jobs_only_no_listeners(
-        self,
-        query_service: TelemetryQueryService,
-        db: tuple[DatabaseService, int],
-    ) -> None:
+    async def test_jobs_only_no_listeners(self, query_service: TelemetryQueryService, db: DbFixture) -> None:
         """App with jobs but no listeners returns correct job totals, zero handler totals."""
         db_svc, session_id = db
 
@@ -153,9 +140,7 @@ class TestGetAppHealthAggregates:
         assert agg.job_avg_duration_ms == pytest.approx(65.0)
 
     async def test_since_filters_handler_and_job_counts(
-        self,
-        query_service: TelemetryQueryService,
-        db: tuple[DatabaseService, int],
+        self, query_service: TelemetryQueryService, db: DbFixture
     ) -> None:
         """Since parameter restricts both handler invocations and job executions by timestamp."""
         db_svc, session_id = db
@@ -194,9 +179,7 @@ class TestGetAppHealthAggregates:
         assert agg.job_avg_duration_ms == pytest.approx(60.0)
 
     async def test_last_activity_ts_is_most_recent_across_both_tables(
-        self,
-        query_service: TelemetryQueryService,
-        db: tuple[DatabaseService, int],
+        self, query_service: TelemetryQueryService, db: DbFixture
     ) -> None:
         """last_activity_ts is the max of handler and job timestamps."""
         db_svc, session_id = db
@@ -216,11 +199,7 @@ class TestGetAppHealthAggregates:
         # Max of the two timestamps
         assert agg.last_activity_ts == pytest.approx(BASE_TS + 99.0)
 
-    async def test_instance_index_scoping(
-        self,
-        query_service: TelemetryQueryService,
-        db: tuple[DatabaseService, int],
-    ) -> None:
+    async def test_instance_index_scoping(self, query_service: TelemetryQueryService, db: DbFixture) -> None:
         """Only records for the specified instance_index are counted."""
         db_svc, session_id = db
 
@@ -248,9 +227,7 @@ class TestGetAppHealthAggregates:
 
 class TestGetListenerSummaryGlobal:
     async def test_returns_all_listeners_across_apps_and_instances(
-        self,
-        query_service: TelemetryQueryService,
-        db: tuple[DatabaseService, int],
+        self, query_service: TelemetryQueryService, db: DbFixture
     ) -> None:
         """All listeners from multiple apps and instances are returned in a single call."""
         db_svc, session_id = db
@@ -278,9 +255,7 @@ class TestGetListenerSummaryGlobal:
         assert app_keys == {"app_alpha", "app_beta"}
 
     async def test_matches_per_instance_get_listener_summary_combined(
-        self,
-        query_service: TelemetryQueryService,
-        db: tuple[DatabaseService, int],
+        self, query_service: TelemetryQueryService, db: DbFixture
     ) -> None:
         """Results match the union of per-instance get_listener_summary() calls."""
         db_svc, session_id = db
@@ -305,11 +280,7 @@ class TestGetListenerSummaryGlobal:
             assert r.failed == expected.failed
             assert r.avg_duration_ms == pytest.approx(expected.avg_duration_ms)
 
-    async def test_last_error_row_coherence(
-        self,
-        query_service: TelemetryQueryService,
-        db: tuple[DatabaseService, int],
-    ) -> None:
+    async def test_last_error_row_coherence(self, query_service: TelemetryQueryService, db: DbFixture) -> None:
         """Multiple errors — all last_error_* columns come from the same (most recent) error row."""
         db_svc, session_id = db
 
@@ -319,25 +290,13 @@ class TestGetListenerSummaryGlobal:
             lambda **kw: insert_invocation(db_svc, listener_id, session_id, **kw),
             lambda: query_service.get_listener_summary(),
             [
-                {
-                    "error_type": "OldError",
-                    "error_message": "old message",
-                    "error_traceback": "old traceback",
-                    "execution_start_ts": BASE_TS + 1.0,
-                },
-                {
-                    "error_type": "NewError",
-                    "error_message": "new message",
-                    "error_traceback": "new traceback",
-                    "execution_start_ts": BASE_TS + 10.0,
-                },
+                error_row("OldError", "old message", "old traceback", BASE_TS + 1.0),
+                error_row("NewError", "new message", "new traceback", BASE_TS + 10.0),
             ],
         )
 
     async def test_source_tier_app_excludes_framework(
-        self,
-        query_service: TelemetryQueryService,
-        db: tuple[DatabaseService, int],
+        self, query_service: TelemetryQueryService, db: DbFixture
     ) -> None:
         """source_tier='app' excludes framework-tier listeners."""
         db_svc, _ = db
@@ -353,9 +312,7 @@ class TestGetListenerSummaryGlobal:
         assert results[0].source_tier == "app"
 
     async def test_source_tier_all_includes_both_tiers(
-        self,
-        query_service: TelemetryQueryService,
-        db: tuple[DatabaseService, int],
+        self, query_service: TelemetryQueryService, db: DbFixture
     ) -> None:
         """source_tier='all' returns both app and framework tier listeners."""
         db_svc, _ = db
@@ -372,9 +329,7 @@ class TestGetListenerSummaryGlobal:
         assert tiers == {"app", "framework"}
 
     async def test_since_filter_restricts_invocation_counts(
-        self,
-        query_service: TelemetryQueryService,
-        db: tuple[DatabaseService, int],
+        self, query_service: TelemetryQueryService, db: DbFixture
     ) -> None:
         """Since parameter filters invocations — listeners still appear but with lower counts."""
         db_svc, session_id = db
@@ -398,20 +353,12 @@ class TestGetListenerSummaryGlobal:
         assert row.total_invocations == 1
         assert row.failed == 0
 
-    async def test_no_listeners_returns_empty_list(
-        self,
-        query_service: TelemetryQueryService,
-        db: tuple[DatabaseService, int],
-    ) -> None:
+    async def test_no_listeners_returns_empty_list(self, query_service: TelemetryQueryService, db: DbFixture) -> None:
         """Empty database returns empty list."""
         results = await query_service.get_listener_summary()
         assert results == []
 
-    async def test_since_filter_scopes_error_cte(
-        self,
-        query_service: TelemetryQueryService,
-        db: tuple[DatabaseService, int],
-    ) -> None:
+    async def test_since_filter_scopes_error_cte(self, query_service: TelemetryQueryService, db: DbFixture) -> None:
         """Error before the since window is excluded from last_error_* fields."""
         db_svc, session_id = db
         since_ts = BASE_TS + 50.0
@@ -422,17 +369,7 @@ class TestGetListenerSummaryGlobal:
             lambda **kw: insert_invocation(db_svc, listener_id, session_id, **kw),
             lambda: query_service.get_listener_summary(since=since_ts),
             [
-                {
-                    "error_type": "OldError",
-                    "error_message": "before window",
-                    "error_traceback": None,
-                    "execution_start_ts": BASE_TS + 1.0,
-                },
-                {
-                    "error_type": "NewError",
-                    "error_message": "inside window",
-                    "error_traceback": None,
-                    "execution_start_ts": BASE_TS + 100.0,
-                },
+                error_row("OldError", "before window", None, BASE_TS + 1.0),
+                error_row("NewError", "inside window", None, BASE_TS + 100.0),
             ],
         )

--- a/tests/integration/telemetry/test_job_queries.py
+++ b/tests/integration/telemetry/test_job_queries.py
@@ -147,8 +147,7 @@ class TestGetJobSummary:
             execution_start_ts=base_ts + 5.0,
         )
 
-        rows = await query_service.get_job_summary("test_app", 0)
-        row = rows[0]
+        row = await only_row(query_service.get_job_summary("test_app", 0))
         assert row.last_error_type == "TimeoutError"
         assert row.last_error_message == "exceeded limit"
         assert row.last_error_ts == pytest.approx(base_ts + 5.0)
@@ -172,8 +171,7 @@ class TestGetJobSummary:
             execution_start_ts=base_ts + 1.0,
         )
 
-        rows = await query_service.get_job_summary("test_app", 0, since=base_ts + 50.0)
-        row = rows[0]
+        row = await only_row(query_service.get_job_summary("test_app", 0, since=base_ts + 50.0))
         assert_no_last_error(row)
 
 

--- a/tests/integration/telemetry/test_job_queries.py
+++ b/tests/integration/telemetry/test_job_queries.py
@@ -2,19 +2,24 @@
 
 import pytest
 
-from hassette.core.database_service import DatabaseService
 from hassette.core.telemetry.query_service import TelemetryQueryService
 from hassette.schemas.job_models import JobSummary
 
-from .helpers import BASE_TS, assert_last_error_row_coherence, insert_execution, insert_job
+from .helpers import (
+    BASE_TS,
+    SINCE_WINDOW_ERROR_ROWS,
+    DbFixture,
+    assert_last_error_row_coherence,
+    assert_no_last_error,
+    error_row,
+    insert_execution,
+    insert_job,
+    only_row,
+)
 
 
 class TestGetJobSummary:
-    async def test_get_job_summary_aggregates(
-        self,
-        query_service: TelemetryQueryService,
-        db: tuple[DatabaseService, int],
-    ) -> None:
+    async def test_get_job_summary_aggregates(self, query_service: TelemetryQueryService, db: DbFixture) -> None:
         """2 jobs, mixed results — correct aggregate totals."""
         db_svc, session_id = db
 
@@ -45,9 +50,7 @@ class TestGetJobSummary:
         assert row2.failed == 0
 
     async def test_get_job_summary_error_fields_populated_when_error_exists(
-        self,
-        query_service: TelemetryQueryService,
-        db: tuple[DatabaseService, int],
+        self, query_service: TelemetryQueryService, db: DbFixture
     ) -> None:
         """A job with at least one error execution returns last_error_message, last_error_type, last_error_ts."""
         db_svc, session_id = db
@@ -78,17 +81,13 @@ class TestGetJobSummary:
             execution_start_ts=base_ts + 10.0,
         )
 
-        rows = await query_service.get_job_summary("test_app", 0)
-        assert len(rows) == 1
-        row = rows[0]
+        row = await only_row(query_service.get_job_summary("test_app", 0))
         assert row.last_error_type == "ValueError"
         assert row.last_error_message == "something went wrong"
         assert row.last_error_ts == pytest.approx(base_ts + 10.0)
 
     async def test_get_job_summary_error_fields_none_when_only_successes(
-        self,
-        query_service: TelemetryQueryService,
-        db: tuple[DatabaseService, int],
+        self, query_service: TelemetryQueryService, db: DbFixture
     ) -> None:
         """A job with only successful executions has None for all error fields."""
         db_svc, session_id = db
@@ -97,36 +96,24 @@ class TestGetJobSummary:
         await insert_execution(db_svc, job_id, session_id, status="success", duration_ms=10.0)
         await insert_execution(db_svc, job_id, session_id, status="success", duration_ms=20.0)
 
-        rows = await query_service.get_job_summary("test_app", 0)
-        assert len(rows) == 1
-        row = rows[0]
-        assert row.last_error_type is None
-        assert row.last_error_message is None
-        assert row.last_error_ts is None
+        row = await only_row(query_service.get_job_summary("test_app", 0))
+        assert_no_last_error(row)
 
     async def test_get_job_summary_error_fields_none_when_no_executions(
-        self,
-        query_service: TelemetryQueryService,
-        db: tuple[DatabaseService, int],
+        self, query_service: TelemetryQueryService, db: DbFixture
     ) -> None:
         """A job with no executions has None for all error fields AND duration fields."""
         db_svc, _session_id = db
 
         await insert_job(db_svc, job_name="idle_job")
 
-        rows = await query_service.get_job_summary("test_app", 0)
-        assert len(rows) == 1
-        row = rows[0]
-        assert row.last_error_type is None
-        assert row.last_error_message is None
-        assert row.last_error_ts is None
+        row = await only_row(query_service.get_job_summary("test_app", 0))
+        assert_no_last_error(row)
         assert row.min_duration_ms is None
         assert row.max_duration_ms is None
 
     async def test_get_job_summary_min_max_duration_correct(
-        self,
-        query_service: TelemetryQueryService,
-        db: tuple[DatabaseService, int],
+        self, query_service: TelemetryQueryService, db: DbFixture
     ) -> None:
         """A job with multiple executions at different durations returns correct min and max."""
         db_svc, session_id = db
@@ -136,17 +123,13 @@ class TestGetJobSummary:
         await insert_execution(db_svc, job_id, session_id, status="success", duration_ms=200.0)
         await insert_execution(db_svc, job_id, session_id, status="error", duration_ms=10.0)
 
-        rows = await query_service.get_job_summary("test_app", 0)
-        assert len(rows) == 1
-        row = rows[0]
+        row = await only_row(query_service.get_job_summary("test_app", 0))
         assert row.min_duration_ms == pytest.approx(10.0)
         assert row.max_duration_ms == pytest.approx(200.0)
         assert row.avg_duration_ms == pytest.approx((50.0 + 200.0 + 10.0) / 3)
 
     async def test_get_job_summary_last_error_picks_up_timed_out(
-        self,
-        query_service: TelemetryQueryService,
-        db: tuple[DatabaseService, int],
+        self, query_service: TelemetryQueryService, db: DbFixture
     ) -> None:
         """A timed-out execution is surfaced as the last error."""
         db_svc, session_id = db
@@ -171,9 +154,7 @@ class TestGetJobSummary:
         assert row.last_error_ts == pytest.approx(base_ts + 5.0)
 
     async def test_get_job_summary_last_error_none_when_error_predates_since(
-        self,
-        query_service: TelemetryQueryService,
-        db: tuple[DatabaseService, int],
+        self, query_service: TelemetryQueryService, db: DbFixture
     ) -> None:
         """Error outside the since window returns None for error fields."""
         db_svc, session_id = db
@@ -193,16 +174,11 @@ class TestGetJobSummary:
 
         rows = await query_service.get_job_summary("test_app", 0, since=base_ts + 50.0)
         row = rows[0]
-        assert row.last_error_type is None
-        assert row.last_error_ts is None
+        assert_no_last_error(row)
 
 
 class TestGetJobSummarySinceScoped:
-    async def test_get_job_summary_since_scoped(
-        self,
-        query_service: TelemetryQueryService,
-        db: tuple[DatabaseService, int],
-    ) -> None:
+    async def test_get_job_summary_since_scoped(self, query_service: TelemetryQueryService, db: DbFixture) -> None:
         """Since filter restricts job execution counts to records after the threshold."""
         db_svc, session_id = db
 
@@ -223,9 +199,7 @@ class TestGetJobSummarySinceScoped:
             db_svc, j1, session_id, status="success", duration_ms=30.0, execution_start_ts=base_ts + 1.0
         )
 
-        rows = await query_service.get_job_summary("test_app", 0, since=since_ts)
-        assert len(rows) == 1
-        row = rows[0]
+        row = await only_row(query_service.get_job_summary("test_app", 0, since=since_ts))
         assert row.total_executions == 2
         assert row.successful == 1
         assert row.failed == 1
@@ -235,9 +209,7 @@ class TestJobSummaryLastErrorRowCoherence:
     """Verify that last_error_* fields all come from the same job_executions row."""
 
     async def test_multiple_errors_returns_most_recent(
-        self,
-        query_service: TelemetryQueryService,
-        db: tuple[DatabaseService, int],
+        self, query_service: TelemetryQueryService, db: DbFixture
     ) -> None:
         """Multiple errors at different timestamps — all error columns from the most recent row."""
         db_svc, session_id = db
@@ -249,27 +221,13 @@ class TestJobSummaryLastErrorRowCoherence:
             lambda **kw: insert_execution(db_svc, job_id, session_id, **kw),
             lambda: query_service.get_job_summary("test_app", 0),
             [
-                {
-                    "error_type": "OldError",
-                    "error_message": "old message",
-                    "error_traceback": "old traceback",
-                    "execution_start_ts": base_ts + 1.0,
-                },
-                {
-                    "error_type": "NewError",
-                    "error_message": "new message",
-                    "error_traceback": "new traceback",
-                    "execution_start_ts": base_ts + 10.0,
-                },
+                error_row("OldError", "old message", "old traceback", base_ts + 1.0),
+                error_row("NewError", "new message", "new traceback", base_ts + 10.0),
             ],
             trailing_success_ts=base_ts + 20.0,
         )
 
-    async def test_single_error_returned(
-        self,
-        query_service: TelemetryQueryService,
-        db: tuple[DatabaseService, int],
-    ) -> None:
+    async def test_single_error_returned(self, query_service: TelemetryQueryService, db: DbFixture) -> None:
         """Single error execution — all error columns are populated from that row."""
         db_svc, session_id = db
         job_id = await insert_job(db_svc, job_name="single_err_job")
@@ -278,20 +236,11 @@ class TestJobSummaryLastErrorRowCoherence:
             lambda **kw: insert_execution(db_svc, job_id, session_id, **kw),
             lambda: query_service.get_job_summary("test_app", 0),
             [
-                {
-                    "error_type": "RuntimeError",
-                    "error_message": "runtime boom",
-                    "error_traceback": "tb: boom at line 1",
-                    "execution_start_ts": BASE_TS + 5.0,
-                },
+                error_row("RuntimeError", "runtime boom", "tb: boom at line 1", BASE_TS + 5.0),
             ],
         )
 
-    async def test_no_errors_returns_none(
-        self,
-        query_service: TelemetryQueryService,
-        db: tuple[DatabaseService, int],
-    ) -> None:
+    async def test_no_errors_returns_none(self, query_service: TelemetryQueryService, db: DbFixture) -> None:
         """No errors — all last_error_* fields are None."""
         db_svc, session_id = db
         job_id = await insert_job(db_svc, job_name="clean_job")
@@ -299,19 +248,10 @@ class TestJobSummaryLastErrorRowCoherence:
         await insert_execution(db_svc, job_id, session_id, status="success")
         await insert_execution(db_svc, job_id, session_id, status="success")
 
-        rows = await query_service.get_job_summary("test_app", 0)
-        assert len(rows) == 1
-        row = rows[0]
-        assert row.last_error_type is None
-        assert row.last_error_message is None
-        assert row.last_error_traceback is None
-        assert row.last_error_ts is None
+        row = await only_row(query_service.get_job_summary("test_app", 0))
+        assert_no_last_error(row)
 
-    async def test_since_filter_scopes_error_cte(
-        self,
-        query_service: TelemetryQueryService,
-        db: tuple[DatabaseService, int],
-    ) -> None:
+    async def test_since_filter_scopes_error_cte(self, query_service: TelemetryQueryService, db: DbFixture) -> None:
         """Error before the since window is excluded; error inside the window is returned."""
         db_svc, session_id = db
         job_id = await insert_job(db_svc, job_name="windowed_job")
@@ -322,26 +262,11 @@ class TestJobSummaryLastErrorRowCoherence:
         await assert_last_error_row_coherence(
             lambda **kw: insert_execution(db_svc, job_id, session_id, **kw),
             lambda: query_service.get_job_summary("test_app", 0, since=since_ts),
-            [
-                {
-                    "error_type": "OldError",
-                    "error_message": "before window",
-                    "error_traceback": "old tb",
-                    "execution_start_ts": base_ts + 1.0,
-                },
-                {
-                    "error_type": "NewError",
-                    "error_message": "inside window",
-                    "error_traceback": "new tb",
-                    "execution_start_ts": base_ts + 100.0,
-                },
-            ],
+            SINCE_WINDOW_ERROR_ROWS,
         )
 
     async def test_since_filter_excludes_all_errors_returns_none(
-        self,
-        query_service: TelemetryQueryService,
-        db: tuple[DatabaseService, int],
+        self, query_service: TelemetryQueryService, db: DbFixture
     ) -> None:
         """All errors before since window — last_error_* fields are None."""
         db_svc, session_id = db
@@ -361,10 +286,5 @@ class TestJobSummaryLastErrorRowCoherence:
             execution_start_ts=base_ts + 1.0,
         )
 
-        rows = await query_service.get_job_summary("test_app", 0, since=since_ts)
-        assert len(rows) == 1
-        row = rows[0]
-        assert row.last_error_type is None
-        assert row.last_error_message is None
-        assert row.last_error_traceback is None
-        assert row.last_error_ts is None
+        row = await only_row(query_service.get_job_summary("test_app", 0, since=since_ts))
+        assert_no_last_error(row)

--- a/tests/integration/telemetry/test_listener_queries.py
+++ b/tests/integration/telemetry/test_listener_queries.py
@@ -2,19 +2,24 @@
 
 import pytest
 
-from hassette.core.database_service import DatabaseService
 from hassette.core.telemetry.query_service import TelemetryQueryService
 from hassette.schemas.listener_models import ListenerSummary
 
-from .helpers import BASE_TS, assert_last_error_row_coherence, insert_invocation, insert_listener
+from .helpers import (
+    BASE_TS,
+    SINCE_WINDOW_ERROR_ROWS,
+    DbFixture,
+    assert_last_error_row_coherence,
+    assert_no_last_error,
+    error_row,
+    insert_invocation,
+    insert_listener,
+    only_row,
+)
 
 
 class TestGetListenerSummary:
-    async def test_get_listener_summary_aggregates(
-        self,
-        query_service: TelemetryQueryService,
-        db: tuple[DatabaseService, int],
-    ) -> None:
+    async def test_get_listener_summary_aggregates(self, query_service: TelemetryQueryService, db: DbFixture) -> None:
         """2 listeners, 3 invocations (2 success, 1 error) — correct aggregates."""
         db_svc, session_id = db
 
@@ -37,26 +42,18 @@ class TestGetListenerSummary:
         assert row.failed == 1
         assert row.avg_duration_ms == pytest.approx((10.0 + 20.0 + 5.0) / 3)
 
-    async def test_get_listener_summary_empty(
-        self,
-        query_service: TelemetryQueryService,
-        db: tuple[DatabaseService, int],
-    ) -> None:
+    async def test_get_listener_summary_empty(self, query_service: TelemetryQueryService, db: DbFixture) -> None:
         """1 listener with no invocations — appears in results with zero counts."""
         db_svc, _session_id = db
         await insert_listener(db_svc, handler_method="on_idle")
 
-        rows = await query_service.get_listener_summary("test_app", 0)
-        assert len(rows) == 1
-        row = rows[0]
+        row = await only_row(query_service.get_listener_summary("test_app", 0))
         assert row.total_invocations == 0
         assert row.successful == 0
         assert row.failed == 0
 
     async def test_get_listener_summary_excludes_cancelled(
-        self,
-        query_service: TelemetryQueryService,
-        db: tuple[DatabaseService, int],
+        self, query_service: TelemetryQueryService, db: DbFixture
     ) -> None:
         """get_listener_summary excludes listeners with removed_at set (replace/cancel)."""
         db_svc, _session_id = db
@@ -69,9 +66,7 @@ class TestGetListenerSummary:
         assert {r.listener_id for r in scoped} == {live}
 
     async def test_get_listener_summary_global_excludes_cancelled(
-        self,
-        query_service: TelemetryQueryService,
-        db: tuple[DatabaseService, int],
+        self, query_service: TelemetryQueryService, db: DbFixture
     ) -> None:
         """get_listener_summary(app_key=None) excludes listeners with removed_at set."""
         db_svc, _session_id = db
@@ -83,11 +78,7 @@ class TestGetListenerSummary:
         all_rows = await query_service.get_listener_summary()
         assert {r.listener_id for r in all_rows} == {live}
 
-    async def test_get_listener_summary_since_scoped(
-        self,
-        query_service: TelemetryQueryService,
-        db: tuple[DatabaseService, int],
-    ) -> None:
+    async def test_get_listener_summary_since_scoped(self, query_service: TelemetryQueryService, db: DbFixture) -> None:
         """2 invocations after since, 1 before — since filter returns only the 2 recent ones."""
         db_svc, session_id = db
 
@@ -101,32 +92,24 @@ class TestGetListenerSummary:
         # One invocation before since_ts — should NOT count
         await insert_invocation(db_svc, listener_id, session_id, status="error", execution_start_ts=base_ts + 1.0)
 
-        rows = await query_service.get_listener_summary("test_app", 0, since=since_ts)
-        assert len(rows) == 1
-        row = rows[0]
+        row = await only_row(query_service.get_listener_summary("test_app", 0, since=since_ts))
         assert row.total_invocations == 2
         assert row.successful == 2
         assert row.failed == 0
 
     async def test_get_listener_summary_min_max_none_when_no_invocations(
-        self,
-        query_service: TelemetryQueryService,
-        db: tuple[DatabaseService, int],
+        self, query_service: TelemetryQueryService, db: DbFixture
     ) -> None:
         """Handler with no invocations returns None for min_duration_ms and max_duration_ms."""
         db_svc, _session_id = db
         await insert_listener(db_svc, handler_method="on_idle")
 
-        rows = await query_service.get_listener_summary("test_app", 0)
-        assert len(rows) == 1
-        row = rows[0]
+        row = await only_row(query_service.get_listener_summary("test_app", 0))
         assert row.min_duration_ms is None
         assert row.max_duration_ms is None
 
     async def test_get_listener_summary_min_max_correct_with_invocations(
-        self,
-        query_service: TelemetryQueryService,
-        db: tuple[DatabaseService, int],
+        self, query_service: TelemetryQueryService, db: DbFixture
     ) -> None:
         """Handler with invocations returns correct min and max duration."""
         db_svc, session_id = db
@@ -136,16 +119,12 @@ class TestGetListenerSummary:
         await insert_invocation(db_svc, listener_id, session_id, status="success", duration_ms=5.0)
         await insert_invocation(db_svc, listener_id, session_id, status="error", duration_ms=100.0)
 
-        rows = await query_service.get_listener_summary("test_app", 0)
-        assert len(rows) == 1
-        row = rows[0]
+        row = await only_row(query_service.get_listener_summary("test_app", 0))
         assert row.min_duration_ms == pytest.approx(5.0)
         assert row.max_duration_ms == pytest.approx(100.0)
 
     async def test_get_listener_summary_last_error_traceback_populated(
-        self,
-        query_service: TelemetryQueryService,
-        db: tuple[DatabaseService, int],
+        self, query_service: TelemetryQueryService, db: DbFixture
     ) -> None:
         """Handler with errors includes last_error_traceback from the most recent error."""
         db_svc, session_id = db
@@ -175,18 +154,14 @@ class TestGetListenerSummary:
             execution_start_ts=base_ts + 10.0,
         )
 
-        rows = await query_service.get_listener_summary("test_app", 0)
-        assert len(rows) == 1
-        row = rows[0]
+        row = await only_row(query_service.get_listener_summary("test_app", 0))
         assert (
             row.last_error_traceback == "Traceback (most recent call last):\n  File test.py, line 42\nValueError: oops"
         )
         assert row.last_error_type == "ValueError"
 
     async def test_get_listener_summary_last_error_traceback_none_when_no_errors(
-        self,
-        query_service: TelemetryQueryService,
-        db: tuple[DatabaseService, int],
+        self, query_service: TelemetryQueryService, db: DbFixture
     ) -> None:
         """Handler with no errors has None for last_error_traceback."""
         db_svc, session_id = db
@@ -195,9 +170,7 @@ class TestGetListenerSummary:
         await insert_invocation(db_svc, listener_id, session_id, status="success", duration_ms=10.0)
         await insert_invocation(db_svc, listener_id, session_id, status="success", duration_ms=20.0)
 
-        rows = await query_service.get_listener_summary("test_app", 0)
-        assert len(rows) == 1
-        row = rows[0]
+        row = await only_row(query_service.get_listener_summary("test_app", 0))
         assert row.last_error_traceback is None
 
 
@@ -205,9 +178,7 @@ class TestListenerSummaryLastErrorRowCoherence:
     """Verify that last_error_* fields all come from the same invocation row (row coherence)."""
 
     async def test_multiple_errors_returns_most_recent(
-        self,
-        query_service: TelemetryQueryService,
-        db: tuple[DatabaseService, int],
+        self, query_service: TelemetryQueryService, db: DbFixture
     ) -> None:
         """Multiple errors at different timestamps — all three error columns come from the most recent row."""
         db_svc, session_id = db
@@ -219,33 +190,14 @@ class TestListenerSummaryLastErrorRowCoherence:
             lambda **kw: insert_invocation(db_svc, listener_id, session_id, **kw),
             lambda: query_service.get_listener_summary("test_app", 0),
             [
-                {
-                    "error_type": "OldError",
-                    "error_message": "old message",
-                    "error_traceback": "old traceback",
-                    "execution_start_ts": base_ts + 1.0,
-                },
-                {
-                    "error_type": "MiddleError",
-                    "error_message": "middle message",
-                    "error_traceback": "middle traceback",
-                    "execution_start_ts": base_ts + 5.0,
-                },
-                {
-                    "error_type": "NewError",
-                    "error_message": "new message",
-                    "error_traceback": "new traceback",
-                    "execution_start_ts": base_ts + 10.0,
-                },
+                error_row("OldError", "old message", "old traceback", base_ts + 1.0),
+                error_row("MiddleError", "middle message", "middle traceback", base_ts + 5.0),
+                error_row("NewError", "new message", "new traceback", base_ts + 10.0),
             ],
             trailing_success_ts=base_ts + 15.0,
         )
 
-    async def test_single_error_returned(
-        self,
-        query_service: TelemetryQueryService,
-        db: tuple[DatabaseService, int],
-    ) -> None:
+    async def test_single_error_returned(self, query_service: TelemetryQueryService, db: DbFixture) -> None:
         """Single error — all error columns are populated from that row."""
         db_svc, session_id = db
         listener_id = await insert_listener(db_svc, handler_method="on_single_err")
@@ -261,18 +213,12 @@ class TestListenerSummaryLastErrorRowCoherence:
             execution_start_ts=BASE_TS + 1.0,
         )
 
-        rows = await query_service.get_listener_summary("test_app", 0)
-        assert len(rows) == 1
-        row = rows[0]
+        row = await only_row(query_service.get_listener_summary("test_app", 0))
         assert row.last_error_type == "ValueError"
         assert row.last_error_message == "bad value"
         assert row.last_error_traceback == "tb line 1\ntb line 2"
 
-    async def test_no_errors_returns_none(
-        self,
-        query_service: TelemetryQueryService,
-        db: tuple[DatabaseService, int],
-    ) -> None:
+    async def test_no_errors_returns_none(self, query_service: TelemetryQueryService, db: DbFixture) -> None:
         """No errors — all last_error_* fields are None."""
         db_svc, session_id = db
         listener_id = await insert_listener(db_svc, handler_method="on_clean")
@@ -280,18 +226,10 @@ class TestListenerSummaryLastErrorRowCoherence:
         await insert_invocation(db_svc, listener_id, session_id, status="success")
         await insert_invocation(db_svc, listener_id, session_id, status="success")
 
-        rows = await query_service.get_listener_summary("test_app", 0)
-        assert len(rows) == 1
-        row = rows[0]
-        assert row.last_error_type is None
-        assert row.last_error_message is None
-        assert row.last_error_traceback is None
+        row = await only_row(query_service.get_listener_summary("test_app", 0))
+        assert_no_last_error(row)
 
-    async def test_since_filter_scopes_error_cte(
-        self,
-        query_service: TelemetryQueryService,
-        db: tuple[DatabaseService, int],
-    ) -> None:
+    async def test_since_filter_scopes_error_cte(self, query_service: TelemetryQueryService, db: DbFixture) -> None:
         """Error before the since window is excluded; error inside the window is returned."""
         db_svc, session_id = db
         listener_id = await insert_listener(db_svc, handler_method="on_windowed")
@@ -302,26 +240,11 @@ class TestListenerSummaryLastErrorRowCoherence:
         await assert_last_error_row_coherence(
             lambda **kw: insert_invocation(db_svc, listener_id, session_id, **kw),
             lambda: query_service.get_listener_summary("test_app", 0, since=since_ts),
-            [
-                {
-                    "error_type": "OldError",
-                    "error_message": "before window",
-                    "error_traceback": "old tb",
-                    "execution_start_ts": base_ts + 1.0,
-                },
-                {
-                    "error_type": "NewError",
-                    "error_message": "inside window",
-                    "error_traceback": "new tb",
-                    "execution_start_ts": base_ts + 100.0,
-                },
-            ],
+            SINCE_WINDOW_ERROR_ROWS,
         )
 
     async def test_since_filter_excludes_all_errors_returns_none(
-        self,
-        query_service: TelemetryQueryService,
-        db: tuple[DatabaseService, int],
+        self, query_service: TelemetryQueryService, db: DbFixture
     ) -> None:
         """All errors before since window — last_error_* fields are None."""
         db_svc, session_id = db
@@ -341,9 +264,5 @@ class TestListenerSummaryLastErrorRowCoherence:
             execution_start_ts=base_ts + 1.0,
         )
 
-        rows = await query_service.get_listener_summary("test_app", 0, since=since_ts)
-        assert len(rows) == 1
-        row = rows[0]
-        assert row.last_error_type is None
-        assert row.last_error_message is None
-        assert row.last_error_traceback is None
+        row = await only_row(query_service.get_listener_summary("test_app", 0, since=since_ts))
+        assert_no_last_error(row)

--- a/tests/integration/telemetry/test_log_record_filters.py
+++ b/tests/integration/telemetry/test_log_record_filters.py
@@ -9,7 +9,7 @@ import time
 from hassette.core.database_service import DatabaseService
 from hassette.core.telemetry.query_service import TelemetryQueryService
 
-from .helpers import insert_listener
+from .helpers import DbFixture, insert_listener
 
 SEQ_COUNTER = 0
 
@@ -38,9 +38,7 @@ async def insert_log_record(
 
 
 class TestGetLogRecordsFilters:
-    async def test_filter_by_execution_id(
-        self, db: tuple[DatabaseService, int], query_service: TelemetryQueryService
-    ) -> None:
+    async def test_filter_by_execution_id(self, db: DbFixture, query_service: TelemetryQueryService) -> None:
         db_svc, _ = db
         await insert_log_record(db_svc, execution_id="exec-aaa", message="match")
         await insert_log_record(db_svc, execution_id="exec-bbb", message="other")
@@ -52,9 +50,7 @@ class TestGetLogRecordsFilters:
         assert results[0]["message"] == "match"
         assert results[0]["execution_id"] == "exec-aaa"
 
-    async def test_filter_by_source_tier(
-        self, db: tuple[DatabaseService, int], query_service: TelemetryQueryService
-    ) -> None:
+    async def test_filter_by_source_tier(self, db: DbFixture, query_service: TelemetryQueryService) -> None:
         db_svc, _ = db
         await insert_log_record(db_svc, source_tier="framework", message="fw")
         await insert_log_record(db_svc, source_tier="app", message="app")
@@ -65,7 +61,7 @@ class TestGetLogRecordsFilters:
         assert results[0]["message"] == "fw"
         assert results[0]["source_tier"] == "framework"
 
-    async def test_filter_by_level(self, db: tuple[DatabaseService, int], query_service: TelemetryQueryService) -> None:
+    async def test_filter_by_level(self, db: DbFixture, query_service: TelemetryQueryService) -> None:
         db_svc, _ = db
         await insert_log_record(db_svc, level="ERROR", message="err")
         await insert_log_record(db_svc, level="INFO", message="info")
@@ -77,7 +73,7 @@ class TestGetLogRecordsFilters:
         assert results[0]["message"] == "err"
         assert results[0]["level"] == "ERROR"
 
-    async def test_filter_by_since(self, db: tuple[DatabaseService, int], query_service: TelemetryQueryService) -> None:
+    async def test_filter_by_since(self, db: DbFixture, query_service: TelemetryQueryService) -> None:
         db_svc, _ = db
         old_ts = 1_000_000.0
         new_ts = 2_000_000.0
@@ -89,9 +85,7 @@ class TestGetLogRecordsFilters:
         assert len(results) == 1
         assert results[0]["message"] == "new"
 
-    async def test_filter_by_app_key(
-        self, db: tuple[DatabaseService, int], query_service: TelemetryQueryService
-    ) -> None:
+    async def test_filter_by_app_key(self, db: DbFixture, query_service: TelemetryQueryService) -> None:
         db_svc, _ = db
         await insert_log_record(db_svc, app_key="app_a", message="a")
         await insert_log_record(db_svc, app_key="app_b", message="b")
@@ -101,9 +95,7 @@ class TestGetLogRecordsFilters:
         assert len(results) == 1
         assert results[0]["message"] == "a"
 
-    async def test_combined_filters(
-        self, db: tuple[DatabaseService, int], query_service: TelemetryQueryService
-    ) -> None:
+    async def test_combined_filters(self, db: DbFixture, query_service: TelemetryQueryService) -> None:
         db_svc, _ = db
         await insert_log_record(db_svc, app_key="my_app", level="ERROR", execution_id="exec-1", message="target")
         await insert_log_record(db_svc, app_key="my_app", level="INFO", execution_id="exec-1", message="wrong level")
@@ -115,7 +107,7 @@ class TestGetLogRecordsFilters:
         assert results[0]["message"] == "target"
 
     async def test_joins_execution_kind_from_executions_table(
-        self, db: tuple[DatabaseService, int], query_service: TelemetryQueryService
+        self, db: DbFixture, query_service: TelemetryQueryService
     ) -> None:
         """Log records JOIN executions to get execution_kind, listener_id, job_id."""
         db_svc, session_id = db
@@ -137,9 +129,7 @@ class TestGetLogRecordsFilters:
         assert results[0]["execution_kind"] == "handler"
         assert results[0]["listener_id"] == listener_id
 
-    async def test_no_filters_returns_all(
-        self, db: tuple[DatabaseService, int], query_service: TelemetryQueryService
-    ) -> None:
+    async def test_no_filters_returns_all(self, db: DbFixture, query_service: TelemetryQueryService) -> None:
         db_svc, _ = db
         await insert_log_record(db_svc, message="one")
         await insert_log_record(db_svc, message="two")

--- a/tests/integration/telemetry/test_query_helpers.py
+++ b/tests/integration/telemetry/test_query_helpers.py
@@ -1,10 +1,9 @@
 """Integration tests for telemetry query helper functions and source_tier scoping behavior."""
 
-from hassette.core.database_service import DatabaseService
 from hassette.core.telemetry.helpers import source_tier_clause
 from hassette.core.telemetry.query_service import TelemetryQueryService
 
-from .helpers import insert_execution, insert_invocation, insert_job, insert_listener
+from .helpers import DbFixture, insert_execution, insert_invocation, insert_job, insert_listener
 
 
 class TestSourceTierClause:
@@ -41,9 +40,7 @@ class TestSourceTierClause:
 
 class TestGetAllAppSummariesFrameworkTier:
     async def test_get_all_app_summaries_framework_tier(
-        self,
-        query_service: TelemetryQueryService,
-        db: tuple[DatabaseService, int],
+        self, query_service: TelemetryQueryService, db: DbFixture
     ) -> None:
         """source_tier='framework' selects active_framework_listeners and active_framework_scheduled_jobs."""
         db_svc, session_id = db
@@ -77,9 +74,7 @@ class TestGetAllAppSummariesFrameworkTier:
         assert "my_app" not in result
 
     async def test_get_all_app_summaries_framework_tier_non_hassette_app_key(
-        self,
-        query_service: TelemetryQueryService,
-        db: tuple[DatabaseService, int],
+        self, query_service: TelemetryQueryService, db: DbFixture
     ) -> None:
         """source_tier='framework' shows framework-tier records for non-__hassette__ app_key."""
         db_svc, session_id = db

--- a/tests/integration/telemetry/test_schema_invariants.py
+++ b/tests/integration/telemetry/test_schema_invariants.py
@@ -5,11 +5,12 @@ import inspect
 import aiosqlite
 import pytest
 
-from hassette.core.database_service import DatabaseService
 from hassette.core.telemetry.repository import TelemetryRepository
 
+from .helpers import DbFixture
 
-async def test_on_conflict_target_matches_index(db: tuple[DatabaseService, int]) -> None:
+
+async def test_on_conflict_target_matches_index(db: DbFixture) -> None:
     """idx_listeners_natural columns exactly match the ON CONFLICT target in register_listener().
 
     Queries sqlite_master for idx_listeners_natural and asserts:
@@ -41,7 +42,7 @@ async def test_on_conflict_target_matches_index(db: tuple[DatabaseService, int])
     )
 
 
-async def test_unique_index_enforced(db: tuple[DatabaseService, int]) -> None:
+async def test_unique_index_enforced(db: DbFixture) -> None:
     """Two listeners with the same natural key (app_key, instance_index, name, topic) raise IntegrityError."""
     db_service, _ = db
     conn = db_service.db
@@ -58,7 +59,7 @@ async def test_unique_index_enforced(db: tuple[DatabaseService, int]) -> None:
         await conn.execute(sql)
 
 
-async def test_active_views_exist(db: tuple[DatabaseService, int]) -> None:
+async def test_active_views_exist(db: DbFixture) -> None:
     """active_listeners and active_scheduled_jobs views are queryable on the canonical schema."""
     db_service, _ = db
     conn = db_service.db

--- a/tests/integration/telemetry/test_session_queries.py
+++ b/tests/integration/telemetry/test_session_queries.py
@@ -18,15 +18,11 @@ from hassette.exceptions import TelemetryUnavailableError
 from hassette.schemas.summary_models import SessionRecord
 from hassette.test_utils.mock_hassette import make_mock_hassette
 
-from .helpers import BASE_TS
+from .helpers import BASE_TS, DbFixture
 
 
 class TestGetSessionList:
-    async def test_get_session_list(
-        self,
-        query_service: TelemetryQueryService,
-        db: tuple[DatabaseService, int],
-    ) -> None:
+    async def test_get_session_list(self, query_service: TelemetryQueryService, db: DbFixture) -> None:
         """3 sessions with different statuses — ordered by started_at DESC, correct duration."""
         db_svc, session_id = db
 
@@ -74,20 +70,12 @@ class TestGetSessionList:
 
 
 class TestCheckHealth:
-    async def test_check_health_succeeds_on_live_db(
-        self,
-        query_service: TelemetryQueryService,
-        db: tuple[DatabaseService, int],
-    ) -> None:
+    async def test_check_health_succeeds_on_live_db(self, query_service: TelemetryQueryService, db: DbFixture) -> None:
         """check_health() completes without raising when the database is live."""
         # Should not raise
         await query_service.check_health()
 
-    async def test_check_health_raises_on_closed_db(
-        self,
-        query_service: TelemetryQueryService,
-        db: tuple[DatabaseService, int],
-    ) -> None:
+    async def test_check_health_raises_on_closed_db(self, query_service: TelemetryQueryService, db: DbFixture) -> None:
         """check_health() raises TelemetryUnavailableError when the read_db connection is closed."""
         db_svc, _session_id = db
         # Close the read connection to simulate a failed connection
@@ -113,7 +101,7 @@ class TestReadTimeout:
         )
 
     @pytest.fixture
-    async def short_timeout_db(self, short_timeout_hassette: MagicMock) -> AsyncIterator[tuple[DatabaseService, int]]:
+    async def short_timeout_db(self, short_timeout_hassette: MagicMock) -> AsyncIterator[DbFixture]:
         db_service = DatabaseService(short_timeout_hassette, parent=None)
         await db_service.on_initialize()
         cursor = await db_service.db.execute(
@@ -130,9 +118,7 @@ class TestReadTimeout:
 
     @pytest.fixture
     def short_timeout_query_service(
-        self,
-        short_timeout_hassette: MagicMock,
-        short_timeout_db: tuple[DatabaseService, int],
+        self, short_timeout_hassette: MagicMock, short_timeout_db: DbFixture
     ) -> TelemetryQueryService:
         service = TelemetryQueryService.__new__(TelemetryQueryService)
         service.hassette = short_timeout_hassette
@@ -141,9 +127,7 @@ class TestReadTimeout:
         return service
 
     async def test_execute_raises_timeout_error(
-        self,
-        short_timeout_query_service: TelemetryQueryService,
-        short_timeout_db: tuple[DatabaseService, int],
+        self, short_timeout_query_service: TelemetryQueryService, short_timeout_db: DbFixture
     ) -> None:
         """execute() raises TelemetryUnavailableError when a query exceeds read_timeout_seconds."""
         db_svc, _ = short_timeout_db
@@ -156,9 +140,7 @@ class TestReadTimeout:
                 await cursor.fetchone()
 
     async def test_normal_query_succeeds_within_timeout(
-        self,
-        short_timeout_query_service: TelemetryQueryService,
-        short_timeout_db: tuple[DatabaseService, int],
+        self, short_timeout_query_service: TelemetryQueryService, short_timeout_db: DbFixture
     ) -> None:
         """A fast query completes within even a short timeout."""
         await short_timeout_query_service.check_health()

--- a/tests/integration/telemetry/test_session_queries.py
+++ b/tests/integration/telemetry/test_session_queries.py
@@ -12,13 +12,12 @@ from unittest.mock import MagicMock
 import aiosqlite
 import pytest
 
-from hassette.core.database_service import DatabaseService
 from hassette.core.telemetry.query_service import TelemetryQueryService
 from hassette.exceptions import TelemetryUnavailableError
 from hassette.schemas.summary_models import SessionRecord
 from hassette.test_utils.mock_hassette import make_mock_hassette
 
-from .helpers import BASE_TS, DbFixture
+from .helpers import BASE_TS, DbFixture, open_db_with_session
 
 
 class TestGetSessionList:
@@ -102,14 +101,7 @@ class TestReadTimeout:
 
     @pytest.fixture
     async def short_timeout_db(self, short_timeout_hassette: MagicMock) -> AsyncIterator[DbFixture]:
-        db_service = DatabaseService(short_timeout_hassette, parent=None)
-        await db_service.on_initialize()
-        cursor = await db_service.db.execute(
-            "INSERT INTO sessions (started_at, last_heartbeat_at, status) VALUES (?, ?, 'running')",
-            (time.time(), time.time()),
-        )
-        session_id = cursor.lastrowid
-        await db_service.db.commit()
+        db_service, session_id = await open_db_with_session(short_timeout_hassette)
         short_timeout_hassette.session_id = session_id
         short_timeout_hassette.try_session_id.return_value = session_id
         short_timeout_hassette.database_service = db_service

--- a/tests/integration/telemetry/test_telemetry_execution_id.py
+++ b/tests/integration/telemetry/test_telemetry_execution_id.py
@@ -7,19 +7,20 @@ import time
 
 import pytest
 
-from hassette.core.database_service import DatabaseService
 from hassette.core.execution_record import ExecutionRecord
 from hassette.core.telemetry.query_service import TelemetryQueryService
 from hassette.core.telemetry.repository import TelemetryRepository, execution_insert_params
 
 from .helpers import (
+    DbFixture,
     insert_job,
     insert_listener,
+    only_row,
 )
 
 
 @pytest.fixture
-def repo(db: tuple[DatabaseService, int]) -> TelemetryRepository:
+def repo(db: DbFixture) -> TelemetryRepository:
     db_service, _ = db
     return TelemetryRepository(db_service)
 
@@ -46,12 +47,7 @@ def make_inv_record(
     )
 
 
-def make_job_record(
-    job_id: int | None,
-    session_id: int,
-    *,
-    execution_id: str | None = None,
-) -> ExecutionRecord:
+def make_job_record(job_id: int | None, session_id: int, *, execution_id: str | None = None) -> ExecutionRecord:
     return ExecutionRecord(
         kind="job",
         job_id=job_id,
@@ -66,7 +62,7 @@ def make_job_record(
 
 class TestHandlerInvocationExecutionId:
     async def test_persist_and_query_handler_invocation_with_execution_id(
-        self, db: tuple[DatabaseService, int], repo: TelemetryRepository, query_service: TelemetryQueryService
+        self, db: DbFixture, repo: TelemetryRepository, query_service: TelemetryQueryService
     ) -> None:
         """Persist a handler ExecutionRecord with all three new fields and query them back."""
         db_svc, session_id = db
@@ -81,15 +77,13 @@ class TestHandlerInvocationExecutionId:
 
         await repo.persist_execution_batch([record])
 
-        results = await query_service.get_executions(listener_id=listener_id, kind="handler", limit=10)
-        assert len(results) == 1
-        inv = results[0]
+        inv = await only_row(query_service.get_executions(listener_id=listener_id, kind="handler", limit=10))
         assert inv.execution_id == "abc-123"
         assert inv.trigger_context_id == "ctx-456"
         assert inv.trigger_origin == "LOCAL"
 
     async def test_null_execution_id_persists_and_queries(
-        self, db: tuple[DatabaseService, int], repo: TelemetryRepository, query_service: TelemetryQueryService
+        self, db: DbFixture, repo: TelemetryRepository, query_service: TelemetryQueryService
     ) -> None:
         """Persist a record with execution_id=None and confirm it comes back as None (not empty string)."""
         db_svc, session_id = db
@@ -103,7 +97,7 @@ class TestHandlerInvocationExecutionId:
         assert results[0].execution_id is None
 
     async def test_fk_fallback_drops_handler_row_on_stale_listener_fk(
-        self, db: tuple[DatabaseService, int], repo: TelemetryRepository
+        self, db: DbFixture, repo: TelemetryRepository
     ) -> None:
         """A stale listener_id FK drops the execution row — orphan null-FK rows are impossible.
 
@@ -131,20 +125,12 @@ class TestHandlerInvocationExecutionId:
         assert count_row is not None
         assert count_row[0] == 0  # no orphan row written
 
-    async def test_shared_params_match_persist_batch_columns(self, db: tuple[DatabaseService, int]) -> None:
+    async def test_shared_params_match_persist_batch_columns(self, db: DbFixture) -> None:
         """execution_insert_params() keys must match the executions table columns used in persist_batch()."""
         db_svc, session_id = db
         listener_id = await insert_listener(db_svc)
-        record = ExecutionRecord(
-            kind="handler",
-            listener_id=listener_id,
-            session_id=session_id,
-            execution_start_ts=time.time(),
-            duration_ms=10.0,
-            status="success",
-            execution_id="abc-test",
-            trigger_context_id="ctx-test",
-            trigger_origin="LOCAL",
+        record = make_inv_record(
+            listener_id, session_id, execution_id="abc-test", trigger_context_id="ctx-test", trigger_origin="LOCAL"
         )
         params = execution_insert_params(record)
 
@@ -177,7 +163,7 @@ class TestHandlerInvocationExecutionId:
 
 class TestJobExecutionExecutionId:
     async def test_persist_and_query_job_execution_with_execution_id(
-        self, db: tuple[DatabaseService, int], repo: TelemetryRepository, query_service: TelemetryQueryService
+        self, db: DbFixture, repo: TelemetryRepository, query_service: TelemetryQueryService
     ) -> None:
         """Persist a job ExecutionRecord with execution_id and query it back."""
         db_svc, session_id = db
@@ -186,25 +172,15 @@ class TestJobExecutionExecutionId:
 
         await repo.persist_execution_batch([record])
 
-        results = await query_service.get_executions(job_id=job_id, kind="job", limit=10)
-        assert len(results) == 1
-        je = results[0]
+        je = await only_row(query_service.get_executions(job_id=job_id, kind="job", limit=10))
         assert je.execution_id == "def-789"
         assert je.trigger_context_id is None, "Job executions must have trigger_context_id=None"
 
-    async def test_job_shared_params_match_persist_batch_columns(self, db: tuple[DatabaseService, int]) -> None:
+    async def test_job_shared_params_match_persist_batch_columns(self, db: DbFixture) -> None:
         """execution_insert_params() keys for kind=job must match the executions table columns."""
         db_svc, session_id = db
         job_id = await insert_job(db_svc)
-        record = ExecutionRecord(
-            kind="job",
-            job_id=job_id,
-            session_id=session_id,
-            execution_start_ts=time.time(),
-            duration_ms=20.0,
-            status="success",
-            execution_id="def-test",
-        )
+        record = make_job_record(job_id, session_id, execution_id="def-test")
         params = execution_insert_params(record)
 
         assert "kind" in params
@@ -236,7 +212,7 @@ class TestGetExecutionById:
     """Coverage for TelemetryQueryService.get_execution_by_id (execution_queries.py)."""
 
     async def test_returns_execution_when_found(
-        self, db: tuple[DatabaseService, int], repo: TelemetryRepository, query_service: TelemetryQueryService
+        self, db: DbFixture, repo: TelemetryRepository, query_service: TelemetryQueryService
     ) -> None:
         db_svc, session_id = db
         listener_id = await insert_listener(db_svc)
@@ -258,14 +234,12 @@ class TestGetExecutionById:
         assert result.kind == "handler"
         assert result.listener_id == listener_id
 
-    async def test_returns_none_when_not_found(
-        self, db: tuple[DatabaseService, int], query_service: TelemetryQueryService
-    ) -> None:
+    async def test_returns_none_when_not_found(self, db: DbFixture, query_service: TelemetryQueryService) -> None:
         result = await query_service.get_execution_by_id("nonexistent-id-xyz")
         assert result is None
 
     async def test_returns_job_execution(
-        self, db: tuple[DatabaseService, int], repo: TelemetryRepository, query_service: TelemetryQueryService
+        self, db: DbFixture, repo: TelemetryRepository, query_service: TelemetryQueryService
     ) -> None:
         db_svc, session_id = db
         job_id = await insert_job(db_svc)

--- a/tests/integration/telemetry/test_telemetry_query_service_aggregates.py
+++ b/tests/integration/telemetry/test_telemetry_query_service_aggregates.py
@@ -10,24 +10,24 @@ import time
 import pytest
 
 from hassette.const.misc import SECONDS_PER_DAY
-from hassette.core.database_service import DatabaseService
 from hassette.core.telemetry.query_service import TelemetryQueryService
 from hassette.schemas.summary_models import AppHealthSummary
 
 from .helpers import (
     BASE_TS,
+    DbFixture,
     insert_execution,
     insert_invocation,
     insert_job,
     insert_listener,
+    insert_tiered_listeners,
+    only_row,
 )
 
 
 class TestGetAllAppSummaries:
     async def test_get_all_app_summaries_returns_dict(
-        self,
-        query_service: TelemetryQueryService,
-        db: tuple[DatabaseService, int],
+        self, query_service: TelemetryQueryService, db: DbFixture
     ) -> None:
         """Two apps with listeners and jobs — returns dict[str, AppHealthSummary]."""
         db_svc, session_id = db
@@ -71,19 +71,13 @@ class TestGetAllAppSummaries:
         assert b.total_executions == 0
         assert b.total_job_errors == 0
 
-    async def test_get_all_app_summaries_empty_db(
-        self,
-        query_service: TelemetryQueryService,
-        db: tuple[DatabaseService, int],
-    ) -> None:
+    async def test_get_all_app_summaries_empty_db(self, query_service: TelemetryQueryService, db: DbFixture) -> None:
         """No listeners or jobs — returns empty dict."""
         result = await query_service.get_all_app_summaries()
         assert result == {}
 
     async def test_get_all_app_summaries_since_scoped(
-        self,
-        query_service: TelemetryQueryService,
-        db: tuple[DatabaseService, int],
+        self, query_service: TelemetryQueryService, db: DbFixture
     ) -> None:
         """Since filter restricts invocation/execution counts to records after the threshold."""
         db_svc, session_id = db
@@ -111,9 +105,7 @@ class TestGetAllAppSummaries:
         assert x.total_job_errors == 0
 
     async def test_get_all_app_summaries_multi_instance_activity_aggregation(
-        self,
-        query_service: TelemetryQueryService,
-        db: tuple[DatabaseService, int],
+        self, query_service: TelemetryQueryService, db: DbFixture
     ) -> None:
         """Multi-instance app: activity sums across all instances; handler_count is distinct identities across all."""
         db_svc, session_id = db
@@ -149,9 +141,7 @@ class TestGetAllAppSummaries:
         assert m.avg_duration_ms == pytest.approx(35.0)
 
     async def test_get_all_app_summaries_asymmetric_instances_handler_count(
-        self,
-        query_service: TelemetryQueryService,
-        db: tuple[DatabaseService, int],
+        self, query_service: TelemetryQueryService, db: DbFixture
     ) -> None:
         """Asymmetric instances: handler_count is the union of distinct identities, not instance 0's set.
 
@@ -172,9 +162,7 @@ class TestGetAllAppSummaries:
         assert result["app_z"].handler_count == 3
 
     async def test_get_all_app_summaries_multi_instance_job_aggregation(
-        self,
-        query_service: TelemetryQueryService,
-        db: tuple[DatabaseService, int],
+        self, query_service: TelemetryQueryService, db: DbFixture
     ) -> None:
         """Multi-instance app: job activity sums across all instances; job_count is distinct job names across all."""
         db_svc, session_id = db
@@ -206,9 +194,7 @@ class TestGetAllAppSummaries:
         assert j.total_job_errors == 2
 
     async def test_get_all_app_summaries_single_instance_equivalence(
-        self,
-        query_service: TelemetryQueryService,
-        db: tuple[DatabaseService, int],
+        self, query_service: TelemetryQueryService, db: DbFixture
     ) -> None:
         """Single-instance app produces equivalent results to current behavior."""
         db_svc, session_id = db
@@ -234,9 +220,7 @@ class TestGetAllAppSummaries:
         assert s.avg_duration_ms == pytest.approx(20.0, abs=0.001)
 
     async def test_get_all_app_summaries_multi_instance_since_scoped(
-        self,
-        query_service: TelemetryQueryService,
-        db: tuple[DatabaseService, int],
+        self, query_service: TelemetryQueryService, db: DbFixture
     ) -> None:
         """Multi-instance data with since filter: only records after threshold count."""
         db_svc, session_id = db
@@ -293,9 +277,7 @@ class TestGetAllAppSummaries:
 
 class TestCrossSessionAndRetiredRows:
     async def test_all_time_aggregates_across_sessions(
-        self,
-        query_service: TelemetryQueryService,
-        db: tuple[DatabaseService, int],
+        self, query_service: TelemetryQueryService, db: DbFixture
     ) -> None:
         """All-time query (no session_id) spans multiple sessions.
 
@@ -325,18 +307,12 @@ class TestCrossSessionAndRetiredRows:
         await insert_invocation(db_svc, listener_id, session_2, status="success")
 
         # All-time query must aggregate across both sessions
-        summary = await query_service.get_listener_summary("test_app", 0)
-        assert len(summary) == 1
-        row = summary[0]
+        row = await only_row(query_service.get_listener_summary("test_app", 0))
         assert row.total_invocations == 5
         assert row.successful == 4
         assert row.failed == 1
 
-    async def test_listener_summary_includes_retired(
-        self,
-        query_service: TelemetryQueryService,
-        db: tuple[DatabaseService, int],
-    ) -> None:
+    async def test_listener_summary_includes_retired(self, query_service: TelemetryQueryService, db: DbFixture) -> None:
         """get_listener_summary queries base tables and includes retired rows.
 
         A retired listener with invocation history must still appear in the summary.
@@ -355,18 +331,13 @@ class TestCrossSessionAndRetiredRows:
         )
         await db_svc.db.commit()
 
-        rows = await query_service.get_listener_summary("test_app", 0)
-        assert len(rows) == 1
-        row = rows[0]
+        row = await only_row(query_service.get_listener_summary("test_app", 0))
         assert row.handler_method == "on_retired"
         assert row.total_invocations == 2
         assert row.successful == 1
         assert row.failed == 1
 
-    async def test_retention_cleanup_deletes_old_retired_rows(
-        self,
-        db: tuple[DatabaseService, int],
-    ) -> None:
+    async def test_retention_cleanup_deletes_old_retired_rows(self, db: DbFixture) -> None:
         """_do_run_retention_cleanup deletes retired registration rows older than retention_days.
 
         Insert a listener and a scheduled_job with old retired_at timestamps and
@@ -437,9 +408,7 @@ class TestCrossSessionAndRetiredRows:
 
 class TestGetAllAppSummariesSourceTier:
     async def test_get_all_app_summaries_excludes_hassette(
-        self,
-        query_service: TelemetryQueryService,
-        db: tuple[DatabaseService, int],
+        self, query_service: TelemetryQueryService, db: DbFixture
     ) -> None:
         """Framework actors (__hassette__) are excluded from get_all_app_summaries."""
         db_svc, session_id = db
@@ -464,11 +433,10 @@ class TestGetAllAppSummariesSourceTier:
         assert "my_app" in result
 
     async def test_get_all_app_summaries_activity_filtered_by_app_tier(
-        self,
-        query_service: TelemetryQueryService,
-        db: tuple[DatabaseService, int],
+        self, query_service: TelemetryQueryService, db: DbFixture
     ) -> None:
         """Framework invocations don't inflate app-tier counts in get_all_app_summaries."""
+        # dup-ignore-start: tier-scoping cases share this setup and differ only in the timestamps/statuses each probes
         db_svc, session_id = db
 
         # App-tier listener for "my_app"
@@ -488,6 +456,7 @@ class TestGetAllAppSummariesSourceTier:
         await insert_invocation(
             db_svc, fw_listener, session_id, status="error", execution_start_ts=base_ts + 3.0, source_tier="framework"
         )
+        # dup-ignore-end
 
         result = await query_service.get_all_app_summaries()
         assert "my_app" in result
@@ -498,11 +467,7 @@ class TestGetAllAppSummariesSourceTier:
 
 
 class TestDiFailureFlag:
-    async def test_di_failure_flag_query(
-        self,
-        query_service: TelemetryQueryService,
-        db: tuple[DatabaseService, int],
-    ) -> None:
+    async def test_di_failure_flag_query(self, query_service: TelemetryQueryService, db: DbFixture) -> None:
         """is_di_failure=1 records are counted as di_failures in get_listener_summary."""
         db_svc, session_id = db
         listener_id = await insert_listener(db_svc, handler_method="on_di")
@@ -518,17 +483,11 @@ class TestDiFailureFlag:
             db_svc, listener_id, session_id, status="error", error_type="ValueError", is_di_failure=0
         )
 
-        rows = await query_service.get_listener_summary("test_app", 0)
-        assert len(rows) == 1
-        row = rows[0]
+        row = await only_row(query_service.get_listener_summary("test_app", 0))
         assert row.di_failures == 2
         assert row.failed == 3
 
-    async def test_di_failure_flag_not_string_match(
-        self,
-        query_service: TelemetryQueryService,
-        db: tuple[DatabaseService, int],
-    ) -> None:
+    async def test_di_failure_flag_not_string_match(self, query_service: TelemetryQueryService, db: DbFixture) -> None:
         """Records with error_type LIKE 'Dependency%' but is_di_failure=0 are NOT counted."""
         db_svc, session_id = db
         listener_id = await insert_listener(db_svc, handler_method="on_test")
@@ -542,19 +501,13 @@ class TestDiFailureFlag:
             db_svc, listener_id, session_id, status="error", error_type="DependencyInjectionError", is_di_failure=1
         )
 
-        rows = await query_service.get_listener_summary("test_app", 0)
-        assert len(rows) == 1
-        row = rows[0]
+        row = await only_row(query_service.get_listener_summary("test_app", 0))
         # Only the one with is_di_failure=1 should count
         assert row.di_failures == 1
 
 
 class TestGetSlowHandlersLeftJoin:
-    async def test_get_slow_handlers_left_join(
-        self,
-        query_service: TelemetryQueryService,
-        db: tuple[DatabaseService, int],
-    ) -> None:
+    async def test_get_slow_handlers_left_join(self, query_service: TelemetryQueryService, db: DbFixture) -> None:
         """Delete a listener; its slow invocations still appear with null app_key."""
         db_svc, session_id = db
         listener_id = await insert_listener(db_svc, handler_method="on_slow")
@@ -574,14 +527,11 @@ class TestGetSlowHandlersLeftJoin:
         assert rows[0].duration_ms == pytest.approx(500.0)
 
     async def test_get_slow_handlers_source_tier_filter(
-        self,
-        query_service: TelemetryQueryService,
-        db: tuple[DatabaseService, int],
+        self, query_service: TelemetryQueryService, db: DbFixture
     ) -> None:
         """source_tier='app' (default) excludes framework slow handlers."""
         db_svc, session_id = db
-        app_listener = await insert_listener(db_svc, handler_method="on_app", source_tier="app")
-        fw_listener = await insert_listener(db_svc, handler_method="on_fw", source_tier="framework")
+        app_listener, fw_listener = await insert_tiered_listeners(db_svc)
 
         await insert_invocation(db_svc, app_listener, session_id, duration_ms=500.0, source_tier="app")
         await insert_invocation(db_svc, fw_listener, session_id, duration_ms=1000.0, source_tier="framework")

--- a/tests/integration/telemetry/test_telemetry_timed_out.py
+++ b/tests/integration/telemetry/test_telemetry_timed_out.py
@@ -4,23 +4,20 @@ Verifies that 'timed_out' is counted as a separate bucket in summaries
 and treated as a failure subtype in error-rate calculations.
 """
 
-from hassette.core.database_service import DatabaseService
 from hassette.core.telemetry.query_service import TelemetryQueryService
 
 from .helpers import (
+    DbFixture,
     insert_execution,
     insert_invocation,
     insert_job,
     insert_listener,
+    only_row,
 )
 
 
 class TestListenerSummaryTimedOut:
-    async def test_listener_summary_counts_timed_out(
-        self,
-        query_service: TelemetryQueryService,
-        db: tuple[DatabaseService, int],
-    ) -> None:
+    async def test_listener_summary_counts_timed_out(self, query_service: TelemetryQueryService, db: DbFixture) -> None:
         """Verify timed_out is a separate bucket in ListenerSummary."""
         db_svc, session_id = db
         listener_id = await insert_listener(db_svc)
@@ -29,9 +26,7 @@ class TestListenerSummaryTimedOut:
         await insert_invocation(db_svc, listener_id, session_id, status="timed_out")
         await insert_invocation(db_svc, listener_id, session_id, status="timed_out")
 
-        summaries = await query_service.get_listener_summary("test_app", 0)
-        assert len(summaries) == 1
-        s = summaries[0]
+        s = await only_row(query_service.get_listener_summary("test_app", 0))
         assert s.total_invocations == 4
         assert s.successful == 1
         assert s.failed == 1
@@ -41,9 +36,7 @@ class TestListenerSummaryTimedOut:
 
 class TestListenerSummaryThreadLeaked:
     async def test_listener_summary_counts_thread_leaked(
-        self,
-        query_service: TelemetryQueryService,
-        db: tuple[DatabaseService, int],
+        self, query_service: TelemetryQueryService, db: DbFixture
     ) -> None:
         """thread_leaked aggregates leaked-worker invocations onto the listener summary (#1049 parity)."""
         db_svc, session_id = db
@@ -60,9 +53,7 @@ class TestListenerSummaryThreadLeaked:
         assert summaries[0].thread_leaked == 2
 
     async def test_all_listeners_summary_counts_thread_leaked(
-        self,
-        query_service: TelemetryQueryService,
-        db: tuple[DatabaseService, int],
+        self, query_service: TelemetryQueryService, db: DbFixture
     ) -> None:
         """thread_leaked also aggregates in the no-app-filter (global) listener summary (#1049 parity)."""
         db_svc, session_id = db
@@ -79,11 +70,7 @@ class TestListenerSummaryThreadLeaked:
 
 
 class TestJobSummaryTimedOut:
-    async def test_job_summary_counts_timed_out(
-        self,
-        query_service: TelemetryQueryService,
-        db: tuple[DatabaseService, int],
-    ) -> None:
+    async def test_job_summary_counts_timed_out(self, query_service: TelemetryQueryService, db: DbFixture) -> None:
         """Verify timed_out is a separate bucket in JobSummary."""
         db_svc, session_id = db
         job_id = await insert_job(db_svc)
@@ -92,9 +79,7 @@ class TestJobSummaryTimedOut:
         await insert_execution(db_svc, job_id, session_id, status="error")
         await insert_execution(db_svc, job_id, session_id, status="timed_out")
 
-        summaries = await query_service.get_job_summary("test_app", 0)
-        assert len(summaries) == 1
-        s = summaries[0]
+        s = await only_row(query_service.get_job_summary("test_app", 0))
         assert s.total_executions == 4
         assert s.successful == 2
         assert s.failed == 1
@@ -102,11 +87,7 @@ class TestJobSummaryTimedOut:
 
 
 class TestJobSummaryThreadLeaked:
-    async def test_job_summary_counts_thread_leaked(
-        self,
-        query_service: TelemetryQueryService,
-        db: tuple[DatabaseService, int],
-    ) -> None:
+    async def test_job_summary_counts_thread_leaked(self, query_service: TelemetryQueryService, db: DbFixture) -> None:
         """thread_leaked_count aggregates leaked-worker executions onto the job summary (#1049)."""
         db_svc, session_id = db
         job_id = await insert_job(db_svc)
@@ -122,9 +103,7 @@ class TestJobSummaryThreadLeaked:
         assert summaries[0].thread_leaked == 2
 
     async def test_all_jobs_summary_counts_thread_leaked(
-        self,
-        query_service: TelemetryQueryService,
-        db: tuple[DatabaseService, int],
+        self, query_service: TelemetryQueryService, db: DbFixture
     ) -> None:
         """thread_leaked also aggregates in the no-app-filter (global) job summary (#1049)."""
         db_svc, session_id = db

--- a/tests/integration/telemetry/test_union_queries.py
+++ b/tests/integration/telemetry/test_union_queries.py
@@ -7,25 +7,30 @@ Covers ``get_app_recent_activity``, ``get_per_app_activity_buckets``, and
 
 import pytest
 
-from hassette.core.database_service import DatabaseService
 from hassette.core.telemetry.query_service import TelemetryQueryService
 from hassette.schemas.execution_models import ActivityFeedEntry
 
-from .helpers import BASE_TS, insert_execution, insert_invocation, insert_job, insert_listener
+from .helpers import (
+    BASE_TS,
+    DbFixture,
+    insert_app_listener_pair,
+    insert_execution,
+    insert_invocation,
+    insert_job,
+    insert_listener,
+    insert_listener_and_job,
+    insert_tiered_listeners,
+    recent_activity,
+)
 
 
 class TestGetAppRecentActivity:
-    async def test_merged_sorted_by_timestamp_desc(
-        self,
-        query_service: TelemetryQueryService,
-        db: tuple[DatabaseService, int],
-    ) -> None:
+    async def test_merged_sorted_by_timestamp_desc(self, query_service: TelemetryQueryService, db: DbFixture) -> None:
         """Handler invocations and job executions are merged and sorted by timestamp DESC."""
         db_svc, session_id = db
 
         base_ts = BASE_TS
-        listener_id = await insert_listener(db_svc, app_key="test_app", handler_method="on_event")
-        job_id = await insert_job(db_svc, app_key="test_app", job_name="my_job", handler_method="run_job")
+        listener_id, job_id = await insert_listener_and_job(db_svc)
 
         # Interleave timestamps so merge order is testable
         await insert_invocation(db_svc, listener_id, session_id, status="success", execution_start_ts=base_ts + 30.0)
@@ -34,13 +39,7 @@ class TestGetAppRecentActivity:
         )
         await insert_execution(db_svc, job_id, session_id, status="success", execution_start_ts=base_ts + 20.0)
 
-        results = await query_service.get_app_recent_activity(
-            app_key="test_app",
-            instance_index=None,
-            limit=50,
-            since=None,
-            source_tier="app",
-        )
+        results = await recent_activity(query_service)
 
         assert len(results) == 3
         assert all(isinstance(r, ActivityFeedEntry) for r in results)
@@ -49,28 +48,17 @@ class TestGetAppRecentActivity:
         assert results[1].timestamp == pytest.approx(base_ts + 20.0)
         assert results[2].timestamp == pytest.approx(base_ts + 10.0)
 
-    async def test_kind_field_correct(
-        self,
-        query_service: TelemetryQueryService,
-        db: tuple[DatabaseService, int],
-    ) -> None:
+    async def test_kind_field_correct(self, query_service: TelemetryQueryService, db: DbFixture) -> None:
         """Handler invocations have kind='handler', job executions have kind='job'."""
         db_svc, session_id = db
 
         base_ts = BASE_TS
-        listener_id = await insert_listener(db_svc, app_key="test_app", handler_method="on_event")
-        job_id = await insert_job(db_svc, app_key="test_app", job_name="my_job", handler_method="run_job")
+        listener_id, job_id = await insert_listener_and_job(db_svc)
 
         await insert_invocation(db_svc, listener_id, session_id, status="success", execution_start_ts=base_ts + 20.0)
         await insert_execution(db_svc, job_id, session_id, status="success", execution_start_ts=base_ts + 10.0)
 
-        results = await query_service.get_app_recent_activity(
-            app_key="test_app",
-            instance_index=None,
-            limit=50,
-            since=None,
-            source_tier="app",
-        )
+        results = await recent_activity(query_service)
 
         assert len(results) == 2
         assert results[0].kind == "handler"
@@ -78,11 +66,7 @@ class TestGetAppRecentActivity:
         assert results[1].kind == "job"
         assert results[1].handler_id == job_id
 
-    async def test_limit_is_respected(
-        self,
-        query_service: TelemetryQueryService,
-        db: tuple[DatabaseService, int],
-    ) -> None:
+    async def test_limit_is_respected(self, query_service: TelemetryQueryService, db: DbFixture) -> None:
         """Limit parameter caps the number of returned entries."""
         db_svc, session_id = db
 
@@ -94,13 +78,7 @@ class TestGetAppRecentActivity:
                 db_svc, listener_id, session_id, status="success", execution_start_ts=base_ts + float(i)
             )
 
-        results = await query_service.get_app_recent_activity(
-            app_key="test_app",
-            instance_index=None,
-            limit=3,
-            since=None,
-            source_tier="app",
-        )
+        results = await recent_activity(query_service, limit=3)
 
         assert len(results) == 3
         # Should be the 3 most recent
@@ -108,19 +86,14 @@ class TestGetAppRecentActivity:
         assert results[1].timestamp == pytest.approx(base_ts + 8.0)
         assert results[2].timestamp == pytest.approx(base_ts + 7.0)
 
-    async def test_since_filters_old_entries(
-        self,
-        query_service: TelemetryQueryService,
-        db: tuple[DatabaseService, int],
-    ) -> None:
+    async def test_since_filters_old_entries(self, query_service: TelemetryQueryService, db: DbFixture) -> None:
         """Since parameter excludes entries older than the threshold."""
         db_svc, session_id = db
 
         base_ts = BASE_TS
         since_ts = base_ts + 15.0
 
-        listener_id = await insert_listener(db_svc, app_key="test_app", handler_method="on_event")
-        job_id = await insert_job(db_svc, app_key="test_app", job_name="my_job", handler_method="run_job")
+        listener_id, job_id = await insert_listener_and_job(db_svc)
 
         # After since_ts — should be included
         await insert_invocation(db_svc, listener_id, session_id, status="success", execution_start_ts=base_ts + 20.0)
@@ -130,28 +103,18 @@ class TestGetAppRecentActivity:
         await insert_invocation(db_svc, listener_id, session_id, status="error", execution_start_ts=base_ts + 5.0)
         await insert_execution(db_svc, job_id, session_id, status="error", execution_start_ts=base_ts + 10.0)
 
-        results = await query_service.get_app_recent_activity(
-            app_key="test_app",
-            instance_index=None,
-            limit=50,
-            since=since_ts,
-            source_tier="app",
-        )
+        results = await recent_activity(query_service, since=since_ts)
 
         assert len(results) == 2
         assert all(r.timestamp >= since_ts for r in results)
 
-    async def test_source_tier_filtering(
-        self,
-        query_service: TelemetryQueryService,
-        db: tuple[DatabaseService, int],
-    ) -> None:
+    async def test_source_tier_filtering(self, query_service: TelemetryQueryService, db: DbFixture) -> None:
         """source_tier='framework' returns only framework-tier entries, not app-tier."""
+        # dup-ignore-start: tier-scoping cases share this setup and differ only in the timestamps/statuses each probes
         db_svc, session_id = db
 
         base_ts = BASE_TS
-        app_listener = await insert_listener(db_svc, app_key="test_app", handler_method="on_app", source_tier="app")
-        fw_listener = await insert_listener(db_svc, app_key="test_app", handler_method="on_fw", source_tier="framework")
+        app_listener, fw_listener = await insert_tiered_listeners(db_svc)
 
         await insert_invocation(
             db_svc, app_listener, session_id, status="success", execution_start_ts=base_ts + 10.0, source_tier="app"
@@ -164,23 +127,14 @@ class TestGetAppRecentActivity:
             execution_start_ts=base_ts + 20.0,
             source_tier="framework",
         )
+        # dup-ignore-end
 
-        results = await query_service.get_app_recent_activity(
-            app_key="test_app",
-            instance_index=None,
-            limit=50,
-            since=None,
-            source_tier="framework",
-        )
+        results = await recent_activity(query_service, source_tier="framework")
 
         assert len(results) == 1
         assert results[0].handler_name == "on_fw"
 
-    async def test_instance_index_scoping(
-        self,
-        query_service: TelemetryQueryService,
-        db: tuple[DatabaseService, int],
-    ) -> None:
+    async def test_instance_index_scoping(self, query_service: TelemetryQueryService, db: DbFixture) -> None:
         """instance_index filters to entries for that instance only."""
         db_svc, session_id = db
 
@@ -191,75 +145,45 @@ class TestGetAppRecentActivity:
         await insert_invocation(db_svc, listener_0, session_id, status="success", execution_start_ts=base_ts + 10.0)
         await insert_invocation(db_svc, listener_1, session_id, status="success", execution_start_ts=base_ts + 20.0)
 
-        results = await query_service.get_app_recent_activity(
-            app_key="test_app",
-            instance_index=0,
-            limit=50,
-            since=None,
-            source_tier="app",
-        )
+        results = await recent_activity(query_service, instance_index=0)
 
         assert len(results) == 1
         assert results[0].timestamp == pytest.approx(base_ts + 10.0)
 
-    async def test_empty_app_returns_empty_list(
-        self,
-        query_service: TelemetryQueryService,
-        db: tuple[DatabaseService, int],
-    ) -> None:
+    async def test_empty_app_returns_empty_list(self, query_service: TelemetryQueryService, db: DbFixture) -> None:
         """App with no invocations or executions returns an empty list."""
         db_svc, _session_id = db
         await insert_listener(db_svc, app_key="test_app", handler_method="on_event")
 
-        results = await query_service.get_app_recent_activity(
-            app_key="test_app",
-            instance_index=None,
-            limit=50,
-            since=None,
-            source_tier="app",
-        )
+        results = await recent_activity(query_service)
 
         assert results == []
 
-    async def test_isolates_to_app_key(
-        self,
-        query_service: TelemetryQueryService,
-        db: tuple[DatabaseService, int],
-    ) -> None:
+    async def test_isolates_to_app_key(self, query_service: TelemetryQueryService, db: DbFixture) -> None:
         """Results are scoped to the requested app_key only."""
+        # dup-ignore-start: cross-app cases share this setup and differ only in the timestamps/statuses each probes
         db_svc, session_id = db
 
         base_ts = BASE_TS
-        listener_a = await insert_listener(db_svc, app_key="app_a", handler_method="on_a")
-        listener_b = await insert_listener(db_svc, app_key="app_b", handler_method="on_b")
+        listener_a, listener_b = await insert_app_listener_pair(db_svc)
 
         await insert_invocation(db_svc, listener_a, session_id, status="success", execution_start_ts=base_ts + 10.0)
         await insert_invocation(db_svc, listener_b, session_id, status="success", execution_start_ts=base_ts + 20.0)
+        # dup-ignore-end
 
-        results = await query_service.get_app_recent_activity(
-            app_key="app_a",
-            instance_index=None,
-            limit=50,
-            since=None,
-            source_tier="app",
-        )
+        results = await recent_activity(query_service, app_key="app_a")
 
         assert len(results) == 1
         assert results[0].app_key == "app_a"
 
-    async def test_row_id_uniqueness_and_prefixes(
-        self,
-        query_service: TelemetryQueryService,
-        db: tuple[DatabaseService, int],
-    ) -> None:
+    async def test_row_id_uniqueness_and_prefixes(self, query_service: TelemetryQueryService, db: DbFixture) -> None:
         """row_id values are unique across all rows and use the correct kind prefix."""
         db_svc, session_id = db
 
         # Same timestamp for both invocations to stress-test uniqueness
         shared_ts = 1_000_000.0
 
-        listener_id = await insert_listener(db_svc, app_key="test_app", handler_method="on_event")
-        job_id = await insert_job(db_svc, app_key="test_app", job_name="my_job", handler_method="run_job")
+        listener_id, job_id = await insert_listener_and_job(db_svc)
 
         # Two handler invocations with the same timestamp
         await insert_invocation(db_svc, listener_id, session_id, status="success", execution_start_ts=shared_ts)
@@ -269,13 +193,7 @@ class TestGetAppRecentActivity:
         # One job execution with the same timestamp
         await insert_execution(db_svc, job_id, session_id, status="success", execution_start_ts=shared_ts)
 
-        results = await query_service.get_app_recent_activity(
-            app_key="test_app",
-            instance_index=None,
-            limit=50,
-            since=None,
-            source_tier="app",
-        )
+        results = await recent_activity(query_service)
 
         assert len(results) == 3
 
@@ -297,11 +215,7 @@ class TestGetAppRecentActivity:
 
 
 class TestGetPerAppActivityBuckets:
-    async def test_basic_bucketed_ok_err_counts(
-        self,
-        query_service: TelemetryQueryService,
-        db: tuple[DatabaseService, int],
-    ) -> None:
+    async def test_basic_bucketed_ok_err_counts(self, query_service: TelemetryQueryService, db: DbFixture) -> None:
         """Executions across 2 apps are bucketed into (ok, err) counts per app_key."""
         db_svc, session_id = db
 
@@ -342,9 +256,7 @@ class TestGetPerAppActivityBuckets:
                 assert result["app_b"][idx] == (0, 0)
 
     async def test_empty_time_range_returns_empty_dict(
-        self,
-        query_service: TelemetryQueryService,
-        db: tuple[DatabaseService, int],
+        self, query_service: TelemetryQueryService, db: DbFixture
     ) -> None:
         """Now <= since short-circuits to an empty dict without querying."""
         db_svc, session_id = db
@@ -357,11 +269,7 @@ class TestGetPerAppActivityBuckets:
         result = await query_service.get_per_app_activity_buckets(since=BASE_TS + 50.0, now=BASE_TS)
         assert result == {}
 
-    async def test_single_bucket_covers_entire_range(
-        self,
-        query_service: TelemetryQueryService,
-        db: tuple[DatabaseService, int],
-    ) -> None:
+    async def test_single_bucket_covers_entire_range(self, query_service: TelemetryQueryService, db: DbFixture) -> None:
         """num_buckets=1 aggregates the whole [since, now) window into one (ok, err) tuple."""
         db_svc, session_id = db
 
@@ -378,23 +286,20 @@ class TestGetPerAppActivityBuckets:
 
         assert result["app_a"] == [(2, 1)]
 
-    async def test_cross_app_isolation(
-        self,
-        query_service: TelemetryQueryService,
-        db: tuple[DatabaseService, int],
-    ) -> None:
+    async def test_cross_app_isolation(self, query_service: TelemetryQueryService, db: DbFixture) -> None:
         """One app's errors do not leak into another app's buckets."""
+        # dup-ignore-start: cross-app cases share this setup and differ only in the timestamps/statuses each probes
         db_svc, session_id = db
 
         base_ts = BASE_TS
-        listener_a = await insert_listener(db_svc, app_key="app_a", handler_method="on_a")
-        listener_b = await insert_listener(db_svc, app_key="app_b", handler_method="on_b")
+        listener_a, listener_b = await insert_app_listener_pair(db_svc)
 
         # Same bucket (bucket 0) for both apps
         await insert_invocation(
             db_svc, listener_a, session_id, status="error", execution_start_ts=base_ts + 1.0, error_type="ValueError"
         )
         await insert_invocation(db_svc, listener_b, session_id, status="success", execution_start_ts=base_ts + 2.0)
+        # dup-ignore-end
 
         result = await query_service.get_per_app_activity_buckets(since=base_ts, now=base_ts + 10.0, num_buckets=1)
 
@@ -402,16 +307,14 @@ class TestGetPerAppActivityBuckets:
         assert result["app_b"] == [(1, 0)]
 
     async def test_source_tier_app_excludes_framework(
-        self,
-        query_service: TelemetryQueryService,
-        db: tuple[DatabaseService, int],
+        self, query_service: TelemetryQueryService, db: DbFixture
     ) -> None:
         """source_tier='app' (the default) excludes framework-tier executions."""
+        # dup-ignore-start: tier-scoping cases share this setup and differ only in the timestamps/statuses each probes
         db_svc, session_id = db
 
         base_ts = BASE_TS
-        app_listener = await insert_listener(db_svc, app_key="test_app", handler_method="on_app", source_tier="app")
-        fw_listener = await insert_listener(db_svc, app_key="test_app", handler_method="on_fw", source_tier="framework")
+        app_listener, fw_listener = await insert_tiered_listeners(db_svc)
 
         await insert_invocation(
             db_svc, app_listener, session_id, status="success", execution_start_ts=base_ts + 5.0, source_tier="app"
@@ -424,6 +327,7 @@ class TestGetPerAppActivityBuckets:
             execution_start_ts=base_ts + 5.0,
             source_tier="framework",
         )
+        # dup-ignore-end
 
         result = await query_service.get_per_app_activity_buckets(
             since=base_ts, now=base_ts + 10.0, num_buckets=1, source_tier="app"
@@ -433,17 +337,13 @@ class TestGetPerAppActivityBuckets:
 
 
 class TestGetPerAppLastErrors:
-    async def test_returns_most_recent_error_per_app(
-        self,
-        query_service: TelemetryQueryService,
-        db: tuple[DatabaseService, int],
-    ) -> None:
+    async def test_returns_most_recent_error_per_app(self, query_service: TelemetryQueryService, db: DbFixture) -> None:
         """Multiple errors per app resolve to the one with the latest timestamp."""
+        # dup-ignore-start: cross-app cases share this setup and differ only in the timestamps/statuses each probes
         db_svc, session_id = db
 
         base_ts = BASE_TS
-        listener_a = await insert_listener(db_svc, app_key="app_a", handler_method="on_a")
-        listener_b = await insert_listener(db_svc, app_key="app_b", handler_method="on_b")
+        listener_a, listener_b = await insert_app_listener_pair(db_svc)
 
         await insert_invocation(
             db_svc,
@@ -472,6 +372,7 @@ class TestGetPerAppLastErrors:
             error_type="KeyError",
             error_message="b_error",
         )
+        # dup-ignore-end
 
         result = await query_service.get_per_app_last_errors()
 
@@ -483,16 +384,14 @@ class TestGetPerAppLastErrors:
         assert result["app_b"].timestamp == pytest.approx(base_ts + 15.0)
 
     async def test_since_window_filtering_excludes_apps_with_no_recent_errors(
-        self,
-        query_service: TelemetryQueryService,
-        db: tuple[DatabaseService, int],
+        self, query_service: TelemetryQueryService, db: DbFixture
     ) -> None:
         """An app whose only error predates the since threshold is excluded entirely."""
+        # dup-ignore-start: cross-app cases share this setup and differ only in the timestamps/statuses each probes
         db_svc, session_id = db
 
         base_ts = BASE_TS
-        listener_a = await insert_listener(db_svc, app_key="app_a", handler_method="on_a")
-        listener_b = await insert_listener(db_svc, app_key="app_b", handler_method="on_b")
+        listener_a, listener_b = await insert_app_listener_pair(db_svc)
 
         await insert_invocation(
             db_svc,
@@ -512,6 +411,7 @@ class TestGetPerAppLastErrors:
             error_type="KeyError",
             error_message="in_window",
         )
+        # dup-ignore-end
 
         result = await query_service.get_per_app_last_errors(since=base_ts + 15.0)
 
@@ -519,16 +419,14 @@ class TestGetPerAppLastErrors:
         assert result["app_b"].error_message == "in_window"
 
     async def test_source_tier_app_excludes_framework_errors(
-        self,
-        query_service: TelemetryQueryService,
-        db: tuple[DatabaseService, int],
+        self, query_service: TelemetryQueryService, db: DbFixture
     ) -> None:
         """source_tier='app' (the default) ignores later framework-tier errors."""
+        # dup-ignore-start: tier-scoping cases share this setup and differ only in the timestamps/statuses each probes
         db_svc, session_id = db
 
         base_ts = BASE_TS
-        app_listener = await insert_listener(db_svc, app_key="test_app", handler_method="on_app", source_tier="app")
-        fw_listener = await insert_listener(db_svc, app_key="test_app", handler_method="on_fw", source_tier="framework")
+        app_listener, fw_listener = await insert_tiered_listeners(db_svc)
 
         await insert_invocation(
             db_svc,
@@ -551,15 +449,14 @@ class TestGetPerAppLastErrors:
             error_message="fw_err",
             source_tier="framework",
         )
+        # dup-ignore-end
 
         result = await query_service.get_per_app_last_errors(source_tier="app")
 
         assert result["test_app"].error_message == "app_err"
 
     async def test_apps_with_only_successful_executions_are_excluded(
-        self,
-        query_service: TelemetryQueryService,
-        db: tuple[DatabaseService, int],
+        self, query_service: TelemetryQueryService, db: DbFixture
     ) -> None:
         """An app with no errors at all does not appear in the result."""
         db_svc, session_id = db


### PR DESCRIPTION
## Summary

Removes the duplicate-code clusters that were internal to `tests/integration/telemetry/` — 32 flagged clusters down to 0 — by extracting the mechanically repeated setup into the directory's `helpers.py` and annotating the cases where the repetition is meaningful parallel test structure rather than accidental copy-paste.

Net effect is roughly 470 fewer lines across the directory with no change to what any test asserts.

## What changed

**Extractions** (in `tests/integration/telemetry/helpers.py` unless noted):

- `DbFixture` type alias for the db fixture's tuple, so most test signatures fit on one line instead of five
- `commit_returning_id()`, `open_db_with_session()`, `running_command_executor()`
- `only_row(query)` — replaces the fetch / assert-len-1 / index-0 triple that appeared throughout
- `error_row()`, `SINCE_WINDOW_ERROR_ROWS`, `assert_no_last_error()`
- `insert_listener_and_job()`, `insert_tiered_listeners()`, `insert_app_listener_pair()`
- `recent_activity()` — `get_app_recent_activity()` with defaults for the four arguments a given test usually doesn't vary
- File-local: `_record_and_fetch()` in `test_blocking_events_persistence.py`; `get_jobs()` / `get_only_job()` / `stub_job_sources()` in `test_global_jobs_and_service_info.py`
- Two inline `ExecutionRecord` literals now use the file's own `make_inv_record()` / `make_job_record()`

**Annotated instead of extracted:** eight setup blocks in `test_union_queries.py` and `test_telemetry_query_service_aggregates.py` are wrapped in dup-ignore markers. The tier-scoping and cross-app cases share a setup shape but differ in the timestamps and statuses each probes; folding that into helper kwargs would hide what each case actually covers.

**Not closable from here:** six flagged lines remain under this directory, all in clusters whose other occurrences live in `test_command_executor.py`, `test_command_executor_error_handler.py`, `test_dispatch_unification.py`, and `test_thread_leaked_observability.py`. The checker only suppresses a cluster once every occurrence is annotated, so those need a change outside this directory. One is the pre-existing CommandExecutor-fixture cluster, which `running_command_executor()` now joins as a single member in place of the three copies this directory used to carry.

`tests/integration/telemetry/CLAUDE.md` documents the new helpers for future work in the directory.

## Testing

- `uv run nox -s dev` — 6901 passed, 1 skipped, 2 xfailed
- `prek -a` — all hooks pass (ruff, ruff format, eslint, stylelint, tsc, house-lint, factory-shadowing check, and the rest)
- `prek pyright -a --stage pre-push` — passes

Test-only change; no source files touched, so no docs or frontend updates apply.

Closes #1564
