### PR TITLE
test: deduplicate CLI test scaffolding

### DIFF
--- a/tests/unit/cli/CLAUDE.md
+++ b/tests/unit/cli/CLAUDE.md
@@ -70,7 +70,8 @@ aborted `nox -s tests_with_coverage` before it wrote `coverage.xml`, since the s
 - `MockTransportBuilder` — route table for mock HTTP responses
 - `GetSpy` — wraps `client.get` to record paths and params; `spy.params_for(fragment)` returns the
   query params of the first recorded GET whose path contains `fragment`
-- `capture_stdout()` / `capture_stderr()` / `capture_json_stdout()` — Rich console capture
+- `capture_stdout()` / `capture_stderr()` — Rich console capture
+- `capture_json_stdout()` — raw `sys.stdout.write` capture for JSON-mode commands
 - `capture_human(func, *args)` — returns `(stdout, stderr)` strings
 - `parse_json_stdout(capsys)` — parses what a json-mode `render_*` wrote to the real stdout
 - `SINCE_EPOCH` — pre-computed epoch float for direct-call tests

--- a/tests/unit/cli/CLAUDE.md
+++ b/tests/unit/cli/CLAUDE.md
@@ -64,12 +64,34 @@ aborted `nox -s tests_with_coverage` before it wrote `coverage.xml`, since the s
 ## Fixtures and helpers
 
 `conftest.py` provides:
-- `CLIClientFactory` — builds `HassetteCLIClient` instances backed by `MockTransport`
+- `CommandRunner` — runs a command function with its module's `make_client` patched (see below)
+- `CLIClientFactory` — builds `HassetteCLIClient` instances backed by `MockTransport`; the
+  keyword-only resolver flags it forwards are declared once as the `ClientFlags` TypedDict
 - `MockTransportBuilder` — route table for mock HTTP responses
-- `GetSpy` — wraps `client.get` to record paths and params
+- `GetSpy` — wraps `client.get` to record paths and params; `spy.params_for(fragment)` returns the
+  query params of the first recorded GET whose path contains `fragment`
 - `capture_stdout()` / `capture_stderr()` / `capture_json_stdout()` — Rich console capture
 - `capture_human(func, *args)` — returns `(stdout, stderr)` strings
+- `parse_json_stdout(capsys)` — parses what a json-mode `render_*` wrote to the real stdout
 - `SINCE_EPOCH` — pre-computed epoch float for direct-call tests
+
+### CommandRunner
+
+Every `test_commands_*.py` module owns one instance, because the `make_client` patch target is
+per-module — each command module imports `make_client` into its own namespace:
+
+```python
+runner = CommandRunner("hassette.cli.commands.log.make_client")
+
+spy = runner.spy(client, cmd_log, app="my-app")          # GET paths and params
+output = runner.stdout(client, cmd_log)                  # human table/panel output
+parsed = runner.json_output(client, cmd_log)             # --json document (ctx is injected)
+assert "No results" in runner.stderr(client, cmd_log)    # stderr, stdout suppressed
+code, stderr = runner.usage_error(client, cmd_log, instance="0")  # expects SystemExit
+```
+
+Reach for these instead of hand-rolling the `patch(...)` / `capture_*()` context-manager stack —
+`tools/check_duplicate_code.py` flags that boilerplate once it appears in three tests.
 
 ## File layout
 

--- a/tests/unit/cli/conftest.py
+++ b/tests/unit/cli/conftest.py
@@ -101,7 +101,7 @@ class GetSpy:
         assert call is not None, f"no GET path contained {path_fragment!r}; requested paths: {self.paths}"
         params = call["params"]
         assert params is not None, f"GET {call['path']} was issued without query params"
-        return params
+        return dict(params)
 
 
 @contextmanager

--- a/tests/unit/cli/conftest.py
+++ b/tests/unit/cli/conftest.py
@@ -1,11 +1,11 @@
 """Shared CLI test fixtures for CLI client and command tests."""
 
 import json
-from collections.abc import Generator
+from collections.abc import Callable, Generator
 from contextlib import contextmanager
 from io import StringIO
 from pathlib import Path
-from typing import Any
+from typing import Any, TypedDict, Unpack
 from unittest.mock import patch
 
 import httpx2 as httpx
@@ -14,6 +14,7 @@ from rich.console import Console
 
 import hassette.cli.output as output_module
 from hassette.cli.client import HassetteCLIClient
+from hassette.cli.context import CLIContext
 from hassette.config.config import HassetteConfig
 from hassette.test_utils import make_test_config
 
@@ -89,6 +90,19 @@ class GetSpy:
         self.calls.append({"path": path, "params": params})
         return self._original(path, model, params=params, **kwargs)
 
+    def params_for(self, path_fragment: str) -> dict[str, Any]:
+        """Return the query params of the first recorded GET whose path contains ``path_fragment``.
+
+        Both failure modes name what went wrong: no request matched the fragment (with the paths
+        that were actually requested), or the matching request carried no params at all — rather
+        than a bare ``StopIteration`` or a ``TypeError`` on ``None``.
+        """
+        call = next((r for r in self.calls if path_fragment in r["path"]), None)
+        assert call is not None, f"no GET path contained {path_fragment!r}; requested paths: {self.paths}"
+        params = call["params"]
+        assert params is not None, f"GET {call['path']} was issued without query params"
+        return params
+
 
 @contextmanager
 def capture_json_stdout() -> Generator[list[str], None, None]:
@@ -96,6 +110,15 @@ def capture_json_stdout() -> Generator[list[str], None, None]:
     captured: list[str] = []
     with patch("sys.stdout.write", side_effect=lambda s: captured.append(s) or len(s)):
         yield captured
+
+
+def parse_json_stdout(capsys: pytest.CaptureFixture[str]) -> Any:
+    """Parse the JSON document a json-mode render wrote to the real stdout.
+
+    For the ``render_*`` functions, which write JSON through ``sys.stdout`` rather than the Rich
+    consoles ``capture_stdout()`` patches.
+    """
+    return json.loads(capsys.readouterr().out)
 
 
 @contextmanager
@@ -133,6 +156,84 @@ def capture_stderr():
     mock_console = Console(file=buf, stderr=True, highlight=False, force_terminal=False)
     with patch.object(output_module, "stderr_console", mock_console):
         yield buf
+
+
+class CommandRunner:
+    """Invokes a CLI command function with its module's ``make_client`` patched to a test client.
+
+    Every ``test_commands_*.py`` module builds a mock-backed client, patches the ``make_client``
+    its command module imported, runs the command, and reads back one thing: the GET calls it
+    made, its human stdout or stderr, the exit it took, or its ``--json`` document. This bundles
+    that boilerplate into one call per test. Instantiate once per module — the patch target is
+    per-module, since each command module imports ``make_client`` into its own namespace::
+
+        runner = CommandRunner("hassette.cli.commands.log.make_client")
+
+        spy = runner.spy(client, cmd_log, app="my-app")
+        output = runner.stdout(client, cmd_log)
+        parsed = runner.json_output(client, cmd_log)
+        assert "No results" in runner.stderr(client, cmd_log)
+        code, stderr = runner.usage_error(client, cmd_log, instance="0")
+    """
+
+    def __init__(self, make_client_path: str) -> None:
+        self.make_client_path = make_client_path
+
+    def spy(self, client: HassetteCLIClient, func: Callable[..., None], *args: Any, **kwargs: Any) -> GetSpy:
+        """Run ``func`` and return the ``GetSpy`` recording its GET paths and params."""
+        spy = GetSpy(client)
+        with (
+            patch.object(client, "get", side_effect=spy),
+            capture_stdout(),
+            patch(self.make_client_path, return_value=client),
+        ):
+            func(*args, **kwargs)
+        return spy
+
+    def stdout(self, client: HassetteCLIClient, func: Callable[..., None], *args: Any, **kwargs: Any) -> str:
+        """Run ``func`` and return what it rendered to the human stdout console."""
+        with capture_stdout() as buf, patch(self.make_client_path, return_value=client):
+            func(*args, **kwargs)
+        return buf.getvalue()
+
+    def stderr(self, client: HassetteCLIClient, func: Callable[..., None], *args: Any, **kwargs: Any) -> str:
+        """Run ``func`` and return its stderr, with stdout captured so tables don't leak out."""
+        with (
+            capture_stdout(),
+            capture_stderr() as err_buf,
+            patch(self.make_client_path, return_value=client),
+        ):
+            func(*args, **kwargs)
+        return err_buf.getvalue()
+
+    def usage_error(
+        self, client: HassetteCLIClient, func: Callable[..., None], *args: Any, **kwargs: Any
+    ) -> tuple[Any, str]:
+        """Run ``func`` expecting it to exit; return the exit code and the stderr it printed.
+
+        Captures stdout for the same reason ``stderr()`` does — whatever the command managed to
+        render before exiting shouldn't leak into the test run's own output.
+        """
+        with (
+            capture_stdout(),
+            capture_stderr() as err_buf,
+            patch(self.make_client_path, return_value=client),
+            pytest.raises(SystemExit) as exc_info,
+        ):
+            func(*args, **kwargs)
+        return exc_info.value.code, err_buf.getvalue()
+
+    def json_output(self, client: HassetteCLIClient, func: Callable[..., None], *args: Any, **kwargs: Any) -> Any:
+        """Run ``func`` in JSON mode and return its parsed stdout document.
+
+        The json-mode ``ctx`` is supplied here, so call sites pass only the command's own args.
+        """
+        with (
+            patch(self.make_client_path, return_value=client),
+            capture_json_stdout() as captured,
+        ):
+            func(*args, ctx=CLIContext(json_mode=True), **kwargs)
+        return json.loads("".join(captured))
 
 
 class MockTransportBuilder:
@@ -180,6 +281,21 @@ class MockTransportBuilder:
         return httpx.MockTransport(handler)
 
 
+class ClientFlags(TypedDict, total=False):
+    """The keyword-only resolver inputs ``HassetteCLIClient.__init__`` accepts.
+
+    Mirrors what ``make_client(ctx)`` unpacks from ``CLIContext`` in real usage — pass these
+    through any ``CLIClientFactory`` builder to test flag-sourced targets, credentials, or TLS
+    settings without hand-building a ``CLIContext``. Declared once here so the builders below
+    forward the list as ``**flags`` instead of each restating it.
+    """
+
+    debug_mode: bool
+    server_url_flag: str | None
+    token_file_flag: Path | None
+    verify_ssl_flag: bool | None
+
+
 class CLIClientFactory:
     """Creates HassetteCLIClient instances with mock transports for testing."""
 
@@ -190,67 +306,35 @@ class CLIClientFactory:
         self,
         transport: httpx.BaseTransport,
         json_mode: bool = False,
-        *,
-        debug_mode: bool = False,
-        server_url_flag: str | None = None,
-        token_file_flag: Path | None = None,
-        verify_ssl_flag: bool | None = None,
+        **flags: Unpack[ClientFlags],
     ) -> HassetteCLIClient:
-        """Build a HassetteCLIClient backed by ``transport``.
-
-        The keyword-only ``*_flag`` arguments mirror ``HassetteCLIClient.__init__``'s resolver
-        inputs (what ``make_client(ctx)`` unpacks from ``CLIContext`` in real usage) — pass them
-        to test flag-sourced targets/credentials/TLS settings without hand-building a
-        ``CLIContext``.
-        """
-        return HassetteCLIClient(
-            self.config,
-            json_mode=json_mode,
-            debug_mode=debug_mode,
-            transport=transport,
-            server_url_flag=server_url_flag,
-            token_file_flag=token_file_flag,
-            verify_ssl_flag=verify_ssl_flag,
-        )
+        """Build a HassetteCLIClient backed by ``transport``."""
+        return HassetteCLIClient(self.config, json_mode=json_mode, transport=transport, **flags)
 
     def build_with_routes(
         self,
         routes: list[tuple[str, str, int, Any]],
         json_mode: bool = False,
-        *,
-        debug_mode: bool = False,
-        server_url_flag: str | None = None,
-        token_file_flag: Path | None = None,
-        verify_ssl_flag: bool | None = None,
+        **flags: Unpack[ClientFlags],
     ) -> HassetteCLIClient:
         """Build a client pre-wired with route responses.
 
         Args:
             routes: List of ``(method, path_fragment, status, body)`` tuples.
             json_mode: Whether the client operates in JSON mode.
+            flags: Resolver inputs forwarded to the client — see ``ClientFlags``.
         """
         builder = MockTransportBuilder()
         for method, path_fragment, status, body in routes:
             builder.add(method, path_fragment, status, body)
-        transport = builder.build()
-        return self.build(
-            transport,
-            json_mode=json_mode,
-            debug_mode=debug_mode,
-            server_url_flag=server_url_flag,
-            token_file_flag=token_file_flag,
-            verify_ssl_flag=verify_ssl_flag,
-        )
+        return self.build(builder.build(), json_mode=json_mode, **flags)
 
     def build_capturing_headers(
         self,
         status_code: int = 200,
         body: Any = None,
         json_mode: bool = False,
-        *,
-        server_url_flag: str | None = None,
-        token_file_flag: Path | None = None,
-        verify_ssl_flag: bool | None = None,
+        **flags: Unpack[ClientFlags],
     ) -> tuple[HassetteCLIClient, list[httpx.Headers]]:
         """Build a client whose mock transport returns a fixed response for every GET request.
 
@@ -260,14 +344,7 @@ class CLIClientFactory:
         """
         builder = MockTransportBuilder()
         builder.add("GET", "", status_code, body if body is not None else {})
-        transport = builder.build()
-        client = self.build(
-            transport,
-            json_mode=json_mode,
-            server_url_flag=server_url_flag,
-            token_file_flag=token_file_flag,
-            verify_ssl_flag=verify_ssl_flag,
-        )
+        client = self.build(builder.build(), json_mode=json_mode, **flags)
         return client, builder.captured_headers
 
 

--- a/tests/unit/cli/test_client.py
+++ b/tests/unit/cli/test_client.py
@@ -70,15 +70,69 @@ def _make_manifest_list(instances: list[AppInstanceResponse], app_key: str = "my
     return make_manifest_list_response(manifests=[manifest])
 
 
-def url_capturing_transport() -> tuple[httpx.MockTransport, list[str]]:
-    """Build a MockTransport that records every request URL and returns an empty JSON array."""
+def url_capturing_client() -> tuple[HassetteCLIClient, list[str]]:
+    """Build a default-target client plus the list its request URLs are recorded into."""
     captured_urls: list[str] = []
 
     def handler(request: httpx.Request) -> httpx.Response:
         captured_urls.append(str(request.url))
         return httpx.Response(200, content=b"[]", headers={"content-type": "application/json"})
 
-    return httpx.MockTransport(handler), captured_urls
+    transport = httpx.MockTransport(handler)
+    return HassetteCLIClient(_make_host_port_config(), json_mode=False, transport=transport), captured_urls
+
+
+def route_listeners(client: HassetteCLIClient, **kwargs: Any) -> Any:
+    """Route a listener request through ``get_with_app_routing``.
+
+    The global/per-app path pair is the same in every routing test — only ``app_key`` and
+    ``instance`` are ever varied, so those stay at the call site.
+    """
+    return client.get_with_app_routing(
+        global_path="/api/bus/listeners",
+        per_app_path_template="/api/telemetry/app/{app_key}/listeners",
+        model=list,
+        **kwargs,
+    )
+
+
+def get_expecting_exit(client: HassetteCLIClient, path: str = HEALTH_ENDPOINT) -> tuple[Any, str]:
+    """GET ``path`` expecting a SystemExit; return the exit code and the human-mode stderr."""
+    with capture_stderr() as buf, pytest.raises(SystemExit) as exc_info:
+        client.get(path, SimpleModel)
+    return exc_info.value.code, buf.getvalue()
+
+
+def get_json_error(
+    client: HassetteCLIClient,
+    capsys: pytest.CaptureFixture[str],
+    path: str = HEALTH_ENDPOINT,
+    *,
+    expect_code: int | None = None,
+) -> Any:
+    """GET ``path`` on a json-mode client expecting a SystemExit; return the parsed error doc.
+
+    Pass ``expect_code`` to also assert the exit status the client exited with.
+    """
+    with pytest.raises(SystemExit) as exc_info:
+        client.get(path, SimpleModel)
+    if expect_code is not None:
+        assert exc_info.value.code == expect_code
+    return json.loads(capsys.readouterr().out)
+
+
+def stderr_for_successful_get(config: HassetteConfig, **client_kwargs: Any) -> str:
+    """Return what a client built from ``config`` writes to stderr on a successful GET.
+
+    The target echo and the TLS-verification warning are both success-path stderr output, so
+    the response body itself never matters — only which config/flags produced the client.
+    """
+    client = HassetteCLIClient(
+        config, json_mode=False, transport=make_transport(200, {"value": "hello"}), **client_kwargs
+    )
+    with capture_stderr() as buf:
+        client.get(HEALTH_ENDPOINT, SimpleModel)
+    return buf.getvalue()
 
 
 # Base URL construction & address substitution
@@ -194,9 +248,8 @@ class TestHttpErrorsHumanMode:
         config = _make_host_port_config()
         transport = make_transport(404, {"detail": "Not found"})
         client = HassetteCLIClient(config, json_mode=False, transport=transport)
-        with capture_stderr() as buf, pytest.raises(SystemExit):
-            client.get("/api/missing", SimpleModel)
-        assert len(buf.getvalue()) > 0
+        _code, stderr = get_expecting_exit(client, "/api/missing")
+        assert len(stderr) > 0
 
     def test_500_exits_with_code_1(self) -> None:
         config = _make_host_port_config()
@@ -224,11 +277,7 @@ class TestHttpErrorsJsonMode:
         config = _make_host_port_config()
         transport = make_transport(404, {"detail": "Not found"})
         client = HassetteCLIClient(config, json_mode=True, transport=transport)
-        with pytest.raises(SystemExit) as exc_info:
-            client.get("/api/missing", SimpleModel)
-        assert exc_info.value.code == 1
-        captured = capsys.readouterr()
-        parsed = json.loads(captured.out)
+        parsed = get_json_error(client, capsys, "/api/missing", expect_code=1)
         assert parsed["error"] is True
         assert parsed["status"] == 404
         assert "detail" in parsed
@@ -237,11 +286,8 @@ class TestHttpErrorsJsonMode:
         config = _make_host_port_config()
         transport = make_transport(500, {"detail": "boom"})
         client = HassetteCLIClient(config, json_mode=True, transport=transport)
-        with pytest.raises(SystemExit):
-            client.get("/api/crash", SimpleModel)
-        captured = capsys.readouterr()
         # In json mode, error goes to stdout only
-        parsed = json.loads(captured.out)
+        parsed = get_json_error(client, capsys, "/api/crash")
         assert parsed["error"] is True
 
 
@@ -261,10 +307,8 @@ class TestNetworkErrors:
         config = _make_host_port_config("127.0.0.1", 8126)
         transport = make_transport(raise_exc=httpx.ConnectError)
         client = HassetteCLIClient(config, json_mode=False, transport=transport)
-        with capture_stderr() as buf, pytest.raises(SystemExit):
-            client.get("/api/health", SimpleModel)
-        output = buf.getvalue()
-        assert "127.0.0.1" in output or "8126" in output
+        _code, stderr = get_expecting_exit(client)
+        assert "127.0.0.1" in stderr or "8126" in stderr
 
     def test_timeout_exits_code_2(self) -> None:
         config = _make_host_port_config()
@@ -278,10 +322,7 @@ class TestNetworkErrors:
         config = _make_host_port_config()
         transport = make_transport(raise_exc=httpx.TimeoutException)
         client = HassetteCLIClient(config, json_mode=True, transport=transport)
-        with pytest.raises(SystemExit):
-            client.get("/api/health", SimpleModel)
-        captured = capsys.readouterr()
-        parsed = json.loads(captured.out)
+        parsed = get_json_error(client, capsys)
         assert parsed["error"] is True
         assert parsed["status"] is None
         assert "detail" in parsed
@@ -290,10 +331,7 @@ class TestNetworkErrors:
         config = _make_host_port_config()
         transport = make_transport(raise_exc=httpx.ConnectError)
         client = HassetteCLIClient(config, json_mode=True, transport=transport)
-        with pytest.raises(SystemExit):
-            client.get("/api/health", SimpleModel)
-        captured = capsys.readouterr()
-        parsed = json.loads(captured.out)
+        parsed = get_json_error(client, capsys)
         assert parsed["error"] is True
         assert parsed["status"] is None
 
@@ -303,29 +341,13 @@ class TestNetworkErrors:
 
 class TestAppKeyRouting:
     def test_no_app_uses_global_listener_url(self) -> None:
-        config = _make_host_port_config()
-        transport, captured_urls = url_capturing_transport()
-
-        client = HassetteCLIClient(config, json_mode=False, transport=transport)
-        client.get_with_app_routing(
-            global_path="/api/bus/listeners",
-            per_app_path_template="/api/telemetry/app/{app_key}/listeners",
-            model=list,
-            app_key=None,
-        )
+        client, captured_urls = url_capturing_client()
+        route_listeners(client, app_key=None)
         assert any("/api/bus/listeners" in u for u in captured_urls)
 
     def test_app_key_uses_per_app_listener_url(self) -> None:
-        config = _make_host_port_config()
-        transport, captured_urls = url_capturing_transport()
-
-        client = HassetteCLIClient(config, json_mode=False, transport=transport)
-        client.get_with_app_routing(
-            global_path="/api/bus/listeners",
-            per_app_path_template="/api/telemetry/app/{app_key}/listeners",
-            model=list,
-            app_key="my_app",
-        )
+        client, captured_urls = url_capturing_client()
+        route_listeners(client, app_key="my_app")
         assert any("/api/telemetry/app/my_app/listeners" in u for u in captured_urls)
 
 
@@ -334,17 +356,8 @@ class TestAppKeyRouting:
 
 class TestInstanceRouting:
     def test_integer_instance_passes_index_as_query_param(self) -> None:
-        config = _make_host_port_config()
-        transport, captured_urls = url_capturing_transport()
-
-        client = HassetteCLIClient(config, json_mode=False, transport=transport)
-        client.get_with_app_routing(
-            global_path="/api/bus/listeners",
-            per_app_path_template="/api/telemetry/app/{app_key}/listeners",
-            model=list,
-            app_key="my_app",
-            instance="1",
-        )
+        client, captured_urls = url_capturing_client()
+        route_listeners(client, app_key="my_app", instance="1")
         assert any("instance_index=1" in u for u in captured_urls)
 
     def test_name_instance_resolves_to_index(self) -> None:
@@ -379,13 +392,7 @@ class TestInstanceRouting:
             return original_handler(request)
 
         client = HassetteCLIClient(config, json_mode=False, transport=httpx.MockTransport(tracking_handler))
-        client.get_with_app_routing(
-            global_path="/api/bus/listeners",
-            per_app_path_template="/api/telemetry/app/{app_key}/listeners",
-            model=list,
-            app_key="my_app",
-            instance="office",
-        )
+        route_listeners(client, app_key="my_app", instance="office")
         assert any("instance_index=1" in u for u in captured_urls)
 
     def test_unknown_instance_name_exits_nonzero(self) -> None:
@@ -408,23 +415,11 @@ class TestInstanceRouting:
 
         client = HassetteCLIClient(config, json_mode=False, transport=httpx.MockTransport(handler))
         with pytest.raises(SystemExit) as exc_info:
-            client.get_with_app_routing(
-                global_path="/api/bus/listeners",
-                per_app_path_template="/api/telemetry/app/{app_key}/listeners",
-                model=list,
-                app_key="my_app",
-                instance="nonexistent",
-            )
+            route_listeners(client, app_key="my_app", instance="nonexistent")
         assert exc_info.value.code != 0
         client2 = HassetteCLIClient(config, json_mode=False, transport=httpx.MockTransport(handler))
         with capture_stderr() as buf, pytest.raises(SystemExit):
-            client2.get_with_app_routing(
-                global_path="/api/bus/listeners",
-                per_app_path_template="/api/telemetry/app/{app_key}/listeners",
-                model=list,
-                app_key="my_app",
-                instance="nonexistent",
-            )
+            route_listeners(client2, app_key="my_app", instance="nonexistent")
         assert "default" in buf.getvalue()
 
     def test_instance_without_app_exits_nonzero(self) -> None:
@@ -432,13 +427,7 @@ class TestInstanceRouting:
         transport = make_transport(200, [])
         client = HassetteCLIClient(config, json_mode=False, transport=transport)
         with capture_stderr() as buf, pytest.raises(SystemExit) as exc_info:
-            client.get_with_app_routing(
-                global_path="/api/bus/listeners",
-                per_app_path_template="/api/telemetry/app/{app_key}/listeners",
-                model=list,
-                app_key=None,
-                instance="office",
-            )
+            route_listeners(client, app_key=None, instance="office")
         assert exc_info.value.code != 0
         assert "--app" in buf.getvalue()
 
@@ -451,21 +440,16 @@ class TestDebugMode:
         config = _make_host_port_config()
         transport = make_transport(500, {"detail": "Internal server error"})
         client = HassetteCLIClient(config, json_mode=False, debug_mode=True, transport=transport)
-        with capture_stderr() as buf, pytest.raises(SystemExit):
-            client.get("/api/crash", SimpleModel)
-        output = buf.getvalue()
-        assert "GET" in output
-        assert "/api/crash" in output
-        assert "Internal server error" in output
+        _code, stderr = get_expecting_exit(client, "/api/crash")
+        assert "GET" in stderr
+        assert "/api/crash" in stderr
+        assert "Internal server error" in stderr
 
     def test_debug_json_mode_includes_debug_key(self, capsys: pytest.CaptureFixture[str]) -> None:
         config = _make_host_port_config()
         transport = make_transport(500, {"detail": "boom"})
         client = HassetteCLIClient(config, json_mode=True, debug_mode=True, transport=transport)
-        with pytest.raises(SystemExit):
-            client.get("/api/crash", SimpleModel)
-        captured = capsys.readouterr()
-        parsed = json.loads(captured.out)
+        parsed = get_json_error(client, capsys, "/api/crash")
         assert parsed["error"] is True
         assert "debug" in parsed
         assert parsed["debug"]["method"] == "GET"
@@ -476,19 +460,14 @@ class TestDebugMode:
         config = _make_host_port_config()
         transport = make_transport(500, {"detail": "Internal server error"})
         client = HassetteCLIClient(config, json_mode=False, debug_mode=False, transport=transport)
-        with capture_stderr() as buf, pytest.raises(SystemExit):
-            client.get("/api/crash", SimpleModel)
-        output = buf.getvalue()
-        assert "URL:" not in output
+        _code, stderr = get_expecting_exit(client, "/api/crash")
+        assert "URL:" not in stderr
 
     def test_no_debug_json_mode_omits_debug_key(self, capsys: pytest.CaptureFixture[str]) -> None:
         config = _make_host_port_config()
         transport = make_transport(500, {"detail": "boom"})
         client = HassetteCLIClient(config, json_mode=True, debug_mode=False, transport=transport)
-        with pytest.raises(SystemExit):
-            client.get("/api/crash", SimpleModel)
-        captured = capsys.readouterr()
-        parsed = json.loads(captured.out)
+        parsed = get_json_error(client, capsys, "/api/crash")
         assert "debug" not in parsed
 
 
@@ -597,21 +576,17 @@ class TestCredentialAttachment:
         factory = CLIClientFactory(make_cli_config(data_dir=tmp_path))
         transport = make_transport(401, {"detail": "Unauthorized"})
         client = factory.build(transport)
-        with capture_stderr() as buf, pytest.raises(SystemExit) as exc_info:
-            client.get(HEALTH_ENDPOINT, SimpleModel)
-        assert exc_info.value.code == 1
-        output = buf.getvalue()
-        assert "has hassette been started" in output
+        code, stderr = get_expecting_exit(client)
+        assert code == 1
+        assert "has hassette been started" in stderr
 
     def test_resolved_token_401_omits_missing_token_hint(self, tmp_path: Path) -> None:
         """A wrong-but-present token gets the plain server error, not the missing-token hint."""
         factory = CLIClientFactory(make_cli_config(data_dir=tmp_path, web_api_auth_token="wrong-token"))
         transport = make_transport(401, {"detail": "Invalid token"})
         client = factory.build(transport)
-        with capture_stderr() as buf, pytest.raises(SystemExit):
-            client.get(HEALTH_ENDPOINT, SimpleModel)
-        output = buf.getvalue()
-        assert "has hassette been started" not in output
+        _code, stderr = get_expecting_exit(client)
+        assert "has hassette been started" not in stderr
 
     def test_empty_string_config_token_sends_no_authorization_header(self, tmp_path: Path) -> None:
         """An empty-string config token (e.g. an unset env var interpolated by docker-compose
@@ -644,10 +619,8 @@ class TestCredentialAttachment:
         factory = CLIClientFactory(make_cli_config(data_dir=tmp_path, web_api_auth_token=""))
         transport = make_transport(401, {"detail": "Unauthorized"})
         client = factory.build(transport)
-        with capture_stderr() as buf, pytest.raises(SystemExit):
-            client.get(HEALTH_ENDPOINT, SimpleModel)
-        output = buf.getvalue()
-        assert "has hassette been started" in output
+        _code, stderr = get_expecting_exit(client)
+        assert "has hassette been started" in stderr
 
 
 # No literal --token CLI argument for the web API credential
@@ -716,16 +689,14 @@ class TestNonLoopback401Message:
         config = make_cli_config(data_dir=tmp_path, cli_server_url=REMOTE_SERVER_URL)
         transport = make_transport(401, {"detail": "Unauthorized"})
         client = HassetteCLIClient(config, json_mode=False, transport=transport)
-        with capture_stderr() as buf, pytest.raises(SystemExit) as exc_info:
-            client.get(HEALTH_ENDPOINT, SimpleModel)
-        assert exc_info.value.code == 1
-        output = buf.getvalue()
-        assert "--token-file" in output
-        assert "cli.token_file" in output
-        assert CLI_AUTH_TOKEN_ENV in output
-        assert "trusted_proxies" in output
-        assert "on the remote instance" in output
-        assert "has hassette been started" not in output
+        code, stderr = get_expecting_exit(client)
+        assert code == 1
+        assert "--token-file" in stderr
+        assert "cli.token_file" in stderr
+        assert CLI_AUTH_TOKEN_ENV in stderr
+        assert "trusted_proxies" in stderr
+        assert "on the remote instance" in stderr
+        assert "has hassette been started" not in stderr
 
     def test_401_with_resolved_credential_omits_the_new_hint(self, tmp_path: Path) -> None:
         """A wrong-but-present credential for a remote target gets the plain server error,
@@ -734,10 +705,8 @@ class TestNonLoopback401Message:
         config = make_cli_config(data_dir=tmp_path, cli_server_url=REMOTE_SERVER_URL, cli_auth_token="wrong-token")
         transport = make_transport(401, {"detail": "Invalid token"})
         client = HassetteCLIClient(config, json_mode=False, transport=transport)
-        with capture_stderr() as buf, pytest.raises(SystemExit):
-            client.get(HEALTH_ENDPOINT, SimpleModel)
-        output = buf.getvalue()
-        assert "trusted_proxies" not in output
+        _code, stderr = get_expecting_exit(client)
+        assert "trusted_proxies" not in stderr
 
 
 # 3xx redirect responses: likely forward-auth login page
@@ -748,22 +717,17 @@ class TestRedirectResponse:
         config = _make_host_port_config()
         transport = make_transport(302, {"detail": "Found"})
         client = HassetteCLIClient(config, json_mode=False, transport=transport)
-        with capture_stderr() as buf, pytest.raises(SystemExit) as exc_info:
-            client.get(HEALTH_ENDPOINT, SimpleModel)
-        assert exc_info.value.code == 1
-        output = buf.getvalue()
-        assert "redirect" in output.lower()
-        assert "forward-auth" in output.lower()
-        assert "cli configuration docs" in output.lower()
+        code, stderr = get_expecting_exit(client)
+        assert code == 1
+        assert "redirect" in stderr.lower()
+        assert "forward-auth" in stderr.lower()
+        assert "cli configuration docs" in stderr.lower()
 
     def test_302_json_mode_mentions_redirect(self, capsys: pytest.CaptureFixture[str]) -> None:
         config = _make_host_port_config()
         transport = make_transport(302, {"detail": "Found"})
         client = HassetteCLIClient(config, json_mode=True, transport=transport)
-        with pytest.raises(SystemExit):
-            client.get(HEALTH_ENDPOINT, SimpleModel)
-        captured = capsys.readouterr()
-        parsed = json.loads(captured.out)
+        parsed = get_json_error(client, capsys)
         assert "redirect" in parsed["detail"].lower()
 
 
@@ -775,17 +739,15 @@ class TestFullBaseUrlInErrorMessages:
         config = make_cli_config(data_dir=tmp_path, cli_server_url=REMOTE_SERVER_URL)
         transport = make_transport(raise_exc=httpx.ConnectError)
         client = HassetteCLIClient(config, json_mode=False, transport=transport)
-        with capture_stderr() as buf, pytest.raises(SystemExit):
-            client.get(HEALTH_ENDPOINT, SimpleModel)
-        assert REMOTE_SERVER_URL in buf.getvalue()
+        _code, stderr = get_expecting_exit(client)
+        assert REMOTE_SERVER_URL in stderr
 
     def test_http_error_reports_full_base_url(self, tmp_path: Path) -> None:
         config = make_cli_config(data_dir=tmp_path, cli_server_url=REMOTE_SERVER_URL)
         transport = make_transport(500, {"detail": "boom"})
         client = HassetteCLIClient(config, json_mode=False, transport=transport)
-        with capture_stderr() as buf, pytest.raises(SystemExit):
-            client.get(HEALTH_ENDPOINT, SimpleModel)
-        assert REMOTE_SERVER_URL in buf.getvalue()
+        _code, stderr = get_expecting_exit(client)
+        assert REMOTE_SERVER_URL in stderr
 
 
 # Target echo: once per invocation on the success path, and unconditionally on HTTP errors
@@ -794,27 +756,20 @@ class TestFullBaseUrlInErrorMessages:
 class TestTargetEcho:
     def test_non_loopback_success_shows_target(self, tmp_path: Path) -> None:
         config = make_cli_config(data_dir=tmp_path, cli_server_url=REMOTE_SERVER_URL)
-        transport = make_transport(200, {"value": "hello"})
-        client = HassetteCLIClient(config, json_mode=False, transport=transport)
-        with capture_stderr() as buf:
-            client.get(HEALTH_ENDPOINT, SimpleModel)
-        assert REMOTE_SERVER_URL in buf.getvalue()
+        stderr = stderr_for_successful_get(config)
+        assert REMOTE_SERVER_URL in stderr
 
     def test_loopback_success_omits_target(self) -> None:
         config = _make_host_port_config()
-        transport = make_transport(200, {"value": "hello"})
-        client = HassetteCLIClient(config, json_mode=False, transport=transport)
-        with capture_stderr() as buf:
-            client.get(HEALTH_ENDPOINT, SimpleModel)
-        assert buf.getvalue() == ""
+        stderr = stderr_for_successful_get(config)
+        assert stderr == ""
 
     def test_401_non_loopback_shows_target_without_debug(self, tmp_path: Path) -> None:
         config = make_cli_config(data_dir=tmp_path, cli_server_url=REMOTE_SERVER_URL)
         transport = make_transport(401, {"detail": "Unauthorized"})
         client = HassetteCLIClient(config, json_mode=False, debug_mode=False, transport=transport)
-        with capture_stderr() as buf, pytest.raises(SystemExit):
-            client.get(HEALTH_ENDPOINT, SimpleModel)
-        assert REMOTE_SERVER_URL in buf.getvalue()
+        _code, stderr = get_expecting_exit(client)
+        assert REMOTE_SERVER_URL in stderr
 
     def test_401_non_loopback_json_mode_includes_target(
         self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
@@ -822,18 +777,14 @@ class TestTargetEcho:
         config = make_cli_config(data_dir=tmp_path, cli_server_url=REMOTE_SERVER_URL)
         transport = make_transport(401, {"detail": "Unauthorized"})
         client = HassetteCLIClient(config, json_mode=True, debug_mode=False, transport=transport)
-        with pytest.raises(SystemExit):
-            client.get(HEALTH_ENDPOINT, SimpleModel)
-        parsed = json.loads(capsys.readouterr().out)
+        parsed = get_json_error(client, capsys)
         assert parsed["target"] == REMOTE_SERVER_URL
 
     def test_loopback_401_json_mode_omits_target(self, capsys: pytest.CaptureFixture[str]) -> None:
         config = _make_host_port_config()
         transport = make_transport(401, {"detail": "Unauthorized"})
         client = HassetteCLIClient(config, json_mode=True, transport=transport)
-        with pytest.raises(SystemExit):
-            client.get(HEALTH_ENDPOINT, SimpleModel)
-        parsed = json.loads(capsys.readouterr().out)
+        parsed = get_json_error(client, capsys)
         assert "target" not in parsed
 
 
@@ -843,32 +794,21 @@ class TestTargetEcho:
 class TestVerifySslWarning:
     def test_config_sourced_insecure_warns(self, tmp_path: Path) -> None:
         config = make_cli_config(data_dir=tmp_path, cli_server_url=REMOTE_SERVER_URL, cli_verify_ssl=False)
-        transport = make_transport(200, {"value": "hello"})
-        client = HassetteCLIClient(config, json_mode=False, transport=transport)
-        with capture_stderr() as buf:
-            client.get(HEALTH_ENDPOINT, SimpleModel)
-        assert "TLS verification is disabled" in buf.getvalue()
+        stderr = stderr_for_successful_get(config)
+        assert "TLS verification is disabled" in stderr
 
     def test_flag_sourced_insecure_does_not_warn(self, tmp_path: Path) -> None:
         config = make_cli_config(data_dir=tmp_path, cli_server_url=REMOTE_SERVER_URL, cli_verify_ssl=False)
-        transport = make_transport(200, {"value": "hello"})
-        client = HassetteCLIClient(
-            config, json_mode=False, transport=transport, verify_ssl_flag=False, server_url_flag=None
-        )
-        with capture_stderr() as buf:
-            client.get(HEALTH_ENDPOINT, SimpleModel)
-        assert "TLS verification is disabled" not in buf.getvalue()
+        stderr = stderr_for_successful_get(config, verify_ssl_flag=False, server_url_flag=None)
+        assert "TLS verification is disabled" not in stderr
 
     def test_loopback_insecure_config_still_warns(self, tmp_path: Path) -> None:
         """The warning is about a config-vs-flag distinction, not a loopback gate — it applies
         regardless of whether the resulting target happens to be loopback.
         """
         config = make_cli_config(data_dir=tmp_path, cli_verify_ssl=False)
-        transport = make_transport(200, {"value": "hello"})
-        client = HassetteCLIClient(config, json_mode=False, transport=transport)
-        with capture_stderr() as buf:
-            client.get(HEALTH_ENDPOINT, SimpleModel)
-        assert "TLS verification is disabled" in buf.getvalue()
+        stderr = stderr_for_successful_get(config)
+        assert "TLS verification is disabled" in stderr
 
     def test_config_sourced_insecure_warns_json_mode_error_path(
         self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
@@ -876,9 +816,7 @@ class TestVerifySslWarning:
         config = make_cli_config(data_dir=tmp_path, cli_server_url=REMOTE_SERVER_URL, cli_verify_ssl=False)
         transport = make_transport(500, {"detail": "boom"})
         client = HassetteCLIClient(config, json_mode=True, transport=transport)
-        with pytest.raises(SystemExit):
-            client.get(HEALTH_ENDPOINT, SimpleModel)
-        parsed = json.loads(capsys.readouterr().out)
+        parsed = get_json_error(client, capsys)
         assert parsed["tls_verified"] is False
 
     def test_flag_sourced_insecure_omits_tls_verified_json_mode_error_path(
@@ -889,9 +827,7 @@ class TestVerifySslWarning:
         client = HassetteCLIClient(
             config, json_mode=True, transport=transport, verify_ssl_flag=False, server_url_flag=None
         )
-        with pytest.raises(SystemExit):
-            client.get(HEALTH_ENDPOINT, SimpleModel)
-        parsed = json.loads(capsys.readouterr().out)
+        parsed = get_json_error(client, capsys)
         assert "tls_verified" not in parsed
 
     def test_config_sourced_insecure_warns_on_network_error_path(self, tmp_path: Path) -> None:
@@ -902,9 +838,8 @@ class TestVerifySslWarning:
         config = make_cli_config(data_dir=tmp_path, cli_server_url=REMOTE_SERVER_URL, cli_verify_ssl=False)
         transport = make_transport(raise_exc=httpx.ConnectError)
         client = HassetteCLIClient(config, json_mode=False, transport=transport)
-        with capture_stderr() as buf, pytest.raises(SystemExit):
-            client.get(HEALTH_ENDPOINT, SimpleModel)
-        assert "TLS verification is disabled" in buf.getvalue()
+        _code, stderr = get_expecting_exit(client)
+        assert "TLS verification is disabled" in stderr
 
     def test_flag_sourced_insecure_does_not_warn_on_network_error_path(self, tmp_path: Path) -> None:
         config = make_cli_config(data_dir=tmp_path, cli_server_url=REMOTE_SERVER_URL, cli_verify_ssl=False)
@@ -912,6 +847,5 @@ class TestVerifySslWarning:
         client = HassetteCLIClient(
             config, json_mode=False, transport=transport, verify_ssl_flag=False, server_url_flag=None
         )
-        with capture_stderr() as buf, pytest.raises(SystemExit):
-            client.get(HEALTH_ENDPOINT, SimpleModel)
-        assert "TLS verification is disabled" not in buf.getvalue()
+        _code, stderr = get_expecting_exit(client)
+        assert "TLS verification is disabled" not in stderr

--- a/tests/unit/cli/test_client.py
+++ b/tests/unit/cli/test_client.py
@@ -264,7 +264,7 @@ class TestHttpErrorsHumanMode:
         transport = make_transport(503, {"detail": "Service unavailable"})
         client = HassetteCLIClient(config, json_mode=False, transport=transport)
         with pytest.raises(SystemExit):
-            client.get("/api/health", SimpleModel)
+            client.get(HEALTH_ENDPOINT, SimpleModel)
         captured = capsys.readouterr()
         assert captured.out == ""
 
@@ -300,7 +300,7 @@ class TestNetworkErrors:
         transport = make_transport(raise_exc=httpx.ConnectError)
         client = HassetteCLIClient(config, json_mode=False, transport=transport)
         with pytest.raises(SystemExit) as exc_info:
-            client.get("/api/health", SimpleModel)
+            client.get(HEALTH_ENDPOINT, SimpleModel)
         assert exc_info.value.code == 2
 
     def test_connection_refused_mentions_address_stderr(self) -> None:
@@ -315,7 +315,7 @@ class TestNetworkErrors:
         transport = make_transport(raise_exc=httpx.TimeoutException)
         client = HassetteCLIClient(config, json_mode=False, transport=transport)
         with pytest.raises(SystemExit) as exc_info:
-            client.get("/api/health", SimpleModel)
+            client.get(HEALTH_ENDPOINT, SimpleModel)
         assert exc_info.value.code == 2
 
     def test_timeout_json_mode_null_status(self, capsys: pytest.CaptureFixture[str]) -> None:

--- a/tests/unit/cli/test_commands_app.py
+++ b/tests/unit/cli/test_commands_app.py
@@ -1,10 +1,10 @@
 """Unit tests for hassette app, app health, app activity, app config, and app source commands."""
 
-import json
-from unittest.mock import patch
+from typing import Any
 
 import pytest
 
+from hassette.cli.client import HassetteCLIClient
 from hassette.cli.commands.app import (
     APP_ACTIVITY_COLUMNS,
     APP_HEALTH_COLUMNS,
@@ -15,7 +15,6 @@ from hassette.cli.commands.app import (
     cmd_app_health,
     cmd_app_source,
 )
-from hassette.cli.context import CLIContext
 from hassette.cli.output import now_epoch
 from hassette.test_utils.web_manifest_helpers import make_manifest_list_response, make_manifest_response
 from hassette.test_utils.web_response_helpers import (
@@ -28,13 +27,11 @@ from hassette.web.models import AppInstanceResponse, AppManifestListResponse
 from tests.unit.cli.conftest import (
     SINCE_EPOCH,
     CLIClientFactory,
-    GetSpy,
-    capture_json_stdout,
-    capture_stderr,
-    capture_stdout,
+    CommandRunner,
 )
 
-MAKE_CLIENT_PATH = "hassette.cli.commands.app.make_client"
+runner = CommandRunner("hassette.cli.commands.app.make_client")
+ACTIVITY_ENDPOINT = "/api/telemetry/app/my-app/activity"
 
 # cmd_app (bare — list all apps)
 
@@ -45,14 +42,7 @@ class TestCmdApp:
         manifest = make_manifest_response()
         data = make_manifest_list_response([manifest])
         client = cli_client_factory.build_with_routes([("GET", "/api/apps/manifests", 200, data.model_dump())])
-        spy = GetSpy(client)
-
-        with (
-            patch.object(client, "get", side_effect=spy),
-            capture_stdout(),
-            patch(MAKE_CLIENT_PATH, return_value=client),
-        ):
-            cmd_app()
+        spy = runner.spy(client, cmd_app)
 
         assert "/api/apps/manifests" in spy.paths
 
@@ -61,12 +51,7 @@ class TestCmdApp:
         manifest = make_manifest_response(app_key="my_app", status="running", display_name="My App")
         data = make_manifest_list_response([manifest])
         client = cli_client_factory.build_with_routes([("GET", "/api/apps/manifests", 200, data.model_dump())])
-        with (
-            capture_stdout() as buf,
-            patch(MAKE_CLIENT_PATH, return_value=client),
-        ):
-            cmd_app()
-        output = buf.getvalue()
+        output = runner.stdout(client, cmd_app)
         assert "my_app" in output
         assert "running" in output
 
@@ -76,13 +61,7 @@ class TestCmdApp:
         data = make_manifest_list_response([manifest])
         client = cli_client_factory.build_with_routes([("GET", "/api/apps/manifests", 200, data.model_dump())])
 
-        with (
-            patch(MAKE_CLIENT_PATH, return_value=client),
-            capture_json_stdout() as captured,
-        ):
-            cmd_app(ctx=CLIContext(json_mode=True))
-
-        parsed = json.loads("".join(captured))
+        parsed = runner.json_output(client, cmd_app)
         assert isinstance(parsed, list)
         assert parsed[0]["app_key"] == "my_app"
 
@@ -90,13 +69,7 @@ class TestCmdApp:
         """App renders a no-results message when manifests list is empty."""
         data = make_manifest_list_response([])
         client = cli_client_factory.build_with_routes([("GET", "/api/apps/manifests", 200, data.model_dump())])
-        with (
-            capture_stdout(),
-            capture_stderr() as err_buf,
-            patch(MAKE_CLIENT_PATH, return_value=client),
-        ):
-            cmd_app()
-        assert "No results" in err_buf.getvalue()
+        assert "No results" in runner.stderr(client, cmd_app)
 
     def test_app_list_columns_defined(self) -> None:
         """APP_LIST_COLUMNS includes the key per-app fields."""
@@ -122,14 +95,7 @@ class TestCmdAppHealth:
         client = cli_client_factory.build_with_routes(
             [("GET", "/api/telemetry/app/my-app/health", 200, health.model_dump())]
         )
-        spy = GetSpy(client)
-
-        with (
-            patch.object(client, "get", side_effect=spy),
-            capture_stdout(),
-            patch(MAKE_CLIENT_PATH, return_value=client),
-        ):
-            cmd_app_health("my-app")
+        spy = runner.spy(client, cmd_app_health, "my-app")
 
         assert any("/api/telemetry/app/my-app/health" in p for p in spy.paths)
 
@@ -139,18 +105,9 @@ class TestCmdAppHealth:
         client = cli_client_factory.build_with_routes(
             [("GET", "/api/telemetry/app/my-app/health", 200, health.model_dump())]
         )
-        spy = GetSpy(client)
+        spy = runner.spy(client, cmd_app_health, "my-app", instance="1")
 
-        with (
-            patch.object(client, "get", side_effect=spy),
-            capture_stdout(),
-            patch(MAKE_CLIENT_PATH, return_value=client),
-        ):
-            cmd_app_health("my-app", instance="1")
-
-        health_call = next(r for r in spy.calls if "health" in r["path"])
-        assert health_call["params"] is not None
-        assert health_call["params"]["instance_index"] == 1
+        assert spy.params_for("health")["instance_index"] == 1
 
     def test_instance_name_resolution(self, cli_client_factory: CLIClientFactory) -> None:
         """App health --instance office resolves the name to an index."""
@@ -170,18 +127,9 @@ class TestCmdAppHealth:
                 ("GET", "/api/telemetry/app/my-app/health", 200, health.model_dump()),
             ]
         )
-        spy = GetSpy(client)
+        spy = runner.spy(client, cmd_app_health, "my-app", instance="office")
 
-        with (
-            patch.object(client, "get", side_effect=spy),
-            capture_stdout(),
-            patch(MAKE_CLIENT_PATH, return_value=client),
-        ):
-            cmd_app_health("my-app", instance="office")
-
-        health_call = next(r for r in spy.calls if "health" in r["path"])
-        assert health_call["params"] is not None
-        assert health_call["params"]["instance_index"] == 2
+        assert spy.params_for("health")["instance_index"] == 2
 
     def test_human_mode_renders_panel(self, cli_client_factory: CLIClientFactory) -> None:
         """App health renders a key-value detail panel."""
@@ -189,12 +137,7 @@ class TestCmdAppHealth:
         client = cli_client_factory.build_with_routes(
             [("GET", "/api/telemetry/app/my-app/health", 200, health.model_dump())]
         )
-        with (
-            capture_stdout() as buf,
-            patch(MAKE_CLIENT_PATH, return_value=client),
-        ):
-            cmd_app_health("my-app")
-        output = buf.getvalue()
+        output = runner.stdout(client, cmd_app_health, "my-app")
         assert "health_status" in output
         assert "excellent" in output
 
@@ -205,13 +148,7 @@ class TestCmdAppHealth:
             [("GET", "/api/telemetry/app/my-app/health", 200, health.model_dump())]
         )
 
-        with (
-            patch(MAKE_CLIENT_PATH, return_value=client),
-            capture_json_stdout() as captured,
-        ):
-            cmd_app_health("my-app", ctx=CLIContext(json_mode=True))
-
-        parsed = json.loads("".join(captured))
+        parsed = runner.json_output(client, cmd_app_health, "my-app")
         assert parsed["error_rate"] == pytest.approx(0.1)
         assert "health_status" in parsed
 
@@ -227,82 +164,41 @@ class TestCmdAppHealth:
 
 
 class TestCmdAppActivity:
-    def test_calls_correct_endpoint(self, cli_client_factory: CLIClientFactory) -> None:
+    @pytest.fixture
+    def activity_client(self, cli_client_factory: CLIClientFactory) -> HassetteCLIClient:
+        """A client serving one default activity entry from my-app's activity feed."""
+        entry = make_activity_feed_entry()
+        return cli_client_factory.build_with_routes([("GET", ACTIVITY_ENDPOINT, 200, [entry.model_dump()])])
+
+    def test_calls_correct_endpoint(self, activity_client: HassetteCLIClient) -> None:
         """App activity fetches from GET /api/telemetry/app/{key}/activity."""
-        entry = make_activity_feed_entry()
-        client = cli_client_factory.build_with_routes(
-            [("GET", "/api/telemetry/app/my-app/activity", 200, [entry.model_dump()])]
-        )
-        spy = GetSpy(client)
+        spy = runner.spy(activity_client, cmd_app_activity, "my-app")
 
-        with (
-            patch.object(client, "get", side_effect=spy),
-            capture_stdout(),
-            patch(MAKE_CLIENT_PATH, return_value=client),
-        ):
-            cmd_app_activity("my-app")
+        assert any(ACTIVITY_ENDPOINT in p for p in spy.paths)
 
-        assert any("/api/telemetry/app/my-app/activity" in p for p in spy.paths)
-
-    def test_no_instance_omits_instance_index(self, cli_client_factory: CLIClientFactory) -> None:
+    def test_no_instance_omits_instance_index(self, activity_client: HassetteCLIClient) -> None:
         """App activity with no --instance does NOT pass instance_index param."""
-        entry = make_activity_feed_entry()
-        client = cli_client_factory.build_with_routes(
-            [("GET", "/api/telemetry/app/my-app/activity", 200, [entry.model_dump()])]
-        )
-        spy = GetSpy(client)
+        spy = runner.spy(activity_client, cmd_app_activity, "my-app")
 
-        with (
-            patch.object(client, "get", side_effect=spy),
-            capture_stdout(),
-            patch(MAKE_CLIENT_PATH, return_value=client),
-        ):
-            cmd_app_activity("my-app")
-
+        # Not spy.params_for() — that asserts params were sent at all, and "no params" is one
+        # of the passing outcomes here: the API returns all instances when instance_index is absent.
         activity_call = next(r for r in spy.calls if "activity" in r["path"])
-        # instance_index must not be present — API returns all instances when absent
-        params = activity_call["params"] or {}
-        assert "instance_index" not in params
+        assert "instance_index" not in (activity_call["params"] or {})
 
-    def test_since_and_limit_passed_as_params(self, cli_client_factory: CLIClientFactory) -> None:
+    def test_since_and_limit_passed_as_params(self, activity_client: HassetteCLIClient) -> None:
         """App activity --since and --limit are forwarded as query params."""
-        entry = make_activity_feed_entry()
-        client = cli_client_factory.build_with_routes(
-            [("GET", "/api/telemetry/app/my-app/activity", 200, [entry.model_dump()])]
-        )
-        spy = GetSpy(client)
-
         since_epoch = SINCE_EPOCH
-        with (
-            patch.object(client, "get", side_effect=spy),
-            capture_stdout(),
-            patch(MAKE_CLIENT_PATH, return_value=client),
-        ):
-            cmd_app_activity("my-app", since=since_epoch, limit=10)
+        spy = runner.spy(activity_client, cmd_app_activity, "my-app", since=since_epoch, limit=10)
 
-        activity_call = next(r for r in spy.calls if "activity" in r["path"])
-        assert activity_call["params"] is not None
-        assert activity_call["params"]["since"] == since_epoch
-        assert activity_call["params"]["limit"] == 10
+        params = spy.params_for("activity")
+        assert params["since"] == since_epoch
+        assert params["limit"] == 10
 
-    def test_instance_integer_passes_index_param(self, cli_client_factory: CLIClientFactory) -> None:
+    def test_instance_integer_passes_index_param(self, activity_client: HassetteCLIClient) -> None:
         """App activity --instance 2 passes instance_index=2."""
-        entry = make_activity_feed_entry()
-        client = cli_client_factory.build_with_routes(
-            [("GET", "/api/telemetry/app/my-app/activity", 200, [entry.model_dump()])]
-        )
-        spy = GetSpy(client)
+        spy = runner.spy(activity_client, cmd_app_activity, "my-app", instance="2")
 
-        with (
-            patch.object(client, "get", side_effect=spy),
-            capture_stdout(),
-            patch(MAKE_CLIENT_PATH, return_value=client),
-        ):
-            cmd_app_activity("my-app", instance="2")
-
-        activity_call = next(r for r in spy.calls if "activity" in r["path"])
-        assert activity_call["params"] is not None
-        assert activity_call["params"]["instance_index"] == 2
+        assert spy.params_for("activity")["instance_index"] == 2
 
     def test_human_mode_renders_table(self, cli_client_factory: CLIClientFactory) -> None:
         """App activity renders a table with handler name and status."""
@@ -311,32 +207,17 @@ class TestCmdAppActivity:
         # every ~10x days elapsed, stealing column width from Handler and truncating it
         # further than this test expects.
         entry = make_activity_feed_entry(handler_name="on_light_change", app_key="my-app", timestamp=now_epoch())
-        client = cli_client_factory.build_with_routes(
-            [("GET", "/api/telemetry/app/my-app/activity", 200, [entry.model_dump()])]
-        )
-        with (
-            capture_stdout() as buf,
-            patch(MAKE_CLIENT_PATH, return_value=client),
-        ):
-            cmd_app_activity("my-app")
-        output = buf.getvalue()
+        client = cli_client_factory.build_with_routes([("GET", ACTIVITY_ENDPOINT, 200, [entry.model_dump()])])
+        output = runner.stdout(client, cmd_app_activity, "my-app")
         # Rich may truncate the handler name in a narrow console — match the prefix
         assert "on_light_c" in output
 
     def test_json_mode_outputs_list(self, cli_client_factory: CLIClientFactory) -> None:
         """App activity --json outputs entries as a JSON array."""
         entry = make_activity_feed_entry(row_id="h-42")
-        client = cli_client_factory.build_with_routes(
-            [("GET", "/api/telemetry/app/my-app/activity", 200, [entry.model_dump()])]
-        )
+        client = cli_client_factory.build_with_routes([("GET", ACTIVITY_ENDPOINT, 200, [entry.model_dump()])])
 
-        with (
-            patch(MAKE_CLIENT_PATH, return_value=client),
-            capture_json_stdout() as captured,
-        ):
-            cmd_app_activity("my-app", ctx=CLIContext(json_mode=True))
-
-        parsed = json.loads("".join(captured))
+        parsed = runner.json_output(client, cmd_app_activity, "my-app")
         assert isinstance(parsed, list)
         assert parsed[0]["row_id"] == "h-42"
 
@@ -361,14 +242,7 @@ class TestCmdAppConfig:
         """App config fetches from GET /api/apps/{key}/config."""
         cfg = make_app_config_response(app_key="my-app")
         client = cli_client_factory.build_with_routes([("GET", "/api/apps/my-app/config", 200, cfg.model_dump())])
-        spy = GetSpy(client)
-
-        with (
-            patch.object(client, "get", side_effect=spy),
-            capture_stdout(),
-            patch(MAKE_CLIENT_PATH, return_value=client),
-        ):
-            cmd_app_config("my-app")
+        spy = runner.spy(client, cmd_app_config, "my-app")
 
         assert any("/api/apps/my-app/config" in p for p in spy.paths)
 
@@ -376,12 +250,7 @@ class TestCmdAppConfig:
         """App config renders a detail panel with app_key and class_name."""
         cfg = make_app_config_response(app_key="my-app", class_name="MyApp")
         client = cli_client_factory.build_with_routes([("GET", "/api/apps/my-app/config", 200, cfg.model_dump())])
-        with (
-            capture_stdout() as buf,
-            patch(MAKE_CLIENT_PATH, return_value=client),
-        ):
-            cmd_app_config("my-app")
-        output = buf.getvalue()
+        output = runner.stdout(client, cmd_app_config, "my-app")
         assert "my-app" in output
         assert "MyApp" in output
 
@@ -390,13 +259,7 @@ class TestCmdAppConfig:
         cfg = make_app_config_response(app_key="my-app", enabled=True)
         client = cli_client_factory.build_with_routes([("GET", "/api/apps/my-app/config", 200, cfg.model_dump())])
 
-        with (
-            patch(MAKE_CLIENT_PATH, return_value=client),
-            capture_json_stdout() as captured,
-        ):
-            cmd_app_config("my-app", ctx=CLIContext(json_mode=True))
-
-        parsed = json.loads("".join(captured))
+        parsed = runner.json_output(client, cmd_app_config, "my-app")
         assert parsed["app_key"] == "my-app"
         assert parsed["enabled"] is True
 
@@ -408,73 +271,34 @@ class TestCmdAppConfig:
             config_schema={"properties": {"setting_name": {"SCHEMA_BLOB_MARKER": True}}},
         )
         client = cli_client_factory.build_with_routes([("GET", "/api/apps/my-app/config", 200, cfg.model_dump())])
-        with (
-            capture_stdout() as buf,
-            patch(MAKE_CLIENT_PATH, return_value=client),
-        ):
-            cmd_app_config("my-app")
-        output = buf.getvalue()
+        output = runner.stdout(client, cmd_app_config, "my-app")
         assert "visible_value" in output
         assert "SCHEMA_BLOB_MARKER" not in output
 
-    def test_json_mode_omits_schema_blob(self, cli_client_factory: CLIClientFactory) -> None:
-        """App config --json emits values and metadata, not the config_schema envelope."""
+    @pytest.mark.parametrize(
+        "app_config",
+        [
+            pytest.param({"setting_name": "visible_value"}, id="single-instance-dict"),
+            pytest.param([{"setting_name": "first"}, {"setting_name": "second"}], id="multi-instance-list"),
+            pytest.param([], id="empty-multi-instance-list"),
+        ],
+    )
+    def test_json_mode_emits_app_config_verbatim_without_schema_blob(
+        self, cli_client_factory: CLIClientFactory, app_config: dict[str, Any] | list[dict[str, Any]]
+    ) -> None:
+        """App config --json round-trips app_config as-is and never dumps the config_schema envelope.
+
+        The empty-list case is the interesting one: it must stay ``[]`` rather than falling back
+        to the default dict when a multi-instance app has no instances.
+        """
         cfg = make_app_config_response(
             app_key="my-app",
-            app_config={"setting_name": "visible_value"},
+            app_config=app_config,
             config_schema={"properties": {"setting_name": {"SCHEMA_BLOB_MARKER": True}}},
         )
         client = cli_client_factory.build_with_routes([("GET", "/api/apps/my-app/config", 200, cfg.model_dump())])
-        with (
-            patch(MAKE_CLIENT_PATH, return_value=client),
-            capture_json_stdout() as captured,
-        ):
-            cmd_app_config("my-app", ctx=CLIContext(json_mode=True))
-
-        parsed = json.loads("".join(captured))
-        assert parsed["app_config"] == {"setting_name": "visible_value"}
-        assert "config_schema" not in parsed
-
-    def test_json_mode_handles_multi_instance_app_config(self, cli_client_factory: CLIClientFactory) -> None:
-        """App config --json renders a list-shaped (multi-instance) app_config without the schema blob."""
-        cfg = make_app_config_response(
-            app_key="my-app",
-            app_config=[
-                {"setting_name": "first"},
-                {"setting_name": "second"},
-            ],
-            config_schema={"properties": {"setting_name": {"SCHEMA_BLOB_MARKER": True}}},
-        )
-        client = cli_client_factory.build_with_routes([("GET", "/api/apps/my-app/config", 200, cfg.model_dump())])
-        with (
-            patch(MAKE_CLIENT_PATH, return_value=client),
-            capture_json_stdout() as captured,
-        ):
-            cmd_app_config("my-app", ctx=CLIContext(json_mode=True))
-
-        parsed = json.loads("".join(captured))
-        assert parsed["app_config"] == [
-            {"setting_name": "first"},
-            {"setting_name": "second"},
-        ]
-        assert "config_schema" not in parsed
-
-    def test_json_mode_preserves_empty_multi_instance_app_config(self, cli_client_factory: CLIClientFactory) -> None:
-        """App config --json keeps an empty list as [], not the default dict, when there are no instances."""
-        cfg = make_app_config_response(
-            app_key="my-app",
-            app_config=[],
-            config_schema={"properties": {"setting_name": {"SCHEMA_BLOB_MARKER": True}}},
-        )
-        client = cli_client_factory.build_with_routes([("GET", "/api/apps/my-app/config", 200, cfg.model_dump())])
-        with (
-            patch(MAKE_CLIENT_PATH, return_value=client),
-            capture_json_stdout() as captured,
-        ):
-            cmd_app_config("my-app", ctx=CLIContext(json_mode=True))
-
-        parsed = json.loads("".join(captured))
-        assert parsed["app_config"] == []
+        parsed = runner.json_output(client, cmd_app_config, "my-app")
+        assert parsed["app_config"] == app_config
         assert "config_schema" not in parsed
 
 
@@ -486,14 +310,7 @@ class TestCmdAppSource:
         """App source fetches from GET /api/apps/{key}/source."""
         src = make_app_source_response(app_key="my-app")
         client = cli_client_factory.build_with_routes([("GET", "/api/apps/my-app/source", 200, src.model_dump())])
-        spy = GetSpy(client)
-
-        with (
-            patch.object(client, "get", side_effect=spy),
-            capture_stdout(),
-            patch(MAKE_CLIENT_PATH, return_value=client),
-        ):
-            cmd_app_source("my-app")
+        spy = runner.spy(client, cmd_app_source, "my-app")
 
         assert any("/api/apps/my-app/source" in p for p in spy.paths)
 
@@ -501,12 +318,7 @@ class TestCmdAppSource:
         """App source renders a detail panel showing filename and content."""
         src = make_app_source_response(app_key="my-app", filename="my_app.py", content="class MyApp: pass\n")
         client = cli_client_factory.build_with_routes([("GET", "/api/apps/my-app/source", 200, src.model_dump())])
-        with (
-            capture_stdout() as buf,
-            patch(MAKE_CLIENT_PATH, return_value=client),
-        ):
-            cmd_app_source("my-app")
-        output = buf.getvalue()
+        output = runner.stdout(client, cmd_app_source, "my-app")
         assert "my_app.py" in output
 
     def test_json_mode_outputs_valid_json(self, cli_client_factory: CLIClientFactory) -> None:
@@ -514,13 +326,7 @@ class TestCmdAppSource:
         src = make_app_source_response(app_key="my-app", content="class MyApp: pass\n", line_count=1)
         client = cli_client_factory.build_with_routes([("GET", "/api/apps/my-app/source", 200, src.model_dump())])
 
-        with (
-            patch(MAKE_CLIENT_PATH, return_value=client),
-            capture_json_stdout() as captured,
-        ):
-            cmd_app_source("my-app", ctx=CLIContext(json_mode=True))
-
-        parsed = json.loads("".join(captured))
+        parsed = runner.json_output(client, cmd_app_source, "my-app")
         assert parsed["app_key"] == "my-app"
         assert "content" in parsed
         assert parsed["line_count"] == 1

--- a/tests/unit/cli/test_commands_job.py
+++ b/tests/unit/cli/test_commands_job.py
@@ -1,10 +1,8 @@
 """Unit tests for hassette job and job <id> commands."""
 
-import json
-from unittest.mock import patch
-
 import pytest
 
+from hassette.cli.client import HassetteCLIClient
 from hassette.cli.commands.job import (
     _SCHEDULE_STATUS_TEXT,
     JOB_EXECUTION_COLUMNS,
@@ -12,19 +10,11 @@ from hassette.cli.commands.job import (
     _next_run_display,
     cmd_job,
 )
-from hassette.cli.context import CLIContext
 from hassette.test_utils.web_job_helpers import make_job_summary
 from hassette.test_utils.web_telemetry_helpers import make_execution
-from tests.unit.cli.conftest import (
-    SINCE_EPOCH,
-    CLIClientFactory,
-    GetSpy,
-    capture_json_stdout,
-    capture_stderr,
-    capture_stdout,
-)
+from tests.unit.cli.conftest import SINCE_EPOCH, CLIClientFactory, CommandRunner
 
-MAKE_CLIENT_PATH = "hassette.cli.commands.job.make_client"
+runner = CommandRunner("hassette.cli.commands.job.make_client")
 JOBS_ENDPOINT = "/api/scheduler/jobs"
 MY_APP_JOBS_ENDPOINT = "/api/telemetry/app/my-app/jobs"
 JOB_5_EXECUTIONS_ENDPOINT = "/api/telemetry/job/5/executions"
@@ -38,14 +28,7 @@ class TestCmdJob:
         """Job (no --app) fetches from GET /api/scheduler/jobs."""
         job = make_job_summary()
         client = cli_client_factory.build_with_routes([("GET", JOBS_ENDPOINT, 200, [job.model_dump()])])
-        spy = GetSpy(client)
-
-        with (
-            patch.object(client, "get", side_effect=spy),
-            capture_stdout(),
-            patch(MAKE_CLIENT_PATH, return_value=client),
-        ):
-            cmd_job()
+        spy = runner.spy(client, cmd_job)
 
         assert JOBS_ENDPOINT in spy.paths
 
@@ -53,14 +36,7 @@ class TestCmdJob:
         """Job --app my-app fetches from /api/telemetry/app/my-app/jobs."""
         job = make_job_summary(app_key="my-app")
         client = cli_client_factory.build_with_routes([("GET", MY_APP_JOBS_ENDPOINT, 200, [job.model_dump()])])
-        spy = GetSpy(client)
-
-        with (
-            patch.object(client, "get", side_effect=spy),
-            capture_stdout(),
-            patch(MAKE_CLIENT_PATH, return_value=client),
-        ):
-            cmd_job(app="my-app")
+        spy = runner.spy(client, cmd_job, app="my-app")
 
         assert any(MY_APP_JOBS_ENDPOINT in p for p in spy.paths)
 
@@ -68,60 +44,32 @@ class TestCmdJob:
         """Job --app my-app --instance 0 passes instance_index=0 as a query param."""
         job = make_job_summary(app_key="my-app", instance_index=0)
         client = cli_client_factory.build_with_routes([("GET", MY_APP_JOBS_ENDPOINT, 200, [job.model_dump()])])
-        spy = GetSpy(client)
+        spy = runner.spy(client, cmd_job, app="my-app", instance="0")
 
-        with (
-            patch.object(client, "get", side_effect=spy),
-            capture_stdout(),
-            patch(MAKE_CLIENT_PATH, return_value=client),
-        ):
-            cmd_job(app="my-app", instance="0")
-
-        jobs_call = next(r for r in spy.calls if "jobs" in r["path"])
-        assert jobs_call["params"] is not None
-        assert jobs_call["params"]["instance_index"] == 0
+        assert spy.params_for("jobs")["instance_index"] == 0
 
     def test_instance_without_app_exits_with_usage_error(self, cli_client_factory: CLIClientFactory) -> None:
         """Job --instance 0 (without --app) exits non-zero with usage error."""
         client = cli_client_factory.build_with_routes([])
 
-        with (
-            capture_stderr(),
-            patch(MAKE_CLIENT_PATH, return_value=client),
-            pytest.raises(SystemExit) as exc_info,
-        ):
-            cmd_job(instance="0")
+        code, _stderr = runner.usage_error(client, cmd_job, instance="0")
 
-        assert exc_info.value.code != 0
+        assert code != 0
 
     def test_source_tier_passed_as_param(self, cli_client_factory: CLIClientFactory) -> None:
         """Job --source-tier app passes source_tier=app as a query param."""
         job = make_job_summary()
         client = cli_client_factory.build_with_routes([("GET", JOBS_ENDPOINT, 200, [job.model_dump()])])
-        spy = GetSpy(client)
+        spy = runner.spy(client, cmd_job, source_tier="app")
 
-        with (
-            patch.object(client, "get", side_effect=spy),
-            capture_stdout(),
-            patch(MAKE_CLIENT_PATH, return_value=client),
-        ):
-            cmd_job(source_tier="app")
-
-        jobs_call = next(r for r in spy.calls if "jobs" in r["path"])
-        assert jobs_call["params"] is not None
-        assert jobs_call["params"]["source_tier"] == "app"
+        assert spy.params_for("jobs")["source_tier"] == "app"
 
     def test_human_mode_renders_table(self, cli_client_factory: CLIClientFactory) -> None:
         """Job renders a table with job_id, app_key, and mode columns."""
         job = make_job_summary(job_id=99, handler_method="check_lights")
         client = cli_client_factory.build_with_routes([("GET", JOBS_ENDPOINT, 200, [job.model_dump()])])
-        with (
-            capture_stdout() as buf,
-            patch(MAKE_CLIENT_PATH, return_value=client),
-        ):
-            cmd_job()
+        output = runner.stdout(client, cmd_job)
 
-        output = buf.getvalue()
         assert "99" in output
         assert "test" in output
         assert "Mode" in output
@@ -131,27 +79,14 @@ class TestCmdJob:
         job = make_job_summary(job_id=3)
         client = cli_client_factory.build_with_routes([("GET", JOBS_ENDPOINT, 200, [job.model_dump()])])
 
-        with (
-            patch(MAKE_CLIENT_PATH, return_value=client),
-            capture_json_stdout() as captured,
-        ):
-            cmd_job(ctx=CLIContext(json_mode=True))
-
-        parsed = json.loads("".join(captured))
+        parsed = runner.json_output(client, cmd_job)
         assert isinstance(parsed, list)
         assert parsed[0]["job_id"] == 3
 
     def test_empty_result_shows_no_results(self, cli_client_factory: CLIClientFactory) -> None:
         """Job renders a no-results message when no jobs are returned."""
         client = cli_client_factory.build_with_routes([("GET", JOBS_ENDPOINT, 200, [])])
-        with (
-            capture_stdout(),
-            capture_stderr() as err_buf,
-            patch(MAKE_CLIENT_PATH, return_value=client),
-        ):
-            cmd_job()
-
-        assert "No results" in err_buf.getvalue()
+        assert "No results" in runner.stderr(client, cmd_job)
 
     @pytest.mark.parametrize(
         ("schedule_status", "schedule_status_reason", "expected_text"),
@@ -211,61 +146,34 @@ class TestCmdJob:
 
 
 class TestCmdJobDetail:
-    def test_calls_executions_endpoint(self, cli_client_factory: CLIClientFactory) -> None:
-        """Job <id> fetches from GET /api/telemetry/job/{id}/executions."""
-        execution = make_execution(kind="job", job_id=1)
-        client = cli_client_factory.build_with_routes(
-            [("GET", JOB_5_EXECUTIONS_ENDPOINT, 200, [execution.model_dump()])]
-        )
-        spy = GetSpy(client)
+    @pytest.fixture
+    def job_5_client(self, cli_client_factory: CLIClientFactory) -> HassetteCLIClient:
+        """A client serving one execution from job 5's endpoint, the id the query-param tests use.
 
-        with (
-            patch.object(client, "get", side_effect=spy),
-            capture_stdout(),
-            patch(MAKE_CLIENT_PATH, return_value=client),
-        ):
-            cmd_job(job_id=5)
+        The execution body's own ``job_id`` is incidental — these tests assert on the request
+        the CLI made, never on the payload it got back.
+        """
+        execution = make_execution(kind="job", job_id=1)
+        return cli_client_factory.build_with_routes([("GET", JOB_5_EXECUTIONS_ENDPOINT, 200, [execution.model_dump()])])
+
+    def test_calls_executions_endpoint(self, job_5_client: HassetteCLIClient) -> None:
+        """Job <id> fetches from GET /api/telemetry/job/{id}/executions."""
+        spy = runner.spy(job_5_client, cmd_job, job_id=5)
 
         assert JOB_5_EXECUTIONS_ENDPOINT in spy.paths
 
-    def test_limit_passed_as_param(self, cli_client_factory: CLIClientFactory) -> None:
+    def test_limit_passed_as_param(self, job_5_client: HassetteCLIClient) -> None:
         """Job <id> --limit 5 passes limit=5 as a query param."""
-        execution = make_execution(kind="job", job_id=1)
-        client = cli_client_factory.build_with_routes(
-            [("GET", JOB_5_EXECUTIONS_ENDPOINT, 200, [execution.model_dump()])]
-        )
-        spy = GetSpy(client)
+        spy = runner.spy(job_5_client, cmd_job, job_id=5, limit=5)
 
-        with (
-            patch.object(client, "get", side_effect=spy),
-            capture_stdout(),
-            patch(MAKE_CLIENT_PATH, return_value=client),
-        ):
-            cmd_job(job_id=5, limit=5)
+        assert spy.params_for("executions")["limit"] == 5
 
-        executions_call = next(r for r in spy.calls if "executions" in r["path"])
-        assert executions_call["params"] is not None
-        assert executions_call["params"]["limit"] == 5
-
-    def test_since_passed_as_param(self, cli_client_factory: CLIClientFactory) -> None:
+    def test_since_passed_as_param(self, job_5_client: HassetteCLIClient) -> None:
         """Job <id> --since passes since as a query param."""
-        execution = make_execution(kind="job", job_id=1)
-        client = cli_client_factory.build_with_routes(
-            [("GET", JOB_5_EXECUTIONS_ENDPOINT, 200, [execution.model_dump()])]
-        )
-        spy = GetSpy(client)
-
         since_epoch = SINCE_EPOCH
-        with (
-            patch.object(client, "get", side_effect=spy),
-            capture_stdout(),
-            patch(MAKE_CLIENT_PATH, return_value=client),
-        ):
-            cmd_job(job_id=5, since=since_epoch)
+        spy = runner.spy(job_5_client, cmd_job, job_id=5, since=since_epoch)
 
-        executions_call = next(r for r in spy.calls if "executions" in r["path"])
-        assert executions_call["params"] is not None
-        assert executions_call["params"]["since"] == since_epoch
+        assert spy.params_for("executions")["since"] == since_epoch
 
     def test_human_mode_renders_table(self, cli_client_factory: CLIClientFactory) -> None:
         """Job <id> renders a table with status and duration."""
@@ -273,13 +181,8 @@ class TestCmdJobDetail:
         client = cli_client_factory.build_with_routes(
             [("GET", JOB_1_EXECUTIONS_ENDPOINT, 200, [execution.model_dump()])]
         )
-        with (
-            capture_stdout() as buf,
-            patch(MAKE_CLIENT_PATH, return_value=client),
-        ):
-            cmd_job(job_id=1)
+        output = runner.stdout(client, cmd_job, job_id=1)
 
-        output = buf.getvalue()
         assert "success" in output.lower() or "Status" in output
 
     def test_json_mode_outputs_list(self, cli_client_factory: CLIClientFactory) -> None:
@@ -289,13 +192,7 @@ class TestCmdJobDetail:
             [("GET", JOB_1_EXECUTIONS_ENDPOINT, 200, [execution.model_dump()])]
         )
 
-        with (
-            patch(MAKE_CLIENT_PATH, return_value=client),
-            capture_json_stdout() as captured,
-        ):
-            cmd_job(job_id=1, ctx=CLIContext(json_mode=True))
-
-        parsed = json.loads("".join(captured))
+        parsed = runner.json_output(client, cmd_job, job_id=1)
         assert isinstance(parsed, list)
         assert parsed[0]["duration_ms"] == pytest.approx(15.0)
 

--- a/tests/unit/cli/test_commands_listener.py
+++ b/tests/unit/cli/test_commands_listener.py
@@ -1,27 +1,18 @@
 """Unit tests for hassette listener and listener <id> commands."""
 
-import json
-from unittest.mock import patch
-
 import pytest
 
+from hassette.cli.client import HassetteCLIClient
 from hassette.cli.commands.listener import (
     LISTENER_INVOCATION_COLUMNS,
     LISTENER_LIST_COLUMNS,
     cmd_listener,
 )
-from hassette.cli.context import CLIContext
 from hassette.test_utils.web_telemetry_helpers import make_execution, make_listener_with_summary
-from tests.unit.cli.conftest import (
-    SINCE_EPOCH,
-    CLIClientFactory,
-    GetSpy,
-    capture_json_stdout,
-    capture_stderr,
-    capture_stdout,
-)
+from tests.unit.cli.conftest import SINCE_EPOCH, CLIClientFactory, CommandRunner
 
-MAKE_CLIENT_PATH = "hassette.cli.commands.listener.make_client"
+runner = CommandRunner("hassette.cli.commands.listener.make_client")
+LISTENER_42_EXECUTIONS_ENDPOINT = "/api/telemetry/listener/42/executions"
 
 # cmd_listener (bare — list all listeners)
 
@@ -31,14 +22,7 @@ class TestCmdListener:
         """Listener (no --app) fetches from GET /api/bus/listeners."""
         listener = make_listener_with_summary()
         client = cli_client_factory.build_with_routes([("GET", "/api/bus/listeners", 200, [listener.model_dump()])])
-        spy = GetSpy(client)
-
-        with (
-            patch.object(client, "get", side_effect=spy),
-            capture_stdout(),
-            patch(MAKE_CLIENT_PATH, return_value=client),
-        ):
-            cmd_listener()
+        spy = runner.spy(client, cmd_listener)
 
         assert "/api/bus/listeners" in spy.paths
 
@@ -48,14 +32,7 @@ class TestCmdListener:
         client = cli_client_factory.build_with_routes(
             [("GET", "/api/telemetry/app/my-app/listeners", 200, [listener.model_dump()])]
         )
-        spy = GetSpy(client)
-
-        with (
-            patch.object(client, "get", side_effect=spy),
-            capture_stdout(),
-            patch(MAKE_CLIENT_PATH, return_value=client),
-        ):
-            cmd_listener(app="my-app")
+        spy = runner.spy(client, cmd_listener, app="my-app")
 
         assert any("/api/telemetry/app/my-app/listeners" in p for p in spy.paths)
 
@@ -65,60 +42,32 @@ class TestCmdListener:
         client = cli_client_factory.build_with_routes(
             [("GET", "/api/telemetry/app/my-app/listeners", 200, [listener.model_dump()])]
         )
-        spy = GetSpy(client)
+        spy = runner.spy(client, cmd_listener, app="my-app", instance="0")
 
-        with (
-            patch.object(client, "get", side_effect=spy),
-            capture_stdout(),
-            patch(MAKE_CLIENT_PATH, return_value=client),
-        ):
-            cmd_listener(app="my-app", instance="0")
-
-        listeners_call = next(r for r in spy.calls if "listeners" in r["path"])
-        assert listeners_call["params"] is not None
-        assert listeners_call["params"]["instance_index"] == 0
+        assert spy.params_for("listeners")["instance_index"] == 0
 
     def test_instance_without_app_exits_with_usage_error(self, cli_client_factory: CLIClientFactory) -> None:
         """Listener --instance 0 (without --app) exits non-zero with usage error."""
         client = cli_client_factory.build_with_routes([])
 
-        with (
-            capture_stderr(),
-            patch(MAKE_CLIENT_PATH, return_value=client),
-            pytest.raises(SystemExit) as exc_info,
-        ):
-            cmd_listener(instance="0")
+        code, _stderr = runner.usage_error(client, cmd_listener, instance="0")
 
-        assert exc_info.value.code != 0
+        assert code != 0
 
     def test_source_tier_passed_as_param(self, cli_client_factory: CLIClientFactory) -> None:
         """Listener --source-tier app passes source_tier=app as a query param."""
         listener = make_listener_with_summary()
         client = cli_client_factory.build_with_routes([("GET", "/api/bus/listeners", 200, [listener.model_dump()])])
-        spy = GetSpy(client)
+        spy = runner.spy(client, cmd_listener, source_tier="app")
 
-        with (
-            patch.object(client, "get", side_effect=spy),
-            capture_stdout(),
-            patch(MAKE_CLIENT_PATH, return_value=client),
-        ):
-            cmd_listener(source_tier="app")
-
-        listeners_call = next(r for r in spy.calls if "listeners" in r["path"])
-        assert listeners_call["params"] is not None
-        assert listeners_call["params"]["source_tier"] == "app"
+        assert spy.params_for("listeners")["source_tier"] == "app"
 
     def test_human_mode_renders_table(self, cli_client_factory: CLIClientFactory) -> None:
         """Listener renders a table with listener_id and target."""
         listener = make_listener_with_summary(listener_id=42, target="light.kitchen")
         client = cli_client_factory.build_with_routes([("GET", "/api/bus/listeners", 200, [listener.model_dump()])])
-        with (
-            capture_stdout() as buf,
-            patch(MAKE_CLIENT_PATH, return_value=client),
-        ):
-            cmd_listener()
+        output = runner.stdout(client, cmd_listener)
 
-        output = buf.getvalue()
         assert "42" in output
         assert "light" in output
         assert "test_" in output
@@ -128,27 +77,14 @@ class TestCmdListener:
         listener = make_listener_with_summary(listener_id=7)
         client = cli_client_factory.build_with_routes([("GET", "/api/bus/listeners", 200, [listener.model_dump()])])
 
-        with (
-            patch(MAKE_CLIENT_PATH, return_value=client),
-            capture_json_stdout() as captured,
-        ):
-            cmd_listener(ctx=CLIContext(json_mode=True))
-
-        parsed = json.loads("".join(captured))
+        parsed = runner.json_output(client, cmd_listener)
         assert isinstance(parsed, list)
         assert parsed[0]["listener_id"] == 7
 
     def test_empty_result_shows_no_results(self, cli_client_factory: CLIClientFactory) -> None:
         """Listener renders a no-results message when no listeners are returned."""
         client = cli_client_factory.build_with_routes([("GET", "/api/bus/listeners", 200, [])])
-        with (
-            capture_stdout(),
-            capture_stderr() as err_buf,
-            patch(MAKE_CLIENT_PATH, return_value=client),
-        ):
-            cmd_listener()
-
-        assert "No results" in err_buf.getvalue()
+        assert "No results" in runner.stderr(client, cmd_listener)
 
     def test_listener_list_columns_defined(self) -> None:
         """LISTENER_LIST_COLUMNS includes key listener fields."""
@@ -165,61 +101,32 @@ class TestCmdListener:
 
 
 class TestCmdListenerDetail:
-    def test_calls_invocations_endpoint(self, cli_client_factory: CLIClientFactory) -> None:
+    @pytest.fixture
+    def listener_42_client(self, cli_client_factory: CLIClientFactory) -> HassetteCLIClient:
+        """A client serving one invocation for listener 42, the id the query-param tests use."""
+        invocation = make_execution(kind="handler", listener_id=42)
+        return cli_client_factory.build_with_routes(
+            [("GET", LISTENER_42_EXECUTIONS_ENDPOINT, 200, [invocation.model_dump()])]
+        )
+
+    def test_calls_invocations_endpoint(self, listener_42_client: HassetteCLIClient) -> None:
         """Listener <id> fetches from GET /api/telemetry/listener/{id}/executions."""
-        invocation = make_execution(kind="handler", listener_id=42)
-        client = cli_client_factory.build_with_routes(
-            [("GET", "/api/telemetry/listener/42/executions", 200, [invocation.model_dump()])]
-        )
-        spy = GetSpy(client)
+        spy = runner.spy(listener_42_client, cmd_listener, listener_id=42)
 
-        with (
-            patch.object(client, "get", side_effect=spy),
-            capture_stdout(),
-            patch(MAKE_CLIENT_PATH, return_value=client),
-        ):
-            cmd_listener(listener_id=42)
+        assert LISTENER_42_EXECUTIONS_ENDPOINT in spy.paths
 
-        assert "/api/telemetry/listener/42/executions" in spy.paths
-
-    def test_limit_passed_as_param(self, cli_client_factory: CLIClientFactory) -> None:
+    def test_limit_passed_as_param(self, listener_42_client: HassetteCLIClient) -> None:
         """Listener <id> --limit 5 passes limit=5 as a query param."""
-        invocation = make_execution(kind="handler", listener_id=42)
-        client = cli_client_factory.build_with_routes(
-            [("GET", "/api/telemetry/listener/42/executions", 200, [invocation.model_dump()])]
-        )
-        spy = GetSpy(client)
+        spy = runner.spy(listener_42_client, cmd_listener, listener_id=42, limit=5)
 
-        with (
-            patch.object(client, "get", side_effect=spy),
-            capture_stdout(),
-            patch(MAKE_CLIENT_PATH, return_value=client),
-        ):
-            cmd_listener(listener_id=42, limit=5)
+        assert spy.params_for("executions")["limit"] == 5
 
-        executions_call = next(r for r in spy.calls if "executions" in r["path"])
-        assert executions_call["params"] is not None
-        assert executions_call["params"]["limit"] == 5
-
-    def test_since_passed_as_param(self, cli_client_factory: CLIClientFactory) -> None:
+    def test_since_passed_as_param(self, listener_42_client: HassetteCLIClient) -> None:
         """Listener <id> --since passes since as a query param."""
-        invocation = make_execution(kind="handler", listener_id=42)
-        client = cli_client_factory.build_with_routes(
-            [("GET", "/api/telemetry/listener/42/executions", 200, [invocation.model_dump()])]
-        )
-        spy = GetSpy(client)
-
         since_epoch = SINCE_EPOCH
-        with (
-            patch.object(client, "get", side_effect=spy),
-            capture_stdout(),
-            patch(MAKE_CLIENT_PATH, return_value=client),
-        ):
-            cmd_listener(listener_id=42, since=since_epoch)
+        spy = runner.spy(listener_42_client, cmd_listener, listener_id=42, since=since_epoch)
 
-        executions_call = next(r for r in spy.calls if "executions" in r["path"])
-        assert executions_call["params"] is not None
-        assert executions_call["params"]["since"] == since_epoch
+        assert spy.params_for("executions")["since"] == since_epoch
 
     def test_human_mode_renders_table(self, cli_client_factory: CLIClientFactory) -> None:
         """Listener <id> renders a table with status and duration."""
@@ -227,13 +134,8 @@ class TestCmdListenerDetail:
         client = cli_client_factory.build_with_routes(
             [("GET", "/api/telemetry/listener/1/executions", 200, [invocation.model_dump()])]
         )
-        with (
-            capture_stdout() as buf,
-            patch(MAKE_CLIENT_PATH, return_value=client),
-        ):
-            cmd_listener(listener_id=1)
+        output = runner.stdout(client, cmd_listener, listener_id=1)
 
-        output = buf.getvalue()
         assert "success" in output.lower() or "Status" in output
 
     def test_json_mode_outputs_list(self, cli_client_factory: CLIClientFactory) -> None:
@@ -243,13 +145,7 @@ class TestCmdListenerDetail:
             [("GET", "/api/telemetry/listener/1/executions", 200, [invocation.model_dump()])]
         )
 
-        with (
-            patch(MAKE_CLIENT_PATH, return_value=client),
-            capture_json_stdout() as captured,
-        ):
-            cmd_listener(listener_id=1, ctx=CLIContext(json_mode=True))
-
-        parsed = json.loads("".join(captured))
+        parsed = runner.json_output(client, cmd_listener, listener_id=1)
         assert isinstance(parsed, list)
         assert parsed[0]["duration_ms"] == pytest.approx(20.0)
 

--- a/tests/unit/cli/test_commands_log.py
+++ b/tests/unit/cli/test_commands_log.py
@@ -1,142 +1,78 @@
 """Unit tests for hassette log and execution commands."""
 
-import json
-from unittest.mock import patch
-
 import pytest
 
+from hassette.cli.client import HassetteCLIClient
 from hassette.cli.commands.log import (
     EXECUTION_LOG_COLUMNS,
     LOG_COLUMNS,
     cmd_execution,
     cmd_log,
 )
-from hassette.cli.context import CLIContext
 from hassette.test_utils.web_telemetry_helpers import make_log_entry_response, make_logs_by_execution_response
-from tests.unit.cli.conftest import (
-    SINCE_EPOCH,
-    CLIClientFactory,
-    GetSpy,
-    capture_json_stdout,
-    capture_stderr,
-    capture_stdout,
-)
+from tests.unit.cli.conftest import SINCE_EPOCH, CLIClientFactory, CommandRunner
 
-MAKE_CLIENT_PATH = "hassette.cli.commands.log.make_client"
+runner = CommandRunner("hassette.cli.commands.log.make_client")
 
 # cmd_log — recent log entries
 
 
 class TestCmdLog:
-    def test_calls_logs_recent_endpoint(self, cli_client_factory: CLIClientFactory) -> None:
-        """Log (no flags) fetches from GET /api/logs/recent."""
+    @pytest.fixture
+    def logs_client(self, cli_client_factory: CLIClientFactory) -> HassetteCLIClient:
+        """A client serving one default log entry from /api/logs/recent."""
         entry = make_log_entry_response()
-        client = cli_client_factory.build_with_routes([("GET", "/api/logs/recent", 200, [entry.model_dump()])])
-        spy = GetSpy(client)
+        return cli_client_factory.build_with_routes([("GET", "/api/logs/recent", 200, [entry.model_dump()])])
 
-        with (
-            patch.object(client, "get", side_effect=spy),
-            capture_stdout(),
-            patch(MAKE_CLIENT_PATH, return_value=client),
-        ):
-            cmd_log()
+    def test_calls_logs_recent_endpoint(self, logs_client: HassetteCLIClient) -> None:
+        """Log (no flags) fetches from GET /api/logs/recent."""
+        spy = runner.spy(logs_client, cmd_log)
 
         assert "/api/logs/recent" in spy.paths
 
-    def test_app_flag_passes_app_key_as_query_param(self, cli_client_factory: CLIClientFactory) -> None:
+    def test_app_flag_passes_app_key_as_query_param(self, logs_client: HassetteCLIClient) -> None:
         """Log --app my-app passes app_key=my-app as a query param (not routing)."""
-        entry = make_log_entry_response(app_key="my-app")
-        client = cli_client_factory.build_with_routes([("GET", "/api/logs/recent", 200, [entry.model_dump()])])
-        spy = GetSpy(client)
+        spy = runner.spy(logs_client, cmd_log, app="my-app")
 
-        with (
-            patch.object(client, "get", side_effect=spy),
-            capture_stdout(),
-            patch(MAKE_CLIENT_PATH, return_value=client),
-        ):
-            cmd_log(app="my-app")
+        assert spy.params_for("logs/recent")["app_key"] == "my-app"
 
-        logs_call = next(r for r in spy.calls if "logs/recent" in r["path"])
-        assert logs_call["params"] is not None
-        assert logs_call["params"]["app_key"] == "my-app"
-
-    def test_app_flag_does_not_route_to_per_app_endpoint(self, cli_client_factory: CLIClientFactory) -> None:
+    def test_app_flag_does_not_route_to_per_app_endpoint(self, logs_client: HassetteCLIClient) -> None:
         """Log --app my-app still uses /api/logs/recent, not a per-app endpoint."""
-        entry = make_log_entry_response(app_key="my-app")
-        client = cli_client_factory.build_with_routes([("GET", "/api/logs/recent", 200, [entry.model_dump()])])
-        spy = GetSpy(client)
-
-        with (
-            patch.object(client, "get", side_effect=spy),
-            capture_stdout(),
-            patch(MAKE_CLIENT_PATH, return_value=client),
-        ):
-            cmd_log(app="my-app")
+        spy = runner.spy(logs_client, cmd_log, app="my-app")
 
         assert all("/api/logs/recent" in p for p in spy.paths)
         assert not any("telemetry/app" in p for p in spy.paths)
 
-    def test_since_and_limit_passed_as_params(self, cli_client_factory: CLIClientFactory) -> None:
+    def test_since_and_limit_passed_as_params(self, logs_client: HassetteCLIClient) -> None:
         """Log --since 1h --limit 20 passes since (epoch float) and limit=20."""
-        entry = make_log_entry_response()
-        client = cli_client_factory.build_with_routes([("GET", "/api/logs/recent", 200, [entry.model_dump()])])
-        spy = GetSpy(client)
-
         since_epoch = SINCE_EPOCH
-        with (
-            patch.object(client, "get", side_effect=spy),
-            capture_stdout(),
-            patch(MAKE_CLIENT_PATH, return_value=client),
-        ):
-            cmd_log(since=since_epoch, limit=20)
+        spy = runner.spy(logs_client, cmd_log, since=since_epoch, limit=20)
 
-        logs_call = next(r for r in spy.calls if "logs/recent" in r["path"])
-        assert logs_call["params"] is not None
-        assert logs_call["params"]["since"] == since_epoch
-        assert logs_call["params"]["limit"] == 20
+        params = spy.params_for("logs/recent")
+        assert params["since"] == since_epoch
+        assert params["limit"] == 20
 
-    def test_source_tier_passed_as_param(self, cli_client_factory: CLIClientFactory) -> None:
+    def test_source_tier_passed_as_param(self, logs_client: HassetteCLIClient) -> None:
         """Log --source-tier framework passes source_tier=framework as a query param."""
-        entry = make_log_entry_response()
-        client = cli_client_factory.build_with_routes([("GET", "/api/logs/recent", 200, [entry.model_dump()])])
-        spy = GetSpy(client)
+        spy = runner.spy(logs_client, cmd_log, source_tier="framework")
 
-        with (
-            patch.object(client, "get", side_effect=spy),
-            capture_stdout(),
-            patch(MAKE_CLIENT_PATH, return_value=client),
-        ):
-            cmd_log(source_tier="framework")
-
-        logs_call = next(r for r in spy.calls if "logs/recent" in r["path"])
-        assert logs_call["params"] is not None
-        assert logs_call["params"]["source_tier"] == "framework"
+        assert spy.params_for("logs/recent")["source_tier"] == "framework"
 
     def test_instance_flag_exits_with_usage_error(self, cli_client_factory: CLIClientFactory) -> None:
         """Log --instance 0 exits non-zero with a usage error (not supported on log)."""
         client = cli_client_factory.build_with_routes([])
 
-        with (
-            capture_stderr() as err_buf,
-            patch(MAKE_CLIENT_PATH, return_value=client),
-            pytest.raises(SystemExit) as exc_info,
-        ):
-            cmd_log(instance="0")
+        code, stderr = runner.usage_error(client, cmd_log, instance="0")
 
-        assert exc_info.value.code != 0
-        assert "instance" in err_buf.getvalue().lower()
+        assert code != 0
+        assert "instance" in stderr.lower()
 
     def test_human_mode_renders_table(self, cli_client_factory: CLIClientFactory) -> None:
         """Log renders a table with timestamp, level, and message."""
         entry = make_log_entry_response(level="INFO", message="System started", app_key="my_app")
         client = cli_client_factory.build_with_routes([("GET", "/api/logs/recent", 200, [entry.model_dump()])])
-        with (
-            capture_stdout() as buf,
-            patch(MAKE_CLIENT_PATH, return_value=client),
-        ):
-            cmd_log()
+        output = runner.stdout(client, cmd_log)
 
-        output = buf.getvalue()
         assert "INFO" in output or "Level" in output
         assert "my_app" in output or "App" in output
 
@@ -145,13 +81,7 @@ class TestCmdLog:
         entry = make_log_entry_response(message="Hello world", level="WARNING")
         client = cli_client_factory.build_with_routes([("GET", "/api/logs/recent", 200, [entry.model_dump()])])
 
-        with (
-            patch(MAKE_CLIENT_PATH, return_value=client),
-            capture_json_stdout() as captured,
-        ):
-            cmd_log(ctx=CLIContext(json_mode=True))
-
-        parsed = json.loads("".join(captured))
+        parsed = runner.json_output(client, cmd_log)
         assert isinstance(parsed, list)
         assert parsed[0]["message"] == "Hello world"
         assert parsed[0]["level"] == "WARNING"
@@ -159,14 +89,7 @@ class TestCmdLog:
     def test_empty_result_shows_no_results(self, cli_client_factory: CLIClientFactory) -> None:
         """Log renders a no-results message when no entries are returned."""
         client = cli_client_factory.build_with_routes([("GET", "/api/logs/recent", 200, [])])
-        with (
-            capture_stdout(),
-            capture_stderr() as err_buf,
-            patch(MAKE_CLIENT_PATH, return_value=client),
-        ):
-            cmd_log()
-
-        assert "No results" in err_buf.getvalue()
+        assert "No results" in runner.stderr(client, cmd_log)
 
     def test_log_columns_defined(self) -> None:
         """LOG_COLUMNS includes key log fields."""
@@ -192,14 +115,7 @@ class TestCmdExecution:
         client = cli_client_factory.build_with_routes(
             [("GET", f"/api/executions/{execution_id}", 200, response_obj.model_dump())]
         )
-        spy = GetSpy(client)
-
-        with (
-            patch.object(client, "get", side_effect=spy),
-            capture_stdout(),
-            patch(MAKE_CLIENT_PATH, return_value=client),
-        ):
-            cmd_execution(uuid="abc-123-def")
+        spy = runner.spy(client, cmd_execution, uuid="abc-123-def")
 
         assert f"/api/executions/{execution_id}" in spy.paths
 
@@ -209,18 +125,9 @@ class TestCmdExecution:
         client = cli_client_factory.build_with_routes(
             [("GET", "/api/executions/abc-123", 200, response_obj.model_dump())]
         )
-        spy = GetSpy(client)
+        spy = runner.spy(client, cmd_execution, uuid="abc-123", limit=50)
 
-        with (
-            patch.object(client, "get", side_effect=spy),
-            capture_stdout(),
-            patch(MAKE_CLIENT_PATH, return_value=client),
-        ):
-            cmd_execution(uuid="abc-123", limit=50)
-
-        exec_call = next(r for r in spy.calls if "executions" in r["path"])
-        assert exec_call["params"] is not None
-        assert exec_call["params"]["limit"] == 50
+        assert spy.params_for("executions")["limit"] == 50
 
     def test_extracts_records_from_wrapper(self, cli_client_factory: CLIClientFactory) -> None:
         """Execution renders the records list from the LogsByExecutionResponse wrapper."""
@@ -229,13 +136,8 @@ class TestCmdExecution:
         client = cli_client_factory.build_with_routes(
             [("GET", "/api/executions/exec-1", 200, response_obj.model_dump())]
         )
-        with (
-            capture_stdout() as buf,
-            patch(MAKE_CLIENT_PATH, return_value=client),
-        ):
-            cmd_execution(uuid="exec-1")
+        output = runner.stdout(client, cmd_execution, uuid="exec-1")
 
-        output = buf.getvalue()
         # Table output should show log entry data
         assert "DEBUG" in output or "Level" in output
 
@@ -246,13 +148,8 @@ class TestCmdExecution:
         client = cli_client_factory.build_with_routes(
             [("GET", "/api/executions/exec-2", 200, response_obj.model_dump())]
         )
-        with (
-            capture_stdout() as buf,
-            patch(MAKE_CLIENT_PATH, return_value=client),
-        ):
-            cmd_execution(uuid="exec-2")
+        output = runner.stdout(client, cmd_execution, uuid="exec-2")
 
-        output = buf.getvalue()
         assert "ERROR" in output or "Level" in output
 
     def test_json_mode_outputs_records_list(self, cli_client_factory: CLIClientFactory) -> None:
@@ -263,13 +160,7 @@ class TestCmdExecution:
             [("GET", "/api/executions/exec-3", 200, response_obj.model_dump())]
         )
 
-        with (
-            patch(MAKE_CLIENT_PATH, return_value=client),
-            capture_json_stdout() as captured,
-        ):
-            cmd_execution(uuid="exec-3", ctx=CLIContext(json_mode=True))
-
-        parsed = json.loads("".join(captured))
+        parsed = runner.json_output(client, cmd_execution, uuid="exec-3")
         assert isinstance(parsed, list)
         assert parsed[0]["message"] == "Executed ok"
 
@@ -279,14 +170,7 @@ class TestCmdExecution:
         client = cli_client_factory.build_with_routes(
             [("GET", "/api/executions/exec-4", 200, response_obj.model_dump())]
         )
-        with (
-            capture_stdout(),
-            capture_stderr() as err_buf,
-            patch(MAKE_CLIENT_PATH, return_value=client),
-        ):
-            cmd_execution(uuid="exec-4")
-
-        assert "No results" in err_buf.getvalue()
+        assert "No results" in runner.stderr(client, cmd_execution, uuid="exec-4")
 
     def test_execution_columns_defined(self) -> None:
         """EXECUTION_LOG_COLUMNS includes key log entry fields."""

--- a/tests/unit/cli/test_commands_misc.py
+++ b/tests/unit/cli/test_commands_misc.py
@@ -1,14 +1,10 @@
 """Unit tests for hassette config command."""
 
-import json
-from unittest.mock import patch
-
 from hassette.cli.commands.misc import cmd_config
-from hassette.cli.context import CLIContext
 from hassette.test_utils.web_response_helpers import make_config_schema_response
-from tests.unit.cli.conftest import CLIClientFactory, GetSpy, capture_json_stdout, capture_stdout
+from tests.unit.cli.conftest import CLIClientFactory, CommandRunner
 
-MAKE_CLIENT_PATH = "hassette.cli.commands.misc.make_client"
+runner = CommandRunner("hassette.cli.commands.misc.make_client")
 
 # cmd_config
 
@@ -18,14 +14,7 @@ class TestCmdConfig:
         """Config command fetches from GET /api/config."""
         config_data = make_config_schema_response()
         client = cli_client_factory.build_with_routes([("GET", "/api/config", 200, config_data.model_dump())])
-        spy = GetSpy(client)
-
-        with (
-            patch.object(client, "get", side_effect=spy),
-            capture_stdout(),
-            patch(MAKE_CLIENT_PATH, return_value=client),
-        ):
-            cmd_config()
+        spy = runner.spy(client, cmd_config)
 
         assert "/api/config" in spy.paths
 
@@ -33,12 +22,7 @@ class TestCmdConfig:
         """Config command produces a key-value panel showing config_values fields."""
         config_data = make_config_schema_response()
         client = cli_client_factory.build_with_routes([("GET", "/api/config", 200, config_data.model_dump())])
-        with (
-            capture_stdout() as buf,
-            patch(MAKE_CLIENT_PATH, return_value=client),
-        ):
-            cmd_config()
-        output = buf.getvalue()
+        output = runner.stdout(client, cmd_config)
         assert "dev_mode" in output
         assert "base_url" in output
 
@@ -47,13 +31,7 @@ class TestCmdConfig:
         config_data = make_config_schema_response()
         client = cli_client_factory.build_with_routes([("GET", "/api/config", 200, config_data.model_dump())])
 
-        with (
-            patch(MAKE_CLIENT_PATH, return_value=client),
-            capture_json_stdout() as captured,
-        ):
-            cmd_config(ctx=CLIContext(json_mode=True))
-
-        parsed = json.loads("".join(captured))
+        parsed = runner.json_output(client, cmd_config)
         assert "web_api" in parsed
         assert parsed["web_api"]["port"] == 8126
 
@@ -62,13 +40,7 @@ class TestCmdConfig:
         config_data = make_config_schema_response()
         client = cli_client_factory.build_with_routes([("GET", "/api/config", 200, config_data.model_dump())])
 
-        with (
-            patch(MAKE_CLIENT_PATH, return_value=client),
-            capture_json_stdout() as captured,
-        ):
-            cmd_config(ctx=CLIContext(json_mode=True))
-
-        parsed = json.loads("".join(captured))
+        parsed = runner.json_output(client, cmd_config)
         # Rendered dict is config_values, not the outer envelope
         assert "config_schema" not in parsed
         assert "config_values" not in parsed

--- a/tests/unit/cli/test_commands_run.py
+++ b/tests/unit/cli/test_commands_run.py
@@ -27,9 +27,16 @@ class TestBareHassetteShowsHelp:
 
 @patch("hassette.cli.commands.run.run_server", new_callable=AsyncMock)
 class TestCmdRun:
-    def test_port_in_use_exits_with_code_1(self, mock_run_server: AsyncMock) -> None:
-        exc = OSError(errno.EADDRINUSE, "Address already in use")
-        mock_run_server.side_effect = exc
+    @pytest.mark.parametrize(
+        "failure",
+        [
+            pytest.param(OSError(errno.EADDRINUSE, "Address already in use"), id="port-in-use"),
+            pytest.param(AppPrecheckFailedError("bad app"), id="precheck-failure"),
+            pytest.param(FatalError("token missing"), id="fatal-error"),
+        ],
+    )
+    def test_startup_failure_exits_with_code_1(self, mock_run_server: AsyncMock, failure: Exception) -> None:
+        mock_run_server.side_effect = failure
         with pytest.raises(SystemExit) as exc_info:
             cmd_run()
         assert exc_info.value.code == 1
@@ -39,18 +46,6 @@ class TestCmdRun:
         mock_run_server.side_effect = exc
         with pytest.raises(OSError, match="Permission denied"):
             cmd_run()
-
-    def test_precheck_failure_exits_with_code_1(self, mock_run_server: AsyncMock) -> None:
-        mock_run_server.side_effect = AppPrecheckFailedError("bad app")
-        with pytest.raises(SystemExit) as exc_info:
-            cmd_run()
-        assert exc_info.value.code == 1
-
-    def test_fatal_error_exits_with_code_1(self, mock_run_server: AsyncMock) -> None:
-        mock_run_server.side_effect = FatalError("token missing")
-        with pytest.raises(SystemExit) as exc_info:
-            cmd_run()
-        assert exc_info.value.code == 1
 
     def test_keyboard_interrupt_does_not_raise(self, mock_run_server: AsyncMock) -> None:
         mock_run_server.side_effect = KeyboardInterrupt

--- a/tests/unit/cli/test_commands_status.py
+++ b/tests/unit/cli/test_commands_status.py
@@ -1,23 +1,19 @@
 """Unit tests for hassette status, telemetry, and dashboard commands."""
 
-import json
-from unittest.mock import patch
-
 from hassette.cli.commands.status import (
     DASHBOARD_COLUMNS,
     cmd_dashboard,
     cmd_status,
     cmd_telemetry,
 )
-from hassette.cli.context import CLIContext
 from hassette.test_utils.web_response_helpers import (
     make_dashboard_app_grid_response,
     make_system_status_response,
     make_telemetry_status_response,
 )
-from tests.unit.cli.conftest import CLIClientFactory, GetSpy, capture_json_stdout, capture_stdout
+from tests.unit.cli.conftest import CLIClientFactory, CommandRunner
 
-MAKE_CLIENT_PATH = "hassette.cli.commands.status.make_client"
+runner = CommandRunner("hassette.cli.commands.status.make_client")
 
 # cmd_status
 
@@ -27,14 +23,7 @@ class TestCmdStatus:
         """Status command fetches from GET /api/health."""
         status_data = make_system_status_response()
         client = cli_client_factory.build_with_routes([("GET", "/api/health", 200, status_data.model_dump())])
-        spy = GetSpy(client)
-
-        with (
-            patch.object(client, "get", side_effect=spy),
-            capture_stdout(),
-            patch(MAKE_CLIENT_PATH, return_value=client),
-        ):
-            cmd_status()
+        spy = runner.spy(client, cmd_status)
 
         assert "/api/health" in spy.paths
 
@@ -42,12 +31,7 @@ class TestCmdStatus:
         """Status command produces a key-value panel in human mode."""
         status_data = make_system_status_response(status="ok", version="0.2.0", uptime_seconds=90.0)
         client = cli_client_factory.build_with_routes([("GET", "/api/health", 200, status_data.model_dump())])
-        with (
-            capture_stdout() as buf,
-            patch(MAKE_CLIENT_PATH, return_value=client),
-        ):
-            cmd_status()
-        output = buf.getvalue()
+        output = runner.stdout(client, cmd_status)
         assert "ok" in output
         assert "0.2.0" in output
 
@@ -56,13 +40,7 @@ class TestCmdStatus:
         status_data = make_system_status_response()
         client = cli_client_factory.build_with_routes([("GET", "/api/health", 200, status_data.model_dump())])
 
-        with (
-            patch(MAKE_CLIENT_PATH, return_value=client),
-            capture_json_stdout() as captured,
-        ):
-            cmd_status(ctx=CLIContext(json_mode=True))
-
-        parsed = json.loads("".join(captured))
+        parsed = runner.json_output(client, cmd_status)
         assert parsed["status"] == "ok"
         assert "websocket_connected" in parsed
 
@@ -70,36 +48,21 @@ class TestCmdStatus:
         """uptime_seconds renders as human-readable via CliFormat annotation."""
         status_data = make_system_status_response(uptime_seconds=3661.0)
         client = cli_client_factory.build_with_routes([("GET", "/api/health", 200, status_data.model_dump())])
-        with (
-            capture_stdout() as buf,
-            patch(MAKE_CLIENT_PATH, return_value=client),
-        ):
-            cmd_status()
-        output = buf.getvalue()
+        output = runner.stdout(client, cmd_status)
         assert "1h 1m 1s" in output
 
     def test_status_degraded_prints_status_not_error(self, cli_client_factory: CLIClientFactory) -> None:
         """Status command prints status body (not an error) when instance is 'degraded' (200)."""
         status_data = make_system_status_response(status="degraded", websocket_connected=False)
         client = cli_client_factory.build_with_routes([("GET", "/api/health", 200, status_data.model_dump())])
-        with (
-            capture_stdout() as buf,
-            patch(MAKE_CLIENT_PATH, return_value=client),
-        ):
-            cmd_status()
-        output = buf.getvalue()
+        output = runner.stdout(client, cmd_status)
         assert "degraded" in output
 
     def test_status_starting_prints_status_not_error(self, cli_client_factory: CLIClientFactory) -> None:
         """Status command prints status body (not an error) when instance is 'starting' (200)."""
         status_data = make_system_status_response(status="starting", websocket_connected=False)
         client = cli_client_factory.build_with_routes([("GET", "/api/health", 200, status_data.model_dump())])
-        with (
-            capture_stdout() as buf,
-            patch(MAKE_CLIENT_PATH, return_value=client),
-        ):
-            cmd_status()
-        output = buf.getvalue()
+        output = runner.stdout(client, cmd_status)
         assert "starting" in output
 
 
@@ -111,14 +74,7 @@ class TestCmdTelemetry:
         """Telemetry command fetches from GET /api/telemetry/status."""
         tel_data = make_telemetry_status_response()
         client = cli_client_factory.build_with_routes([("GET", "/api/telemetry/status", 200, tel_data.model_dump())])
-        spy = GetSpy(client)
-
-        with (
-            patch.object(client, "get", side_effect=spy),
-            capture_stdout(),
-            patch(MAKE_CLIENT_PATH, return_value=client),
-        ):
-            cmd_telemetry()
+        spy = runner.spy(client, cmd_telemetry)
 
         assert "/api/telemetry/status" in spy.paths
 
@@ -126,12 +82,7 @@ class TestCmdTelemetry:
         """Telemetry command produces a key-value panel showing degraded field."""
         tel_data = make_telemetry_status_response(degraded=False)
         client = cli_client_factory.build_with_routes([("GET", "/api/telemetry/status", 200, tel_data.model_dump())])
-        with (
-            capture_stdout() as buf,
-            patch(MAKE_CLIENT_PATH, return_value=client),
-        ):
-            cmd_telemetry()
-        output = buf.getvalue()
+        output = runner.stdout(client, cmd_telemetry)
         assert "degraded" in output
 
     def test_json_mode_outputs_valid_json(self, cli_client_factory: CLIClientFactory) -> None:
@@ -139,38 +90,22 @@ class TestCmdTelemetry:
         tel_data = make_telemetry_status_response(dropped_overflow=5)
         client = cli_client_factory.build_with_routes([("GET", "/api/telemetry/status", 200, tel_data.model_dump())])
 
-        with (
-            patch(MAKE_CLIENT_PATH, return_value=client),
-            capture_json_stdout() as captured,
-        ):
-            cmd_telemetry(ctx=CLIContext(json_mode=True))
-
-        parsed = json.loads("".join(captured))
+        parsed = runner.json_output(client, cmd_telemetry)
         assert parsed["dropped_overflow"] == 5
 
     def test_503_renders_degraded_status_human_mode(self, cli_client_factory: CLIClientFactory) -> None:
         """A 503 (degraded DB) prints the status body, not an error, and does not exit."""
         tel_data = make_telemetry_status_response(degraded=True)
         client = cli_client_factory.build_with_routes([("GET", "/api/telemetry/status", 503, tel_data.model_dump())])
-        with (
-            capture_stdout() as buf,
-            patch(MAKE_CLIENT_PATH, return_value=client),
-        ):
-            cmd_telemetry()
-        assert "degraded" in buf.getvalue()
+        output = runner.stdout(client, cmd_telemetry)
+        assert "degraded" in output
 
     def test_503_outputs_status_json_mode_exit_zero(self, cli_client_factory: CLIClientFactory) -> None:
         """A 503 in json mode emits the deserialized status (no error doc) and exits 0."""
         tel_data = make_telemetry_status_response(degraded=True)
         client = cli_client_factory.build_with_routes([("GET", "/api/telemetry/status", 503, tel_data.model_dump())])
 
-        with (
-            patch(MAKE_CLIENT_PATH, return_value=client),
-            capture_json_stdout() as captured,
-        ):
-            cmd_telemetry(ctx=CLIContext(json_mode=True))
-
-        parsed = json.loads("".join(captured))
+        parsed = runner.json_output(client, cmd_telemetry)
         assert parsed["degraded"] is True
         assert "error" not in parsed
 
@@ -185,14 +120,7 @@ class TestCmdDashboard:
         client = cli_client_factory.build_with_routes(
             [("GET", "/api/telemetry/dashboard/app-grid", 200, grid.model_dump())]
         )
-        spy = GetSpy(client)
-
-        with (
-            patch.object(client, "get", side_effect=spy),
-            capture_stdout(),
-            patch(MAKE_CLIENT_PATH, return_value=client),
-        ):
-            cmd_dashboard()
+        spy = runner.spy(client, cmd_dashboard)
 
         assert any("/api/telemetry/dashboard/app-grid" in p for p in spy.paths)
 
@@ -202,12 +130,7 @@ class TestCmdDashboard:
         client = cli_client_factory.build_with_routes(
             [("GET", "/api/telemetry/dashboard/app-grid", 200, grid.model_dump())]
         )
-        with (
-            capture_stdout() as buf,
-            patch(MAKE_CLIENT_PATH, return_value=client),
-        ):
-            cmd_dashboard()
-        output = buf.getvalue()
+        output = runner.stdout(client, cmd_dashboard)
         # Table headers must always be visible
         assert "App" in output
         assert "Health" in output
@@ -221,13 +144,7 @@ class TestCmdDashboard:
             [("GET", "/api/telemetry/dashboard/app-grid", 200, grid.model_dump())]
         )
 
-        with (
-            patch(MAKE_CLIENT_PATH, return_value=client),
-            capture_json_stdout() as captured,
-        ):
-            cmd_dashboard(ctx=CLIContext(json_mode=True))
-
-        parsed = json.loads("".join(captured))
+        parsed = runner.json_output(client, cmd_dashboard)
         assert isinstance(parsed, list)
         assert parsed[0]["app_key"] == "test_app"
 

--- a/tests/unit/cli/test_context.py
+++ b/tests/unit/cli/test_context.py
@@ -7,9 +7,18 @@ from unittest.mock import patch
 import pytest
 from cyclopts import App, Parameter
 
-from hassette.cli.client import make_client
+from hassette.cli.client import HassetteCLIClient, make_client
 from hassette.cli.context import DEFAULT_CLI_CONTEXT, CLIContext, CLIContextParam
+from hassette.config.config import HassetteConfig
 from tests.unit.cli.conftest import CLIClientFactory
+
+
+def make_client_from_context(ctx: CLIContext, config: HassetteConfig) -> HassetteCLIClient:
+    """Run ``make_client(ctx)`` against ``config`` instead of a real on-disk configuration."""
+    with patch("hassette.cli.client.HassetteConfig") as mock_config_cls:
+        mock_config_cls.return_value = config
+        mock_config_cls.model_config = {}
+        return make_client(ctx)
 
 
 class TestCLIContextDefaults:
@@ -31,19 +40,11 @@ class TestCLIContextFrozen:
 
 class TestMakeClientReceivesContext:
     def test_make_client_receives_json_mode(self, cli_client_factory: CLIClientFactory) -> None:
-        ctx = CLIContext(json_mode=True)
-        with patch("hassette.cli.client.HassetteConfig") as mock_config_cls:
-            mock_config_cls.return_value = cli_client_factory.config
-            mock_config_cls.model_config = {}
-            client = make_client(ctx)
+        client = make_client_from_context(CLIContext(json_mode=True), cli_client_factory.config)
         assert client.json_mode is True
 
     def test_make_client_receives_debug_mode(self, cli_client_factory: CLIClientFactory) -> None:
-        ctx = CLIContext(debug_mode=True)
-        with patch("hassette.cli.client.HassetteConfig") as mock_config_cls:
-            mock_config_cls.return_value = cli_client_factory.config
-            mock_config_cls.model_config = {}
-            client = make_client(ctx)
+        client = make_client_from_context(CLIContext(debug_mode=True), cli_client_factory.config)
         assert client.debug_mode is True
 
     def test_make_client_no_args_raises_type_error(self) -> None:
@@ -52,10 +53,7 @@ class TestMakeClientReceivesContext:
 
     def test_make_client_forwards_server_url_flag(self, cli_client_factory: CLIClientFactory) -> None:
         ctx = CLIContext(server_url="https://example.com/hassette")
-        with patch("hassette.cli.client.HassetteConfig") as mock_config_cls:
-            mock_config_cls.return_value = cli_client_factory.config
-            mock_config_cls.model_config = {}
-            client = make_client(ctx)
+        client = make_client_from_context(ctx, cli_client_factory.config)
         assert client.base_url == "https://example.com/hassette"
         assert client.is_loopback is False
 

--- a/tests/unit/cli/test_context.py
+++ b/tests/unit/cli/test_context.py
@@ -10,7 +10,7 @@ from cyclopts import App, Parameter
 from hassette.cli.client import HassetteCLIClient, make_client
 from hassette.cli.context import DEFAULT_CLI_CONTEXT, CLIContext, CLIContextParam
 from hassette.config.config import HassetteConfig
-from tests.unit.cli.conftest import CLIClientFactory
+from tests.unit.cli.conftest import REMOTE_SERVER_URL, CLIClientFactory
 
 
 def make_client_from_context(ctx: CLIContext, config: HassetteConfig) -> HassetteCLIClient:
@@ -52,9 +52,9 @@ class TestMakeClientReceivesContext:
             make_client()  # pyright: ignore[reportCallIssue]
 
     def test_make_client_forwards_server_url_flag(self, cli_client_factory: CLIClientFactory) -> None:
-        ctx = CLIContext(server_url="https://example.com/hassette")
+        ctx = CLIContext(server_url=REMOTE_SERVER_URL)
         client = make_client_from_context(ctx, cli_client_factory.config)
-        assert client.base_url == "https://example.com/hassette"
+        assert client.base_url == REMOTE_SERVER_URL
         assert client.is_loopback is False
 
 

--- a/tests/unit/cli/test_output.py
+++ b/tests/unit/cli/test_output.py
@@ -301,9 +301,8 @@ class TestRenderTableJsonMode:
         items = [SimpleItem(name="x", count=99)]
         columns = [Column("name", "Name"), Column("count", "Count")]
         render_table(items, columns, json_mode=True)
-        captured = capsys.readouterr()
         # Must be valid JSON — no ANSI codes, no Rich markup
-        parsed = json.loads(captured.out)
+        parsed = parse_json_stdout(capsys)
         assert parsed[0]["name"] == "x"
 
 
@@ -553,17 +552,15 @@ class TestStdoutCleanliness:
         items = [SimpleItem(name="x", count=1), SimpleItem(name="y", count=2)]
         columns = [Column("name", "Name")]
         render_table(items, columns, json_mode=True)
-        captured = capsys.readouterr()
-        # Strip trailing newline and parse — must succeed without error
-        parsed = json.loads(captured.out.strip())
+        # Must succeed without error
+        parsed = parse_json_stdout(capsys)
         assert isinstance(parsed, list)
 
     def test_json_detail_stdout_is_valid_json_only(self, capsys: pytest.CaptureFixture[str]) -> None:
         """Stdout in JSON mode for detail must be exactly one valid JSON document."""
         item = SimpleItem(name="hello", count=3)
         render_detail(item, json_mode=True)
-        captured = capsys.readouterr()
-        parsed = json.loads(captured.out.strip())
+        parsed = parse_json_stdout(capsys)
         assert isinstance(parsed, dict)
 
     def test_human_table_nothing_on_stderr_for_non_empty(self) -> None:

--- a/tests/unit/cli/test_output.py
+++ b/tests/unit/cli/test_output.py
@@ -24,7 +24,7 @@ from hassette.cli.output import (
     render_table,
 )
 from hassette.types.types import CliFormat
-from tests.unit.cli.conftest import capture_human
+from tests.unit.cli.conftest import capture_human, parse_json_stdout
 
 # Simple test models
 
@@ -262,8 +262,7 @@ class TestRenderTableJsonMode:
         items = [SimpleItem(name="a", count=1), SimpleItem(name="b", count=2)]
         columns = [Column("name", "Name"), Column("count", "Count")]
         render_table(items, columns, json_mode=True)
-        captured = capsys.readouterr()
-        parsed = json.loads(captured.out)
+        parsed = parse_json_stdout(capsys)
         assert isinstance(parsed, list)
         assert len(parsed) == 2
 
@@ -271,8 +270,7 @@ class TestRenderTableJsonMode:
         items = [SimpleItem(name="alpha", count=10, active=True, note="hi")]
         columns = [Column("name", "Name")]
         render_table(items, columns, json_mode=True)
-        captured = capsys.readouterr()
-        parsed = json.loads(captured.out)
+        parsed = parse_json_stdout(capsys)
         # JSON uses the full model dump, not just column fields
         assert parsed[0]["name"] == "alpha"
         assert parsed[0]["count"] == 10
@@ -281,8 +279,7 @@ class TestRenderTableJsonMode:
     def test_empty_list_json_outputs_empty_array(self, capsys: pytest.CaptureFixture[str]) -> None:
         columns = [Column("name", "Name")]
         render_table([], columns, json_mode=True)
-        captured = capsys.readouterr()
-        parsed = json.loads(captured.out)
+        parsed = parse_json_stdout(capsys)
         assert parsed == []
 
     def test_json_mode_nothing_on_stderr(self, capsys: pytest.CaptureFixture[str]) -> None:
@@ -396,8 +393,7 @@ class TestRenderTableCliFormatFallback:
         items = [AnnotatedTableItem(name="job1", avg_duration_ms=450.0, next_run=None)]
         columns = [Column("avg_duration_ms", "Avg"), Column("next_run", "Next Run")]
         render_table(items, columns, json_mode=True)
-        captured = capsys.readouterr()
-        parsed = json.loads(captured.out)
+        parsed = parse_json_stdout(capsys)
         assert parsed[0]["avg_duration_ms"] == 450.0
         assert parsed[0]["next_run"] is None
 
@@ -448,8 +444,7 @@ class TestRenderDetailJsonMode:
     def test_valid_json_on_stdout(self, capsys: pytest.CaptureFixture[str]) -> None:
         item = SimpleItem(name="test", count=7, active=True)
         render_detail(item, json_mode=True)
-        captured = capsys.readouterr()
-        parsed = json.loads(captured.out)
+        parsed = parse_json_stdout(capsys)
         assert parsed["name"] == "test"
         assert parsed["count"] == 7
 
@@ -462,8 +457,7 @@ class TestRenderDetailJsonMode:
     def test_json_contains_all_fields(self, capsys: pytest.CaptureFixture[str]) -> None:
         item = SimpleItem(name="alpha", count=10, active=False, note="hi")
         render_detail(item, json_mode=True)
-        captured = capsys.readouterr()
-        parsed = json.loads(captured.out)
+        parsed = parse_json_stdout(capsys)
         assert parsed["name"] == "alpha"
         assert parsed["count"] == 10
         assert parsed["active"] is False

--- a/tests/unit/cli/test_output_detail.py
+++ b/tests/unit/cli/test_output_detail.py
@@ -19,7 +19,7 @@ from hassette.cli.output import (
     render_detail_dict,
 )
 from hassette.types.types import CliFormat
-from tests.unit.cli.conftest import capture_human
+from tests.unit.cli.conftest import capture_human, parse_json_stdout
 
 
 class SimpleItem(BaseModel):
@@ -219,8 +219,7 @@ class TestRenderDetailCliFormat:
             last_seen=None,
         )
         render_detail(item, json_mode=True)
-        captured = capsys.readouterr()
-        parsed = json.loads(captured.out)
+        parsed = parse_json_stdout(capsys)
         assert parsed["uptime_seconds"] == 9005.0
         assert parsed["avg_duration"] == 450.0
 


### PR DESCRIPTION
## Summary

`tools/check_duplicate_code.py` (PMD CPD) flagged 31 duplicate clusters across `tests/unit/cli/`. All 31 are resolved by extraction — no `dup-ignore` annotation was needed, because every cluster turned out to be mechanical boilerplate rather than deliberate parallel structure worth keeping repeated.

## What changed

- **`CommandRunner` (conftest)** replaces the patch/capture context-manager stack every `test_commands_*.py` test hand-rolled, with one method per read-back shape: `spy`, `stdout`, `stderr`, `json_output`, `usage_error`. It's instantiated once per module, since each command module imports `make_client` into its own namespace.
- **`GetSpy.params_for(fragment)`** replaces the repeated "find the recorded GET, assert params is not None, index one key" idiom, and names both failure modes instead of surfacing a bare `StopIteration`/`TypeError`.
- **`ClientFlags` (TypedDict + `Unpack`)** declares `CLIClientFactory`'s keyword-only resolver flags once instead of restating the list on all three builders. This also closes the cluster it shared with `HassetteCLIClient.__init__`.
- **`parse_json_stdout(capsys)`** for the `render_*` json-mode tests in `test_output.py` / `test_output_detail.py`.
- **File-local helpers** where the pattern didn't generalize: `test_client.py` gains `route_listeners`, `get_expecting_exit`, `get_json_error`, `stderr_for_successful_get`, and `url_capturing_client`; `test_context.py` gains `make_client_from_context`.
- **Per-class fixtures** (`logs_client`, `job_5_client`, `listener_42_client`, `activity_client`) hoist the identical route setup the query-param tests shared. Two sets of tests that differed only in input became parametrized cases (app-config json shapes, `cmd_run` startup failures).

`tests/unit/cli/CLAUDE.md` is updated to point at the new scaffolding so the next test added to this directory reaches for it instead of re-hand-rolling the stack.

## Testing

- `uv run nox -s dev` — 6901 passed, 1 skipped, 2 xfailed
- `prek -a` and `prek -a --hook-stage pre-push` (includes pyright, tsc, eslint, stylelint) — all hooks pass
- `uv run python tools/check_duplicate_code.py` — zero clusters touching `tests/unit/cli/` (remaining clusters are the pre-existing frontend baseline, untouched by this branch)
- `tests/unit/cli` collects 436 tests, unchanged from before the refactor — this is a pure restructuring, no behavior coverage was dropped

Closes #1565