### PR TITLE
test: deduplicate tests/unit/scheduler test patterns

### DIFF
--- a/tests/integration/test_scheduler.py
+++ b/tests/integration/test_scheduler.py
@@ -223,30 +223,7 @@ def test_scheduled_job_defaults_empty_app_key() -> None:
     assert job.instance_index == 0
 
 
-def test_scheduled_job_mark_registered_sets_db_id() -> None:
-    """mark_registered() sets db_id on first call."""
-    job = Job(
-        owner_id="test",
-        next_run=ZonedDateTime.from_system_tz(2030, 1, 1, 0, 0, 0),
-        job=lambda: None,
-    )
-    assert job.db_id is None
-
-    job.mark_registered(42)
-    assert job.db_id == 42
-
-
-def test_scheduled_job_mark_registered_keeps_original_on_double_call() -> None:
-    """mark_registered() keeps the original db_id when called a second time."""
-    job = Job(
-        owner_id="test",
-        next_run=ZonedDateTime.from_system_tz(2030, 1, 1, 0, 0, 0),
-        job=lambda: None,
-    )
-    job.mark_registered(42)
-    job.mark_registered(99)
-
-    assert job.db_id == 42
+# mark_registered() coverage lives in tests/unit/scheduler/test_scheduled_job_mark_registered.py.
 
 
 class _ExhaustionConfig(AppConfig):

--- a/tests/unit/bus/test_bus_coroutine_conversion.py
+++ b/tests/unit/bus/test_bus_coroutine_conversion.py
@@ -26,12 +26,19 @@ from tests.unit.test_forgotten_await_completeness import CANONICAL_PROTECTED
 from .conftest import mock_add_listener
 
 # Derived from the canonical single source of truth — see test_forgotten_await_completeness.py.
+# dup-ignore-start: the _drain fixture two statements below is a documented per-file opt-in
+# pattern (see drain_forgotten_await_handles docstring in tests/unit/conftest.py) — every
+# warning-heavy test module repeats this one-line wrapper by design. This marker also covers the
+# _PUBLIC_REGISTRATION_METHODS assignment immediately below, which is unrelated — PMD's clone
+# match for the fixture happens to extend back to include it, so it has to sit inside the ignored
+# range.
 _PUBLIC_REGISTRATION_METHODS = sorted(CANONICAL_PROTECTED[Bus])
 
 
 @pytest.fixture(autouse=True)
 def _drain(drain_forgotten_await_handles: None) -> None:
     """Drain dropped handles after each test (shared fixture in tests/unit/conftest.py)."""
+    # dup-ignore-end
 
 
 async def handler(event: object) -> None:
@@ -87,6 +94,9 @@ async def test_await_returns_subscription(bus: "Bus", call) -> None:
 # returned handle IS a RegistrationHandle / collections.abc.Coroutine
 
 
+# dup-ignore-start: the "returns a RegistrationHandle before awaiting, must be closed" invariant is
+# intentionally mirrored across the Bus/Scheduler/Api coroutine-conversion test suites — each class
+# was converted the same way and needs the same coverage. Not extractable across unrelated classes.
 async def test_on_returns_registration_handle(bus: "Bus") -> None:
     """Bus.on() returns a RegistrationHandle before it is awaited."""
     with mock_add_listener(bus):
@@ -112,6 +122,7 @@ async def test_on_returns_registration_handle(bus: "Bus") -> None:
         ),
     ],
 )
+# dup-ignore-end
 def test_forgotten_await_warns(bus: "Bus", call) -> None:
     """Dropping un-awaited handle emits HassetteForgottenAwaitWarning."""
     with mock_add_listener(bus), pytest.warns(HassetteForgottenAwaitWarning):

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -44,6 +44,10 @@ if TYPE_CHECKING:
 
 TEST_TOKEN = "test-token"
 
+#: Shared timezone for tests that build fixed ZonedDateTime instances — America/Chicago
+#: covers DST transitions in a way UTC doesn't, so most scheduler/trigger tests use it.
+TZ = "America/Chicago"
+
 
 def make_sync_executor_config(
     max_workers: int = 4,

--- a/tests/unit/scheduler/conftest.py
+++ b/tests/unit/scheduler/conftest.py
@@ -9,8 +9,8 @@ from whenever import ZonedDateTime
 from hassette.scheduler.scheduler import Scheduler
 from hassette.test_utils.config import TEST_SOURCE_LOCATION
 from hassette.test_utils.factories import make_scheduler as make_scheduler
+from tests.unit.conftest import TZ as TZ
 
-TZ = "America/Chicago"
 PATCH_TARGET = "hassette.scheduler.scheduler.capture_registration_source"
 
 

--- a/tests/unit/scheduler/conftest.py
+++ b/tests/unit/scheduler/conftest.py
@@ -1,7 +1,13 @@
 """Shared fixtures for unit/scheduler tests."""
 
+from collections.abc import Iterator
+from unittest.mock import patch
+
+import pytest
 from whenever import ZonedDateTime
 
+from hassette.scheduler.scheduler import Scheduler
+from hassette.test_utils.config import TEST_SOURCE_LOCATION
 from hassette.test_utils.factories import make_scheduler as make_scheduler
 
 TZ = "America/Chicago"
@@ -10,3 +16,19 @@ PATCH_TARGET = "hassette.scheduler.scheduler.capture_registration_source"
 
 def zdt(year: int, month: int, day: int, hour: int = 0, minute: int = 0, second: int = 0) -> ZonedDateTime:
     return ZonedDateTime(year, month, day, hour, minute, second, tz=TZ)
+
+
+@pytest.fixture
+def patched_scheduler() -> Iterator[Scheduler]:
+    """A Scheduler with capture_registration_source patched for the duration of the test.
+
+    Matches the ``with patch(PATCH_TARGET, ...): scheduler = make_scheduler()`` shape used
+    across this directory's test files wherever a real scheduler.schedule()/convenience-method
+    call needs the registration-source patch active. The mocked return value's label is always
+    ``"schedule(...)"`` regardless of which convenience method the test actually calls — no test
+    in this directory asserts on ``registration_source``/``source_location`` content, so this is
+    a shared placeholder, not a per-method label. A test that starts asserting on that value needs
+    its own ``patch(PATCH_TARGET, ...)`` instead of this fixture.
+    """
+    with patch(PATCH_TARGET, return_value=(TEST_SOURCE_LOCATION, "schedule(...)")):
+        yield make_scheduler()

--- a/tests/unit/scheduler/test_scheduler_coroutine_conversion.py
+++ b/tests/unit/scheduler/test_scheduler_coroutine_conversion.py
@@ -27,13 +27,36 @@ from tests.unit.test_forgotten_await_completeness import CANONICAL_PROTECTED
 
 from .conftest import make_scheduler
 
+# Shared across test_await_returns_scheduled_job and test_forgotten_await_warns (all methods),
+# and test_returns_registration_handle (first three — add_job/schedule/run_in).
+_SCHEDULING_METHOD_CALLS = [
+    pytest.param(
+        lambda s: s.add_job(Job(owner_id="o", next_run=now(), job=noop, name="t")),
+        id="add_job",
+    ),
+    pytest.param(lambda s: s.schedule(noop, Every(hours=1), name="t"), id="schedule"),
+    pytest.param(lambda s: s.run_in(noop, 30, name="t"), id="run_in"),
+    pytest.param(lambda s: s.run_every(noop, minutes=5, name="t"), id="run_every"),
+    pytest.param(lambda s: s.run_daily(noop, at="08:00", name="t"), id="run_daily"),
+    pytest.param(lambda s: s.run_cron(noop, "0 9 * * 1-5", name="t"), id="run_cron"),
+    pytest.param(lambda s: s.run_once(noop, at="23:59", name="t"), id="run_once"),
+    pytest.param(lambda s: s.run_minutely(noop, minutes=5, name="t"), id="run_minutely"),
+    pytest.param(lambda s: s.run_hourly(noop, hours=2, name="t"), id="run_hourly"),
+]
+
 # Derived from the canonical single source of truth — see test_forgotten_await_completeness.py.
+# dup-ignore-start: the _drain fixture two statements below is a documented per-file opt-in
+# pattern (see drain_forgotten_await_handles docstring in tests/unit/conftest.py) — every
+# warning-heavy test module repeats this one-line wrapper by design. This marker also covers the
+# _PUBLIC_SCHEDULING_METHODS assignment immediately below, which is unrelated — PMD's clone match
+# for the fixture happens to extend back to include it, so it has to sit inside the ignored range.
 _PUBLIC_SCHEDULING_METHODS = sorted(CANONICAL_PROTECTED[Scheduler])
 
 
 @pytest.fixture(autouse=True)
 def _drain(drain_forgotten_await_handles: None) -> None:
     """Drain dropped handles after each test (shared fixture in tests/unit/conftest.py)."""
+    # dup-ignore-end
 
 
 # Public scheduling methods must be plain def, not async def
@@ -55,23 +78,7 @@ def test_scheduling_method_is_plain_def(method_name: str) -> None:
 # Awaiting returns Job with db_id; no warnings emitted
 
 
-@pytest.mark.parametrize(
-    "call",
-    [
-        pytest.param(
-            lambda s: s.add_job(Job(owner_id="o", next_run=now(), job=noop, name="t")),
-            id="add_job",
-        ),
-        pytest.param(lambda s: s.schedule(noop, Every(hours=1), name="t"), id="schedule"),
-        pytest.param(lambda s: s.run_in(noop, 30, name="t"), id="run_in"),
-        pytest.param(lambda s: s.run_every(noop, minutes=5, name="t"), id="run_every"),
-        pytest.param(lambda s: s.run_daily(noop, at="08:00", name="t"), id="run_daily"),
-        pytest.param(lambda s: s.run_cron(noop, "0 9 * * 1-5", name="t"), id="run_cron"),
-        pytest.param(lambda s: s.run_once(noop, at="23:59", name="t"), id="run_once"),
-        pytest.param(lambda s: s.run_minutely(noop, minutes=5, name="t"), id="run_minutely"),
-        pytest.param(lambda s: s.run_hourly(noop, hours=2, name="t"), id="run_hourly"),
-    ],
-)
+@pytest.mark.parametrize("call", _SCHEDULING_METHOD_CALLS)
 async def test_await_returns_scheduled_job(call) -> None:
     """Awaiting any scheduling method returns a Job with db_id set, no warning."""
     scheduler = make_scheduler()
@@ -108,17 +115,11 @@ def test_add_job_existing_name_no_valueerror_at_call_time() -> None:
 # Returned handle is a RegistrationHandle / collections.abc.Coroutine
 
 
-@pytest.mark.parametrize(
-    "call",
-    [
-        pytest.param(
-            lambda s: s.add_job(Job(owner_id="o", next_run=now(), job=noop, name="t")),
-            id="add_job",
-        ),
-        pytest.param(lambda s: s.schedule(noop, Every(hours=1), name="t"), id="schedule"),
-        pytest.param(lambda s: s.run_in(noop, 30, name="t"), id="run_in"),
-    ],
-)
+# dup-ignore-start: the "returns a RegistrationHandle before awaiting, must be closed" invariant is
+# intentionally mirrored across the Bus/Scheduler/Api coroutine-conversion test suites — each class
+# was converted the same way and needs the same coverage. Not extractable across unrelated classes.
+# [:3] relies on list order — first three entries of _SCHEDULING_METHOD_CALLS are add_job/schedule/run_in.
+@pytest.mark.parametrize("call", _SCHEDULING_METHOD_CALLS[:3])
 def test_returns_registration_handle(call) -> None:
     """Scheduling methods return a RegistrationHandle before awaiting."""
     scheduler = make_scheduler()
@@ -130,23 +131,8 @@ def test_returns_registration_handle(call) -> None:
 # Dropping un-awaited handle emits HassetteForgottenAwaitWarning
 
 
-@pytest.mark.parametrize(
-    "call",
-    [
-        pytest.param(
-            lambda s: s.add_job(Job(owner_id="o", next_run=now(), job=noop, name="t")),
-            id="add_job",
-        ),
-        pytest.param(lambda s: s.schedule(noop, Every(hours=1), name="t"), id="schedule"),
-        pytest.param(lambda s: s.run_in(noop, 30, name="t"), id="run_in"),
-        pytest.param(lambda s: s.run_every(noop, minutes=5, name="t"), id="run_every"),
-        pytest.param(lambda s: s.run_daily(noop, at="08:00", name="t"), id="run_daily"),
-        pytest.param(lambda s: s.run_cron(noop, "0 9 * * 1-5", name="t"), id="run_cron"),
-        pytest.param(lambda s: s.run_once(noop, at="23:59", name="t"), id="run_once"),
-        pytest.param(lambda s: s.run_minutely(noop, minutes=5, name="t"), id="run_minutely"),
-        pytest.param(lambda s: s.run_hourly(noop, hours=2, name="t"), id="run_hourly"),
-    ],
-)
+@pytest.mark.parametrize("call", _SCHEDULING_METHOD_CALLS)
+# dup-ignore-end
 def test_forgotten_await_warns(call) -> None:
     """Dropping un-awaited handle emits HassetteForgottenAwaitWarning."""
     scheduler = make_scheduler()

--- a/tests/unit/scheduler/test_scheduler_error_handler.py
+++ b/tests/unit/scheduler/test_scheduler_error_handler.py
@@ -2,11 +2,11 @@
 
 from unittest.mock import patch
 
+from hassette.scheduler.scheduler import Scheduler
 from hassette.scheduler.triggers import Every
-from hassette.test_utils.config import TEST_SOURCE_LOCATION
 from hassette.test_utils.helpers import noop
 
-from .conftest import PATCH_TARGET, make_scheduler
+from .conftest import make_scheduler
 
 
 async def handler_a(ctx) -> None:
@@ -55,58 +55,51 @@ class TestSchedulerOnErrorMethod:
 
 
 class TestPerJobOnError:
-    async def test_per_job_on_error_stored(self) -> None:
+    async def test_per_job_on_error_stored(self, patched_scheduler: Scheduler) -> None:
         """on_error= kwarg on schedule() is stored on the ScheduledJob."""
-        with patch(PATCH_TARGET, return_value=(TEST_SOURCE_LOCATION, "schedule(...)")):
-            scheduler = make_scheduler()
-            job = await scheduler.schedule(
-                noop, Every(hours=1), on_error=handler_a, name="per_job_on_error_stored_schedule"
-            )
-            assert job.error_handler is handler_a
+        job = await patched_scheduler.schedule(
+            noop, Every(hours=1), on_error=handler_a, name="per_job_on_error_stored_schedule"
+        )
+        assert job.error_handler is handler_a
 
-    async def test_job_error_handler_default_none(self) -> None:
+    async def test_job_error_handler_default_none(self, patched_scheduler: Scheduler) -> None:
         """error_handler defaults to None on ScheduledJob when not provided."""
-        with patch(PATCH_TARGET, return_value=(TEST_SOURCE_LOCATION, "schedule(...)")):
-            scheduler = make_scheduler()
-            job = await scheduler.schedule(noop, Every(hours=1), name="job_error_handler_default_none_schedule")
-            assert job.error_handler is None
+        job = await patched_scheduler.schedule(noop, Every(hours=1), name="job_error_handler_default_none_schedule")
+        assert job.error_handler is None
 
-    async def test_convenience_methods_pass_on_error(self) -> None:
+    async def test_convenience_methods_pass_on_error(self, patched_scheduler: Scheduler) -> None:
         """All 7 convenience methods accept and pass on_error to ScheduledJob."""
-        with patch(PATCH_TARGET, return_value=(TEST_SOURCE_LOCATION, "schedule(...)")):
-            scheduler = make_scheduler()
+        job_run_in = await patched_scheduler.run_in(
+            noop, delay=60, on_error=handler_a, name="convenience_methods_pass_on_error_run_in"
+        )
+        assert job_run_in.error_handler is handler_a
 
-            job_run_in = await scheduler.run_in(
-                noop, delay=60, on_error=handler_a, name="convenience_methods_pass_on_error_run_in"
-            )
-            assert job_run_in.error_handler is handler_a
+        job_run_every = await patched_scheduler.run_every(
+            noop, seconds=30, on_error=handler_a, name="convenience_methods_pass_on_error_run_every"
+        )
+        assert job_run_every.error_handler is handler_a
 
-            job_run_every = await scheduler.run_every(
-                noop, seconds=30, on_error=handler_a, name="convenience_methods_pass_on_error_run_every"
-            )
-            assert job_run_every.error_handler is handler_a
+        job_run_hourly = await patched_scheduler.run_hourly(
+            noop, on_error=handler_a, name="convenience_methods_pass_on_error_run_hourly"
+        )
+        assert job_run_hourly.error_handler is handler_a
 
-            job_run_hourly = await scheduler.run_hourly(
-                noop, on_error=handler_a, name="convenience_methods_pass_on_error_run_hourly"
-            )
-            assert job_run_hourly.error_handler is handler_a
+        job_run_minutely = await patched_scheduler.run_minutely(
+            noop, on_error=handler_a, name="convenience_methods_pass_on_error_run_minutely"
+        )
+        assert job_run_minutely.error_handler is handler_a
 
-            job_run_minutely = await scheduler.run_minutely(
-                noop, on_error=handler_a, name="convenience_methods_pass_on_error_run_minutely"
-            )
-            assert job_run_minutely.error_handler is handler_a
+        job_run_daily = await patched_scheduler.run_daily(
+            noop, at="00:00", on_error=handler_a, name="convenience_methods_pass_on_error_run_daily"
+        )
+        assert job_run_daily.error_handler is handler_a
 
-            job_run_daily = await scheduler.run_daily(
-                noop, at="00:00", on_error=handler_a, name="convenience_methods_pass_on_error_run_daily"
-            )
-            assert job_run_daily.error_handler is handler_a
+        job_run_cron = await patched_scheduler.run_cron(
+            noop, "0 * * * *", on_error=handler_a, name="convenience_methods_pass_on_error_run_cron"
+        )
+        assert job_run_cron.error_handler is handler_a
 
-            job_run_cron = await scheduler.run_cron(
-                noop, "0 * * * *", on_error=handler_a, name="convenience_methods_pass_on_error_run_cron"
-            )
-            assert job_run_cron.error_handler is handler_a
-
-            job_run_once = await scheduler.run_once(
-                noop, at="23:59", on_error=handler_a, name="convenience_methods_pass_on_error_run_once"
-            )
-            assert job_run_once.error_handler is handler_a
+        job_run_once = await patched_scheduler.run_once(
+            noop, at="23:59", on_error=handler_a, name="convenience_methods_pass_on_error_run_once"
+        )
+        assert job_run_once.error_handler is handler_a

--- a/tests/unit/scheduler/test_scheduler_error_handler.py
+++ b/tests/unit/scheduler/test_scheduler_error_handler.py
@@ -2,6 +2,8 @@
 
 from unittest.mock import patch
 
+import pytest
+
 from hassette.scheduler.scheduler import Scheduler
 from hassette.scheduler.triggers import Every
 from hassette.test_utils.helpers import noop
@@ -15,6 +17,39 @@ async def handler_a(ctx) -> None:
 
 async def handler_b(ctx) -> None:
     pass
+
+
+# All 7 convenience methods accept and pass on_error to ScheduledJob.
+_ON_ERROR_CONVENIENCE_CALLS = [
+    pytest.param(
+        lambda s: s.run_in(noop, delay=60, on_error=handler_a, name="convenience_methods_pass_on_error_run_in"),
+        id="run_in",
+    ),
+    pytest.param(
+        lambda s: s.run_every(noop, seconds=30, on_error=handler_a, name="convenience_methods_pass_on_error_run_every"),
+        id="run_every",
+    ),
+    pytest.param(
+        lambda s: s.run_hourly(noop, on_error=handler_a, name="convenience_methods_pass_on_error_run_hourly"),
+        id="run_hourly",
+    ),
+    pytest.param(
+        lambda s: s.run_minutely(noop, on_error=handler_a, name="convenience_methods_pass_on_error_run_minutely"),
+        id="run_minutely",
+    ),
+    pytest.param(
+        lambda s: s.run_daily(noop, at="00:00", on_error=handler_a, name="convenience_methods_pass_on_error_run_daily"),
+        id="run_daily",
+    ),
+    pytest.param(
+        lambda s: s.run_cron(noop, "0 * * * *", on_error=handler_a, name="convenience_methods_pass_on_error_run_cron"),
+        id="run_cron",
+    ),
+    pytest.param(
+        lambda s: s.run_once(noop, at="23:59", on_error=handler_a, name="convenience_methods_pass_on_error_run_once"),
+        id="run_once",
+    ),
+]
 
 
 class TestSchedulerOnErrorMethod:
@@ -67,39 +102,8 @@ class TestPerJobOnError:
         job = await patched_scheduler.schedule(noop, Every(hours=1), name="job_error_handler_default_none_schedule")
         assert job.error_handler is None
 
-    async def test_convenience_methods_pass_on_error(self, patched_scheduler: Scheduler) -> None:
-        """All 7 convenience methods accept and pass on_error to ScheduledJob."""
-        job_run_in = await patched_scheduler.run_in(
-            noop, delay=60, on_error=handler_a, name="convenience_methods_pass_on_error_run_in"
-        )
-        assert job_run_in.error_handler is handler_a
-
-        job_run_every = await patched_scheduler.run_every(
-            noop, seconds=30, on_error=handler_a, name="convenience_methods_pass_on_error_run_every"
-        )
-        assert job_run_every.error_handler is handler_a
-
-        job_run_hourly = await patched_scheduler.run_hourly(
-            noop, on_error=handler_a, name="convenience_methods_pass_on_error_run_hourly"
-        )
-        assert job_run_hourly.error_handler is handler_a
-
-        job_run_minutely = await patched_scheduler.run_minutely(
-            noop, on_error=handler_a, name="convenience_methods_pass_on_error_run_minutely"
-        )
-        assert job_run_minutely.error_handler is handler_a
-
-        job_run_daily = await patched_scheduler.run_daily(
-            noop, at="00:00", on_error=handler_a, name="convenience_methods_pass_on_error_run_daily"
-        )
-        assert job_run_daily.error_handler is handler_a
-
-        job_run_cron = await patched_scheduler.run_cron(
-            noop, "0 * * * *", on_error=handler_a, name="convenience_methods_pass_on_error_run_cron"
-        )
-        assert job_run_cron.error_handler is handler_a
-
-        job_run_once = await patched_scheduler.run_once(
-            noop, at="23:59", on_error=handler_a, name="convenience_methods_pass_on_error_run_once"
-        )
-        assert job_run_once.error_handler is handler_a
+    @pytest.mark.parametrize("call", _ON_ERROR_CONVENIENCE_CALLS)
+    async def test_convenience_methods_pass_on_error(self, patched_scheduler: Scheduler, call) -> None:
+        """Each of the 7 convenience methods accepts and passes on_error to ScheduledJob."""
+        job = await call(patched_scheduler)
+        assert job.error_handler is handler_a

--- a/tests/unit/scheduler/test_scheduler_timeout_threading.py
+++ b/tests/unit/scheduler/test_scheduler_timeout_threading.py
@@ -1,44 +1,32 @@
 """Tests for timeout parameter threading through Scheduler public methods."""
 
-from unittest.mock import patch
-
+from hassette.scheduler.scheduler import Scheduler
 from hassette.scheduler.triggers import Every
-from hassette.test_utils.config import TEST_SOURCE_LOCATION
 from hassette.test_utils.helpers import noop
-
-from .conftest import PATCH_TARGET, make_scheduler
 
 
 class TestSchedulePassesTimeout:
-    async def test_schedule_passes_timeout_to_job(self) -> None:
+    async def test_schedule_passes_timeout_to_job(self, patched_scheduler: Scheduler) -> None:
         """scheduler.schedule(fn, trigger, timeout=5.0) produces job with timeout=5.0."""
-        with patch(PATCH_TARGET, return_value=(TEST_SOURCE_LOCATION, "schedule(...)")):
-            scheduler = make_scheduler()
-            job = await scheduler.schedule(
-                noop, Every(hours=1), timeout=5.0, name="schedule_passes_timeout_to_job_schedule"
-            )
-            assert job.timeout == 5.0
-            assert job.timeout_disabled is False
+        job = await patched_scheduler.schedule(
+            noop, Every(hours=1), timeout=5.0, name="schedule_passes_timeout_to_job_schedule"
+        )
+        assert job.timeout == 5.0
+        assert job.timeout_disabled is False
 
-    async def test_run_in_passes_timeout(self) -> None:
+    async def test_run_in_passes_timeout(self, patched_scheduler: Scheduler) -> None:
         """run_in() threads timeout through to the job."""
-        with patch(PATCH_TARGET, return_value=(TEST_SOURCE_LOCATION, "run_in(...)")):
-            scheduler = make_scheduler()
-            job = await scheduler.run_in(noop, 10, timeout=3.0, name="run_in_passes_timeout_run_in")
-            assert job.timeout == 3.0
+        job = await patched_scheduler.run_in(noop, 10, timeout=3.0, name="run_in_passes_timeout_run_in")
+        assert job.timeout == 3.0
 
-    async def test_run_every_passes_timeout(self) -> None:
+    async def test_run_every_passes_timeout(self, patched_scheduler: Scheduler) -> None:
         """run_every() threads timeout through to the job."""
-        with patch(PATCH_TARGET, return_value=(TEST_SOURCE_LOCATION, "run_every(...)")):
-            scheduler = make_scheduler()
-            job = await scheduler.run_every(noop, hours=1, timeout=7.5, name="run_every_passes_timeout_run_every")
-            assert job.timeout == 7.5
+        job = await patched_scheduler.run_every(noop, hours=1, timeout=7.5, name="run_every_passes_timeout_run_every")
+        assert job.timeout == 7.5
 
-    async def test_run_daily_passes_timeout_disabled(self) -> None:
+    async def test_run_daily_passes_timeout_disabled(self, patched_scheduler: Scheduler) -> None:
         """run_daily() threads timeout_disabled=True through to the job."""
-        with patch(PATCH_TARGET, return_value=(TEST_SOURCE_LOCATION, "run_daily(...)")):
-            scheduler = make_scheduler()
-            job = await scheduler.run_daily(
-                noop, at="08:00", timeout_disabled=True, name="run_daily_passes_timeout_disabled_run_daily"
-            )
-            assert job.timeout_disabled is True
+        job = await patched_scheduler.run_daily(
+            noop, at="08:00", timeout_disabled=True, name="run_daily_passes_timeout_disabled_run_daily"
+        )
+        assert job.timeout_disabled is True

--- a/tests/unit/scheduler/test_scheduler_waiting_status.py
+++ b/tests/unit/scheduler/test_scheduler_waiting_status.py
@@ -8,54 +8,48 @@ lands in a later task — this only covers the Job construction shape, using
 make_scheduler()'s mocked scheduler_service.add_job() which never touches the heap.
 """
 
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock
 
 from hassette.scheduler.classes import ScheduleStatus
+from hassette.scheduler.scheduler import Scheduler
 from hassette.scheduler.triggers import EntityTime
-from hassette.test_utils.config import TEST_SOURCE_LOCATION
 from hassette.test_utils.helpers import noop
 
-from .conftest import PATCH_TARGET, make_scheduler
 
-
-async def test_schedule_with_unresolvable_entity_time_builds_waiting_job() -> None:
+async def test_schedule_with_unresolvable_entity_time_builds_waiting_job(patched_scheduler: Scheduler) -> None:
     """An EntityTime trigger whose bound state reader has no usable time builds a WAITING job."""
-    with patch(PATCH_TARGET, return_value=(TEST_SOURCE_LOCATION, "schedule(...)")):
-        scheduler = make_scheduler()
-        # schedule() rebinds EntityTime's state reader to hassette.bus_service.read_entity_state —
-        # returning None here (entity absent from the cache) simulates the unresolvable case.
-        scheduler.hassette.bus_service.read_entity_state = lambda _entity_id: None
-        # _add_job_and_watch_entity awaits this to register the reconciliation listener.
-        scheduler.hassette.bus.on_state_change = AsyncMock(return_value=object())
+    # schedule() rebinds EntityTime's state reader to hassette.bus_service.read_entity_state —
+    # returning None here (entity absent from the cache) simulates the unresolvable case.
+    patched_scheduler.hassette.bus_service.read_entity_state = lambda _entity_id: None
+    # _add_job_and_watch_entity awaits this to register the reconciliation listener.
+    patched_scheduler.hassette.bus.on_state_change = AsyncMock(return_value=object())
 
-        job = await scheduler.schedule(
-            noop,
-            EntityTime("sensor.phone_next_alarm"),
-            name="waiting_job",
-        )
+    job = await patched_scheduler.schedule(
+        noop,
+        EntityTime("sensor.phone_next_alarm"),
+        name="waiting_job",
+    )
 
-        assert job.schedule_status is ScheduleStatus.WAITING
-        assert job.next_run is None
-        assert job.fire_at is None
-        assert job.trigger is not None
+    assert job.schedule_status is ScheduleStatus.WAITING
+    assert job.next_run is None
+    assert job.fire_at is None
+    assert job.trigger is not None
 
 
-async def test_schedule_with_resolvable_entity_time_builds_scheduled_job() -> None:
+async def test_schedule_with_resolvable_entity_time_builds_scheduled_job(patched_scheduler: Scheduler) -> None:
     """An EntityTime trigger with a usable time builds a normal SCHEDULED job, not WAITING."""
-    with patch(PATCH_TARGET, return_value=(TEST_SOURCE_LOCATION, "schedule(...)")):
-        scheduler = make_scheduler()
-        scheduler.hassette.bus_service.read_entity_state = lambda entity_id: {
-            "entity_id": entity_id,
-            "state": "2030-01-01T07:00:00-05:00",
-            "attributes": {},
-        }
-        scheduler.hassette.bus.on_state_change = AsyncMock(return_value=object())
+    patched_scheduler.hassette.bus_service.read_entity_state = lambda entity_id: {
+        "entity_id": entity_id,
+        "state": "2030-01-01T07:00:00-05:00",
+        "attributes": {},
+    }
+    patched_scheduler.hassette.bus.on_state_change = AsyncMock(return_value=object())
 
-        job = await scheduler.schedule(
-            noop,
-            EntityTime("sensor.phone_next_alarm"),
-            name="scheduled_entity_job",
-        )
+    job = await patched_scheduler.schedule(
+        noop,
+        EntityTime("sensor.phone_next_alarm"),
+        name="scheduled_entity_job",
+    )
 
-        assert job.schedule_status is ScheduleStatus.SCHEDULED
-        assert job.next_run is not None
+    assert job.schedule_status is ScheduleStatus.SCHEDULED
+    assert job.next_run is not None

--- a/tests/unit/scheduler/test_scheduler_where.py
+++ b/tests/unit/scheduler/test_scheduler_where.py
@@ -55,6 +55,39 @@ def _pred_multiple_positional(_a: int, _b: str) -> bool:
     return True
 
 
+# All 7 convenience methods accept where= and it ends up on the registered job.
+_WHERE_CONVENIENCE_CALLS = [
+    pytest.param(
+        lambda s: s.run_in(noop, delay=60, where=_pred_zero_arg, name="all_seven_conv_methods_where_run_in"),
+        id="run_in",
+    ),
+    pytest.param(
+        lambda s: s.run_once(noop, at="23:59", where=_pred_zero_arg, name="all_seven_conv_methods_where_run_once"),
+        id="run_once",
+    ),
+    pytest.param(
+        lambda s: s.run_every(noop, seconds=30, where=_pred_zero_arg, name="all_seven_conv_methods_where_run_every"),
+        id="run_every",
+    ),
+    pytest.param(
+        lambda s: s.run_minutely(noop, where=_pred_zero_arg, name="all_seven_conv_methods_where_run_minutely"),
+        id="run_minutely",
+    ),
+    pytest.param(
+        lambda s: s.run_hourly(noop, where=_pred_zero_arg, name="all_seven_conv_methods_where_run_hourly"),
+        id="run_hourly",
+    ),
+    pytest.param(
+        lambda s: s.run_daily(noop, at="00:00", where=_pred_zero_arg, name="all_seven_conv_methods_where_run_daily"),
+        id="run_daily",
+    ),
+    pytest.param(
+        lambda s: s.run_cron(noop, "0 * * * *", where=_pred_zero_arg, name="all_seven_conv_methods_where_run_cron"),
+        id="run_cron",
+    ),
+]
+
+
 class TestBuildPredicateInvoker:
     """Unit tests for `_build_predicate_invoker()` — DI-based Job detection."""
 
@@ -305,44 +338,10 @@ class TestScheduleAcceptsWhere:
 class TestConvenienceMethodsForwardWhereToJob:
     """All seven convenience methods accept where= and it ends up on the registered job."""
 
-    async def test_all_seven_convenience_methods_store_where_on_job(self, patched_scheduler: Scheduler) -> None:
-        def pred() -> bool:
-            return True
-
-        job_run_in = await patched_scheduler.run_in(
-            noop, delay=60, where=pred, name="all_seven_conv_methods_where_run_in"
-        )
-        assert job_run_in.predicate is pred
-
-        job_run_once = await patched_scheduler.run_once(
-            noop, at="23:59", where=pred, name="all_seven_conv_methods_where_run_once"
-        )
-        assert job_run_once.predicate is pred
-
-        job_run_every = await patched_scheduler.run_every(
-            noop, seconds=30, where=pred, name="all_seven_conv_methods_where_run_every"
-        )
-        assert job_run_every.predicate is pred
-
-        job_run_minutely = await patched_scheduler.run_minutely(
-            noop, where=pred, name="all_seven_conv_methods_where_run_minutely"
-        )
-        assert job_run_minutely.predicate is pred
-
-        job_run_hourly = await patched_scheduler.run_hourly(
-            noop, where=pred, name="all_seven_conv_methods_where_run_hourly"
-        )
-        assert job_run_hourly.predicate is pred
-
-        job_run_daily = await patched_scheduler.run_daily(
-            noop, at="00:00", where=pred, name="all_seven_conv_methods_where_run_daily"
-        )
-        assert job_run_daily.predicate is pred
-
-        job_run_cron = await patched_scheduler.run_cron(
-            noop, "0 * * * *", where=pred, name="all_seven_conv_methods_where_run_cron"
-        )
-        assert job_run_cron.predicate is pred
+    @pytest.mark.parametrize("call", _WHERE_CONVENIENCE_CALLS)
+    async def test_convenience_method_stores_where_on_job(self, patched_scheduler: Scheduler, call) -> None:
+        job = await call(patched_scheduler)
+        assert job.predicate is _pred_zero_arg
 
 
 class TestConvenienceMethodsForwardWhereKwarg:

--- a/tests/unit/scheduler/test_scheduler_where.py
+++ b/tests/unit/scheduler/test_scheduler_where.py
@@ -12,12 +12,11 @@ import pytest
 
 from hassette.exceptions import DependencyInjectionError
 from hassette.scheduler.classes import Job
-from hassette.scheduler.scheduler import _build_predicate_invoker, _normalize_where
+from hassette.scheduler.scheduler import Scheduler, _build_predicate_invoker, _normalize_where
 from hassette.scheduler.triggers import Every
-from hassette.test_utils.config import TEST_SOURCE_LOCATION
 from hassette.test_utils.helpers import noop
 
-from .conftest import PATCH_TARGET, make_scheduler
+from .conftest import make_scheduler
 
 
 def is_home() -> bool:
@@ -28,59 +27,60 @@ def is_dark() -> bool:
     return True
 
 
+def _pred_zero_arg() -> bool:
+    return True
+
+
+def _pred_annotated_job(_job: Job) -> bool:
+    return True
+
+
+def _pred_optional_job(_job: Job | None = None) -> bool:
+    return True
+
+
+def _pred_job_with_extra_optional(_job: Job, _threshold: float = 0.5) -> bool:
+    return True
+
+
+def _pred_unannotated_one_arg(_x) -> bool:
+    return True
+
+
+def _pred_wrong_annotation(_x: int) -> bool:
+    return True
+
+
+def _pred_multiple_positional(_a: int, _b: str) -> bool:
+    return True
+
+
 class TestBuildPredicateInvoker:
     """Unit tests for `_build_predicate_invoker()` — DI-based Job detection."""
 
-    def test_zero_arg_predicate_empty_plan(self) -> None:
-        def pred() -> bool:
-            return True
-
+    @pytest.mark.parametrize(
+        ("pred", "expected_param_count"),
+        [
+            pytest.param(_pred_zero_arg, 0, id="zero_arg"),
+            pytest.param(_pred_annotated_job, 1, id="annotated_job"),
+            pytest.param(_pred_optional_job, 1, id="optional_job"),
+            pytest.param(_pred_job_with_extra_optional, 1, id="job_with_extra_optional"),
+            pytest.param(_pred_unannotated_one_arg, 0, id="unannotated_one_arg"),
+            pytest.param(_pred_wrong_annotation, 0, id="wrong_annotation"),
+            pytest.param(_pred_multiple_positional, 0, id="multiple_positional"),
+        ],
+    )
+    def test_param_count_for_predicate_signature(self, pred, expected_param_count: int) -> None:
         invoker = _build_predicate_invoker(pred)
-        assert len(invoker.params) == 0
+        assert len(invoker.params) == expected_param_count
 
-    def test_annotated_scheduled_job_has_plan(self) -> None:
-        def pred(_job: Job) -> bool:
-            return True
-
-        invoker = _build_predicate_invoker(pred)
-        assert len(invoker.params) == 1
+    def test_annotated_scheduled_job_param_has_source_type(self) -> None:
+        invoker = _build_predicate_invoker(_pred_annotated_job)
         assert invoker.params[0].source_type is Job
 
-    def test_optional_scheduled_job_annotation_has_plan(self) -> None:
-        def pred(_job: Job | None = None) -> bool:
-            return True
-
-        invoker = _build_predicate_invoker(pred)
-        assert len(invoker.params) == 1
-
-    def test_scheduled_job_with_extra_optional_has_plan(self) -> None:
-        def pred(_job: Job, _threshold: float = 0.5) -> bool:
-            return True
-
-        invoker = _build_predicate_invoker(pred)
-        assert len(invoker.params) == 1
+    def test_scheduled_job_with_extra_optional_param_name(self) -> None:
+        invoker = _build_predicate_invoker(_pred_job_with_extra_optional)
         assert invoker.params[0].name == "_job"
-
-    def test_unannotated_one_arg_empty_plan(self) -> None:
-        def pred(_x) -> bool:
-            return True
-
-        invoker = _build_predicate_invoker(pred)
-        assert len(invoker.params) == 0
-
-    def test_wrong_annotation_empty_plan(self) -> None:
-        def pred(_x: int) -> bool:
-            return True
-
-        invoker = _build_predicate_invoker(pred)
-        assert len(invoker.params) == 0
-
-    def test_multiple_positional_no_scheduled_job_empty_plan(self) -> None:
-        def pred(_a: int, _b: str) -> bool:
-            return True
-
-        invoker = _build_predicate_invoker(pred)
-        assert len(invoker.params) == 0
 
     def test_async_predicate_raises_type_error(self) -> None:
         async def pred() -> bool:
@@ -260,100 +260,89 @@ class TestNormalizeWhere:
 class TestScheduleAcceptsWhere:
     """`Scheduler.schedule()` accepts where= and stores the normalized predicate on the job."""
 
-    async def test_schedule_stores_zero_arg_predicate(self) -> None:
-        with patch(PATCH_TARGET, return_value=(TEST_SOURCE_LOCATION, "schedule(...)")):
-            scheduler = make_scheduler()
+    async def test_schedule_stores_zero_arg_predicate(self, patched_scheduler: Scheduler) -> None:
+        def pred() -> bool:
+            return True
 
-            def pred() -> bool:
-                return True
+        job = await patched_scheduler.schedule(
+            noop, Every(hours=1), where=pred, name="schedule_stores_zero_arg_predicate_schedule"
+        )
 
-            job = await scheduler.schedule(
-                noop, Every(hours=1), where=pred, name="schedule_stores_zero_arg_predicate_schedule"
+        assert job.predicate is pred
+        assert job.predicate_invoker is not None
+        assert len(job.predicate_invoker.params) == 0
+
+    async def test_schedule_stores_annotated_predicate_with_invoker(self, patched_scheduler: Scheduler) -> None:
+        def pred(_job: Job) -> bool:
+            return True
+
+        job = await patched_scheduler.schedule(
+            noop, Every(hours=1), where=pred, name="schedule_stores_annotated_predicate_with_schedule"
+        )
+
+        assert job.predicate is pred
+        assert job.predicate_invoker is not None
+        assert len(job.predicate_invoker.params) == 1
+
+    async def test_schedule_defaults_predicate_to_none(self, patched_scheduler: Scheduler) -> None:
+        job = await patched_scheduler.schedule(
+            noop, Every(hours=1), name="schedule_defaults_predicate_to_none_schedule"
+        )
+
+        assert job.predicate is None
+        assert job.predicate_invoker is None
+
+    async def test_schedule_raises_for_async_predicate(self, patched_scheduler: Scheduler) -> None:
+        async def pred() -> bool:
+            return True
+
+        with pytest.raises(TypeError, match="synchronous"):
+            await patched_scheduler.schedule(
+                noop, Every(hours=1), where=pred, name="schedule_raises_for_async_predicate_schedule"
             )
-
-            assert job.predicate is pred
-            assert job.predicate_invoker is not None
-            assert len(job.predicate_invoker.params) == 0
-
-    async def test_schedule_stores_annotated_predicate_with_invoker(self) -> None:
-        with patch(PATCH_TARGET, return_value=(TEST_SOURCE_LOCATION, "schedule(...)")):
-            scheduler = make_scheduler()
-
-            def pred(_job: Job) -> bool:
-                return True
-
-            job = await scheduler.schedule(
-                noop, Every(hours=1), where=pred, name="schedule_stores_annotated_predicate_with_schedule"
-            )
-
-            assert job.predicate is pred
-            assert job.predicate_invoker is not None
-            assert len(job.predicate_invoker.params) == 1
-
-    async def test_schedule_defaults_predicate_to_none(self) -> None:
-        with patch(PATCH_TARGET, return_value=(TEST_SOURCE_LOCATION, "schedule(...)")):
-            scheduler = make_scheduler()
-
-            job = await scheduler.schedule(noop, Every(hours=1), name="schedule_defaults_predicate_to_none_schedule")
-
-            assert job.predicate is None
-            assert job.predicate_invoker is None
-
-    async def test_schedule_raises_for_async_predicate(self) -> None:
-        with patch(PATCH_TARGET, return_value=(TEST_SOURCE_LOCATION, "schedule(...)")):
-            scheduler = make_scheduler()
-
-            async def pred() -> bool:
-                return True
-
-            with pytest.raises(TypeError, match="synchronous"):
-                await scheduler.schedule(
-                    noop, Every(hours=1), where=pred, name="schedule_raises_for_async_predicate_schedule"
-                )
 
 
 class TestConvenienceMethodsForwardWhereToJob:
     """All seven convenience methods accept where= and it ends up on the registered job."""
 
-    async def test_all_seven_convenience_methods_store_where_on_job(self) -> None:
-        with patch(PATCH_TARGET, return_value=(TEST_SOURCE_LOCATION, "schedule(...)")):
-            scheduler = make_scheduler()
+    async def test_all_seven_convenience_methods_store_where_on_job(self, patched_scheduler: Scheduler) -> None:
+        def pred() -> bool:
+            return True
 
-            def pred() -> bool:
-                return True
+        job_run_in = await patched_scheduler.run_in(
+            noop, delay=60, where=pred, name="all_seven_conv_methods_where_run_in"
+        )
+        assert job_run_in.predicate is pred
 
-            job_run_in = await scheduler.run_in(noop, delay=60, where=pred, name="all_seven_conv_methods_where_run_in")
-            assert job_run_in.predicate is pred
+        job_run_once = await patched_scheduler.run_once(
+            noop, at="23:59", where=pred, name="all_seven_conv_methods_where_run_once"
+        )
+        assert job_run_once.predicate is pred
 
-            job_run_once = await scheduler.run_once(
-                noop, at="23:59", where=pred, name="all_seven_conv_methods_where_run_once"
-            )
-            assert job_run_once.predicate is pred
+        job_run_every = await patched_scheduler.run_every(
+            noop, seconds=30, where=pred, name="all_seven_conv_methods_where_run_every"
+        )
+        assert job_run_every.predicate is pred
 
-            job_run_every = await scheduler.run_every(
-                noop, seconds=30, where=pred, name="all_seven_conv_methods_where_run_every"
-            )
-            assert job_run_every.predicate is pred
+        job_run_minutely = await patched_scheduler.run_minutely(
+            noop, where=pred, name="all_seven_conv_methods_where_run_minutely"
+        )
+        assert job_run_minutely.predicate is pred
 
-            job_run_minutely = await scheduler.run_minutely(
-                noop, where=pred, name="all_seven_conv_methods_where_run_minutely"
-            )
-            assert job_run_minutely.predicate is pred
+        job_run_hourly = await patched_scheduler.run_hourly(
+            noop, where=pred, name="all_seven_conv_methods_where_run_hourly"
+        )
+        assert job_run_hourly.predicate is pred
 
-            job_run_hourly = await scheduler.run_hourly(
-                noop, where=pred, name="all_seven_conv_methods_where_run_hourly"
-            )
-            assert job_run_hourly.predicate is pred
+        job_run_daily = await patched_scheduler.run_daily(
+            noop, at="00:00", where=pred, name="all_seven_conv_methods_where_run_daily"
+        )
+        assert job_run_daily.predicate is pred
 
-            job_run_daily = await scheduler.run_daily(
-                noop, at="00:00", where=pred, name="all_seven_conv_methods_where_run_daily"
-            )
-            assert job_run_daily.predicate is pred
-
-            job_run_cron = await scheduler.run_cron(
-                noop, "0 * * * *", where=pred, name="all_seven_conv_methods_where_run_cron"
-            )
-            assert job_run_cron.predicate is pred
+        job_run_cron = await patched_scheduler.run_cron(
+            noop, "0 * * * *", where=pred, name="all_seven_conv_methods_where_run_cron"
+        )
+        assert job_run_cron.predicate is pred
 
 
 class TestConvenienceMethodsForwardWhereKwarg:

--- a/tests/unit/test_api_coroutine_conversion.py
+++ b/tests/unit/test_api_coroutine_conversion.py
@@ -36,7 +36,7 @@ _API_METHODS = [
 
 
 @pytest.fixture(autouse=True)
-def drain(drain_forgotten_await_handles: None) -> None:
+def _drain(drain_forgotten_await_handles: None) -> None:
     """Drain dropped handles after each test (shared fixture in tests/unit/conftest.py)."""
 
 

--- a/tests/unit/test_api_coroutine_conversion.py
+++ b/tests/unit/test_api_coroutine_conversion.py
@@ -113,6 +113,9 @@ async def test_await_set_state_returns_dict() -> None:
 # Returned handle is a RegistrationHandle before awaiting
 
 
+# dup-ignore-start: the "returns a RegistrationHandle before awaiting, must be closed" invariant is
+# intentionally mirrored across the Bus/Scheduler/Api coroutine-conversion test suites — each class
+# was converted the same way and needs the same coverage. Not extractable across unrelated classes.
 @pytest.mark.parametrize("call", _API_METHODS)
 def test_returns_registration_handle(call) -> None:
     """Api methods return a RegistrationHandle before awaiting."""
@@ -126,6 +129,7 @@ def test_returns_registration_handle(call) -> None:
 
 
 @pytest.mark.parametrize("call", _API_METHODS)
+# dup-ignore-end
 def test_forgotten_await_warns(call) -> None:
     """Dropping un-awaited Api handle emits HassetteForgottenAwaitWarning."""
     api = make_api()

--- a/tests/unit/test_api_notify.py
+++ b/tests/unit/test_api_notify.py
@@ -17,7 +17,7 @@ from tests.unit.conftest import make_api
 
 
 @pytest.fixture(autouse=True)
-def drain(drain_forgotten_await_handles: None) -> None:
+def _drain(drain_forgotten_await_handles: None) -> None:
     """Drain dropped handles after each test (shared fixture in tests/unit/conftest.py)."""
 
 

--- a/tests/unit/test_entity_coroutine_conversion.py
+++ b/tests/unit/test_entity_coroutine_conversion.py
@@ -32,9 +32,12 @@ _ENTITIES_DIR = _REPO_ROOT / "src" / "hassette" / "models" / "entities"
 _MANIFEST = _REPO_ROOT / ".generated-manifest"
 
 
+# dup-ignore-start: documented per-file opt-in pattern (see drain_forgotten_await_handles docstring
+# in tests/unit/conftest.py) — every warning-heavy test module repeats this one-line wrapper by design.
 @pytest.fixture(autouse=True)
 def _drain(drain_forgotten_await_handles: None) -> None:
     """Drain dropped handles after each test (shared fixture in tests/unit/conftest.py)."""
+    # dup-ignore-end
 
 
 if TYPE_CHECKING:

--- a/tests/unit/test_forgotten_await_completeness.py
+++ b/tests/unit/test_forgotten_await_completeness.py
@@ -188,6 +188,15 @@ _API_METHOD_CALLS: dict[str, object] = {
 }
 
 
+# dup-ignore-start: the _drain fixture below is a documented per-file opt-in pattern (see
+# drain_forgotten_await_handles docstring in tests/unit/conftest.py) — every warning-heavy test
+# module repeats this one-line wrapper by design.
+@pytest.fixture(autouse=True)
+def _drain(drain_forgotten_await_handles: None) -> None:
+    """Drain dropped handles after each test (shared fixture in tests/unit/conftest.py)."""
+    # dup-ignore-end
+
+
 def _is_detected(cls: type, name: str) -> bool:
     """Return True if ``name`` on ``cls`` satisfies the completeness detection criterion.
 
@@ -511,11 +520,3 @@ def test_scheduler_add_job_warns_on_forgotten_await() -> None:
         _ = sched.add_job(job)
         del _
         gc.collect()
-
-
-# Suppress stray HassetteForgottenAwaitWarning from gc.collect() at teardown
-
-
-@pytest.fixture(autouse=True)
-def _drain(drain_forgotten_await_handles: None) -> None:
-    """Drain dropped handles after each test (shared fixture in tests/unit/conftest.py)."""

--- a/tests/unit/test_scheduled_job.py
+++ b/tests/unit/test_scheduled_job.py
@@ -89,20 +89,4 @@ class TestFireAt:
         assert job.fire_at == job.next_run
 
 
-class TestMarkRegistered:
-    def test_mark_registered_sets_db_id(self) -> None:
-        """mark_registered() sets db_id to the given value."""
-        job = make_scheduled_job()
-        assert job.db_id is None
-        job.mark_registered(42)
-        assert job.db_id == 42
-
-    def test_mark_registered_keeps_original_on_double_call(self) -> None:
-        """mark_registered() is first-call-wins: a second call does not overwrite the id."""
-        job = make_scheduled_job()
-        job.mark_registered(42)
-        assert job.db_id == 42
-
-        # Second call is a no-op — the original id is kept (mirrors Listener.mark_registered)
-        job.mark_registered(99)
-        assert job.db_id == 42
+# mark_registered() coverage lives in tests/unit/scheduler/test_scheduled_job_mark_registered.py.

--- a/tests/unit/test_triggers.py
+++ b/tests/unit/test_triggers.py
@@ -58,13 +58,17 @@ def test_after_trigger_id() -> None:
     assert After(seconds=30).trigger_id() == "after:30"
 
 
+def _once_first_run_time(fake_now: ZonedDateTime, monkeypatch: pytest.MonkeyPatch) -> ZonedDateTime:
+    """Build a Once(at='07:00') trigger and compute its first_run_time against a mocked now()."""
+    monkeypatch.setattr("hassette.utils.date_utils.now", lambda: fake_now)
+    trigger = Once(at="07:00")
+    return trigger.first_run_time(fake_now)
+
+
 def test_once_today(monkeypatch: pytest.MonkeyPatch) -> None:
     """Once(at='07:00') when current time is 06:00 fires today at 07:00."""
     fake_now = zdt(2025, 8, 18, 6, 0, 0)
-    monkeypatch.setattr("hassette.utils.date_utils.now", lambda: fake_now)
-
-    trigger = Once(at="07:00")
-    fire_time = trigger.first_run_time(fake_now)
+    fire_time = _once_first_run_time(fake_now, monkeypatch)
 
     expected = zdt(2025, 8, 18, 7, 0, 0)
     assert fire_time == expected, f"Got {fire_time.format_iso()}"
@@ -73,10 +77,7 @@ def test_once_today(monkeypatch: pytest.MonkeyPatch) -> None:
 def test_once_tomorrow_default(monkeypatch: pytest.MonkeyPatch) -> None:
     """Once(at='07:00') when current time is 08:00 fires tomorrow at 07:00."""
     fake_now = zdt(2025, 8, 18, 8, 0, 0)
-    monkeypatch.setattr("hassette.utils.date_utils.now", lambda: fake_now)
-
-    trigger = Once(at="07:00")
-    fire_time = trigger.first_run_time(fake_now)
+    fire_time = _once_first_run_time(fake_now, monkeypatch)
 
     expected = zdt(2025, 8, 19, 7, 0, 0)
     assert fire_time == expected, f"Got {fire_time.format_iso()}"

--- a/tests/unit/test_triggers.py
+++ b/tests/unit/test_triggers.py
@@ -8,10 +8,10 @@ from whenever import ZonedDateTime
 import hassette.scheduler.classes as classes_module
 from hassette.scheduler import After, Cron, Daily, Every, Once, TriggerProtocol
 
+from .conftest import TZ as TZ
+
 if TYPE_CHECKING:
     from hassette.test_utils.harness import HassetteHarness
-
-TZ = "America/Chicago"
 
 
 def zdt(year: int, month: int, day: int, hour: int = 0, minute: int = 0, second: int = 0) -> ZonedDateTime:

--- a/tests/unit/utils/test_await_guard.py
+++ b/tests/unit/utils/test_await_guard.py
@@ -33,9 +33,12 @@ from hassette.utils.await_guard import RegistrationHandle, guard_await
 from hassette.utils.source_capture import capture_registration_source, is_internal_frame
 
 
+# dup-ignore-start: documented per-file opt-in pattern (see drain_forgotten_await_handles docstring
+# in tests/unit/conftest.py) — every warning-heavy test module repeats this one-line wrapper by design.
 @pytest.fixture(autouse=True)
 def _drain(drain_forgotten_await_handles: None) -> None:
     """Drain dropped handles after each test (shared fixture in tests/unit/conftest.py)."""
+    # dup-ignore-end
 
 
 # Helpers

--- a/tests/unit/utils/test_await_guard.py
+++ b/tests/unit/utils/test_await_guard.py
@@ -359,30 +359,24 @@ def test_source_capture_is_internal_frame_module_name():
     assert is_internal_frame(types.SimpleNamespace(f_globals={"__name__": ""})) is False
 
 
-def test_source_capture_skips_hassette_frames(monkeypatch):
-    """capture_registration_source walks past hassette.* frames to the first user frame."""
-    # Inject a fake stack: first frame is our own (skipped by [1:]),
-    # next two are hassette internals, last is user code.
-    fake_frames = [
-        # Our own frame (skipped by [1:])
+def _fake_stack_frames():
+    """A 4-frame fake stack: own frame, two hassette internals, then user code."""
+    return [
         types.SimpleNamespace(
             filename="<self>",
             lineno=0,
             frame=types.SimpleNamespace(f_globals={"__name__": "hassette.utils.source_capture"}),
         ),
-        # hassette internal
         types.SimpleNamespace(
             filename="/site-packages/hassette/bus/bus.py",
             lineno=350,
             frame=types.SimpleNamespace(f_globals={"__name__": "hassette.bus.bus"}),
         ),
-        # hassette internal
         types.SimpleNamespace(
             filename="/site-packages/hassette/utils/await_guard.py",
             lineno=10,
             frame=types.SimpleNamespace(f_globals={"__name__": "hassette.utils.await_guard"}),
         ),
-        # user code (non-hassette)
         types.SimpleNamespace(
             filename="/home/user/apps/my_automation.py",
             lineno=77,
@@ -390,7 +384,10 @@ def test_source_capture_skips_hassette_frames(monkeypatch):
         ),
     ]
 
-    monkeypatch.setattr(inspect, "stack", lambda *_args, **_kw: fake_frames)
+
+def test_source_capture_skips_hassette_frames(monkeypatch):
+    """capture_registration_source walks past hassette.* frames to the first user frame."""
+    monkeypatch.setattr(inspect, "stack", lambda *_args, **_kw: _fake_stack_frames())
 
     source_location, _ = capture_registration_source()
     # Must resolve to the user frame, not a hassette internal
@@ -418,32 +415,6 @@ def test_source_capture_has_limit_parameter(monkeypatch):
     assert call_args, "inspect.stack was not called"
     _, kwargs = call_args[0]
     assert kwargs.get("context") == 0, f"Expected context=0, got {kwargs}"
-
-
-def _fake_stack_frames():
-    """A 4-frame fake stack: own frame, two hassette internals, then user code."""
-    return [
-        types.SimpleNamespace(
-            filename="<self>",
-            lineno=0,
-            frame=types.SimpleNamespace(f_globals={"__name__": "hassette.utils.source_capture"}),
-        ),
-        types.SimpleNamespace(
-            filename="/site-packages/hassette/bus/bus.py",
-            lineno=350,
-            frame=types.SimpleNamespace(f_globals={"__name__": "hassette.bus.bus"}),
-        ),
-        types.SimpleNamespace(
-            filename="/site-packages/hassette/utils/await_guard.py",
-            lineno=10,
-            frame=types.SimpleNamespace(f_globals={"__name__": "hassette.utils.await_guard"}),
-        ),
-        types.SimpleNamespace(
-            filename="/home/user/apps/my_automation.py",
-            lineno=77,
-            frame=types.SimpleNamespace(f_globals={"__name__": "my_automation"}),
-        ),
-    ]
 
 
 def test_source_capture_limit_applied_after_skip(monkeypatch):


### PR DESCRIPTION
### tests/unit/scheduler/

Resolved all 8 clusters the duplicate-code checker flagged for `tests/unit/scheduler/`:

- `test_scheduler_where.py` — extracted a `patched_scheduler` fixture (now shared via `conftest.py`) for the repeated patch+`make_scheduler` setup; collapsed `TestBuildPredicateInvoker`'s repeated pred/invoker bodies into one parametrized test.
- `test_scheduler_coroutine_conversion.py` — collapsed three near-identical `pytest.param` lists into a single `_SCHEDULING_METHOD_CALLS` constant.
- `test_triggers.py` — extracted `_once_first_run_time` to remove in-file duplication that was also being mirrored by `test_trigger_timezone.py`.
- Promoted the `patched_scheduler` fixture into `tests/unit/scheduler/conftest.py` and adopted it in `test_scheduler_error_handler.py`, `test_scheduler_waiting_status.py`, and `test_scheduler_timeout_threading.py`, which inlined the same block without being flagged.
- Deleted fully-redundant `mark_registered()` coverage from `test_scheduled_job.py` and `tests/integration/test_scheduler.py` — both duplicated `test_scheduled_job_mark_registered.py` with no unique assertions.
- Annotated genuinely intentional cross-suite mirroring (the `_drain` autouse-fixture opt-in pattern, and the `RegistrationHandle`-must-be-closed invariant shared across Bus/Scheduler/Api coroutine-conversion suites) with `dup-ignore-start`/`end` markers so the checker stops flagging deliberate repetition.

### Housekeeping

- Follow-up pass addressing clean-code findings from the deduplication work above: further tightened `test_scheduler_error_handler.py` and `test_scheduler_where.py`, trimmed `test_await_guard.py`'s redundant setup, and minor cleanup in `test_api_coroutine_conversion.py`, `test_api_notify.py`, and `test_triggers.py`.

Closes #1619
