### PR TITLE
perf: remove state_changed WebSocket broadcast to browser clients

### DIFF
--- a/docs/pages/core-concepts/internals/service-details.md
+++ b/docs/pages/core-concepts/internals/service-details.md
@@ -372,7 +372,7 @@ When `config.web_api.run` is `False`, `serve()` blocks on `shutdown_event.wait()
 
 ### RuntimeQueryService
 
-`RuntimeQueryService` subscribes to bus events on initialization and broadcasts WebSocket-push-worthy events as they arrive. State changes, app status changes, service status changes, connectivity events, and batched execution completions are serialized by `build_and_broadcast()` or `broadcast()` and fanned out to all registered WebSocket clients. It also wires the logging capture handler to the same broadcast path so live log records can stream to the UI.
+`RuntimeQueryService` subscribes to bus events on initialization and broadcasts WebSocket-push-worthy events as they arrive. App status changes, service status changes, connectivity events, and batched execution completions are serialized by `build_and_broadcast()` or `broadcast()` and fanned out to all registered WebSocket clients. It also wires the logging capture handler to the same broadcast path so live log records can stream to the UI.
 
 Each connected client gets its own `asyncio.Queue` of bounded size (`_WS_CLIENT_QUEUE_MAX`). A slow client that exhausts its queue causes its frames to be dropped with a rate-limited log line. Clients register via `register_ws_client()` and deregister via `unregister_ws_client()`.
 

--- a/frontend/src/api/ws-types.ts
+++ b/frontend/src/api/ws-types.ts
@@ -8,7 +8,6 @@ export type WsServerMessage =
   | LogWsMessage
   | ConnectedWsMessage
   | ConnectivityWsMessage
-  | StateChangedWsMessage
   | ServiceStatusWsMessage
   | ExecutionCompletedWsMessage;
 
@@ -77,23 +76,6 @@ export interface ConnectivityWsMessage {
  */
 export interface ConnectivityData {
   connected: boolean;
-}
-export interface StateChangedWsMessage {
-  type: "state_changed";
-  data: StateChangedData;
-  timestamp: number;
-}
-/**
- * Payload for a Home Assistant ``state_changed`` event broadcast over WebSocket.
- */
-export interface StateChangedData {
-  entity_id: string;
-  new_state?: {
-    [k: string]: unknown;
-  } | null;
-  old_state?: {
-    [k: string]: unknown;
-  } | null;
 }
 export interface ServiceStatusWsMessage {
   type: "service_status";

--- a/frontend/src/hooks/use-websocket.ts
+++ b/frontend/src/hooks/use-websocket.ts
@@ -149,7 +149,6 @@ export function useWebSocket(): void {
             break;
 
           case "connectivity":
-          case "state_changed":
             // Intentionally ignored — not consumed by the frontend UI.
             break;
 

--- a/frontend/ws-schema.json
+++ b/frontend/ws-schema.json
@@ -639,69 +639,6 @@
       ],
       "title": "ServiceStatusWsMessage",
       "type": "object"
-    },
-    "StateChangedData": {
-      "description": "Payload for a Home Assistant ``state_changed`` event broadcast over WebSocket.",
-      "properties": {
-        "entity_id": {
-          "title": "Entity Id",
-          "type": "string"
-        },
-        "new_state": {
-          "anyOf": [
-            {
-              "additionalProperties": true,
-              "type": "object"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "title": "New State"
-        },
-        "old_state": {
-          "anyOf": [
-            {
-              "additionalProperties": true,
-              "type": "object"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "title": "Old State"
-        }
-      },
-      "required": [
-        "entity_id"
-      ],
-      "title": "StateChangedData",
-      "type": "object"
-    },
-    "StateChangedWsMessage": {
-      "properties": {
-        "type": {
-          "const": "state_changed",
-          "title": "Type",
-          "type": "string"
-        },
-        "data": {
-          "$ref": "#/$defs/StateChangedData"
-        },
-        "timestamp": {
-          "title": "Timestamp",
-          "type": "number"
-        }
-      },
-      "required": [
-        "type",
-        "data",
-        "timestamp"
-      ],
-      "title": "StateChangedWsMessage",
-      "type": "object"
     }
   },
   "discriminator": {
@@ -711,8 +648,7 @@
       "connectivity": "#/$defs/ConnectivityWsMessage",
       "execution_completed": "#/$defs/ExecutionCompletedWsMessage",
       "log": "#/$defs/LogWsMessage",
-      "service_status": "#/$defs/ServiceStatusWsMessage",
-      "state_changed": "#/$defs/StateChangedWsMessage"
+      "service_status": "#/$defs/ServiceStatusWsMessage"
     },
     "propertyName": "type"
   },
@@ -728,9 +664,6 @@
     },
     {
       "$ref": "#/$defs/ConnectivityWsMessage"
-    },
-    {
-      "$ref": "#/$defs/StateChangedWsMessage"
     },
     {
       "$ref": "#/$defs/ServiceStatusWsMessage"

--- a/src/hassette/core/runtime_query_service.py
+++ b/src/hassette/core/runtime_query_service.py
@@ -13,7 +13,7 @@ from hassette.core.app_registry import overlay_runtime_state
 from hassette.core.bus_service import BusService
 from hassette.core.logging_service import LoggingService
 from hassette.core.state_proxy import StateProxy
-from hassette.events import Event, RawStateChangeEvent
+from hassette.events import Event
 from hassette.resources.base import Resource
 from hassette.resources.lifecycle import mark_ready
 from hassette.schemas.app_snapshots import AppManifestInfo, AppStatusSnapshot
@@ -23,7 +23,6 @@ from hassette.schemas.domain_models import (
     ConnectivityData,
     ServiceInfo,
     ServiceStatusData,
-    StateChangedData,
     SystemStatus,
 )
 from hassette.types import Topic
@@ -96,13 +95,6 @@ class RuntimeQueryService(Resource):
 
         # Subscribe to bus events
         self._subscriptions.append(
-            await self.bus.on(
-                topic=Topic.HASS_EVENT_STATE_CHANGED,
-                handler=self.on_state_change,
-                name="hassette.rqs.on_state_change",
-            )
-        )
-        self._subscriptions.append(
             await self.bus.on_app_state_changed(
                 handler=self.on_app_state_changed, name="hassette.rqs.on_app_state_changed"
             )
@@ -160,14 +152,6 @@ class RuntimeQueryService(Resource):
     async def build_and_broadcast(self, event_type: str, payload: BaseModel) -> None:
         entry: dict[str, Any] = {"type": event_type, "data": payload.model_dump(), "timestamp": time.time()}
         await self.broadcast(entry)
-
-    async def on_state_change(self, event: RawStateChangeEvent) -> None:
-        payload = StateChangedData(
-            entity_id=event.payload.data.entity_id,
-            new_state=dict(event.payload.data.new_state) if event.payload.data.new_state else None,
-            old_state=dict(event.payload.data.old_state) if event.payload.data.old_state else None,
-        )
-        await self.build_and_broadcast("state_changed", payload)
 
     async def on_app_state_changed(self, event: Event) -> None:
         data = event.payload.data

--- a/src/hassette/schemas/__init__.py
+++ b/src/hassette/schemas/__init__.py
@@ -26,7 +26,6 @@ from hassette.schemas.domain_models import (
     ConnectivityData,
     ServiceInfo,
     ServiceStatusData,
-    StateChangedData,
     SystemStatus,
 )
 from hassette.schemas.live_counts import LiveCounts
@@ -47,6 +46,5 @@ __all__ = [
     "ManifestStatus",
     "ServiceInfo",
     "ServiceStatusData",
-    "StateChangedData",
     "SystemStatus",
 ]

--- a/src/hassette/schemas/domain_models.py
+++ b/src/hassette/schemas/domain_models.py
@@ -22,7 +22,7 @@ models via ``hassette.web.mappers``. Core services must NOT import from
 ``hassette.web``.
 """
 
-from typing import Any, Literal
+from typing import Literal
 
 from pydantic import BaseModel, Field
 
@@ -102,14 +102,6 @@ class SystemStatus(BaseModel):
     False means log persistence is unavailable, so ``db_write_queue_drops`` of 0 reflects a
     dead pipeline rather than a healthy one.
     """
-
-
-class StateChangedData(BaseModel):
-    """Payload for a Home Assistant ``state_changed`` event broadcast over WebSocket."""
-
-    entity_id: str
-    new_state: dict[str, Any] | None = None
-    old_state: dict[str, Any] | None = None
 
 
 class AppStatusChangedData(BaseModel):

--- a/src/hassette/web/models.py
+++ b/src/hassette/web/models.py
@@ -4,7 +4,7 @@ from typing import Annotated, Any, Literal
 
 from pydantic import BaseModel, ConfigDict, Field
 
-from hassette.schemas.domain_models import AppStatusChangedData, ConnectivityData, ServiceStatusData, StateChangedData
+from hassette.schemas.domain_models import AppStatusChangedData, ConnectivityData, ServiceStatusData
 from hassette.types.enums import (
     DEFAULT_BACKPRESSURE_POLICY,
     DEFAULT_OVERLAP_MODE,
@@ -275,12 +275,6 @@ class ConnectivityWsMessage(BaseModel):
     timestamp: float
 
 
-class StateChangedWsMessage(BaseModel):
-    type: Literal["state_changed"]
-    data: StateChangedData
-    timestamp: float
-
-
 class ServiceStatusWsMessage(BaseModel):
     type: Literal["service_status"]
     data: ServiceStatusData
@@ -317,7 +311,6 @@ WsServerMessage = Annotated[
     | LogWsMessage
     | ConnectedWsMessage
     | ConnectivityWsMessage
-    | StateChangedWsMessage
     | ServiceStatusWsMessage
     | ExecutionCompletedWsMessage,
     Field(discriminator="type"),

--- a/tests/integration/test_schema_freshness.py
+++ b/tests/integration/test_schema_freshness.py
@@ -53,7 +53,6 @@ class TestSchemaFreshness:
             "LogWsMessage",
             "ConnectedWsMessage",
             "ConnectivityWsMessage",
-            "StateChangedWsMessage",
             "ServiceStatusWsMessage",
             "ExecutionCompletedWsMessage",
         ],

--- a/tests/integration/web_api/test_ws_endpoint.py
+++ b/tests/integration/web_api/test_ws_endpoint.py
@@ -186,9 +186,9 @@ class TestWebSocketConnection:
             # Log should be filtered (subscribe_logs is False by default)
             put_message(runtime_query_service, "log", level="INFO", message="should not arrive")
             # Non-log message to verify the connection is alive
-            put_message(runtime_query_service, "state_changed", entity_id="light.kitchen")
+            put_message(runtime_query_service, "app_status_changed", app_key="my_app")
 
-            expect_message(ws, "state_changed")
+            expect_message(ws, "app_status_changed")
 
     def test_non_log_messages_pass_through_without_subscription(
         self, client: "TestClient", runtime_query_service: RuntimeQueryService
@@ -282,9 +282,9 @@ class TestWebSocketEdgeCases:
             # Log messages should NOT pass through (logs=False by default)
             put_message(runtime_query_service, "log", level="INFO", message="should not arrive")
             # Non-log message confirms connection is alive and log was filtered
-            put_message(runtime_query_service, "state_changed", entity_id="light.kitchen")
+            put_message(runtime_query_service, "app_status_changed", app_key="my_app")
 
-            expect_message(ws, "state_changed")
+            expect_message(ws, "app_status_changed")
 
     def test_subscribe_with_missing_data_key_uses_defaults(
         self, client: "TestClient", runtime_query_service: RuntimeQueryService

--- a/tests/system/test_web_api.py
+++ b/tests/system/test_web_api.py
@@ -155,12 +155,12 @@ async def test_telemetry_after_activity(ha_container: str, tmp_path) -> None:
             await wait_for(_has_invocations, timeout=20.0, interval=0.3, desc="telemetry to show handler activity")
 
 
-async def test_websocket_receives_events(ha_container: str, tmp_path) -> None:
-    """Connecting to /api/ws yields an initial 'connected' message then event messages on activity."""
+async def test_websocket_connects_and_receives_handshake(ha_container: str, tmp_path) -> None:
+    """Connecting to /api/ws yields an initial 'connected' message with expected fields."""
     config, base_url = make_web_system_config(ha_container, tmp_path)
     ws_url = base_url.replace("http://", "ws://", 1) + "/api/ws"
 
-    async with startup_context(config) as hassette:
+    async with startup_context(config):
         await wait_for_web_server(base_url)
 
         async with ws_connect(ws_url, ping_interval=None) as ws:
@@ -169,20 +169,3 @@ async def test_websocket_receives_events(ha_container: str, tmp_path) -> None:
             assert connected_msg["type"] == "connected"
             assert "data" in connected_msg
             assert "timestamp" in connected_msg
-
-            await hassette.api.call_service(DOMAIN, "toggle", {"entity_id": ENTITY})
-
-            event_msg: dict[str, Any] | None = None
-            deadline = asyncio.get_running_loop().time() + 15.0
-            while asyncio.get_running_loop().time() < deadline:
-                try:
-                    raw = await asyncio.wait_for(ws.recv(), timeout=2.0)
-                    msg: dict[str, Any] = json.loads(raw)
-                    if msg.get("type") != "connected":
-                        event_msg = msg
-                        break
-                except TimeoutError:
-                    continue
-
-            assert event_msg is not None, "No event message received over WebSocket after toggling light"
-            assert "type" in event_msg

--- a/tests/unit/test_ws_models.py
+++ b/tests/unit/test_ws_models.py
@@ -8,7 +8,6 @@ from pydantic import TypeAdapter
 from hassette.events.hassette import AppStateChangePayload, ServiceStatusPayload
 from hassette.schemas.domain_models import AppStatusChangedData as AppStatusChangedPayload
 from hassette.schemas.domain_models import ServiceStatusData as WsServiceStatusPayload
-from hassette.schemas.domain_models import StateChangedData as StateChangedPayload
 from hassette.types.enums import ResourceRole, ResourceStatus
 from hassette.web.models import (
     AppStatusChangedWsMessage,
@@ -18,7 +17,6 @@ from hassette.web.models import (
     ExecutionCompletedWsMessage,
     LogWsMessage,
     ServiceStatusWsMessage,
-    StateChangedWsMessage,
     WsServerMessage,
 )
 
@@ -73,21 +71,6 @@ class TestServiceStatusPayloadMatchesDataclass:
         assert payload.resource_name == "telemetry"
         assert payload.ready is True
         assert payload.ready_phase == "connected"
-
-
-class TestStateChangedNormalizedEnvelope:
-    """Verify state_changed uses the { type, data, timestamp } envelope."""
-
-    def test_state_changed_has_data_wrapper(self) -> None:
-        msg = StateChangedWsMessage(
-            type="state_changed",
-            data=StateChangedPayload(entity_id="light.kitchen", new_state={"state": "on"}, old_state={"state": "off"}),
-            timestamp=1234567890.0,
-        )
-        dumped = msg.model_dump()
-        assert "data" in dumped
-        assert dumped["data"]["entity_id"] == "light.kitchen"
-        assert "entity_id" not in dumped  # not at top level
 
 
 class TestConnectedPayloadIncludesUptimeSeconds:
@@ -151,16 +134,6 @@ class TestWsServerMessageDiscriminates:
         msg = self.adapter.validate_python(raw)
         assert isinstance(msg, ConnectivityWsMessage)
         assert msg.data.connected is True
-
-    def test_state_changed(self) -> None:
-        raw = {
-            "type": "state_changed",
-            "data": {"entity_id": "light.kitchen", "new_state": {"state": "on"}, "old_state": {"state": "off"}},
-            "timestamp": 1234567890.0,
-        }
-        msg = self.adapter.validate_python(raw)
-        assert isinstance(msg, StateChangedWsMessage)
-        assert msg.data.entity_id == "light.kitchen"
 
     def test_service_status(self) -> None:
         raw = {


### PR DESCRIPTION
### Performance

- Removed the `state_changed` WebSocket broadcast to browser clients. `RuntimeQueryService` subscribed to every HA `state_changed` event and pushed each one to all connected dashboard clients, but the frontend only parsed and immediately discarded the message (`case 'state_changed': break`). A typical HA instance fires dozens of state changes per second, producing 700+ msg/sec bursts that triggered continuous GC pressure (`TOO_MUCH_MALLOC`) in the browser and degraded dashboard responsiveness.
- Deleted the now-dead `StateChangedData` model, `StateChangedWsMessage` type, and all generated schema/type artifacts (`ws-schema.json`, `ws-types.ts`) along with their tests. The `connectivity` message type is also ignored by the frontend but is retained — it only fires on connect/disconnect and has no perf impact.
