### PR TITLE
test: deduplicate codegen test assertions

### DIFF
--- a/codegen/tests/conftest.py
+++ b/codegen/tests/conftest.py
@@ -1,4 +1,4 @@
-"""Shared fixtures and constants for codegen tests.
+"""Shared fixtures, constants, and assertion helpers for codegen tests.
 
 ``src`` is added to the import path via the ``pythonpath`` pytest option in
 ``codegen/pyproject.toml``, so ``hassette_codegen`` is importable without any
@@ -6,10 +6,30 @@ per-file path manipulation.
 """
 
 import os
+import py_compile
+import tempfile
 from pathlib import Path
+
+from hassette_codegen.domain_data import ExtractedDomain
+from hassette_codegen.generators.entities import generate_entity_wrapper
 
 HA_CORE = Path(os.environ.get("HA_CORE_PATH", "~/source/core")).expanduser()
 """Local checkout of Home Assistant core, used by tests that extract data from HA source."""
 
 HAS_HA_CORE = HA_CORE.exists()
 """Whether HA_CORE points at a real checkout — tests that need it skip when this is False."""
+
+
+def assert_compiles(source: str) -> None:
+    """Write source to a temp file and verify it compiles without errors."""
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".py", delete=False) as f:
+        f.write(source)
+        f.flush()
+        py_compile.compile(f.name, doraise=True)
+
+
+def generate_wrapper_or_fail(domain: ExtractedDomain) -> str:
+    """Generate an entity wrapper and assert the domain produces output."""
+    output = generate_entity_wrapper(domain)
+    assert output is not None
+    return output

--- a/codegen/tests/conftest.py
+++ b/codegen/tests/conftest.py
@@ -22,14 +22,14 @@ HAS_HA_CORE = HA_CORE.exists()
 
 def assert_compiles(source: str) -> None:
     """Write source to a temp file and verify it compiles without errors."""
-    with tempfile.NamedTemporaryFile(mode="w", suffix=".py", delete=False) as f:
-        f.write(source)
-        f.flush()
-        py_compile.compile(f.name, doraise=True)
+    with tempfile.TemporaryDirectory() as tmpdir:
+        source_path = Path(tmpdir) / "generated.py"
+        source_path.write_text(source)
+        py_compile.compile(str(source_path), doraise=True)
 
 
 def generate_wrapper_or_fail(domain: ExtractedDomain) -> str:
     """Generate an entity wrapper and assert the domain produces output."""
     output = generate_entity_wrapper(domain)
-    assert output is not None
+    assert output and output.strip()
     return output

--- a/codegen/tests/test_constants_and_exports.py
+++ b/codegen/tests/test_constants_and_exports.py
@@ -1,8 +1,6 @@
 """Unit tests for constants extraction and __init__.py generation."""
 
 import ast
-import py_compile
-import tempfile
 from pathlib import Path
 
 import pytest
@@ -18,6 +16,7 @@ from hassette_codegen.pipeline import _check_predicate_freshness
 
 from .conftest import HA_CORE as _HA_CORE
 from .conftest import HAS_HA_CORE as _HAS_HA_CORE
+from .conftest import assert_compiles
 
 _STATES_DIR = Path(__file__).resolve().parent.parent.parent / "src" / "hassette" / "models" / "states"
 
@@ -45,11 +44,7 @@ class TestConstantsExtraction:
 
     def test_generated_constants_compile(self) -> None:
         results = extract_sensor_constants(_HA_CORE)
-        output = generate_sensor_constants(results)
-        with tempfile.NamedTemporaryFile(mode="w", suffix=".py", delete=False) as f:
-            f.write(output)
-            f.flush()
-            py_compile.compile(f.name, doraise=True)
+        assert_compiles(generate_sensor_constants(results))
 
 
 class TestExportsGenerator:
@@ -73,11 +68,7 @@ class TestExportsGenerator:
         assert names == sorted(names)
 
     def test_output_compiles(self) -> None:
-        output = generate_init_py(_STATES_DIR)
-        with tempfile.NamedTemporaryFile(mode="w", suffix=".py", delete=False) as f:
-            f.write(output)
-            f.flush()
-            py_compile.compile(f.name, doraise=True)
+        assert_compiles(generate_init_py(_STATES_DIR))
 
 
 class TestConstantsEscaping:

--- a/codegen/tests/test_entity_generator.py
+++ b/codegen/tests/test_entity_generator.py
@@ -1,9 +1,7 @@
 """Unit tests for the entity wrapper generator."""
 
 import ast
-import py_compile
 import re
-import tempfile
 
 import pytest
 
@@ -14,8 +12,61 @@ from hassette_codegen.generators.entities import generate_entity_wrapper
 from hassette_codegen.overrides import DomainOverride
 from hassette_codegen.rendering import UnsafeGeneratedValueError
 
+from .conftest import assert_compiles, generate_wrapper_or_fail
+
+
+# dup-ignore-start: fan domain factories share the ExtractedDomain(name="fan") preamble by design
+def _fan_single_service_domain() -> ExtractedDomain:
+    return ExtractedDomain(
+        name="fan",
+        base_class="BoolBaseState",
+        services=[
+            ExtractedService(
+                name="turn_on",
+                method_name="turn_on",
+                fields=[ServiceField(name="pct", selector_type="number", selector_data={})],
+            ),
+        ],
+    )
+
+
+def _fan_turn_off_domain() -> ExtractedDomain:
+    return ExtractedDomain(
+        name="fan",
+        base_class="BoolBaseState",
+        services=[
+            ExtractedService(name="turn_off", method_name="turn_off", fields=[]),
+        ],
+    )
+
+
+# dup-ignore-end
+
+
+def _cover_domain() -> ExtractedDomain:
+    return ExtractedDomain(
+        name="cover",
+        base_class="StringBaseState",
+        services=[
+            ExtractedService(name="open_cover", method_name="open_cover", fields=[]),
+            ExtractedService(
+                name="set_cover_position",
+                method_name="set_cover_position",
+                fields=[
+                    ServiceField(
+                        name="position",
+                        selector_type="number",
+                        selector_data={"min": 0, "max": 100},
+                        required=True,
+                    ),
+                ],
+            ),
+        ],
+    )
+
 
 class TestEntityWrapperGenerator:
+    # dup-ignore-start: multi-service fan domain with unique field combos, not extractable to a shared factory
     def test_fan_entity(self) -> None:
         domain = ExtractedDomain(
             name="fan",
@@ -44,8 +95,7 @@ class TestEntityWrapperGenerator:
                 ),
             ],
         )
-        output = generate_entity_wrapper(domain)
-        assert output is not None
+        output = generate_wrapper_or_fail(domain)
         assert "class FanEntity(BaseEntity[FanState, str]):" in output
         assert "def turn_on(" in output
         assert "def turn_off(" in output
@@ -59,20 +109,10 @@ class TestEntityWrapperGenerator:
         assert "from collections.abc import Coroutine" in output
         assert "from typing import Any" in output
 
+    # dup-ignore-end
+
     def test_all_params_keyword_only(self) -> None:
-        domain = ExtractedDomain(
-            name="fan",
-            base_class="BoolBaseState",
-            services=[
-                ExtractedService(
-                    name="turn_on",
-                    method_name="turn_on",
-                    fields=[ServiceField(name="pct", selector_type="number", selector_data={})],
-                ),
-            ],
-        )
-        output = generate_entity_wrapper(domain)
-        assert output is not None
+        output = generate_wrapper_or_fail(_fan_single_service_domain())
         assert "self,\n        *," in output
 
     def test_no_services_returns_none(self) -> None:
@@ -97,11 +137,13 @@ class TestEntityWrapperGenerator:
                 service_param_renames={"media_content_type": "media_type"},
             ),
         )
-        output = generate_entity_wrapper(domain)
-        assert output is not None
+        output = generate_wrapper_or_fail(domain)
         assert "media_type" in output
         assert "media_content_type" not in output.split("call_service")[0]
 
+    # dup-ignore-start: selector-field tests each build domains with deliberately varied options
+    # to test alias dedup, collision, and list-wrapping — the ServiceField/ExtractedService
+    # constructor syntax repeats but the specific option values and selector types are the inputs
     def test_same_param_name_different_literals_get_distinct_aliases(self) -> None:
         # Two services share the param name "mode" but expose different Literal sets.
         # Keying the alias cache by param name alone would emit two `Mode = ...` lines,
@@ -136,18 +178,14 @@ class TestEntityWrapperGenerator:
                 ),
             ],
         )
-        output = generate_entity_wrapper(domain)
-        assert output is not None
+        output = generate_wrapper_or_fail(domain)
         # Each Literal set gets its own alias, defined exactly once.
         assert output.count('ClimateMode = Literal["heat", "cool"]') == 1
         assert output.count('ClimateMode2 = Literal["low", "high"]') == 1
         # Both aliases are referenced — the first uses the bare name, the second the suffixed one.
         assert re.search(r"mode: ClimateMode\b", output)  # \b stops this matching "ClimateMode2"
         assert "mode: ClimateMode2" in output
-        with tempfile.NamedTemporaryFile(mode="w", suffix=".py", delete=False) as f:
-            f.write(output)
-            f.flush()
-            py_compile.compile(f.name, doraise=True)
+        assert_compiles(output)
 
     def test_shared_literal_reuses_single_alias(self) -> None:
         # The same Literal shape under the same param name should still collapse to one alias.
@@ -181,8 +219,7 @@ class TestEntityWrapperGenerator:
                 ),
             ],
         )
-        output = generate_entity_wrapper(domain)
-        assert output is not None
+        output = generate_wrapper_or_fail(domain)
         assert output.count('ClimateMode = Literal["heat", "cool"]') == 1
         assert "ClimateMode2" not in output
 
@@ -206,8 +243,7 @@ class TestEntityWrapperGenerator:
                 ),
             ],
         )
-        output = generate_entity_wrapper(domain)
-        assert output is not None
+        output = generate_wrapper_or_fail(domain)
         assert "group_members: list[str]" in output
 
     def test_multiple_select_aliases_inner_literal(self) -> None:
@@ -241,32 +277,17 @@ class TestEntityWrapperGenerator:
                 ),
             ],
         )
-        output = generate_entity_wrapper(domain)
-        assert output is not None
+        output = generate_wrapper_or_fail(domain)
         # One alias definition, shared by the bare and the list-wrapped usage.
         assert output.count('TodoStatus = Literal["needs_action", "completed"]') == 1
         assert "status: list[TodoStatus] | None" in output
         assert "status: TodoStatus | None" in output
         assert "list[Literal[" not in output  # inner literal is aliased, not inlined
 
+    # dup-ignore-end
+
     def test_output_compiles(self) -> None:
-        domain = ExtractedDomain(
-            name="fan",
-            base_class="BoolBaseState",
-            services=[
-                ExtractedService(
-                    name="turn_on",
-                    method_name="turn_on",
-                    fields=[ServiceField(name="pct", selector_type="number", selector_data={})],
-                ),
-            ],
-        )
-        output = generate_entity_wrapper(domain)
-        assert output is not None
-        with tempfile.NamedTemporaryFile(mode="w", suffix=".py", delete=False) as f:
-            f.write(output)
-            f.flush()
-            py_compile.compile(f.name, doraise=True)
+        assert_compiles(generate_wrapper_or_fail(_fan_single_service_domain()))
 
     def test_facade_class_emitted(self) -> None:
         domain = ExtractedDomain(
@@ -281,47 +302,18 @@ class TestEntityWrapperGenerator:
                 ExtractedService(name="turn_off", method_name="turn_off", fields=[]),
             ],
         )
-        output = generate_entity_wrapper(domain)
-        assert output is not None
+        output = generate_wrapper_or_fail(domain)
         assert "class FanEntitySyncFacade(BaseEntitySyncFacade[FanState, str]):" in output
 
     def test_sync_property_override_emitted(self) -> None:
-        domain = ExtractedDomain(
-            name="fan",
-            base_class="BoolBaseState",
-            services=[
-                ExtractedService(name="turn_off", method_name="turn_off", fields=[]),
-            ],
-        )
-        output = generate_entity_wrapper(domain)
-        assert output is not None
+        output = generate_wrapper_or_fail(_fan_turn_off_domain())
         assert 'def sync(self) -> "FanEntitySyncFacade":' in output
         # Caching is delegated to the base helper; no per-file construction or cast.
         assert "self._get_or_create_sync(FanEntitySyncFacade)" in output
         assert "cast(" not in output
 
     def test_facade_methods_match_async_signatures(self) -> None:
-        domain = ExtractedDomain(
-            name="cover",
-            base_class="StringBaseState",
-            services=[
-                ExtractedService(name="open_cover", method_name="open_cover", fields=[]),
-                ExtractedService(
-                    name="set_cover_position",
-                    method_name="set_cover_position",
-                    fields=[
-                        ServiceField(
-                            name="position",
-                            selector_type="number",
-                            selector_data={"min": 0, "max": 100},
-                            required=True,
-                        ),
-                    ],
-                ),
-            ],
-        )
-        output = generate_entity_wrapper(domain)
-        assert output is not None
+        output = generate_wrapper_or_fail(_cover_domain())
         # Facade class present
         assert "class CoverEntitySyncFacade(BaseEntitySyncFacade[CoverState, str]):" in output
         # No-param service emits a void method with just self
@@ -336,27 +328,7 @@ class TestEntityWrapperGenerator:
         assert 'target={"entity_id": self.entity.entity_id}' in output
 
     def test_facade_methods_are_void(self) -> None:
-        domain = ExtractedDomain(
-            name="cover",
-            base_class="StringBaseState",
-            services=[
-                ExtractedService(name="open_cover", method_name="open_cover", fields=[]),
-                ExtractedService(
-                    name="set_cover_position",
-                    method_name="set_cover_position",
-                    fields=[
-                        ServiceField(
-                            name="position",
-                            selector_type="number",
-                            selector_data={"min": 0, "max": 100},
-                            required=True,
-                        ),
-                    ],
-                ),
-            ],
-        )
-        output = generate_entity_wrapper(domain)
-        assert output is not None
+        output = generate_wrapper_or_fail(_cover_domain())
         # Split on the facade class to inspect only the facade portion
         facade_portion = output.split("class CoverEntitySyncFacade", 1)[1]
         # Facade methods are synchronous and void: explicit `-> None`, no `return` of the
@@ -371,46 +343,14 @@ class TestEntityWrapperGenerator:
         assert "Must be awaited" not in facade_portion
 
     def test_facade_imports_base_facade_not_cast(self) -> None:
-        domain = ExtractedDomain(
-            name="fan",
-            base_class="BoolBaseState",
-            services=[
-                ExtractedService(name="turn_off", method_name="turn_off", fields=[]),
-            ],
-        )
-        output = generate_entity_wrapper(domain)
-        assert output is not None
+        output = generate_wrapper_or_fail(_fan_turn_off_domain())
         # The base caching helper removed the per-file cast, so `cast` is no longer imported.
         assert "from typing import Any\n" in output
         assert "cast" not in output
         assert "BaseEntitySyncFacade" in output.split("class FanEntity")[0]
 
     def test_output_compiles_with_facade(self) -> None:
-        domain = ExtractedDomain(
-            name="cover",
-            base_class="StringBaseState",
-            services=[
-                ExtractedService(name="open_cover", method_name="open_cover", fields=[]),
-                ExtractedService(
-                    name="set_cover_position",
-                    method_name="set_cover_position",
-                    fields=[
-                        ServiceField(
-                            name="position",
-                            selector_type="number",
-                            selector_data={"min": 0, "max": 100},
-                            required=True,
-                        ),
-                    ],
-                ),
-            ],
-        )
-        output = generate_entity_wrapper(domain)
-        assert output is not None
-        with tempfile.NamedTemporaryFile(mode="w", suffix=".py", delete=False) as f:
-            f.write(output)
-            f.flush()
-            py_compile.compile(f.name, doraise=True)
+        assert_compiles(generate_wrapper_or_fail(_cover_domain()))
 
     def test_facade_param_lists_match_async_entity_methods(self) -> None:
         """Each facade method's parameter names mirror the async entity method's.
@@ -418,27 +358,7 @@ class TestEntityWrapperGenerator:
         String-presence checks would miss a template change that emits a parameter
         subset on the facade; this parses the AST and compares names directly.
         """
-        domain = ExtractedDomain(
-            name="cover",
-            base_class="StringBaseState",
-            services=[
-                ExtractedService(name="open_cover", method_name="open_cover", fields=[]),
-                ExtractedService(
-                    name="set_cover_position",
-                    method_name="set_cover_position",
-                    fields=[
-                        ServiceField(
-                            name="position",
-                            selector_type="number",
-                            selector_data={"min": 0, "max": 100},
-                            required=True,
-                        ),
-                    ],
-                ),
-            ],
-        )
-        output = generate_entity_wrapper(domain)
-        assert output is not None
+        output = generate_wrapper_or_fail(_cover_domain())
         tree = ast.parse(output)
 
         def method_params(class_name: str, method_name: str) -> list[str]:
@@ -476,28 +396,44 @@ def _domain(
     )
 
 
+def _hvac_mode_service(*, required: bool = True) -> list[ExtractedService]:
+    return [
+        ExtractedService(
+            name="set_hvac_mode",
+            method_name="set_hvac_mode",
+            fields=[
+                ServiceField(name="hvac_mode", selector_type="text", selector_data={}, required=required),
+            ],
+        ),
+    ]
+
+
+def _hvac_mode_domain(
+    *,
+    members: list[tuple[str, str]] | None = None,
+    required: bool = True,
+    override: DomainOverride | None = None,
+) -> ExtractedDomain:
+    if members is None:
+        members = [("OFF", "off"), ("HEAT", "heat")]
+    return _domain(
+        "climate",
+        strenums=[_enum("HVACMode", *members)],
+        services=_hvac_mode_service(required=required),
+        override=override,
+    )
+
+
 class TestStrEnumMatching:
     """StrEnum cross-referencing for service params (issue #718)."""
 
     def test_name_based_match_str_to_strenum(self) -> None:
-        domain = _domain(
-            "climate",
-            strenums=[_enum("HVACMode", ("OFF", "off"), ("HEAT", "heat"), ("COOL", "cool"))],
-            services=[
-                ExtractedService(
-                    name="set_hvac_mode",
-                    method_name="set_hvac_mode",
-                    fields=[
-                        ServiceField(name="hvac_mode", selector_type="text", selector_data={}, required=True),
-                    ],
-                ),
-            ],
-        )
-        output = generate_entity_wrapper(domain)
-        assert output is not None
+        domain = _hvac_mode_domain(members=[("OFF", "off"), ("HEAT", "heat"), ("COOL", "cool")])
+        output = generate_wrapper_or_fail(domain)
         assert "hvac_mode: HVACMode" in output
         assert "import ClimateAttributes, HVACMode" in output
 
+    # dup-ignore-start: select-field service construction shares structure with other selector tests
     def test_value_based_match_literal_to_strenum(self) -> None:
         domain = _domain(
             "media_player",
@@ -517,13 +453,15 @@ class TestStrEnumMatching:
                 ),
             ],
         )
-        output = generate_entity_wrapper(domain)
-        assert output is not None
+        output = generate_wrapper_or_fail(domain)
         assert "repeat: RepeatMode" in output
         assert "RepeatMode" in output.split("class")[0]
         # Literal alias should NOT be generated — StrEnum supersedes it
         assert "MediaPlayerRepeat = Literal" not in output
 
+    # dup-ignore-end
+
+    # dup-ignore-start: status select field shares structure with test_multiple_select_aliases_inner_literal above
     def test_value_based_match_list_literal_to_strenum(self) -> None:
         domain = _domain(
             "todo",
@@ -542,10 +480,11 @@ class TestStrEnumMatching:
                 ),
             ],
         )
-        output = generate_entity_wrapper(domain)
-        assert output is not None
+        output = generate_wrapper_or_fail(domain)
         assert "status: list[TodoItemStatus] | None" in output
         assert "TodoStatus = Literal" not in output
+
+    # dup-ignore-end
 
     def test_metadata_enums_excluded_from_matching(self) -> None:
         domain = _domain(
@@ -561,50 +500,20 @@ class TestStrEnumMatching:
                 ),
             ],
         )
-        output = generate_entity_wrapper(domain)
-        assert output is not None
+        output = generate_wrapper_or_fail(domain)
         # Should remain str because ClimateEntityStateAttribute ends with "Attribute"
         assert "fan_mode: str" in output
 
     def test_param_type_override_wins_over_enum_match(self) -> None:
-        domain = _domain(
-            "climate",
-            strenums=[_enum("HVACMode", ("OFF", "off"), ("HEAT", "heat"))],
-            services=[
-                ExtractedService(
-                    name="set_hvac_mode",
-                    method_name="set_hvac_mode",
-                    fields=[
-                        ServiceField(name="hvac_mode", selector_type="text", selector_data={}, required=True),
-                    ],
-                ),
-            ],
-            override=DomainOverride(
-                domain="climate",
-                param_type_overrides={"hvac_mode": "str"},
-            ),
+        domain = _hvac_mode_domain(
+            override=DomainOverride(domain="climate", param_type_overrides={"hvac_mode": "str"}),
         )
-        output = generate_entity_wrapper(domain)
-        assert output is not None
+        output = generate_wrapper_or_fail(domain)
         assert "hvac_mode: str" in output
         assert "HVACMode" not in output
 
     def test_optional_enum_param_gets_none_union(self) -> None:
-        domain = _domain(
-            "climate",
-            strenums=[_enum("HVACMode", ("OFF", "off"), ("HEAT", "heat"))],
-            services=[
-                ExtractedService(
-                    name="set_hvac_mode",
-                    method_name="set_hvac_mode",
-                    fields=[
-                        ServiceField(name="hvac_mode", selector_type="text", selector_data={}, required=False),
-                    ],
-                ),
-            ],
-        )
-        output = generate_entity_wrapper(domain)
-        assert output is not None
+        output = generate_wrapper_or_fail(_hvac_mode_domain(required=False))
         assert "hvac_mode: HVACMode | None" in output
 
     def test_enum_match_with_renamed_param(self) -> None:
@@ -625,11 +534,11 @@ class TestStrEnumMatching:
                 service_param_renames={"media_content_type": "media_type"},
             ),
         )
-        output = generate_entity_wrapper(domain)
-        assert output is not None
+        output = generate_wrapper_or_fail(domain)
         # Renamed param "media_type" should match StrEnum "MediaType"
         assert "media_type: MediaType | None" in output
 
+    # dup-ignore-start: select-field service construction shares structure with other selector tests
     def test_collision_renamed_enum_uses_value_suffix(self) -> None:
         """StrEnums renamed by the state generator (name collides with Pydantic class) use the renamed name."""
         domain = _domain(
@@ -650,32 +559,15 @@ class TestStrEnumMatching:
                 ),
             ],
         )
-        output = generate_entity_wrapper(domain)
-        assert output is not None
+        output = generate_wrapper_or_fail(domain)
         # The state generator renames SceneState → SceneStateValue to avoid collision
         assert "SceneStateValue" in output
         assert "import SceneAttributes, SceneStateValue" in output
 
+    # dup-ignore-end
+
     def test_output_compiles_with_enum_imports(self) -> None:
-        domain = _domain(
-            "climate",
-            strenums=[_enum("HVACMode", ("OFF", "off"), ("HEAT", "heat"))],
-            services=[
-                ExtractedService(
-                    name="set_hvac_mode",
-                    method_name="set_hvac_mode",
-                    fields=[
-                        ServiceField(name="hvac_mode", selector_type="text", selector_data={}, required=True),
-                    ],
-                ),
-            ],
-        )
-        output = generate_entity_wrapper(domain)
-        assert output is not None
-        with tempfile.NamedTemporaryFile(mode="w", suffix=".py", delete=False) as f:
-            f.write(output)
-            f.flush()
-            py_compile.compile(f.name, doraise=True)
+        assert_compiles(generate_wrapper_or_fail(_hvac_mode_domain()))
 
 
 class TestEntityWrapperEscaping:
@@ -685,6 +577,7 @@ class TestEntityWrapperEscaping:
     params), so every assertion here checks all occurrences rather than the first.
     """
 
+    # dup-ignore-start: fan domain factory with hostile-input overrides, shares preamble with module factories
     @staticmethod
     def _domain(
         service_name: str = "turn_on", method_name: str = "turn_on", field_name: str = "percentage"
@@ -702,10 +595,11 @@ class TestEntityWrapperEscaping:
             ],
         )
 
+    # dup-ignore-end
+
     def test_quote_in_service_name_stays_one_literal_at_every_site(self) -> None:
         hostile = 'turn_on", target={"entity_id": "light.evil'
-        output = generate_entity_wrapper(self._domain(service_name=hostile))
-        assert output is not None
+        output = generate_wrapper_or_fail(self._domain(service_name=hostile))
 
         module = ast.parse(output)
         rendered = [
@@ -734,9 +628,8 @@ class TestEntityWrapperEscaping:
         # An override that maps a bad name to a good one must be honoured, not rejected first.
         domain = self._domain(field_name="for")
         domain.override = DomainOverride(domain="fan", service_param_renames={"for": "for_"})
-        output = generate_entity_wrapper(domain)
+        output = generate_wrapper_or_fail(domain)
 
-        assert output is not None
         assert "for_:" in output
 
     def test_whitespace_only_descriptions_do_not_swallow_sibling_methods(self) -> None:
@@ -751,8 +644,7 @@ class TestEntityWrapperEscaping:
                 ExtractedService(name="third", method_name="third", fields=[], description="Turn on."),
             ],
         )
-        output = generate_entity_wrapper(domain)
-        assert output is not None
+        output = generate_wrapper_or_fail(domain)
 
         module = ast.parse(output)
         facade = next(n for n in module.body if isinstance(n, ast.ClassDef) and n.name.endswith("SyncFacade"))

--- a/codegen/tests/test_integration.py
+++ b/codegen/tests/test_integration.py
@@ -1,7 +1,5 @@
 """Integration tests — full pipeline against real HA core domains."""
 
-import py_compile
-import tempfile
 import time
 
 import pytest
@@ -20,6 +18,7 @@ from hassette_codegen.overrides import get_override, load_overrides
 
 from .conftest import HA_CORE as _HA_CORE
 from .conftest import HAS_HA_CORE as _HAS_HA_CORE
+from .conftest import assert_compiles, generate_wrapper_or_fail
 
 _COMPONENTS = _HA_CORE / "homeassistant" / "components"
 
@@ -59,30 +58,17 @@ class TestFanFullPipeline:
         assert "supports_direction" in output
 
     def test_entity_wrapper_structure(self) -> None:
-        domain = _extract_full_domain("fan")
-        output = generate_entity_wrapper(domain)
-        assert output is not None
+        output = generate_wrapper_or_fail(_extract_full_domain("fan"))
         assert "class FanEntity(BaseEntity[FanState, str]):" in output
         assert "def turn_on(" in output
         assert "def turn_off(" in output
         assert "-> Coroutine[Any, Any, None]:" in output
 
     def test_state_model_compiles(self) -> None:
-        domain = _extract_full_domain("fan")
-        output = generate_state_model(domain)
-        with tempfile.NamedTemporaryFile(mode="w", suffix=".py", delete=False) as f:
-            f.write(output)
-            f.flush()
-            py_compile.compile(f.name, doraise=True)
+        assert_compiles(generate_state_model(_extract_full_domain("fan")))
 
     def test_entity_wrapper_compiles(self) -> None:
-        domain = _extract_full_domain("fan")
-        output = generate_entity_wrapper(domain)
-        assert output is not None
-        with tempfile.NamedTemporaryFile(mode="w", suffix=".py", delete=False) as f:
-            f.write(output)
-            f.flush()
-            py_compile.compile(f.name, doraise=True)
+        assert_compiles(generate_wrapper_or_fail(_extract_full_domain("fan")))
 
 
 @pytest.mark.skipif(not _HAS_HA_CORE, reason="HA core checkout not available")
@@ -94,18 +80,14 @@ class TestLightFullPipeline:
         assert "IntFlag" in output
 
     def test_entity_has_advanced_fields(self) -> None:
-        domain = _extract_full_domain("light")
-        output = generate_entity_wrapper(domain)
-        assert output is not None
+        output = generate_wrapper_or_fail(_extract_full_domain("light"))
         assert "def turn_on(" in output
         assert "-> Coroutine[Any, Any, None]:" in output
         field_count = output.count("None,") + output.count("None)")
         assert field_count >= 5
 
     def test_color_override_applied(self) -> None:
-        domain = _extract_full_domain("light")
-        output = generate_entity_wrapper(domain)
-        assert output is not None
+        output = generate_wrapper_or_fail(_extract_full_domain("light"))
         assert "Color" in output
 
 
@@ -147,11 +129,7 @@ class TestAllDomainsCompile:
                     services=extract_services(domain_info.path) if domain_info.has_services_yaml else [],
                     override=get_override(overrides, domain_info.name),
                 )
-                output = generate_state_model(extracted)
-                with tempfile.NamedTemporaryFile(mode="w", suffix=".py", delete=False) as f:
-                    f.write(output)
-                    f.flush()
-                    py_compile.compile(f.name, doraise=True)
+                assert_compiles(generate_state_model(extracted))
             except Exception as exc:
                 failures.append(f"{domain_info.name}: {exc}")
 

--- a/codegen/tests/test_overrides.py
+++ b/codegen/tests/test_overrides.py
@@ -61,6 +61,7 @@ class TestValidateOverrides:
         validate_overrides(overrides, {"light", "fan"})
 
 
+# dup-ignore-start: parallel property-override tests each vary inputs and expected survivors
 class TestApplyPropertyOverridesRemove:
     def test_removes_matching_property(self) -> None:
         properties = [
@@ -109,3 +110,6 @@ class TestApplyPropertyOverridesRemove:
         captured = capsys.readouterr()
         assert "nonexistent_field" in captured.err
         assert "WARNING" in captured.err
+
+
+# dup-ignore-end

--- a/codegen/tests/test_pipeline_guards.py
+++ b/codegen/tests/test_pipeline_guards.py
@@ -210,6 +210,7 @@ class TestCheckModeReportsRejections:
     — the exit code then turns on the rejection alone, not on drift.
     """
 
+    # dup-ignore-start: each test needs its own generate-then-check lifecycle
     def test_a_clean_tree_passes(self, tmp_path: Path) -> None:
         # The control: without a rejection the same setup exits 0, so the failures below are not
         # just "check mode always fails on a freshly generated tree".
@@ -252,3 +253,5 @@ class TestCheckModeReportsRejections:
         run_pipeline(ha_source, repo_root, check_mode=False)
 
         assert run_pipeline(ha_source, repo_root, check_mode=True, domain_filter={"fan"}) == 0
+
+    # dup-ignore-end

--- a/codegen/tests/test_state_generator.py
+++ b/codegen/tests/test_state_generator.py
@@ -1,14 +1,26 @@
 """Unit tests for the state model generator."""
 
 import ast
-import py_compile
-import tempfile
 
 from hassette_codegen.domain_data import ExtractedDomain
 from hassette_codegen.extractors.features import ExtractedEnum
 from hassette_codegen.extractors.properties import ExtractedProperty
 from hassette_codegen.generators.states import _normalize_enum_prefixes, generate_state_model
 from hassette_codegen.overrides import DomainOverride
+
+from .conftest import assert_compiles
+
+
+def _datetime_domain() -> ExtractedDomain:
+    return ExtractedDomain(
+        name="script",
+        base_class="BoolBaseState",
+        properties=[
+            ExtractedProperty(name="last_triggered", python_type="ZonedDateTime | None", has_default=True),
+            ExtractedProperty(name="mode", python_type="str | None", has_default=True),
+        ],
+        features=[],
+    )
 
 
 class TestStateModelGenerator:
@@ -65,11 +77,7 @@ class TestStateModelGenerator:
                 ExtractedEnum(name="FanEntityFeature", members=[("SET_SPEED", 1)]),
             ],
         )
-        output = generate_state_model(domain)
-        with tempfile.NamedTemporaryFile(mode="w", suffix=".py", delete=False) as f:
-            f.write(output)
-            f.flush()
-            py_compile.compile(f.name, doraise=True)
+        assert_compiles(generate_state_model(domain))
 
     def test_fields_all_use_field_default_none(self) -> None:
         domain = ExtractedDomain(
@@ -84,32 +92,10 @@ class TestStateModelGenerator:
         assert "Field(default=None)" in output
 
     def test_output_with_datetime_field_compiles(self) -> None:
-        domain = ExtractedDomain(
-            name="script",
-            base_class="BoolBaseState",
-            properties=[
-                ExtractedProperty(name="last_triggered", python_type="ZonedDateTime | None", has_default=True),
-                ExtractedProperty(name="mode", python_type="str | None", has_default=True),
-            ],
-            features=[],
-        )
-        output = generate_state_model(domain)
-        with tempfile.NamedTemporaryFile(mode="w", suffix=".py", delete=False) as f:
-            f.write(output)
-            f.flush()
-            py_compile.compile(f.name, doraise=True)
+        assert_compiles(generate_state_model(_datetime_domain()))
 
     def test_datetime_fields_get_validator(self) -> None:
-        domain = ExtractedDomain(
-            name="script",
-            base_class="BoolBaseState",
-            properties=[
-                ExtractedProperty(name="last_triggered", python_type="ZonedDateTime | None", has_default=True),
-                ExtractedProperty(name="mode", python_type="str | None", has_default=True),
-            ],
-            features=[],
-        )
-        output = generate_state_model(domain)
+        output = generate_state_model(_datetime_domain())
         assert "field_validator" in output
         assert '"last_triggered"' in output
         assert "convert_datetime_str_to_tz" in output

--- a/codegen/tests/test_state_generator.py
+++ b/codegen/tests/test_state_generator.py
@@ -12,6 +12,7 @@ from .conftest import assert_compiles
 
 
 def _datetime_domain() -> ExtractedDomain:
+    """Build a test domain with a datetime property to exercise datetime-specific codegen."""
     return ExtractedDomain(
         name="script",
         base_class="BoolBaseState",


### PR DESCRIPTION
## Summary

Eliminates all 23 PMD CPD duplication clusters flagged in `codegen/tests/` by the `duplicate-code` CI job.

### What changed

**Extracted shared helpers** into `codegen/tests/conftest.py`:
- `assert_compiles(source)` — consolidates the repeated write-to-tempfile + `py_compile.compile(doraise=True)` pattern (was inlined in 6+ call sites across 4 files)
- `generate_wrapper_or_fail(domain)` — consolidates the `generate_entity_wrapper(domain)` + `assert output is not None` two-liner

**Consolidated domain factories** into module-level functions in the files that use them:
- `_fan_single_service_domain()`, `_fan_turn_off_domain()`, `_cover_domain()` in `test_entity_generator.py`
- `_hvac_mode_domain()` with parameterized members/required/override in `test_entity_generator.py`
- `_datetime_domain()` in `test_state_generator.py`

**Annotated intentional duplication** with `dup-ignore-start/end` markers where the repeated structure is the test input (varied selector options, parallel assertion structure) and extracting it would obscure what each test is actually checking.

### How it was tested

- `uv run nox -s dev` — all 6908 tests pass
- `prek -a` — all hooks pass (ruff, pyright, factory shadowing, etc.)
- PMD CPD (`tools/check_duplicate_code.py`) reports 0 unresolved clusters in `codegen/tests/` (down from 23)
- All `dup-ignore` markers validated as properly balanced by `validate_markers()`

Net diff: +186 / -312 lines.

Closes #1567