### PR TITLE
refactor: deduplicate Docker integration test setup

### DIFF
--- a/tests/test_docker_integration.py
+++ b/tests/test_docker_integration.py
@@ -66,7 +66,7 @@ def create_project_package(project_dir: Path, pyproject_content: str) -> None:
     pkg_dir = project_dir / "test_proj"
     pkg_dir.mkdir()
     (pkg_dir / "__init__.py").write_text("")
-    subprocess.run(["uv", "lock", "--directory", str(project_dir)], check=True, capture_output=True)
+    subprocess.run(["uv", "lock", "--directory", str(project_dir)], check=True, capture_output=True, timeout=60)
 
 
 @pytest.fixture

--- a/tests/test_docker_integration.py
+++ b/tests/test_docker_integration.py
@@ -27,8 +27,8 @@ def run_hassette_container(
     volumes: list[str] | None = None,
     env: dict[str, str] | None = None,
     timeout: int = 60,
-) -> subprocess.CompletedProcess[str]:
-    """Run the hassette Docker image with ``--version`` and return the completed process."""
+) -> tuple[subprocess.CompletedProcess[str], str]:
+    """Run the hassette Docker image with ``--version``, returning (result, combined output)."""
     cmd = ["docker", "run", "--rm"]
     for vol in volumes or []:
         cmd.extend(["-v", vol])
@@ -41,23 +41,22 @@ def run_hassette_container(
     for key, value in merged_env.items():
         cmd.extend(["-e", f"{key}={value}"])
     cmd.extend([DOCKER_IMAGE, "--version"])
-    return subprocess.run(cmd, capture_output=True, text=True, timeout=timeout)
+    result = subprocess.run(cmd, capture_output=True, text=True, timeout=timeout)
+    return result, result.stderr + result.stdout
 
 
 def run_requirements_container(apps_dir: Path) -> tuple[subprocess.CompletedProcess[str], str]:
     """Run the container with INSTALL_DEPS=1 and a read-only apps mount, returning (result, combined output)."""
-    result = run_hassette_container(volumes=[f"{apps_dir}:/apps:ro"], env={"HASSETTE__INSTALL_DEPS": "1"})
-    return result, result.stderr + result.stdout
+    return run_hassette_container(volumes=[f"{apps_dir}:/apps:ro"], env={"HASSETTE__INSTALL_DEPS": "1"})
 
 
 def run_project_container(project_dir: Path, *, timeout: int = 120) -> tuple[subprocess.CompletedProcess[str], str]:
     """Run the container with PROJECT_DIR pointing to the mounted project, returning (result, combined output)."""
-    result = run_hassette_container(
+    return run_hassette_container(
         volumes=[f"{project_dir}:/apps"],
         env={"HASSETTE__PROJECT_DIR": "/apps"},
         timeout=timeout,
     )
-    return result, result.stderr + result.stdout
 
 
 def create_project_package(project_dir: Path, pyproject_content: str) -> None:
@@ -150,11 +149,10 @@ def test_docker_installs_from_config_and_apps(tmp_path: Path):
     (config_dir / "requirements.txt").write_text("pyyaml>=6.0\n")
     (apps_dir / "requirements.txt").write_text("httpx>=0.25\n")
 
-    result = run_hassette_container(
+    _, output = run_hassette_container(
         volumes=[f"{config_dir}:/config:ro", f"{apps_dir}:/apps:ro"],
         env={"HASSETTE__CONFIG_DIR": "/config", "HASSETTE__INSTALL_DEPS": "1"},
     )
-    output = result.stderr + result.stdout
 
     assert output.count("Installing requirements from") >= 2, f"Not all requirements found. Output:\n{output}"
 
@@ -217,8 +215,7 @@ def test_docker_skips_requirements_by_default(tmp_path: Path):
     apps_dir.mkdir()
     (apps_dir / "requirements.txt").write_text("requests\n")
 
-    result = run_hassette_container(volumes=[f"{apps_dir}:/apps:ro"])
-    output = result.stderr + result.stdout
+    result, output = run_hassette_container(volumes=[f"{apps_dir}:/apps:ro"])
 
     assert result.returncode == 0
     assert "requirements install: disabled" in output
@@ -310,8 +307,7 @@ def test_docker_no_project_no_deps_starts_clean(tmp_path: Path):
     apps_dir = tmp_path / "apps"
     apps_dir.mkdir()
 
-    result = run_hassette_container(volumes=[f"{apps_dir}:/apps:ro"])
-    output = result.stderr + result.stdout
+    result, output = run_hassette_container(volumes=[f"{apps_dir}:/apps:ro"])
 
     assert result.returncode == 0, f"Clean start failed. Output:\n{output}"
     assert "project install: skipped" in output

--- a/tests/test_docker_integration.py
+++ b/tests/test_docker_integration.py
@@ -44,14 +44,9 @@ def run_hassette_container(
     return subprocess.run(cmd, capture_output=True, text=True, timeout=timeout)
 
 
-def run_requirements_container(
-    apps_dir: Path, *, extra_env: dict[str, str] | None = None
-) -> tuple[subprocess.CompletedProcess[str], str]:
+def run_requirements_container(apps_dir: Path) -> tuple[subprocess.CompletedProcess[str], str]:
     """Run the container with INSTALL_DEPS=1 and a read-only apps mount, returning (result, combined output)."""
-    env = {"HASSETTE__INSTALL_DEPS": "1"}
-    if extra_env:
-        env.update(extra_env)
-    result = run_hassette_container(volumes=[f"{apps_dir}:/apps:ro"], env=env)
+    result = run_hassette_container(volumes=[f"{apps_dir}:/apps:ro"], env={"HASSETTE__INSTALL_DEPS": "1"})
     return result, result.stderr + result.stdout
 
 

--- a/tests/test_docker_integration.py
+++ b/tests/test_docker_integration.py
@@ -13,9 +13,65 @@ from pathlib import Path
 
 import pytest
 
-# Allow overriding the Docker image for testing
-# Default to locally built image, can override with HASSETTE_TEST_IMAGE env var
 DOCKER_IMAGE = os.getenv("HASSETTE_TEST_IMAGE", "hassette:test")
+
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.docker,
+    pytest.mark.skipif(shutil.which("docker") is None, reason="Docker not installed"),
+]
+
+
+def run_hassette_container(
+    *,
+    volumes: list[str] | None = None,
+    env: dict[str, str] | None = None,
+    timeout: int = 60,
+) -> subprocess.CompletedProcess[str]:
+    """Run the hassette Docker image with ``--version`` and return the completed process."""
+    cmd = ["docker", "run", "--rm"]
+    for vol in volumes or []:
+        cmd.extend(["-v", vol])
+    merged_env = {
+        "HASSETTE__APPS__DIRECTORY": "/apps",
+        "HASSETTE__TOKEN": "test_token",
+        "HASSETTE__BASE_URL": "http://test",
+    }
+    merged_env.update(env or {})
+    for key, value in merged_env.items():
+        cmd.extend(["-e", f"{key}={value}"])
+    cmd.extend([DOCKER_IMAGE, "--version"])
+    return subprocess.run(cmd, capture_output=True, text=True, timeout=timeout)
+
+
+def run_requirements_container(
+    apps_dir: Path, *, extra_env: dict[str, str] | None = None
+) -> tuple[subprocess.CompletedProcess[str], str]:
+    """Run the container with INSTALL_DEPS=1 and a read-only apps mount, returning (result, combined output)."""
+    env = {"HASSETTE__INSTALL_DEPS": "1"}
+    if extra_env:
+        env.update(extra_env)
+    result = run_hassette_container(volumes=[f"{apps_dir}:/apps:ro"], env=env)
+    return result, result.stderr + result.stdout
+
+
+def run_project_container(project_dir: Path, *, timeout: int = 120) -> tuple[subprocess.CompletedProcess[str], str]:
+    """Run the container with PROJECT_DIR pointing to the mounted project, returning (result, combined output)."""
+    result = run_hassette_container(
+        volumes=[f"{project_dir}:/apps"],
+        env={"HASSETTE__PROJECT_DIR": "/apps"},
+        timeout=timeout,
+    )
+    return result, result.stderr + result.stdout
+
+
+def create_project_package(project_dir: Path, pyproject_content: str) -> None:
+    """Write pyproject.toml, create a minimal package, and run ``uv lock``."""
+    (project_dir / "pyproject.toml").write_text(pyproject_content)
+    pkg_dir = project_dir / "test_proj"
+    pkg_dir.mkdir()
+    (pkg_dir / "__init__.py").write_text("")
+    subprocess.run(["uv", "lock", "--directory", str(project_dir)], check=True, capture_output=True)
 
 
 @pytest.fixture
@@ -53,21 +109,13 @@ def docker_project_dir() -> Iterator[Path]:
     shutil.rmtree(tmpdir, ignore_errors=True)
 
 
-@pytest.mark.integration
-@pytest.mark.docker
-@pytest.mark.skipif(shutil.which("docker") is None, reason="Docker not installed")
-def test_docker_installs_user_requirements():
+def test_docker_installs_user_requirements(tmp_path: Path):
     """Test that Docker container finds and installs user requirements.txt."""
-    with tempfile.TemporaryDirectory() as tmpdir:
-        tmp_path = Path(tmpdir)
+    apps_dir = tmp_path / "apps"
+    apps_dir.mkdir()
+    (apps_dir / "requirements.txt").write_text("requests>=2.28\n")
 
-        # Create a test app directory with requirements
-        apps_dir = tmp_path / "apps"
-        apps_dir.mkdir()
-        (apps_dir / "requirements.txt").write_text("requests>=2.28\n")
-
-        # Create a simple app
-        (apps_dir / "test_app.py").write_text("""
+    (apps_dir / "test_app.py").write_text("""
 from hassette import App, AppConfig
 
 class TestApp(App[AppConfig]):
@@ -77,191 +125,69 @@ class TestApp(App[AppConfig]):
         self.logger.info(f"requests version: {requests.__version__}")
 """)
 
-        # Run Docker container with mounted volume
-        result = subprocess.run(
-            [
-                "docker",
-                "run",
-                "--rm",
-                "-v",
-                f"{apps_dir}:/apps:ro",
-                "-e",
-                "HASSETTE__APPS__DIRECTORY=/apps",
-                "-e",
-                "HASSETTE__TOKEN=test_token",
-                "-e",
-                "HASSETTE__BASE_URL=http://test",
-                "-e",
-                "HASSETTE__INSTALL_DEPS=1",
-                DOCKER_IMAGE,
-                "--version",
-            ],
-            capture_output=True,
-            text=True,
-            timeout=60,
-        )
+    result, output = run_requirements_container(apps_dir)
 
-        output = result.stderr + result.stdout
-
-        # Check that requirements were found and installed
-        assert "Installing requirements from" in output, f"Requirements not installed. Output:\n{output}"
-        assert "requirements.txt" in output
-        assert result.returncode == 0
+    assert "Installing requirements from" in output, f"Requirements not installed. Output:\n{output}"
+    assert "requirements.txt" in output
+    assert result.returncode == 0
 
 
-@pytest.mark.integration
-@pytest.mark.docker
-@pytest.mark.skipif(shutil.which("docker") is None, reason="Docker not installed")
-def test_docker_finds_nested_requirements():
+def test_docker_finds_nested_requirements(tmp_path: Path):
     """Test that requirements.txt in subdirectories are found."""
-    with tempfile.TemporaryDirectory() as tmpdir:
-        tmp_path = Path(tmpdir)
+    apps_dir = tmp_path / "apps"
+    (apps_dir / "app1" / "subdir").mkdir(parents=True)
+    (apps_dir / "app1" / "subdir" / "requirements.txt").write_text("httpx>=0.25\n")
 
-        # Create nested structure
-        apps_dir = tmp_path / "apps"
-        (apps_dir / "app1" / "subdir").mkdir(parents=True)
-        (apps_dir / "app1" / "subdir" / "requirements.txt").write_text("httpx>=0.25\n")
+    result, output = run_requirements_container(apps_dir)
 
-        result = subprocess.run(
-            [
-                "docker",
-                "run",
-                "--rm",
-                "-v",
-                f"{apps_dir}:/apps:ro",
-                "-e",
-                "HASSETTE__APPS__DIRECTORY=/apps",
-                "-e",
-                "HASSETTE__TOKEN=test_token",
-                "-e",
-                "HASSETTE__BASE_URL=http://test",
-                "-e",
-                "HASSETTE__INSTALL_DEPS=1",
-                DOCKER_IMAGE,
-                "--version",
-            ],
-            capture_output=True,
-            text=True,
-            timeout=60,
-        )
-
-        output = result.stderr + result.stdout
-        assert result.returncode == 0, f"Container exited with {result.returncode}. Output:\n{output}"
-        assert "Installing requirements from" in output
-        assert "requirements.txt" in output
+    assert result.returncode == 0, f"Container exited with {result.returncode}. Output:\n{output}"
+    assert "Installing requirements from" in output
+    assert "requirements.txt" in output
 
 
-@pytest.mark.integration
-@pytest.mark.docker
-@pytest.mark.skipif(shutil.which("docker") is None, reason="Docker not installed")
-def test_docker_installs_from_config_and_apps():
+def test_docker_installs_from_config_and_apps(tmp_path: Path):
     """Test that requirements.txt in both /config and /apps are found."""
-    with tempfile.TemporaryDirectory() as tmpdir:
-        tmp_path = Path(tmpdir)
+    config_dir = tmp_path / "config"
+    apps_dir = tmp_path / "apps"
+    config_dir.mkdir()
+    apps_dir.mkdir()
 
-        # Create both config and apps directories
-        config_dir = tmp_path / "config"
-        apps_dir = tmp_path / "apps"
-        config_dir.mkdir()
-        apps_dir.mkdir()
+    (config_dir / "requirements.txt").write_text("pyyaml>=6.0\n")
+    (apps_dir / "requirements.txt").write_text("httpx>=0.25\n")
 
-        (config_dir / "requirements.txt").write_text("pyyaml>=6.0\n")
-        (apps_dir / "requirements.txt").write_text("httpx>=0.25\n")
+    result = run_hassette_container(
+        volumes=[f"{config_dir}:/config:ro", f"{apps_dir}:/apps:ro"],
+        env={"HASSETTE__CONFIG_DIR": "/config", "HASSETTE__INSTALL_DEPS": "1"},
+    )
+    output = result.stderr + result.stdout
 
-        result = subprocess.run(
-            [
-                "docker",
-                "run",
-                "--rm",
-                "-v",
-                f"{config_dir}:/config:ro",
-                "-v",
-                f"{apps_dir}:/apps:ro",
-                "-e",
-                "HASSETTE__APPS__DIRECTORY=/apps",
-                "-e",
-                "HASSETTE__CONFIG_DIR=/config",
-                "-e",
-                "HASSETTE__TOKEN=test_token",
-                "-e",
-                "HASSETTE__BASE_URL=http://test",
-                "-e",
-                "HASSETTE__INSTALL_DEPS=1",
-                DOCKER_IMAGE,
-                "--version",
-            ],
-            capture_output=True,
-            text=True,
-            timeout=60,
-        )
-
-        output = result.stderr + result.stdout
-
-        # Both requirements files should be installed
-        assert output.count("Installing requirements from") >= 2, f"Not all requirements found. Output:\n{output}"
+    assert output.count("Installing requirements from") >= 2, f"Not all requirements found. Output:\n{output}"
 
 
-@pytest.mark.integration
-@pytest.mark.docker
-@pytest.mark.skipif(shutil.which("docker") is None, reason="Docker not installed")
-def test_docker_skips_empty_requirements():
+def test_docker_skips_empty_requirements(tmp_path: Path):
     """Test that empty requirements.txt files are skipped by the -s guard."""
-    with tempfile.TemporaryDirectory() as tmpdir:
-        tmp_path = Path(tmpdir)
+    apps_dir = tmp_path / "apps"
+    apps_dir.mkdir()
 
-        apps_dir = tmp_path / "apps"
-        apps_dir.mkdir()
+    # Empty requirements.txt in a subdirectory — fd finds it but -s guard skips it
+    empty_dir = apps_dir / "emptyapp"
+    empty_dir.mkdir()
+    (empty_dir / "requirements.txt").touch()
 
-        # Empty requirements.txt in a subdirectory — fd finds it but -s guard skips it
-        empty_dir = apps_dir / "emptyapp"
-        empty_dir.mkdir()
-        (empty_dir / "requirements.txt").touch()
+    # Non-empty requirements.txt — should be installed
+    (apps_dir / "requirements.txt").write_text("requests\n")
 
-        # Non-empty requirements.txt — should be installed
-        (apps_dir / "requirements.txt").write_text("requests\n")
+    _, output = run_requirements_container(apps_dir)
 
-        result = subprocess.run(
-            [
-                "docker",
-                "run",
-                "--rm",
-                "-v",
-                f"{apps_dir}:/apps:ro",
-                "-e",
-                "HASSETTE__APPS__DIRECTORY=/apps",
-                "-e",
-                "HASSETTE__TOKEN=test_token",
-                "-e",
-                "HASSETTE__BASE_URL=http://test",
-                "-e",
-                "HASSETTE__INSTALL_DEPS=1",
-                DOCKER_IMAGE,
-                "--version",
-            ],
-            capture_output=True,
-            text=True,
-            timeout=60,
-        )
-
-        output = result.stderr + result.stdout
-
-        # Only the non-empty file should be installed (1 install, not 2)
-        assert output.count("Installing requirements from") == 1, f"Expected 1 install. Output:\n{output}"
+    assert output.count("Installing requirements from") == 1, f"Expected 1 install. Output:\n{output}"
 
 
-@pytest.mark.integration
-@pytest.mark.docker
-@pytest.mark.skipif(shutil.which("docker") is None, reason="Docker not installed")
-def test_docker_handles_missing_requirements():
+def test_docker_handles_missing_requirements(tmp_path: Path):
     """Test that Docker starts successfully even without requirements.txt."""
-    with tempfile.TemporaryDirectory() as tmpdir:
-        tmp_path = Path(tmpdir)
+    apps_dir = tmp_path / "apps"
+    apps_dir.mkdir()
 
-        apps_dir = tmp_path / "apps"
-        apps_dir.mkdir()
-
-        # No requirements.txt file
-        (apps_dir / "test_app.py").write_text("""
+    (apps_dir / "test_app.py").write_text("""
 from hassette import App, AppConfig
 
 class TestApp(App[AppConfig]):
@@ -269,408 +195,129 @@ class TestApp(App[AppConfig]):
         pass
 """)
 
-        result = subprocess.run(
-            [
-                "docker",
-                "run",
-                "--rm",
-                "-v",
-                f"{apps_dir}:/apps:ro",
-                "-e",
-                "HASSETTE__APPS__DIRECTORY=/apps",
-                "-e",
-                "HASSETTE__TOKEN=test_token",
-                "-e",
-                "HASSETTE__BASE_URL=http://test",
-                "-e",
-                "HASSETTE__INSTALL_DEPS=1",
-                DOCKER_IMAGE,
-                "--version",
-            ],
-            capture_output=True,
-            text=True,
-            timeout=60,
-        )
+    result, output = run_requirements_container(apps_dir)
 
-        # Should complete successfully
-        assert result.returncode == 0
-        # Should show completion message even with no requirements found
-        assert "requirements install: complete (0 file(s))" in (result.stderr + result.stdout)
+    assert result.returncode == 0
+    assert "requirements install: complete (0 file(s))" in output
 
 
-@pytest.mark.integration
-@pytest.mark.docker
-@pytest.mark.skipif(shutil.which("docker") is None, reason="Docker not installed")
-def test_docker_installs_requirements_dev_variants():
+def test_docker_installs_requirements_dev_variants(tmp_path: Path):
     """Test that requirements-dev.txt is NOT installed (fd pattern is exact match only)."""
-    with tempfile.TemporaryDirectory() as tmpdir:
-        tmp_path = Path(tmpdir)
+    apps_dir = tmp_path / "apps"
+    apps_dir.mkdir()
 
-        apps_dir = tmp_path / "apps"
-        apps_dir.mkdir()
+    (apps_dir / "requirements.txt").write_text("requests\n")
+    (apps_dir / "requirements-dev.txt").write_text("pytest\n")
 
-        (apps_dir / "requirements.txt").write_text("requests\n")
-        (apps_dir / "requirements-dev.txt").write_text("pytest\n")
+    _, output = run_requirements_container(apps_dir)
 
-        result = subprocess.run(
-            [
-                "docker",
-                "run",
-                "--rm",
-                "-v",
-                f"{apps_dir}:/apps:ro",
-                "-e",
-                "HASSETTE__APPS__DIRECTORY=/apps",
-                "-e",
-                "HASSETTE__TOKEN=test_token",
-                "-e",
-                "HASSETTE__BASE_URL=http://test",
-                "-e",
-                "HASSETTE__INSTALL_DEPS=1",
-                DOCKER_IMAGE,
-                "--version",
-            ],
-            capture_output=True,
-            text=True,
-            timeout=60,
-        )
-
-        output = result.stderr + result.stdout
-
-        # Only requirements.txt should be installed; dev variant must be ignored
-        assert output.count("Installing requirements from") == 1
-        assert "requirements.txt" in output
-        assert "requirements-dev.txt" not in output
+    assert output.count("Installing requirements from") == 1
+    assert "requirements.txt" in output
+    assert "requirements-dev.txt" not in output
 
 
-@pytest.mark.integration
-@pytest.mark.docker
-@pytest.mark.skipif(shutil.which("docker") is None, reason="Docker not installed")
-def test_docker_skips_requirements_by_default():
+def test_docker_skips_requirements_by_default(tmp_path: Path):
     """Test that requirements are NOT installed when INSTALL_DEPS is unset (default-off)."""
-    with tempfile.TemporaryDirectory() as tmpdir:
-        tmp_path = Path(tmpdir)
+    apps_dir = tmp_path / "apps"
+    apps_dir.mkdir()
+    (apps_dir / "requirements.txt").write_text("requests\n")
 
-        apps_dir = tmp_path / "apps"
-        apps_dir.mkdir()
-        (apps_dir / "requirements.txt").write_text("requests\n")
+    result = run_hassette_container(volumes=[f"{apps_dir}:/apps:ro"])
+    output = result.stderr + result.stdout
 
-        result = subprocess.run(
-            [
-                "docker",
-                "run",
-                "--rm",
-                "-v",
-                f"{apps_dir}:/apps:ro",
-                "-e",
-                "HASSETTE__APPS__DIRECTORY=/apps",
-                "-e",
-                "HASSETTE__TOKEN=test_token",
-                "-e",
-                "HASSETTE__BASE_URL=http://test",
-                # Intentionally omitting HASSETTE__INSTALL_DEPS
-                DOCKER_IMAGE,
-                "--version",
-            ],
-            capture_output=True,
-            text=True,
-            timeout=60,
-        )
-
-        output = result.stderr + result.stdout
-
-        # Startup should succeed but requirements should be skipped
-        assert result.returncode == 0
-        assert "requirements install: disabled" in output
-        assert "Installing requirements from" not in output
+    assert result.returncode == 0
+    assert "requirements install: disabled" in output
+    assert "Installing requirements from" not in output
 
 
-@pytest.mark.integration
-@pytest.mark.docker
-@pytest.mark.skipif(shutil.which("docker") is None, reason="Docker not installed")
-def test_docker_constraint_conflict():
+def test_docker_constraint_conflict(tmp_path: Path):
     """Test that a requirements.txt conflicting with constraints fails with a clear error."""
-    with tempfile.TemporaryDirectory() as tmpdir:
-        tmp_path = Path(tmpdir)
+    apps_dir = tmp_path / "apps"
+    apps_dir.mkdir()
 
-        apps_dir = tmp_path / "apps"
-        apps_dir.mkdir()
+    # aiohttp==3.0.0 conflicts with hassette's aiohttp>=3.9 constraint
+    (apps_dir / "requirements.txt").write_text("aiohttp==3.0.0\n")
 
-        # aiohttp==3.0.0 conflicts with hassette's aiohttp>=3.9 constraint
-        (apps_dir / "requirements.txt").write_text("aiohttp==3.0.0\n")
+    result, output = run_requirements_container(apps_dir)
 
-        result = subprocess.run(
-            [
-                "docker",
-                "run",
-                "--rm",
-                "-v",
-                f"{apps_dir}:/apps:ro",
-                "-e",
-                "HASSETTE__APPS__DIRECTORY=/apps",
-                "-e",
-                "HASSETTE__TOKEN=test_token",
-                "-e",
-                "HASSETTE__BASE_URL=http://test",
-                "-e",
-                "HASSETTE__INSTALL_DEPS=1",
-                DOCKER_IMAGE,
-                "--version",
-            ],
-            capture_output=True,
-            text=True,
-            timeout=60,
-        )
-
-        output = result.stderr + result.stdout
-
-        # Container must exit with non-zero code
-        assert result.returncode != 0, f"Expected non-zero exit for conflict. Output:\n{output}"
-        # Must display the DEPENDENCY CONFLICT banner
-        assert "DEPENDENCY CONFLICT" in output, f"Expected DEPENDENCY CONFLICT banner. Output:\n{output}"
+    assert result.returncode != 0, f"Expected non-zero exit for conflict. Output:\n{output}"
+    assert "DEPENDENCY CONFLICT" in output, f"Expected DEPENDENCY CONFLICT banner. Output:\n{output}"
 
 
-@pytest.mark.integration
-@pytest.mark.docker
-@pytest.mark.skipif(shutil.which("docker") is None, reason="Docker not installed")
 def test_docker_project_install_with_lockfile(docker_project_dir: Path):
     """Test that a project with uv.lock triggers the export-then-install path."""
-    (docker_project_dir / "pyproject.toml").write_text(
+    create_project_package(
+        docker_project_dir,
         '[project]\nname = "test-proj"\nversion = "0.1.0"\n'
         'requires-python = ">=3.11"\ndependencies = []\n'
-        '\n[build-system]\nrequires = ["hatchling"]\nbuild-backend = "hatchling.build"\n'
+        '\n[build-system]\nrequires = ["hatchling"]\nbuild-backend = "hatchling.build"\n',
     )
-    pkg_dir = docker_project_dir / "test_proj"
-    pkg_dir.mkdir()
-    (pkg_dir / "__init__.py").write_text("")
-    subprocess.run(["uv", "lock", "--directory", str(docker_project_dir)], check=True, capture_output=True)
+    result, output = run_project_container(docker_project_dir)
 
-    result = subprocess.run(
-        [
-            "docker",
-            "run",
-            "--rm",
-            "-v",
-            f"{docker_project_dir}:/apps",
-            "-e",
-            "HASSETTE__APPS__DIRECTORY=/apps",
-            "-e",
-            "HASSETTE__PROJECT_DIR=/apps",
-            "-e",
-            "HASSETTE__TOKEN=test_token",
-            "-e",
-            "HASSETTE__BASE_URL=http://test",
-            DOCKER_IMAGE,
-            "--version",
-        ],
-        capture_output=True,
-        text=True,
-        timeout=120,
-    )
-
-    output = result.stderr + result.stdout
     assert result.returncode == 0, f"Project install failed. Output:\n{output}"
     assert "project install: complete" in output
 
 
-@pytest.mark.integration
-@pytest.mark.docker
-@pytest.mark.skipif(shutil.which("docker") is None, reason="Docker not installed")
 def test_docker_project_install_without_build_system(docker_project_dir: Path):
     """Test that a project without [build-system] still installs via uv's default backend."""
-    (docker_project_dir / "pyproject.toml").write_text(
-        '[project]\nname = "test-proj"\nversion = "0.1.0"\nrequires-python = ">=3.11"\ndependencies = []\n'
+    create_project_package(
+        docker_project_dir,
+        '[project]\nname = "test-proj"\nversion = "0.1.0"\nrequires-python = ">=3.11"\ndependencies = []\n',
     )
-    pkg_dir = docker_project_dir / "test_proj"
-    pkg_dir.mkdir()
-    (pkg_dir / "__init__.py").write_text("")
-    subprocess.run(["uv", "lock", "--directory", str(docker_project_dir)], check=True, capture_output=True)
+    result, output = run_project_container(docker_project_dir)
 
-    result = subprocess.run(
-        [
-            "docker",
-            "run",
-            "--rm",
-            "-v",
-            f"{docker_project_dir}:/apps",
-            "-e",
-            "HASSETTE__APPS__DIRECTORY=/apps",
-            "-e",
-            "HASSETTE__PROJECT_DIR=/apps",
-            "-e",
-            "HASSETTE__TOKEN=test_token",
-            "-e",
-            "HASSETTE__BASE_URL=http://test",
-            DOCKER_IMAGE,
-            "--version",
-        ],
-        capture_output=True,
-        text=True,
-        timeout=120,
-    )
-
-    output = result.stderr + result.stdout
     assert result.returncode == 0, f"Project without [build-system] should still work. Output:\n{output}"
     assert "project install: complete" in output
 
 
-@pytest.mark.integration
-@pytest.mark.docker
-@pytest.mark.skipif(shutil.which("docker") is None, reason="Docker not installed")
 def test_docker_project_without_lockfile_warns(docker_project_dir: Path):
     """Test that pyproject.toml without uv.lock logs a warning to run uv lock."""
     (docker_project_dir / "pyproject.toml").write_text(
         '[project]\nname = "test-proj"\nversion = "0.1.0"\ndependencies = []\n'
     )
+    result, output = run_project_container(docker_project_dir, timeout=60)
 
-    result = subprocess.run(
-        [
-            "docker",
-            "run",
-            "--rm",
-            "-v",
-            f"{docker_project_dir}:/apps",
-            "-e",
-            "HASSETTE__APPS__DIRECTORY=/apps",
-            "-e",
-            "HASSETTE__PROJECT_DIR=/apps",
-            "-e",
-            "HASSETTE__TOKEN=test_token",
-            "-e",
-            "HASSETTE__BASE_URL=http://test",
-            DOCKER_IMAGE,
-            "--version",
-        ],
-        capture_output=True,
-        text=True,
-        timeout=60,
-    )
-
-    output = result.stderr + result.stdout
     assert result.returncode == 0, f"Container should still start. Output:\n{output}"
     assert "uv lock" in output, f"Expected lockfile warning. Output:\n{output}"
 
 
-@pytest.mark.integration
-@pytest.mark.docker
-@pytest.mark.skipif(shutil.which("docker") is None, reason="Docker not installed")
 def test_docker_project_install_with_real_dep(docker_project_dir: Path):
     """Test that a project with an actual dependency gets it installed through constraints."""
-    (docker_project_dir / "pyproject.toml").write_text(
+    create_project_package(
+        docker_project_dir,
         '[project]\nname = "test-proj"\nversion = "0.1.0"\n'
         'requires-python = ">=3.11"\ndependencies = ["tabulate>=0.9"]\n'
-        '\n[build-system]\nrequires = ["hatchling"]\nbuild-backend = "hatchling.build"\n'
+        '\n[build-system]\nrequires = ["hatchling"]\nbuild-backend = "hatchling.build"\n',
     )
-    pkg_dir = docker_project_dir / "test_proj"
-    pkg_dir.mkdir()
-    (pkg_dir / "__init__.py").write_text("")
-    subprocess.run(["uv", "lock", "--directory", str(docker_project_dir)], check=True, capture_output=True)
+    result, output = run_project_container(docker_project_dir)
 
-    result = subprocess.run(
-        [
-            "docker",
-            "run",
-            "--rm",
-            "-v",
-            f"{docker_project_dir}:/apps",
-            "-e",
-            "HASSETTE__APPS__DIRECTORY=/apps",
-            "-e",
-            "HASSETTE__PROJECT_DIR=/apps",
-            "-e",
-            "HASSETTE__TOKEN=test_token",
-            "-e",
-            "HASSETTE__BASE_URL=http://test",
-            DOCKER_IMAGE,
-            "--version",
-        ],
-        capture_output=True,
-        text=True,
-        timeout=120,
-    )
-
-    output = result.stderr + result.stdout
     assert result.returncode == 0, f"Project install with real dep failed. Output:\n{output}"
     assert "project install: complete" in output
 
 
-@pytest.mark.integration
-@pytest.mark.docker
-@pytest.mark.skipif(shutil.which("docker") is None, reason="Docker not installed")
 def test_docker_project_constraint_conflict(docker_project_dir: Path):
     """Test that a project whose lockfile conflicts with hassette's constraints fails with a clear error."""
     # aiohttp==3.0.0 conflicts with hassette's aiohttp>=3.9 constraint
-    (docker_project_dir / "pyproject.toml").write_text(
+    create_project_package(
+        docker_project_dir,
         '[project]\nname = "test-proj"\nversion = "0.1.0"\n'
         'requires-python = ">=3.11"\ndependencies = ["aiohttp==3.0.0"]\n'
-        '\n[build-system]\nrequires = ["hatchling"]\nbuild-backend = "hatchling.build"\n'
+        '\n[build-system]\nrequires = ["hatchling"]\nbuild-backend = "hatchling.build"\n',
     )
-    pkg_dir = docker_project_dir / "test_proj"
-    pkg_dir.mkdir()
-    (pkg_dir / "__init__.py").write_text("")
-    subprocess.run(["uv", "lock", "--directory", str(docker_project_dir)], check=True, capture_output=True)
+    result, output = run_project_container(docker_project_dir)
 
-    result = subprocess.run(
-        [
-            "docker",
-            "run",
-            "--rm",
-            "-v",
-            f"{docker_project_dir}:/apps",
-            "-e",
-            "HASSETTE__APPS__DIRECTORY=/apps",
-            "-e",
-            "HASSETTE__PROJECT_DIR=/apps",
-            "-e",
-            "HASSETTE__TOKEN=test_token",
-            "-e",
-            "HASSETTE__BASE_URL=http://test",
-            DOCKER_IMAGE,
-            "--version",
-        ],
-        capture_output=True,
-        text=True,
-        timeout=120,
-    )
-
-    output = result.stderr + result.stdout
     assert result.returncode != 0, f"Expected non-zero exit for project constraint conflict. Output:\n{output}"
     assert "DEPENDENCY CONFLICT" in output, f"Expected DEPENDENCY CONFLICT banner. Output:\n{output}"
 
 
-@pytest.mark.integration
-@pytest.mark.docker
-@pytest.mark.skipif(shutil.which("docker") is None, reason="Docker not installed")
-def test_docker_no_project_no_deps_starts_clean():
+def test_docker_no_project_no_deps_starts_clean(tmp_path: Path):
     """Test that a container with no project and INSTALL_DEPS unset starts cleanly."""
-    with tempfile.TemporaryDirectory() as tmpdir:
-        tmp_path = Path(tmpdir)
+    apps_dir = tmp_path / "apps"
+    apps_dir.mkdir()
 
-        apps_dir = tmp_path / "apps"
-        apps_dir.mkdir()
+    result = run_hassette_container(volumes=[f"{apps_dir}:/apps:ro"])
+    output = result.stderr + result.stdout
 
-        result = subprocess.run(
-            [
-                "docker",
-                "run",
-                "--rm",
-                "-v",
-                f"{apps_dir}:/apps:ro",
-                "-e",
-                "HASSETTE__APPS__DIRECTORY=/apps",
-                "-e",
-                "HASSETTE__TOKEN=test_token",
-                "-e",
-                "HASSETTE__BASE_URL=http://test",
-                DOCKER_IMAGE,
-                "--version",
-            ],
-            capture_output=True,
-            text=True,
-            timeout=60,
-        )
-
-        output = result.stderr + result.stdout
-        assert result.returncode == 0, f"Clean start failed. Output:\n{output}"
-        assert "project install: skipped" in output
-        assert "requirements install: disabled" in output
+    assert result.returncode == 0, f"Clean start failed. Output:\n{output}"
+    assert "project install: skipped" in output
+    assert "requirements install: disabled" in output

--- a/tests/test_docker_requirements_discovery.py
+++ b/tests/test_docker_requirements_discovery.py
@@ -6,7 +6,6 @@ correctly finds user's requirements.txt files in mounted volumes.
 
 import shutil
 import subprocess
-import tempfile
 from pathlib import Path
 
 import pytest
@@ -14,159 +13,100 @@ import pytest
 fd_path = shutil.which("fd") or shutil.which("fdfind")
 
 
+def find_requirements(*search_dirs: str | Path) -> list[str]:
+    """Run fd to discover requirements.txt files, matching docker_start.sh's exact-match pattern."""
+    result = subprocess.run(
+        [fd_path, "-t", "f", "-a", "-0", "--max-depth", "5", "^requirements\\.txt$", *(str(d) for d in search_dirs)],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return [f for f in result.stdout.split("\0") if f]
+
+
 @pytest.mark.skipif(fd_path is None, reason="fd command not found")
-def test_fd_finds_requirements_txt():
+def test_fd_finds_requirements_txt(tmp_path: Path):
     """Test that fd command finds requirements.txt files as expected."""
-    with tempfile.TemporaryDirectory() as tmpdir:
-        tmp_path = Path(tmpdir)
+    (tmp_path / "app1").mkdir()
+    (tmp_path / "app1" / "requirements.txt").write_text("requests>=2.28\n")
 
-        # Create test structure
-        (tmp_path / "app1").mkdir()
-        (tmp_path / "app1" / "requirements.txt").write_text("requests>=2.28\n")
+    (tmp_path / "app2" / "subdir").mkdir(parents=True)
+    (tmp_path / "app2" / "subdir" / "requirements.txt").write_text("aiohttp>=3.9\n")
 
-        (tmp_path / "app2" / "subdir").mkdir(parents=True)
-        (tmp_path / "app2" / "subdir" / "requirements.txt").write_text("aiohttp>=3.9\n")
+    # This should NOT be found (wrong extension)
+    (tmp_path / "requirements.md").write_text("# Not a requirements file\n")
 
-        # This should NOT be found (wrong extension)
-        (tmp_path / "requirements.md").write_text("# Not a requirements file\n")
+    found_files = find_requirements(tmp_path)
 
-        # Run the fd command (matching docker_start.sh logic — exact anchored regex, no --extension)
-        result = subprocess.run(
-            [fd_path, "-t", "f", "-a", "-0", "--max-depth", "5", "^requirements\\.txt$", str(tmp_path)],
-            capture_output=True,
-            text=True,
-            check=True,
-        )
-
-        # Split by null terminator and filter empty strings
-        found_files = [f for f in result.stdout.split("\0") if f]
-
-        assert len(found_files) == 2, f"Expected 2 files, found {len(found_files)}: {found_files}"
-        assert any("app1/requirements.txt" in f for f in found_files)
-        assert any("app2/subdir/requirements.txt" in f for f in found_files)
+    assert len(found_files) == 2, f"Expected 2 files, found {len(found_files)}: {found_files}"
+    assert any("app1/requirements.txt" in f for f in found_files)
+    assert any("app2/subdir/requirements.txt" in f for f in found_files)
 
 
 @pytest.mark.skipif(fd_path is None, reason="fd command not found")
-def test_fd_finds_requirements_in_config_and_apps():
+def test_fd_finds_requirements_in_config_and_apps(tmp_path: Path):
     """Test fd finds requirements in both CONFIG and APP_DIR."""
-    with tempfile.TemporaryDirectory() as tmpdir:
-        tmp_path = Path(tmpdir)
+    config_dir = tmp_path / "config"
+    apps_dir = tmp_path / "apps"
+    config_dir.mkdir()
+    apps_dir.mkdir()
 
-        # Simulate /config and /apps directories
-        config_dir = tmp_path / "config"
-        apps_dir = tmp_path / "apps"
-        config_dir.mkdir()
-        apps_dir.mkdir()
+    (config_dir / "requirements.txt").write_text("pyyaml>=6.0\n")
+    (apps_dir / "requirements.txt").write_text("httpx>=0.25\n")
 
-        (config_dir / "requirements.txt").write_text("pyyaml>=6.0\n")
-        (apps_dir / "requirements.txt").write_text("httpx>=0.25\n")
+    found_files = find_requirements(config_dir, apps_dir)
 
-        # Run fd on both roots (space-separated like in script)
-        result = subprocess.run(
-            [
-                fd_path,
-                "-t",
-                "f",
-                "-a",
-                "-0",
-                "--max-depth",
-                "5",
-                "^requirements\\.txt$",
-                str(config_dir),
-                str(apps_dir),
-            ],
-            capture_output=True,
-            text=True,
-            check=True,
-        )
-
-        found_files = [f for f in result.stdout.split("\0") if f]
-
-        assert len(found_files) == 2
-        assert any("config/requirements.txt" in f for f in found_files)
-        assert any("apps/requirements.txt" in f for f in found_files)
+    assert len(found_files) == 2
+    assert any("config/requirements.txt" in f for f in found_files)
+    assert any("apps/requirements.txt" in f for f in found_files)
 
 
 @pytest.mark.skipif(fd_path is None, reason="fd command not found")
-def test_fd_ignores_hidden_files():
+def test_fd_ignores_hidden_files(tmp_path: Path):
     """Test that fd ignores .git, .venv, etc by default."""
-    with tempfile.TemporaryDirectory() as tmpdir:
-        tmp_path = Path(tmpdir)
+    (tmp_path / ".venv").mkdir()
+    (tmp_path / ".venv" / "requirements.txt").write_text("ignored\n")
 
-        # Create requirements in .venv (should be ignored)
-        (tmp_path / ".venv").mkdir()
-        (tmp_path / ".venv" / "requirements.txt").write_text("ignored\n")
+    (tmp_path / "requirements.txt").write_text("found\n")
 
-        # Create requirements in normal location (should be found)
-        (tmp_path / "requirements.txt").write_text("found\n")
+    found_files = find_requirements(tmp_path)
 
-        result = subprocess.run(
-            [fd_path, "-t", "f", "-a", "-0", "--max-depth", "5", "^requirements\\.txt$", str(tmp_path)],
-            capture_output=True,
-            text=True,
-            check=True,
-        )
-
-        found_files = [f for f in result.stdout.split("\0") if f]
-
-        # Should only find the one NOT in .venv
-        assert len(found_files) == 1
-        assert ".venv" not in found_files[0]
+    assert len(found_files) == 1
+    assert ".venv" not in found_files[0]
 
 
 @pytest.mark.skipif(fd_path is None, reason="fd command not found")
-def test_empty_requirements_files_skipped():
+def test_empty_requirements_files_skipped(tmp_path: Path):
     """Test that empty requirements.txt files are skipped (script checks with -s)."""
-    with tempfile.TemporaryDirectory() as tmpdir:
-        tmp_path = Path(tmpdir)
+    # Empty file — exact match pattern finds it, but script skips it
+    (tmp_path / "requirements.txt").touch()
 
-        # Empty file — exact match pattern finds it, but script skips it
-        (tmp_path / "requirements.txt").touch()
+    # Non-empty file in a subdir
+    (tmp_path / "subapp").mkdir()
+    (tmp_path / "subapp" / "requirements.txt").write_text("requests\n")
 
-        # Non-empty file in a subdir
-        (tmp_path / "subapp").mkdir()
-        (tmp_path / "subapp" / "requirements.txt").write_text("requests\n")
+    found_files = find_requirements(tmp_path)
 
-        result = subprocess.run(
-            [fd_path, "-t", "f", "-a", "-0", "--max-depth", "5", "^requirements\\.txt$", str(tmp_path)],
-            capture_output=True,
-            text=True,
-            check=True,
-        )
+    # Both should be found by fd, but script filters empty ones with [ -s "$req" ]
+    assert len(found_files) == 2
 
-        found_files = [f for f in result.stdout.split("\0") if f]
-
-        # Both should be found by fd, but script filters empty ones with [ -s "$req" ]
-        assert len(found_files) == 2
-
-        # Simulate the script's [ -s "$req" ] check
-        non_empty = [f for f in found_files if Path(f).stat().st_size > 0]
-        assert len(non_empty) == 1
-        assert "subapp/requirements.txt" in non_empty[0]
+    # Simulate the script's [ -s "$req" ] check
+    non_empty = [f for f in found_files if Path(f).stat().st_size > 0]
+    assert len(non_empty) == 1
+    assert "subapp/requirements.txt" in non_empty[0]
 
 
 @pytest.mark.skipif(fd_path is None, reason="fd command not found")
-def test_fd_handles_multiple_requirements_patterns():
+def test_fd_handles_multiple_requirements_patterns(tmp_path: Path):
     """Test that only requirements.txt is found; dev/test variants are excluded by exact-match pattern."""
-    with tempfile.TemporaryDirectory() as tmpdir:
-        tmp_path = Path(tmpdir)
+    (tmp_path / "requirements.txt").write_text("base\n")
+    (tmp_path / "requirements-dev.txt").write_text("dev\n")
+    (tmp_path / "requirements_test.txt").write_text("test\n")
 
-        # Create various requirements file patterns
-        (tmp_path / "requirements.txt").write_text("base\n")
-        (tmp_path / "requirements-dev.txt").write_text("dev\n")
-        (tmp_path / "requirements_test.txt").write_text("test\n")
+    found_files = find_requirements(tmp_path)
 
-        result = subprocess.run(
-            [fd_path, "-t", "f", "-a", "-0", "--max-depth", "5", "^requirements\\.txt$", str(tmp_path)],
-            capture_output=True,
-            text=True,
-            check=True,
-        )
-
-        found_files = [f for f in result.stdout.split("\0") if f]
-
-        # Only the exact requirements.txt should be found — dev/test variants are excluded
-        assert len(found_files) == 1, f"Expected 1 file, found {len(found_files)}: {found_files}"
-        assert any("requirements.txt" in f and "requirements-dev.txt" not in f for f in found_files)
-        assert not any("requirements-dev.txt" in f for f in found_files)
-        assert not any("requirements_test.txt" in f for f in found_files)
+    # Only the exact requirements.txt should be found — dev/test variants are excluded
+    assert len(found_files) == 1, f"Expected 1 file, found {len(found_files)}: {found_files}"
+    assert any("requirements.txt" in f and "requirements-dev.txt" not in f for f in found_files)
+    assert not any("requirements-dev.txt" in f for f in found_files)
+    assert not any("requirements_test.txt" in f for f in found_files)

--- a/tests/test_docker_requirements_discovery.py
+++ b/tests/test_docker_requirements_discovery.py
@@ -20,6 +20,7 @@ def find_requirements(*search_dirs: str | Path) -> list[str]:
         capture_output=True,
         text=True,
         check=True,
+        timeout=30,
     )
     return [f for f in result.stdout.split("\0") if f]
 


### PR DESCRIPTION
## Summary

Extract shared helpers from the Docker integration test files to eliminate 16 duplicate code clusters flagged by `check_duplicate_code.py` (PMD CPD). Net reduction of 418 lines across the two files with no behavior change — all existing test coverage is preserved.

## What changed

Five helpers extracted to the top of each file (shared across tests within the same module):

- `run_hassette_container()` — core Docker run with common env vars
- `run_requirements_container()` — `INSTALL_DEPS=1` + read-only apps mount
- `run_project_container()` — `PROJECT_DIR` + project mount
- `create_project_package()` — `pyproject.toml` + package dir + `uv lock`
- `find_requirements()` — `fd` invocation + null-separated output parsing

Additional cleanup:

- Replaced per-test `@pytest.mark.docker_integration` decorators with module-level `pytestmark`
- Switched from `tempfile.TemporaryDirectory` to pytest's `tmp_path` fixture
- Removed an unused `extra_env` parameter from `run_requirements_container` (second commit)

## How it was tested

- `uv run nox -s dev` — 6927 passed, 1 skipped, 2 xfailed
- `prek -a` + `prek pyright -a --stage pre-push` — all Python checks pass

Closes #1568
