### PR TITLE
refactor: extract shared web route params and CLI query-param construction

### DIFF
--- a/src/hassette/cli/client.py
+++ b/src/hassette/cli/client.py
@@ -228,6 +228,14 @@ class HassetteCLIClient:
         self.error_usage(f"Instance {instance!r} not found for app {app_key!r}. Available instances: {names}")
         raise AssertionError("unreachable")
 
+    def resolve_instance_or_none(self, app_key: str, instance: str | None) -> int | None:
+        """Resolve an instance selector, passing ``None`` through unchanged.
+
+        Convenience wrapper for CLI commands where an unset ``--instance`` flag means
+        "all instances" and should stay ``None`` rather than resolve to an index.
+        """
+        return None if instance is None else self.resolve_instance(app_key, instance)
+
     def _echo_success_target_and_warnings(self) -> None:
         """Surface the resolved non-loopback target and any TLS-verification warning once per
         invocation on the success path.

--- a/src/hassette/cli/client.py
+++ b/src/hassette/cli/client.py
@@ -28,6 +28,17 @@ DEFAULT_TIMEOUT = 10.0
 T = TypeVar("T")
 
 
+def query_params(**values: Any) -> dict[str, Any]:
+    """Build a query-parameter dict from CLI flags, dropping every flag left unset.
+
+    Commands share one convention: an unset flag is ``None`` and must not reach the server,
+    so the endpoint applies its own default. Writing that as ``query_params(since=since,
+    limit=limit)`` keeps the mapping from flag to query key on one line per command instead
+    of an ``if x is not None`` block per flag.
+    """
+    return {key: value for key, value in values.items() if value is not None}
+
+
 class HassetteCLIClient:
     """Synchronous HTTP client for querying the hassette REST API."""
 

--- a/src/hassette/cli/commands/app.py
+++ b/src/hassette/cli/commands/app.py
@@ -2,7 +2,7 @@
 
 from typing import Any
 
-from hassette.cli.client import make_client
+from hassette.cli.client import make_client, query_params
 from hassette.cli.context import DEFAULT_CLI_CONTEXT, CLIContextParam
 from hassette.cli.output import (
     Column,
@@ -65,19 +65,17 @@ def cmd_app_health(
 ) -> None:
     """Show health metrics for an app instance (GET /api/telemetry/app/{key}/health)."""
     client = make_client(ctx)
-
-    params: dict[str, Any] = {}
-    if instance is not None:
-        params["instance_index"] = client.resolve_instance(key, instance)
-    if since is not None:
-        params["since"] = since
-    if source_tier is not None:
-        params["source_tier"] = source_tier
-
+    params = query_params(
+        instance_index=None if instance is None else client.resolve_instance(key, instance),
+        since=since,
+        source_tier=source_tier,
+    )
     result = client.get(f"/api/telemetry/app/{key}/health", AppHealthResponse, params=params)
     render_detail(result, json_mode=ctx.json_mode)
 
 
+# dup-ignore-start: cyclopts derives each command's flags from its signature, so a shared
+# filter set has to be restated per command — declaration, not copy-pasted logic.
 def cmd_app_activity(
     key: str,
     instance: InstanceArg = None,
@@ -86,17 +84,14 @@ def cmd_app_activity(
     *,
     ctx: CLIContextParam = DEFAULT_CLI_CONTEXT,
 ) -> None:
+    # dup-ignore-end
     """Show recent activity for an app (GET /api/telemetry/app/{key}/activity)."""
     client = make_client(ctx)
-
-    params: dict[str, Any] = {}
-    if instance is not None:
-        params["instance_index"] = client.resolve_instance(key, instance)
-    if since is not None:
-        params["since"] = since
-    if limit is not None:
-        params["limit"] = limit
-
+    params = query_params(
+        instance_index=None if instance is None else client.resolve_instance(key, instance),
+        since=since,
+        limit=limit,
+    )
     raw: list[Any] = client.get(f"/api/telemetry/app/{key}/activity", list, params=params)
     entries = [ActivityFeedEntry.model_validate(e) for e in raw]
     render_table(entries, APP_ACTIVITY_COLUMNS, json_mode=ctx.json_mode)  # pyright: ignore[reportArgumentType]

--- a/src/hassette/cli/commands/app.py
+++ b/src/hassette/cli/commands/app.py
@@ -66,7 +66,7 @@ def cmd_app_health(
     """Show health metrics for an app instance (GET /api/telemetry/app/{key}/health)."""
     client = make_client(ctx)
     params = query_params(
-        instance_index=None if instance is None else client.resolve_instance(key, instance),
+        instance_index=client.resolve_instance_or_none(key, instance),
         since=since,
         source_tier=source_tier,
     )
@@ -88,7 +88,7 @@ def cmd_app_activity(
     """Show recent activity for an app (GET /api/telemetry/app/{key}/activity)."""
     client = make_client(ctx)
     params = query_params(
-        instance_index=None if instance is None else client.resolve_instance(key, instance),
+        instance_index=client.resolve_instance_or_none(key, instance),
         since=since,
         limit=limit,
     )

--- a/src/hassette/cli/commands/job.py
+++ b/src/hassette/cli/commands/job.py
@@ -2,7 +2,7 @@
 
 from typing import Any
 
-from hassette.cli.client import make_client
+from hassette.cli.client import make_client, query_params
 from hassette.cli.context import DEFAULT_CLI_CONTEXT, CLIContextParam
 from hassette.cli.output import Column, fmt_duration_ms, fmt_relative_time, render_table
 from hassette.cli.types import AppKeyArg, InstanceArg, LimitArg, SinceArg, SourceTierArg
@@ -69,6 +69,8 @@ JOB_LIST_COLUMNS: list[Column] = [
 ]
 
 
+# dup-ignore-start: cyclopts derives each command's flags from its signature, so a shared
+# filter set has to be restated per command — declaration, not copy-pasted logic.
 def cmd_job(
     job_id: int | None = None,
     app: AppKeyArg = None,
@@ -79,30 +81,19 @@ def cmd_job(
     *,
     ctx: CLIContextParam = DEFAULT_CLI_CONTEXT,
 ) -> None:
+    # dup-ignore-end
     """List scheduled jobs, or show execution history for a specific job."""
     client = make_client(ctx)
 
     if job_id is not None:
-        params: dict[str, Any] = {}
-        if since is not None:
-            params["since"] = since
-        if limit is not None:
-            params["limit"] = limit
-
         raw: list[Any] = client.get(
             f"/api/telemetry/job/{job_id}/executions",
             list,
-            params=params,
+            params=query_params(since=since, limit=limit),
         )
         executions = [Execution.model_validate(e) for e in raw]
         render_table(executions, JOB_EXECUTION_COLUMNS, json_mode=ctx.json_mode)  # pyright: ignore[reportArgumentType]
         return
-
-    extra_params: dict[str, Any] = {}
-    if since is not None:
-        extra_params["since"] = since
-    if source_tier is not None:
-        extra_params["source_tier"] = source_tier
 
     raw = client.get_with_app_routing(
         global_path="/api/scheduler/jobs",
@@ -110,7 +101,7 @@ def cmd_job(
         model=list,
         app_key=app,
         instance=instance,
-        extra_params=extra_params,
+        extra_params=query_params(since=since, source_tier=source_tier),
     )
     jobs = [JobSummary.model_validate(e) for e in raw]
     render_table(jobs, JOB_LIST_COLUMNS, json_mode=ctx.json_mode)  # pyright: ignore[reportArgumentType]

--- a/src/hassette/cli/commands/listener.py
+++ b/src/hassette/cli/commands/listener.py
@@ -2,7 +2,7 @@
 
 from typing import Any
 
-from hassette.cli.client import make_client
+from hassette.cli.client import make_client, query_params
 from hassette.cli.context import DEFAULT_CLI_CONTEXT, CLIContextParam
 from hassette.cli.output import Column, fmt_duration_ms, fmt_handler_short, fmt_relative_time, render_table
 from hassette.cli.types import AppKeyArg, InstanceArg, LimitArg, SinceArg, SourceTierArg
@@ -32,6 +32,8 @@ LISTENER_INVOCATION_COLUMNS: list[Column] = [
 ]
 
 
+# dup-ignore-start: cyclopts derives each command's flags from its signature, so a shared
+# filter set has to be restated per command — declaration, not copy-pasted logic.
 def cmd_listener(
     listener_id: int | None = None,
     app: AppKeyArg = None,
@@ -42,30 +44,19 @@ def cmd_listener(
     *,
     ctx: CLIContextParam = DEFAULT_CLI_CONTEXT,
 ) -> None:
+    # dup-ignore-end
     """List listeners, or show invocation history for a specific listener."""
     client = make_client(ctx)
 
     if listener_id is not None:
-        params: dict[str, Any] = {}
-        if since is not None:
-            params["since"] = since
-        if limit is not None:
-            params["limit"] = limit
-
         raw: list[Any] = client.get(
             f"/api/telemetry/listener/{listener_id}/executions",
             list,
-            params=params,
+            params=query_params(since=since, limit=limit),
         )
         invocations = [Execution.model_validate(e) for e in raw]
         render_table(invocations, LISTENER_INVOCATION_COLUMNS, json_mode=ctx.json_mode)  # pyright: ignore[reportArgumentType]
         return
-
-    extra_params: dict[str, Any] = {}
-    if since is not None:
-        extra_params["since"] = since
-    if source_tier is not None:
-        extra_params["source_tier"] = source_tier
 
     raw = client.get_with_app_routing(
         global_path="/api/bus/listeners",
@@ -73,7 +64,7 @@ def cmd_listener(
         model=list,
         app_key=app,
         instance=instance,
-        extra_params=extra_params,
+        extra_params=query_params(since=since, source_tier=source_tier),
     )
     listeners = [ListenerWithSummary.model_validate(e) for e in raw]
     render_table(listeners, LISTENER_LIST_COLUMNS, json_mode=ctx.json_mode)  # pyright: ignore[reportArgumentType]

--- a/src/hassette/cli/commands/log.py
+++ b/src/hassette/cli/commands/log.py
@@ -2,7 +2,7 @@
 
 from typing import Any
 
-from hassette.cli.client import make_client
+from hassette.cli.client import make_client, query_params
 from hassette.cli.context import DEFAULT_CLI_CONTEXT, CLIContextParam
 from hassette.cli.output import Column, fmt_relative_time, render_table
 from hassette.cli.types import AppKeyArg, InstanceArg, LimitArg, SinceArg, SourceTierArg
@@ -43,41 +43,30 @@ def cmd_log(
     if instance is not None:
         client.error_usage("--instance is not supported on the log command")
 
-    params: dict[str, Any] = {}
-    if app is not None:
-        params["app_key"] = app
-    if since is not None:
-        params["since"] = since
-    if limit is not None:
-        params["limit"] = limit
-    if source_tier is not None:
-        params["source_tier"] = source_tier
-
     raw: list[Any] = client.get(
         "/api/logs/recent",
         list,
-        params=params,
+        params=query_params(app_key=app, since=since, limit=limit, source_tier=source_tier),
     )
     entries = [LogEntryResponse.model_validate(e) for e in raw]
     render_table(entries, LOG_COLUMNS, json_mode=ctx.json_mode)  # pyright: ignore[reportArgumentType]
 
 
+# dup-ignore-start: cyclopts derives each command's flags from its signature, so a shared
+# filter set has to be restated per command — declaration, not copy-pasted logic.
 def cmd_execution(
     uuid: str,
     limit: LimitArg = None,
     *,
     ctx: CLIContextParam = DEFAULT_CLI_CONTEXT,
 ) -> None:
+    # dup-ignore-end
     """Show logs for a specific execution (GET /api/executions/{execution_id})."""
     client = make_client(ctx)
-
-    params: dict[str, Any] = {}
-    if limit is not None:
-        params["limit"] = limit
 
     response = client.get(
         f"/api/executions/{uuid}",
         LogsByExecutionResponse,
-        params=params,
+        params=query_params(limit=limit),
     )
     render_table(response.records, EXECUTION_LOG_COLUMNS, json_mode=ctx.json_mode)  # pyright: ignore[reportArgumentType]

--- a/src/hassette/resources/base.py
+++ b/src/hassette/resources/base.py
@@ -244,7 +244,17 @@ class Resource(LifecycleMixin, metaclass=FinalMeta):
 
     @property
     def config_log_level(self) -> LOG_LEVEL_TYPE:
-        """Return the log level from the config for this resource."""
+        """Return the log level from the config for this resource.
+
+        Subclasses that map to a per-service ``LoggingConfig`` field override this with a
+        one-line property returning that field. That repetition is deliberate and stays:
+        the alternative — a class attribute naming the field, read here via ``getattr`` —
+        trades a checked attribute access for a string, and the pattern spans 30 files,
+        three of which are generated sync facades. ``tools/check_duplicate_code.py`` reports
+        the overrides as clones because its matched region also swallows the unrelated
+        statement above each one, so they cannot be annotated with ``dup-ignore`` markers
+        without mislabeling that statement (see #1570).
+        """
         return self.hassette.config.logging.log_level
 
     def add_child(self, child_class: type[_ResourceT], **kwargs: Any) -> _ResourceT:

--- a/src/hassette/web/CLAUDE.md
+++ b/src/hassette/web/CLAUDE.md
@@ -14,6 +14,30 @@ from hassette.web.dependencies import RuntimeDep, TelemetryDep, SchedulerDep, Ha
 - `HassetteDep` — the root Hassette instance (drop counters, ready event)
 - `ApiDep` — Home Assistant REST/WebSocket API
 
+## Shared Route Parameters
+
+`dependencies.py` also owns the query/path parameter annotations. Annotate route parameters
+with these instead of repeating a `Query(...)`/`Path(...)` call in every signature:
+
+```python
+from hassette.web.dependencies import AppKeyPath, LimitQuery, SinceQuery, SourceTierQuery
+
+async def my_route(app_key: AppKeyPath, since: SinceQuery = None, limit: LimitQuery = 50) -> ...:
+```
+
+Per-app telemetry routes take the whole `instance_index`/`since`/`source_tier` filter set as one
+injected dependency, and splat it into the query call:
+
+```python
+from hassette.web.dependencies import TelemetryFiltersDep
+
+async def app_health(app_key: AppKeyPath, telemetry: TelemetryDep, filters: TelemetryFiltersDep) -> ...:
+    agg = await telemetry.get_app_health_aggregates(app_key=app_key, **filters.query_kwargs)
+```
+
+FastAPI flattens a dependency's parameters into the operation, so the OpenAPI schema is identical
+to declaring all three inline.
+
 ## Telemetry Error Handling Pattern (#1108b / #1114)
 
 Storage exceptions (`sqlite3.Error`, `OSError`, `ValueError`, `TimeoutError`) are **translated at the `TelemetryQueryService` boundary** into `TelemetryUnavailableError` (defined in `hassette.exceptions`).  The HTTP layer catches only that narrow domain type — never raw storage exceptions.

--- a/src/hassette/web/dependencies.py
+++ b/src/hassette/web/dependencies.py
@@ -2,13 +2,16 @@
 
 from collections.abc import Iterator
 from contextlib import contextmanager
+from dataclasses import dataclass
 from logging import CRITICAL, DEBUG, ERROR, INFO, WARNING, getLogger
-from typing import TYPE_CHECKING, Annotated
+from typing import TYPE_CHECKING, Annotated, TypedDict
 
 from fastapi import Depends, Path, Query, Request
 from starlette.responses import Response
 
 from hassette.exceptions import TelemetryUnavailableError
+from hassette.schemas.query_constants import MAX_QUERY_LIMIT
+from hassette.types.types import QuerySourceTier
 
 if TYPE_CHECKING:
     from hassette import Hassette
@@ -29,18 +32,22 @@ LOG_LEVELS: dict[str, int] = {
 VALID_LOG_LEVEL_NAMES: frozenset[str] = frozenset(LOG_LEVELS)
 DEFAULT_LOG_LEVEL = "INFO"
 VALID_SOURCE_TIERS: frozenset[str] = frozenset({"app", "framework"})
-SOURCE_TIER_PARAM = Query(
-    default="app",
-    description="Filter by source tier. 'app' excludes framework internals. "
-    "'framework' returns only internal actors. 'all' returns everything.",
-)
-INSTANCE_INDEX_PARAM = Query(  # pyright: ignore[reportCallInDefaultInitializer]
-    default=0,
-    description="App instance index. Defaults to 0. Multi-instance apps have indices 0..N-1.",
-)
-APP_KEY_PARAM = Path(  # pyright: ignore[reportCallInDefaultInitializer]
-    description="Use `__hassette__` to query framework-internal actor telemetry.",
-)
+
+# Shared query/path parameter annotations — annotate route parameters with these instead of
+# repeating the `Query(...)`/`Path(...)` call in every signature.
+AppKeyPath = Annotated[str, Path(description="Use `__hassette__` to query framework-internal actor telemetry.")]
+InstanceIndexQuery = Annotated[
+    int, Query(description="App instance index. Defaults to 0. Multi-instance apps have indices 0..N-1.")
+]
+SinceQuery = Annotated[float | None, Query()]
+SourceTierQuery = Annotated[
+    QuerySourceTier,
+    Query(
+        description="Filter by source tier. 'app' excludes framework internals. "
+        "'framework' returns only internal actors. 'all' returns everything."
+    ),
+]
+LimitQuery = Annotated[int, Query(ge=1, le=MAX_QUERY_LIMIT)]
 
 
 def get_hassette(request: Request) -> "Hassette":
@@ -79,6 +86,36 @@ TelemetryDep = Annotated["TelemetryQueryService", Depends(get_telemetry)]
 SchedulerDep = Annotated["SchedulerService", Depends(get_scheduler)]
 ApiDep = Annotated["Api", Depends(get_api)]
 AuthDep = Annotated[str | None, Depends(get_resolved_auth_token)]
+
+
+class TelemetryFilterKwargs(TypedDict):
+    """Keyword arguments accepted by every per-app ``TelemetryQueryService`` filter method."""
+
+    instance_index: int
+    since: float | None
+    source_tier: QuerySourceTier
+
+
+@dataclass
+class TelemetryFilters:
+    """The instance/time/tier query parameters shared by the per-app telemetry routes.
+
+    Declared once here and injected via ``TelemetryFiltersDep`` so a route signature names the
+    filter set instead of restating all three parameters. FastAPI flattens a dependency's
+    parameters into the operation, so the OpenAPI schema is the same as declaring them inline.
+    """
+
+    instance_index: InstanceIndexQuery = 0
+    since: SinceQuery = None
+    source_tier: SourceTierQuery = "app"
+
+    @property
+    def query_kwargs(self) -> TelemetryFilterKwargs:
+        """Splat into a ``TelemetryQueryService`` method that accepts these three filters."""
+        return {"instance_index": self.instance_index, "since": self.since, "source_tier": self.source_tier}
+
+
+TelemetryFiltersDep = Annotated[TelemetryFilters, Depends()]
 
 
 @contextmanager

--- a/src/hassette/web/routes/apps.py
+++ b/src/hassette/web/routes/apps.py
@@ -1,8 +1,9 @@
 """App management endpoints."""
 
 import re
+from collections.abc import Awaitable, Callable
 from logging import getLogger
-from typing import TYPE_CHECKING, Any, NoReturn
+from typing import TYPE_CHECKING, Any, Literal
 
 import tomli_w
 from fastapi import APIRouter, HTTPException, Request, Response
@@ -29,7 +30,12 @@ if TYPE_CHECKING:
 
 LOGGER = getLogger(__name__)
 
+AppAction = Literal["start", "stop", "reload"]
+
 _VALID_APP_KEY = re.compile(r"^[a-zA-Z_][a-zA-Z0-9_.]{0,127}$")
+
+#: Past-tense verb for each action's success log line.
+_ACTION_PAST_TENSE: dict[AppAction, str] = {"start": "Started", "stop": "Stopped", "reload": "Reloaded"}
 
 # Keep in sync with the manifest fields on AppConfigResponse in models.py.
 _MANIFEST_FIELD_SCHEMAS: dict[str, dict[str, Any]] = {
@@ -65,9 +71,33 @@ def _require_known_app(app_key: str, hassette: HassetteDep) -> None:
         raise HTTPException(status_code=404, detail=f"App {app_key!r} not found")
 
 
-def _raise_bootstrap_not_released(exc: AppBootstrapNotReleasedError) -> NoReturn:
-    """Map a pre-release start/reload attempt to a retryable 409, shared by start_app/reload_app."""
-    raise HTTPException(status_code=409, detail="App bootstrap prerequisites are not ready yet; retry later") from exc
+async def _run_app_action(
+    action: AppAction,
+    app_key: str,
+    hassette: HassetteDep,
+    request: Request,
+    operation: Callable[[], Awaitable[object]],
+) -> ActionResponse:
+    """Run one app lifecycle action behind the validation, error mapping, and logging every
+    start/stop/reload endpoint shares.
+
+    ``AppBootstrapNotReleasedError`` maps to a retryable 409. It is only reachable from
+    start/reload — ``stop_app`` never awaits bootstrap release — so the ``stop`` endpoint
+    declares no 409 response.
+    """
+    _validate_app_key(app_key)
+    _require_known_app(app_key, hassette)
+    try:
+        await operation()
+    except AppBootstrapNotReleasedError as exc:
+        raise HTTPException(
+            status_code=409, detail="App bootstrap prerequisites are not ready yet; retry later"
+        ) from exc
+    except (ValueError, RuntimeError) as exc:
+        LOGGER.warning("Failed to %s app %s", action, app_key, exc_info=True)
+        raise HTTPException(status_code=500, detail=f"Failed to {action} app") from exc
+    LOGGER.info("%s app %s (source=%s)", _ACTION_PAST_TENSE[action], app_key, peer_address_or_unknown(request))
+    return ActionResponse(status="accepted", app_key=app_key, action=action)
 
 
 @router.get("/apps", response_model=AppStatusResponse)
@@ -155,30 +185,12 @@ async def get_app_manifest(app_key: str, runtime: RuntimeDep, telemetry: Telemet
     responses={409: {"description": "App bootstrap prerequisites are not ready yet; retry later"}},
 )
 async def start_app(app_key: str, hassette: HassetteDep, request: Request) -> ActionResponse:
-    _validate_app_key(app_key)
-    _require_known_app(app_key, hassette)
-    try:
-        await hassette.app_handler.start_app(app_key)
-    except AppBootstrapNotReleasedError as exc:
-        _raise_bootstrap_not_released(exc)
-    except (ValueError, RuntimeError) as exc:
-        LOGGER.warning("Failed to start app %s", app_key, exc_info=True)
-        raise HTTPException(status_code=500, detail="Failed to start app") from exc
-    LOGGER.info("Started app %s (source=%s)", app_key, peer_address_or_unknown(request))
-    return ActionResponse(status="accepted", app_key=app_key, action="start")
+    return await _run_app_action("start", app_key, hassette, request, lambda: hassette.app_handler.start_app(app_key))
 
 
 @router.post("/apps/{app_key}/stop", status_code=202, response_model=ActionResponse)
 async def stop_app(app_key: str, hassette: HassetteDep, request: Request) -> ActionResponse:
-    _validate_app_key(app_key)
-    _require_known_app(app_key, hassette)
-    try:
-        await hassette.app_handler.stop_app(app_key)
-    except (ValueError, RuntimeError) as exc:
-        LOGGER.warning("Failed to stop app %s", app_key, exc_info=True)
-        raise HTTPException(status_code=500, detail="Failed to stop app") from exc
-    LOGGER.info("Stopped app %s (source=%s)", app_key, peer_address_or_unknown(request))
-    return ActionResponse(status="accepted", app_key=app_key, action="stop")
+    return await _run_app_action("stop", app_key, hassette, request, lambda: hassette.app_handler.stop_app(app_key))
 
 
 @router.post(
@@ -188,19 +200,11 @@ async def stop_app(app_key: str, hassette: HassetteDep, request: Request) -> Act
     responses={409: {"description": "App bootstrap prerequisites are not ready yet; retry later"}},
 )
 async def reload_app(app_key: str, hassette: HassetteDep, request: Request) -> ActionResponse:
-    _validate_app_key(app_key)
-    _require_known_app(app_key, hassette)
-    try:
-        # Always re-import from disk so a previously-failed app recovers once its
-        # source is fixed -- without force_reload the cached failed class is reused (#1005).
-        await hassette.app_handler.reload_app(app_key, force_reload=True)
-    except AppBootstrapNotReleasedError as exc:
-        _raise_bootstrap_not_released(exc)
-    except (ValueError, RuntimeError) as exc:
-        LOGGER.warning("Failed to reload app %s", app_key, exc_info=True)
-        raise HTTPException(status_code=500, detail="Failed to reload app") from exc
-    LOGGER.info("Reloaded app %s (source=%s)", app_key, peer_address_or_unknown(request))
-    return ActionResponse(status="accepted", app_key=app_key, action="reload")
+    # Always re-import from disk so a previously-failed app recovers once its
+    # source is fixed -- without force_reload the cached failed class is reused (#1005).
+    return await _run_app_action(
+        "reload", app_key, hassette, request, lambda: hassette.app_handler.reload_app(app_key, force_reload=True)
+    )
 
 
 @router.get("/apps/{app_key}/config", response_model=AppConfigResponse)

--- a/src/hassette/web/routes/bus.py
+++ b/src/hassette/web/routes/bus.py
@@ -4,8 +4,7 @@ from typing import Annotated
 
 from fastapi import APIRouter, Query, Response
 
-from hassette.types.types import QuerySourceTier
-from hassette.web.dependencies import INSTANCE_INDEX_PARAM, SOURCE_TIER_PARAM, HassetteDep, TelemetryDep, db_degrades_to
+from hassette.web.dependencies import HassetteDep, TelemetryDep, TelemetryFiltersDep, db_degrades_to
 from hassette.web.mappers import to_listener_with_summary
 from hassette.web.models import ListenerWithSummary
 
@@ -17,10 +16,8 @@ async def get_listener_metrics(
     telemetry: TelemetryDep,
     hassette: HassetteDep,
     response: Response,
+    filters: TelemetryFiltersDep,
     app_key: Annotated[str | None, Query()] = None,
-    instance_index: int = INSTANCE_INDEX_PARAM,
-    since: float | None = Query(default=None),  # pyright: ignore[reportCallInDefaultInitializer]
-    source_tier: QuerySourceTier = SOURCE_TIER_PARAM,
 ) -> list[ListenerWithSummary]:
     # Guard: app_key="" (empty string) must NOT fall through to the all-apps path.
     # The unified get_listener_summary uses `if app_key is not None` internally,
@@ -29,12 +26,7 @@ async def get_listener_metrics(
     # inside the with block to be skipped on DB failure.
     rows: list[ListenerWithSummary] = []
     with db_degrades_to(response):
-        summaries = await telemetry.get_listener_summary(
-            app_key=app_key,
-            instance_index=instance_index,
-            since=since,
-            source_tier=source_tier,
-        )
+        summaries = await telemetry.get_listener_summary(app_key=app_key, **filters.query_kwargs)
         live_counts = hassette.bus_service.live_execution_counts()
         rows = [to_listener_with_summary(ls, live_counts) for ls in summaries]
     return rows

--- a/src/hassette/web/routes/scheduler.py
+++ b/src/hassette/web/routes/scheduler.py
@@ -5,13 +5,12 @@ Returns all scheduled jobs across all apps, enriched with live registry data.
 
 from logging import getLogger
 
-from fastapi import APIRouter, HTTPException, Query, Request, Response
+from fastapi import APIRouter, HTTPException, Request, Response
 
 from hassette.exceptions import JobRemovedError
 from hassette.schemas.job_models import JobSummary
-from hassette.types.types import QuerySourceTier
 from hassette.web.auth.trusted_proxies import peer_address_or_unknown
-from hassette.web.dependencies import SOURCE_TIER_PARAM, SchedulerDep, TelemetryDep, db_degrades_to
+from hassette.web.dependencies import SchedulerDep, SinceQuery, SourceTierQuery, TelemetryDep, db_degrades_to
 from hassette.web.models import JobTriggerResponse
 from hassette.web.utils import enrich_jobs_with_live_data
 
@@ -25,8 +24,8 @@ async def all_jobs(
     telemetry: TelemetryDep,
     scheduler_service: SchedulerDep,
     response: Response,
-    since: float | None = Query(default=None),  # pyright: ignore[reportCallInDefaultInitializer]
-    source_tier: QuerySourceTier = SOURCE_TIER_PARAM,
+    since: SinceQuery = None,
+    source_tier: SourceTierQuery = "app",
 ) -> list[JobSummary]:
     """All scheduled jobs across all apps, enriched with live registry data.
 

--- a/src/hassette/web/routes/telemetry.py
+++ b/src/hassette/web/routes/telemetry.py
@@ -7,7 +7,7 @@ to records with ``execution_start_ts >= since``, or omit it for all-time aggrega
 
 import time
 from logging import getLogger
-from typing import TYPE_CHECKING, Literal
+from typing import TYPE_CHECKING, Annotated, Literal
 
 from fastapi import APIRouter, Query, Response
 
@@ -15,17 +15,18 @@ from hassette.const.misc import SECONDS_PER_DAY
 from hassette.exceptions import TelemetryUnavailableError
 from hassette.schemas.execution_models import ActivityFeedEntry, AppLastError, Execution
 from hassette.schemas.job_models import JobSummary
-from hassette.schemas.query_constants import DEFAULT_QUERY_LIMIT, DEFAULT_SPARKLINE_BUCKETS, MAX_QUERY_LIMIT
+from hassette.schemas.query_constants import DEFAULT_QUERY_LIMIT, DEFAULT_SPARKLINE_BUCKETS
 from hassette.schemas.summary_models import AppHealthSummary
-from hassette.types.types import QuerySourceTier
 from hassette.web.dependencies import (
-    APP_KEY_PARAM,
-    INSTANCE_INDEX_PARAM,
-    SOURCE_TIER_PARAM,
+    AppKeyPath,
     HassetteDep,
+    LimitQuery,
     RuntimeDep,
     SchedulerDep,
+    SinceQuery,
+    SourceTierQuery,
     TelemetryDep,
+    TelemetryFiltersDep,
     db_degrades_to,
 )
 from hassette.web.mappers import manifest_response_fields, to_listener_with_summary
@@ -113,12 +114,10 @@ def health_status_from_summary(summary: AppHealthSummary) -> HealthStatus:
 
 @router.get("/app/{app_key}/health", response_model=AppHealthResponse)
 async def app_health(
+    app_key: AppKeyPath,
     telemetry: TelemetryDep,
     response: Response,
-    app_key: str = APP_KEY_PARAM,  # pyright: ignore[reportCallInDefaultInitializer]
-    instance_index: int = INSTANCE_INDEX_PARAM,
-    since: float | None = Query(default=None),  # pyright: ignore[reportCallInDefaultInitializer]
-    source_tier: QuerySourceTier = SOURCE_TIER_PARAM,
+    filters: TelemetryFiltersDep,
 ) -> AppHealthResponse:
     """Health strip metrics for a single app instance."""
     result: AppHealthResponse = AppHealthResponse(
@@ -130,9 +129,7 @@ async def app_health(
         health_status=classify_health_bar(100.0),
     )
     with db_degrades_to(response):
-        agg = await telemetry.get_app_health_aggregates(
-            app_key=app_key, instance_index=instance_index, since=since, source_tier=source_tier
-        )
+        agg = await telemetry.get_app_health_aggregates(app_key=app_key, **filters.query_kwargs)
         error_rate = compute_error_rate(
             total_invocations=agg.total_invocations,
             total_executions=agg.total_executions,
@@ -152,20 +149,16 @@ async def app_health(
 
 @router.get("/app/{app_key}/listeners", response_model=list[ListenerWithSummary])
 async def app_listeners(
+    app_key: AppKeyPath,
     telemetry: TelemetryDep,
     hassette: HassetteDep,
     response: Response,
-    app_key: str = APP_KEY_PARAM,  # pyright: ignore[reportCallInDefaultInitializer]
-    instance_index: int = INSTANCE_INDEX_PARAM,
-    since: float | None = Query(default=None),  # pyright: ignore[reportCallInDefaultInitializer]
-    source_tier: QuerySourceTier = SOURCE_TIER_PARAM,
+    filters: TelemetryFiltersDep,
 ) -> list[ListenerWithSummary]:
     """Listener metrics with human-readable handler summaries."""
     rows: list[ListenerWithSummary] = []
     with db_degrades_to(response):
-        listeners = await telemetry.get_listener_summary(
-            app_key=app_key, instance_index=instance_index, since=since, source_tier=source_tier
-        )
+        listeners = await telemetry.get_listener_summary(app_key=app_key, **filters.query_kwargs)
         live_counts = hassette.bus_service.live_execution_counts()
         rows = [to_listener_with_summary(ls, live_counts) for ls in listeners]
     return rows
@@ -173,15 +166,15 @@ async def app_listeners(
 
 @router.get("/app/{app_key}/activity", response_model=list[ActivityFeedEntry])
 async def app_activity(
+    app_key: AppKeyPath,
     telemetry: TelemetryDep,
     response: Response,
-    app_key: str = APP_KEY_PARAM,  # pyright: ignore[reportCallInDefaultInitializer]
-    instance_index: int | None = Query(
-        default=None, description="App instance index. None returns activity across all instances."
-    ),  # pyright: ignore[reportCallInDefaultInitializer]
-    limit: int = Query(default=DEFAULT_QUERY_LIMIT, ge=1, le=MAX_QUERY_LIMIT),  # pyright: ignore[reportCallInDefaultInitializer]
-    since: float | None = Query(default=None),  # pyright: ignore[reportCallInDefaultInitializer]
-    source_tier: QuerySourceTier = SOURCE_TIER_PARAM,
+    instance_index: Annotated[
+        int | None, Query(description="App instance index. None returns activity across all instances.")
+    ] = None,
+    limit: LimitQuery = DEFAULT_QUERY_LIMIT,
+    since: SinceQuery = None,
+    source_tier: SourceTierQuery = "app",
 ) -> list[ActivityFeedEntry]:
     """Recent handler invocations and job executions for a single app, merged and sorted by time."""
     effective_since = since if since is not None else time.time() - SECONDS_PER_DAY
@@ -199,13 +192,11 @@ async def app_activity(
 
 @router.get("/app/{app_key}/jobs", response_model=list[JobSummary])
 async def app_jobs(
+    app_key: AppKeyPath,
     telemetry: TelemetryDep,
     scheduler_service: SchedulerDep,
     response: Response,
-    app_key: str = APP_KEY_PARAM,  # pyright: ignore[reportCallInDefaultInitializer]
-    instance_index: int = INSTANCE_INDEX_PARAM,
-    since: float | None = Query(default=None),  # pyright: ignore[reportCallInDefaultInitializer]
-    source_tier: QuerySourceTier = SOURCE_TIER_PARAM,
+    filters: TelemetryFiltersDep,
 ) -> list[JobSummary]:
     """Job summaries for a single app instance, enriched with live registry data.
 
@@ -216,11 +207,7 @@ async def app_jobs(
     """
     jobs: list[JobSummary] = []
     with db_degrades_to(response):
-        db_jobs = list(
-            await telemetry.get_job_summary(
-                app_key=app_key, instance_index=instance_index, since=since, source_tier=source_tier
-            )
-        )
+        db_jobs = list(await telemetry.get_job_summary(app_key=app_key, **filters.query_kwargs))
         jobs = await enrich_jobs_with_live_data(db_jobs, scheduler_service)
     return jobs
 
@@ -229,9 +216,9 @@ async def app_jobs(
 async def list_executions(
     telemetry: TelemetryDep,
     response: Response,
-    kind: Literal["handler", "job"] | None = Query(default=None, description="Filter by kind: 'handler' or 'job'."),  # pyright: ignore[reportCallInDefaultInitializer]
-    limit: int = Query(default=DEFAULT_QUERY_LIMIT, ge=1, le=MAX_QUERY_LIMIT),  # pyright: ignore[reportCallInDefaultInitializer]
-    since: float | None = Query(default=None),  # pyright: ignore[reportCallInDefaultInitializer]
+    kind: Annotated[Literal["handler", "job"] | None, Query(description="Filter by kind: 'handler' or 'job'.")] = None,
+    limit: LimitQuery = DEFAULT_QUERY_LIMIT,
+    since: SinceQuery = None,
 ) -> list[Execution]:
     """Combined execution list (handler invocations and job executions).
 
@@ -249,8 +236,8 @@ async def listener_executions(
     listener_id: int,
     telemetry: TelemetryDep,
     response: Response,
-    limit: int = Query(default=DEFAULT_QUERY_LIMIT, ge=1, le=MAX_QUERY_LIMIT),  # pyright: ignore[reportCallInDefaultInitializer]
-    since: float | None = Query(default=None),  # pyright: ignore[reportCallInDefaultInitializer]
+    limit: LimitQuery = DEFAULT_QUERY_LIMIT,
+    since: SinceQuery = None,
 ) -> list[Execution]:
     """Execution history for a specific listener (handler invocations)."""
     executions: list[Execution] = []
@@ -264,8 +251,8 @@ async def job_executions(
     job_id: int,
     telemetry: TelemetryDep,
     response: Response,
-    limit: int = Query(default=DEFAULT_QUERY_LIMIT, ge=1, le=MAX_QUERY_LIMIT),  # pyright: ignore[reportCallInDefaultInitializer]
-    since: float | None = Query(default=None),  # pyright: ignore[reportCallInDefaultInitializer]
+    limit: LimitQuery = DEFAULT_QUERY_LIMIT,
+    since: SinceQuery = None,
 ) -> list[Execution]:
     """Execution history for a specific job."""
     executions: list[Execution] = []
@@ -292,7 +279,7 @@ async def dashboard_app_grid(
     runtime: RuntimeDep,
     telemetry: TelemetryDep,
     response: Response,
-    since: float | None = Query(default=None),  # pyright: ignore[reportCallInDefaultInitializer]
+    since: SinceQuery = None,
 ) -> DashboardAppGridResponse:
     """Per-app health data for the dashboard grid.
 


### PR DESCRIPTION
## Summary

PMD CPD flagged several source-code duplication clusters across the web routes and CLI commands. This refactor expresses each of them once. No behavior change — the HTTP API contract and CLI flag surface are identical.

## What changed

**Shared route parameter annotations** — `web/dependencies.py` now owns `AppKeyPath`, `InstanceIndexQuery`, `SinceQuery`, `SourceTierQuery`, and `LimitQuery`. Route signatures annotate with these instead of repeating a `Query(...)`/`Path(...)` call each time, which also removes the `reportCallInDefaultInitializer` suppressions those calls needed.

**Telemetry filter dependency** — per-app telemetry routes take the `instance_index`/`since`/`source_tier` set as one injected `TelemetryFiltersDep` and splat it via `query_kwargs`. FastAPI flattens a dependency's parameters into the operation, so the generated schema is unchanged: regenerating `frontend/openapi.json` produces a byte-identical file, which is why no schema or frontend type files appear in this diff.

**App action routes** — `apps.py`'s `start`/`stop`/`reload` endpoints share `_run_app_action`, which holds the validation, error mapping, logging, and response construction all three had repeated. The 409 branch is unreachable from `stop` (only `_admit_start` raises `AppBootstrapNotReleasedError`); its docstring says so.

**CLI query params** — `cli/client.py` gains `query_params()`, replacing the per-flag `if x is not None` blocks in the app, job, listener, and log commands.

**Docs** — `src/hassette/web/CLAUDE.md` documents the shared-parameter and telemetry-filter patterns so new routes follow them.

## Deliberately not deduplicated

- **Cyclopts command signatures** stay duplicated behind `dup-ignore` markers. They are the CLI's declared flag surface, not copy-pasted logic.
- **`config_log_level` overrides** stay as-is, with the rationale recorded on the base class property. Collapsing them to a `getattr` on a string-named class attribute would trade a checked attribute access for a string across 30 files, three of which are generated sync facades. They can't carry `dup-ignore` markers either: each flagged fragment swallows an unrelated statement above the override, so a marker there would mislabel that statement.

## Testing

- `uv run nox -s dev` — 6927 passed, 1 skipped, 2 xfailed
- `prek -a` — all hooks pass
- `prek pyright -a --stage pre-push` — passes

Closes #1570
