### PR TITLE
chore(ui): consolidate drawer helpers and named constants in app.tsx

### DIFF
--- a/frontend/src/app.test.tsx
+++ b/frontend/src/app.test.tsx
@@ -5,7 +5,7 @@ import type * as React from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { components } from "./api/generated-types";
-import { App } from "./app";
+import { App, MAIN_CONTENT_ID } from "./app";
 import { useTelemetryHealth } from "./hooks/use-telemetry-health";
 import { useWebSocket } from "./hooks/use-websocket";
 import { appStatusKey, useAppStore } from "./state/store";
@@ -129,16 +129,16 @@ describe("App — layout structure", () => {
     expect(screen.getByRole("main")).toBeDefined();
   });
 
-  it("main content has id=main-content for skip link", () => {
+  it("main content carries MAIN_CONTENT_ID for the skip link", () => {
     const { container } = render(<App />);
     const main = container.querySelector("main");
-    expect(main!.getAttribute("id")).toBe("main-content");
+    expect(main!.getAttribute("id")).toBe(MAIN_CONTENT_ID);
   });
 
   it("renders a skip link", () => {
     render(<App />);
     const skipLink = screen.getByTestId("skip-link");
-    expect(skipLink.getAttribute("href")).toBe("#main-content");
+    expect(skipLink.getAttribute("href")).toBe(`#${MAIN_CONTENT_ID}`);
   });
 });
 

--- a/frontend/src/app.tsx
+++ b/frontend/src/app.tsx
@@ -50,7 +50,7 @@ import { HOME_PATH, LOGIN_PATH } from "./utils/app-routes";
 import { isFailureStatus, statusToKind } from "./utils/status";
 
 const PALETTE_STALE_TIME_MS = 300_000;
-const MAIN_CONTENT_ID = "main-content";
+export const MAIN_CONTENT_ID = "main-content";
 const SKIP_LINK_CLASS =
   "sr-only focus:not-sr-only focus:fixed focus:top-2 focus:left-2 focus:z-[var(--z-skip-link)] focus:rounded-md focus:border-2 focus:border-primary focus:bg-card focus:px-4 focus:py-2 focus:text-foreground";
 const LAYOUT_CLASS =

--- a/frontend/src/app.tsx
+++ b/frontend/src/app.tsx
@@ -1,5 +1,5 @@
 import { QueryClientProvider, useQuery } from "@tanstack/react-query";
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Toaster } from "sonner";
 import { Redirect, Route, Switch, useLocation, useSearch } from "wouter";
 
@@ -50,12 +50,16 @@ import { HOME_PATH, LOGIN_PATH } from "./utils/app-routes";
 import { isFailureStatus, statusToKind } from "./utils/status";
 
 const PALETTE_STALE_TIME_MS = 300_000;
+const MAIN_CONTENT_ID = "main-content";
 const SKIP_LINK_CLASS =
   "sr-only focus:not-sr-only focus:fixed focus:top-2 focus:left-2 focus:z-[var(--z-skip-link)] focus:rounded-md focus:border-2 focus:border-primary focus:bg-card focus:px-4 focus:py-2 focus:text-foreground";
 const LAYOUT_CLASS =
   "relative grid min-h-screen min-h-dvh [grid-template-columns:var(--size-sidebar)_1fr] gap-2 pt-2 pr-2 pb-2 pl-0 max-sidebar:grid-cols-1 max-sidebar:gap-0 max-sidebar:p-0";
 const MAIN_CLASS =
   "col-start-2 flex min-w-0 flex-col overflow-y-auto rounded-t-lg bg-card shadow-md [scrollbar-gutter:stable] max-sidebar:col-start-1 max-sidebar:rounded-none max-sidebar:shadow-none";
+
+/** Where focus lands after the mobile drawer closes: the hamburger that opened it, or main content. */
+type DrawerCloseFocusTarget = "main" | "opener";
 
 /** Bare-key shortcuts must not fire while the user is typing into the app filter or palette. */
 function isTypingTarget(target: EventTarget | null): boolean {
@@ -83,35 +87,41 @@ export function App() {
   const drawerRef = useRef<HTMLDivElement>(null);
   const drawerEverOpenedRef = useRef(false);
   const prevDrawerOpenRef = useRef(drawerOpen);
-  const drawerCloseFocusTargetRef = useRef<"main" | "opener">("opener");
+  const drawerCloseFocusTargetRef = useRef<DrawerCloseFocusTarget>("opener");
 
   if (drawerOpen && !drawerMounted) setDrawerMounted(true);
 
+  // Every close/toggle records where focus should land before flipping state, so the
+  // focus-restoration effect below has exactly one place to read that decision from.
+  const closeDrawer = useCallback((focusTarget: DrawerCloseFocusTarget = "opener") => {
+    drawerCloseFocusTargetRef.current = focusTarget;
+    setDrawerOpen(false);
+  }, []);
+
+  const toggleDrawer = useCallback(() => {
+    drawerCloseFocusTargetRef.current = "opener";
+    setDrawerOpen((prev) => !prev);
+  }, []);
+
   useEffect(() => {
-    const id = setInterval(() => {
-      if (!document.hidden) useAppStore.getState().incrementTick();
-    }, RELATIVE_TIME_TICK_MS);
-    const onVisible = () => {
+    const tickIfVisible = () => {
       if (!document.hidden) useAppStore.getState().incrementTick();
     };
-    document.addEventListener("visibilitychange", onVisible);
+    const id = setInterval(tickIfVisible, RELATIVE_TIME_TICK_MS);
+    document.addEventListener("visibilitychange", tickIfVisible);
     return () => {
       clearInterval(id);
-      document.removeEventListener("visibilitychange", onVisible);
+      document.removeEventListener("visibilitychange", tickIfVisible);
     };
   }, []);
 
   useEffect(() => {
-    drawerCloseFocusTargetRef.current = "main";
-    setDrawerOpen(false);
-  }, [location, search]);
+    closeDrawer("main");
+  }, [location, search, closeDrawer]);
 
   useEffect(() => {
-    if (!belowSidebarBreakpoint) {
-      drawerCloseFocusTargetRef.current = "main";
-      setDrawerOpen(false);
-    }
-  }, [belowSidebarBreakpoint]);
+    if (!belowSidebarBreakpoint) closeDrawer("main");
+  }, [belowSidebarBreakpoint, closeDrawer]);
 
   useEffect(() => {
     if (drawerOpen) {
@@ -122,7 +132,7 @@ export function App() {
       if (drawerCloseFocusTargetRef.current === "opener" && belowSidebarBreakpoint) {
         hamburgerRef.current?.focus();
       } else {
-        document.getElementById("main-content")?.focus();
+        document.getElementById(MAIN_CONTENT_ID)?.focus();
       }
       drawerCloseFocusTargetRef.current = "opener";
     }
@@ -135,10 +145,7 @@ export function App() {
         e.preventDefault();
         setPaletteOpen((prev) => !prev);
       }
-      if (e.key === "Escape" && drawerOpen) {
-        drawerCloseFocusTargetRef.current = "opener";
-        setDrawerOpen(false);
-      }
+      if (e.key === "Escape" && drawerOpen) closeDrawer();
       // Collapsing is desktop-only: below the breakpoint the sidebar is a drawer and its
       // collapse toggle is hidden, so honoring [ there would silently flip persisted state
       // the user cannot see until they resize back.
@@ -157,7 +164,7 @@ export function App() {
     };
     document.addEventListener("keydown", handler);
     return () => document.removeEventListener("keydown", handler);
-  }, [drawerOpen, belowSidebarBreakpoint]);
+  }, [drawerOpen, belowSidebarBreakpoint, closeDrawer]);
 
   // The login view bypasses the always-mounted shell entirely: WebSocketEffect and
   // TelemetryHealthEffect would immediately hit a rejected handshake / 401 against an
@@ -181,7 +188,7 @@ export function App() {
         <Toaster position="bottom-right" theme={theme} closeButton richColors />
 
         {/* Skip link */}
-        <a href="#main-content" className={SKIP_LINK_CLASS} data-testid="skip-link">
+        <a href={`#${MAIN_CONTENT_ID}`} className={SKIP_LINK_CLASS} data-testid="skip-link">
           Skip to main content
         </a>
 
@@ -189,12 +196,12 @@ export function App() {
         <div
           ref={drawerRef}
           className={cn(
-            "fixed top-0 bottom-0 left-0 z-[var(--z-drawer-layer)] w-60 overflow-y-auto bg-card transition-transform duration-[var(--duration-med)] ease-[var(--ease-default)]",
+            "fixed top-0 bottom-0 left-0 z-[var(--z-drawer-layer)] w-[var(--size-sidebar)] overflow-y-auto bg-card transition-transform duration-[var(--duration-med)] ease-[var(--ease-default)]",
             drawerOpen ? "translate-x-0" : "-translate-x-full",
           )}
           aria-hidden={!drawerOpen}
           data-testid="mobile-drawer"
-          {...(!drawerOpen ? { inert: true } : {})}
+          inert={!drawerOpen}
         >
           {drawerMounted && (
             <>
@@ -203,10 +210,7 @@ export function App() {
                   type="button"
                   className="flex size-[var(--size-touch)] cursor-pointer items-center justify-center rounded-md border border-border bg-transparent text-foreground-secondary transition-colors hover:bg-[var(--highlight-bg)] hover:text-foreground focus-visible:outline focus-visible:outline-2 focus-visible:outline-primary [&_svg]:size-5 [&_svg]:fill-none [&_svg]:stroke-current [&_svg]:stroke-2 [&_svg]:stroke-linecap-round [&_svg]:stroke-linejoin-round"
                   aria-label="Close navigation"
-                  onClick={() => {
-                    drawerCloseFocusTargetRef.current = "opener";
-                    setDrawerOpen(false);
-                  }}
+                  onClick={() => closeDrawer()}
                 >
                   <svg viewBox="0 0 24 24" aria-hidden="true">
                     <line x1="6" y1="6" x2="18" y2="18" />
@@ -223,10 +227,7 @@ export function App() {
             className="fixed inset-0 z-[var(--z-drawer-backdrop)] bg-[var(--overlay-background)]"
             role="presentation"
             data-testid="mobile-drawer-backdrop"
-            onClick={() => {
-              drawerCloseFocusTargetRef.current = "opener";
-              setDrawerOpen(false);
-            }}
+            onClick={() => closeDrawer()}
           />
         )}
 
@@ -235,21 +236,16 @@ export function App() {
           className={cn(
             LAYOUT_CLASS,
             sidebarCollapsed &&
-              "is-collapsed min-[901px]:[grid-template-columns:0_1fr] min-[901px]:gap-0 min-[901px]:pl-2",
+              // `not-max-sidebar` is the exact complement of the `max-sidebar` (drawer) breakpoint
+              // above, so both derive from `--breakpoint-sidebar` and can never drift apart.
+              "is-collapsed not-max-sidebar:[grid-template-columns:0_1fr] not-max-sidebar:gap-0 not-max-sidebar:pl-2",
           )}
           data-testid="layout"
         >
           {!sidebarCollapsed && <Sidebar onOpenPalette={() => setPaletteOpen(true)} />}
-          <main className={MAIN_CLASS} id="main-content" tabIndex={-1}>
-            <StatusBar
-              onMenuClick={() => {
-                drawerCloseFocusTargetRef.current = "opener";
-                setDrawerOpen((prev) => !prev);
-              }}
-              drawerOpen={drawerOpen}
-              hamburgerRef={hamburgerRef}
-            />
-            <div {...(drawerOpen ? { inert: true } : {})}>
+          <main className={MAIN_CLASS} id={MAIN_CONTENT_ID} tabIndex={-1}>
+            <StatusBar onMenuClick={toggleDrawer} drawerOpen={drawerOpen} hamburgerRef={hamburgerRef} />
+            <div inert={drawerOpen}>
               <TelemetryDegradedBanner />
               <FailedAppsAlert />
               <ErrorBoundary resetKey={location}>

--- a/tests/unit/tools/test_check_internal_anchor_links.py
+++ b/tests/unit/tools/test_check_internal_anchor_links.py
@@ -26,6 +26,8 @@ CHECK_TAG_CASES: list[tuple[str, str, str | None]] = [
     ("dynamic_expr_flagged", "<a href={appUrl}>", "{appUrl}"),
     ("dynamic_expr_external_template_not_flagged", "<a href={`https://x.com/${id}`}>", None),
     ("dynamic_expr_external_string_not_flagged", '<a href={"https://x.com"}>', None),
+    ("dynamic_expr_fragment_template_not_flagged", "<a href={`#${MAIN_CONTENT_ID}`}>", None),
+    ("dynamic_expr_fragment_string_not_flagged", '<a href={"#top"}>', None),
 ]
 
 

--- a/tools/frontend/check_internal_anchor_links.py
+++ b/tools/frontend/check_internal_anchor_links.py
@@ -29,6 +29,10 @@ EXPR_HREF = re.compile(r"\bhref\s*=\s*\{([^}]+)\}")
 # Prefixes that indicate external or non-route hrefs
 EXTERNAL_PREFIXES = ("http://", "https://", "mailto:", "tel:", "#")
 
+# Expression hrefs (href={...}) that cannot be an internal route: an absolute URL, or a
+# same-page fragment such as href={`#${MAIN_CONTENT_ID}`} (a skip link, not navigation).
+SAFE_EXPR_PREFIXES = ("`http", '"http', "`#", '"#')
+
 # file:line exemptions for cases where a native <a> is intentional
 # JSX tags can span multiple lines when attributes are wrapped. 5 lines covers
 # the longest realistic <a ... > opening tag in this codebase.
@@ -81,11 +85,11 @@ def _check_tag(tag: str, path: Path, line_num: int) -> tuple[Path, int, str] | N
     expr = EXPR_HREF.search(tag)
     if expr:
         expr_text = expr.group(1).strip()
-        # Flag all dynamic hrefs unless the expression is clearly an external URL.
-        # This is intentionally broad: a false positive is a CI failure with an
-        # actionable EXEMPTIONS entry, while a false negative is a silent full-page
-        # reload on an internal route.
-        if not (expr_text.startswith("`http") or expr_text.startswith('"http')):
+        # Flag all dynamic hrefs unless the expression is clearly an external URL or a
+        # same-page fragment. This is intentionally broad: a false positive is a CI
+        # failure with an actionable EXEMPTIONS entry, while a false negative is a
+        # silent full-page reload on an internal route.
+        if not expr_text.startswith(SAFE_EXPR_PREFIXES):
             return (path, line_num, f"{{{expr_text}}}")
 
     return None


### PR DESCRIPTION
## Summary

Clears the six pre-existing code-quality findings the quality scanner flagged in
`frontend/src/app.tsx`. All of them are local to that one component — no API,
schema, or behavior changes for app authors.

## What changed

**Drawer state handling.** The pair of "record where focus should land, then flip
`drawerOpen`" statements was duplicated across six call sites (Escape key, close
button, backdrop click, route change, breakpoint change, hamburger toggle) and had
to stay in lockstep. Extracted `closeDrawer(focusTarget)` and `toggleDrawer()` so
the focus-restoration effect reads that decision from exactly one place.

**Named constants over magic values.**
- `MAIN_CONTENT_ID` now backs the skip-link href, the `<main>` id, and the
  focus-restoration `getElementById` lookup, which previously repeated the literal
  `"main-content"` three times.
- The mobile drawer uses `w-[var(--size-sidebar)]` instead of `w-60`, sharing a
  width token with the desktop sidebar column. Both resolve to 240px, so this is a
  no-op today and stops the two from drifting.

**Breakpoint complement.** The collapsed-sidebar grid overrides used a hardcoded
`min-[901px]` arbitrary value while the surrounding layout used the `max-sidebar`
variant. These are now `not-max-sidebar`, the exact complement, so both derive from
`--breakpoint-sidebar`.

**Smaller cleanups.** Extracted `tickIfVisible` so the interval and the
`visibilitychange` listener share one callback, and replaced the conditional
`{...(cond ? { inert: true } : {})}` spreads with React 19's boolean `inert` prop.

**Lint tool.** `check_internal_anchor_links` flags every dynamic `href={...}`,
which the skip link now has after the `MAIN_CONTENT_ID` extraction. Taught it that
an expression href starting with `#` is a same-page fragment rather than
navigation, and covered both the template-literal and string forms with tests.

## One behavior note

`min-[901px]` meant `width >= 901px`, while `max-sidebar` means `width < 900px` —
so at a viewport of exactly 900px the sidebar rendered as a desktop column but the
collapse overrides did not apply. `not-max-sidebar` compiles to
`@media (width >= 900px)`, closing that one-pixel gap. This is the only rendered
difference in the PR, and it is a correction rather than a regression. Every other
width renders identically, hence the `no-visual-change` label.

Verified against the built CSS rather than by inspection:

```
@media (width>=900px){.not-max-sidebar\:\[grid-template-columns\:0_1fr\]{grid-template-columns:0 1fr} ...}
```

## Testing

- `uv run nox -s dev` — 7034 passed, 1 skipped, 2 xfailed
- `prek -a` — all hooks pass (ruff, eslint, stylelint, tsc, the frontend CSS guards,
  and `check_internal_anchor_links` against its new cases)
- `prek pyright -a --stage pre-push` — pass
- `npm run test` (frontend) — 1544 passed across 106 files
- `npm run build` — succeeds; generated CSS inspected to confirm the new
  `not-max-sidebar` variant actually emits a rule rather than silently compiling to
  nothing

Closes #1596
