### PR TITLE
refactor: remove dead status helpers and name constants in apps page

### DIFF
--- a/frontend/src/hooks/use-websocket.test.ts
+++ b/frontend/src/hooks/use-websocket.test.ts
@@ -5,7 +5,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { ApiError } from "../api/client";
 import { getSystemStatus, type SystemStatus } from "../api/endpoints";
 import { useAppStore } from "../state/store";
-import { createLogEntry } from "../test/factories";
+import { createLogEntry, createSystemStatus } from "../test/factories";
 // dup-ignore-end
 import { createWouterMock } from "../test/mock-wouter";
 import {
@@ -33,20 +33,7 @@ const mockedGetSystemStatus = vi.mocked(getSystemStatus);
 // Mirrors use-websocket.ts's internal (unexported) HANDSHAKE_TIMEOUT_MS.
 const HANDSHAKE_TIMEOUT_MS = 10_000;
 
-const HEALTHY_SYSTEM_STATUS: SystemStatus = {
-  status: "ok",
-  websocket_connected: true,
-  bootstrap_released: true,
-  uptime_seconds: 120,
-  entity_count: 10,
-  app_count: 2,
-  services: [],
-  version: "1.0.0",
-  boot_issues: [],
-  log_queue_drops: 0,
-  db_write_queue_drops: 0,
-  log_persistence_active: true,
-};
+const HEALTHY_SYSTEM_STATUS: SystemStatus = createSystemStatus();
 
 describe("useWebSocket", () => {
   beforeEach(() => {

--- a/frontend/src/pages/apps.tsx
+++ b/frontend/src/pages/apps.tsx
@@ -46,7 +46,8 @@ const SECONDS_PER_HOUR = 3600;
 const VALID_SORT_KEYS: ReadonlySet<string> = new Set<AppSortState["key"]>(["name", "status", "error", "runs", "last"]);
 
 /** StatusShape size (px) for the status-filter menu rows, sized to sit inline with their
- * text-xs labels rather than with the table's larger STATUS_DOT_SIZE glyphs. */
+ * text-xs labels. Smaller than the shared STATUS_DOT_SIZE (10px), which is sized for the
+ * list rows and detail panes that import it — this page's table does not use it. */
 const FILTER_SHAPE_SIZE = 8;
 
 /** Stats-strip grid columns below the sidebar breakpoint. Mirrors StatsStrip's own
@@ -95,7 +96,7 @@ const DATA_TABLE_CLASS = [TABLE_FRAME_CLASS, TABLE_HEAD_CELL_CLASS, TABLE_BODY_C
 /** True when a raw `?filter=` query param names one of the FILTER_OPTIONS. Narrows to FilterId so
  * callers need no cast. */
 function isFilterId(value: string | null): value is FilterId {
-  return value !== null && (FILTER_OPTIONS as readonly string[]).includes(value);
+  return value !== null && FILTER_OPTIONS.some((option) => option === value);
 }
 
 function buildAppsCells(

--- a/frontend/src/pages/apps.tsx
+++ b/frontend/src/pages/apps.tsx
@@ -44,6 +44,34 @@ const FILTER_TONES: Record<FilterId, StatusKind | null> = {
 const MIN_WINDOW_FOR_RATE_CALC = 60;
 const SECONDS_PER_HOUR = 3600;
 const VALID_SORT_KEYS: ReadonlySet<string> = new Set<AppSortState["key"]>(["name", "status", "error", "runs", "last"]);
+
+/** StatusShape size (px) for the status-filter menu rows, sized to sit inline with their
+ * text-xs labels rather than with the table's larger STATUS_DOT_SIZE glyphs. */
+const FILTER_SHAPE_SIZE = 8;
+
+/** Stats-strip grid columns below the sidebar breakpoint. Mirrors StatsStrip's own
+ * `max-sidebar:grid-cols-4` so the two agree regardless of CSS rule ordering; above the
+ * breakpoint we pass no override and StatsStrip's default column count applies. */
+const COMPACT_STATS_COLUMNS = 4;
+
+/** `<colgroup>` widths as a percent of table width, index-aligned with the `<th>` cells below.
+ * The compact layout drops the last-error, runs, last-fired, and actions columns, so app and
+ * status absorb their width. Both lists total 100%. */
+const COLUMN_WIDTHS: Record<"compact" | "full", readonly { column: string; width: string }[]> = {
+  compact: [
+    { column: "app", width: "72%" },
+    { column: "status", width: "28%" },
+  ],
+  full: [
+    { column: "app", width: "35%" },
+    { column: "status", width: "12%" },
+    { column: "error", width: "22%" },
+    { column: "runs", width: "10%" },
+    { column: "last", width: "11%" },
+    { column: "actions", width: "10%" },
+  ],
+};
+
 const PAGE_CLASS = "flex min-h-0 flex-1 flex-col gap-8 p-8 max-mobile:p-3 max-small-mobile:p-2";
 const PAGE_HEADER_CLASS = "flex items-baseline gap-4 border-b border-border pb-3";
 const PAGE_TITLE_CLASS =
@@ -53,8 +81,22 @@ const SEARCH_INPUT_CLASS =
   "min-w-[var(--size-search-min)] self-end rounded-md border border-[var(--border-strong)] bg-input px-2 py-1.5 font-sans text-[length:var(--text-mono-sm)] text-foreground outline-none placeholder:text-foreground-faint focus-visible:border-primary focus-visible:shadow-[0_0_0_2px_var(--primary-soft)] max-mobile:w-full max-mobile:min-w-0 max-mobile:self-stretch";
 const ALERT_CLASS =
   "flex items-start gap-3 rounded-md border border-destructive bg-[var(--destructive-bg)] px-4 py-3 text-sm text-foreground";
-const DATA_TABLE_CLASS =
-  "w-full table-fixed border-collapse bg-card [&_thead_tr]:bg-muted [&_th]:border-b [&_th]:border-border [&_th]:px-3 [&_th]:py-2 [&_th]:text-left [&_th]:font-mono [&_th]:text-xs [&_th]:font-medium [&_th]:uppercase [&_th]:text-muted-foreground [&_th]:whitespace-nowrap [&_td]:border-b [&_td]:border-border [&_td]:px-3 [&_td]:py-2 [&_td]:align-middle [&_td]:text-[length:var(--text-small)] [&_td]:overflow-hidden [&_td]:text-ellipsis [&_tbody_tr:last-child_td]:border-b-0 [&_tbody_tr:hover]:bg-muted";
+// This page hand-rolls its <table>, so cell styling rides on the table element as `[&_th]`/
+// `[&_td]` child selectors. Split by what each group styles, then joined verbatim (not via cn(),
+// which would reorder and merge the groups).
+const TABLE_FRAME_CLASS = "w-full table-fixed border-collapse bg-card";
+const TABLE_HEAD_CELL_CLASS =
+  "[&_thead_tr]:bg-muted [&_th]:border-b [&_th]:border-border [&_th]:px-3 [&_th]:py-2 [&_th]:text-left [&_th]:font-mono [&_th]:text-xs [&_th]:font-medium [&_th]:uppercase [&_th]:text-muted-foreground [&_th]:whitespace-nowrap";
+const TABLE_BODY_CELL_CLASS =
+  "[&_td]:border-b [&_td]:border-border [&_td]:px-3 [&_td]:py-2 [&_td]:align-middle [&_td]:text-[length:var(--text-small)] [&_td]:overflow-hidden [&_td]:text-ellipsis";
+const TABLE_ROW_CLASS = "[&_tbody_tr:last-child_td]:border-b-0 [&_tbody_tr:hover]:bg-muted";
+const DATA_TABLE_CLASS = [TABLE_FRAME_CLASS, TABLE_HEAD_CELL_CLASS, TABLE_BODY_CELL_CLASS, TABLE_ROW_CLASS].join(" ");
+
+/** True when a raw `?filter=` query param names one of the FILTER_OPTIONS. Narrows to FilterId so
+ * callers need no cast. */
+function isFilterId(value: string | null): value is FilterId {
+  return value !== null && (FILTER_OPTIONS as readonly string[]).includes(value);
+}
 
 function buildAppsCells(
   apps: AppRow[],
@@ -127,7 +169,7 @@ function StatusFilterContent({
             data-testid={`filter-${f}`}
           >
             <span className="inline-flex w-full items-center gap-[var(--spacing-1-5)]">
-              {tone && <StatusShape kind={tone} size={8} />}
+              {tone && <StatusShape kind={tone} size={FILTER_SHAPE_SIZE} />}
               <span>{f}</span>
               <span className="ml-auto font-mono text-xs text-muted-foreground">{count}</span>
             </span>
@@ -165,8 +207,7 @@ export function AppsPage() {
   const isCompact = useMediaQuery(BREAKPOINT_SIDEBAR);
   const qp = useQueryParams();
   const rawFilter = qp.get("filter");
-  const filter: FilterId =
-    rawFilter !== null && (FILTER_OPTIONS as readonly string[]).includes(rawFilter) ? (rawFilter as FilterId) : "all";
+  const filter: FilterId = isFilterId(rawFilter) ? rawFilter : "all";
   const rawSort = qp.get("sort");
   const sort: AppSortState = {
     key: (rawSort !== null && VALID_SORT_KEYS.has(rawSort) ? rawSort : "status") as AppSortState["key"],
@@ -286,7 +327,7 @@ export function AppsPage() {
       <div className={TABLE_SECTION_CLASS}>
         <StatsStrip
           cells={buildAppsCells(allApps, appStatus, windowSeconds, isCompact)}
-          cols={isCompact ? 4 : undefined}
+          cols={isCompact ? COMPACT_STATS_COLUMNS : undefined}
           data-testid="apps-stats-strip"
         />
         {searchInput}
@@ -305,21 +346,9 @@ export function AppsPage() {
               data-testid="apps-table"
             >
               <colgroup>
-                {isCompact ? (
-                  <>
-                    <col className="w-[72%]" />
-                    <col className="w-[28%]" />
-                  </>
-                ) : (
-                  <>
-                    <col className="w-[35%]" />
-                    <col className="w-[12%]" />
-                    <col className="w-[22%]" />
-                    <col className="w-[10%]" />
-                    <col className="w-[11%]" />
-                    <col className="w-[10%]" />
-                  </>
-                )}
+                {COLUMN_WIDTHS[isCompact ? "compact" : "full"].map(({ column, width }) => (
+                  <col key={column} style={{ width }} />
+                ))}
               </colgroup>
               <thead>
                 <tr>

--- a/frontend/src/pages/diagnostics.test.tsx
+++ b/frontend/src/pages/diagnostics.test.tsx
@@ -4,6 +4,7 @@ import { describe, expect, it, vi } from "vitest";
 import type { components } from "../api/generated-types";
 import { queryKeys } from "../lib/query-keys";
 import type { ServiceStatusEntry } from "../state/store";
+import { createSystemStatus } from "../test/factories";
 import { createTestQueryClient } from "../test/query-test-utils";
 import { renderWithAppState } from "../test/render-helpers";
 import { server } from "../test/server";
@@ -13,26 +14,7 @@ vi.mock("../components/shared/spinner", () => ({
   Spinner: () => <div data-testid="spinner" />,
 }));
 
-type SystemStatusResponse = components["schemas"]["SystemStatusResponse"];
 type ServiceInfoResponse = components["schemas"]["ServiceInfoResponse"];
-
-function makeSystemStatus(overrides: Partial<SystemStatusResponse> = {}): SystemStatusResponse {
-  return {
-    status: "ok",
-    websocket_connected: true,
-    bootstrap_released: true,
-    uptime_seconds: 120,
-    entity_count: 10,
-    app_count: 2,
-    services: [],
-    version: "1.0.0",
-    boot_issues: [],
-    log_queue_drops: 0,
-    db_write_queue_drops: 0,
-    log_persistence_active: true,
-    ...overrides,
-  };
-}
 
 function makeServiceInfo(overrides: Partial<ServiceInfoResponse> = {}): ServiceInfoResponse {
   return {
@@ -83,7 +65,7 @@ describe("DiagnosticsPage", () => {
   });
 
   it("shows empty state when no services returned from HTTP seed", async () => {
-    server.use(http.get("/api/health", () => HttpResponse.json(makeSystemStatus({ services: [] }))));
+    server.use(http.get("/api/health", () => HttpResponse.json(createSystemStatus({ services: [] }))));
     const { findByTestId } = renderWithAppState(<DiagnosticsPage />);
     expect(await findByTestId("diag-services-empty")).toBeDefined();
   });
@@ -92,7 +74,7 @@ describe("DiagnosticsPage", () => {
     server.use(
       http.get("/api/health", () =>
         HttpResponse.json(
-          makeSystemStatus({
+          createSystemStatus({
             services: [
               makeServiceInfo({ name: "bus", status: "running" }),
               makeServiceInfo({ name: "scheduler", status: "running" }),
@@ -110,7 +92,7 @@ describe("DiagnosticsPage", () => {
     server.use(
       http.get("/api/health", () =>
         HttpResponse.json(
-          makeSystemStatus({
+          createSystemStatus({
             services: [makeServiceInfo({ name: "bus", status: "running" })],
           }),
         ),
@@ -132,7 +114,7 @@ describe("DiagnosticsPage", () => {
     server.use(
       http.get("/api/health", () =>
         HttpResponse.json(
-          makeSystemStatus({
+          createSystemStatus({
             services: [
               makeServiceInfo({ name: "db", status: "exhausted_cooling", role: "service", retry_at: futureRetryAt }),
             ],
@@ -161,7 +143,7 @@ describe("DiagnosticsPage", () => {
   });
 
   it("hides the boot issues panel when startup was clean", async () => {
-    server.use(http.get("/api/health", () => HttpResponse.json(makeSystemStatus({ boot_issues: [] }))));
+    server.use(http.get("/api/health", () => HttpResponse.json(createSystemStatus({ boot_issues: [] }))));
     const { findByTestId, queryByTestId } = renderWithAppState(<DiagnosticsPage />);
     await findByTestId("diag-services-panel");
     expect(queryByTestId("diag-boot-panel")).toBeNull();
@@ -171,7 +153,7 @@ describe("DiagnosticsPage", () => {
     server.use(
       http.get("/api/health", () =>
         HttpResponse.json(
-          makeSystemStatus({
+          createSystemStatus({
             boot_issues: [
               { severity: "warn", label: "Config warning", detail: "check your config" },
               { severity: "err", label: "Critical error", detail: "failed to load something" },
@@ -191,7 +173,7 @@ describe("DiagnosticsPage", () => {
     server.use(
       http.get("/api/health", () =>
         HttpResponse.json(
-          makeSystemStatus({
+          createSystemStatus({
             boot_issues: [{ severity: "err", label: "Some error", detail: "The full detail text" }],
           }),
         ),
@@ -256,7 +238,7 @@ describe("DiagnosticsPage", () => {
   it("flags inactive log persistence even when zero records were dropped", async () => {
     server.use(
       http.get("/api/health", () =>
-        HttpResponse.json(makeSystemStatus({ log_persistence_active: false, db_write_queue_drops: 0 })),
+        HttpResponse.json(createSystemStatus({ log_persistence_active: false, db_write_queue_drops: 0 })),
       ),
     );
     const { findByTestId } = renderWithAppState(<DiagnosticsPage />);
@@ -267,7 +249,7 @@ describe("DiagnosticsPage", () => {
   it("shows DB write drops while persistence is still active", async () => {
     server.use(
       http.get("/api/health", () =>
-        HttpResponse.json(makeSystemStatus({ log_persistence_active: true, db_write_queue_drops: 42 })),
+        HttpResponse.json(createSystemStatus({ log_persistence_active: true, db_write_queue_drops: 42 })),
       ),
     );
     const { findByTestId, queryByTestId } = renderWithAppState(<DiagnosticsPage />);
@@ -286,7 +268,7 @@ describe("DiagnosticsPage", () => {
     const queryClient = createTestQueryClient();
     queryClient.setQueryData(
       queryKeys.systemStatus(),
-      makeSystemStatus({
+      createSystemStatus({
         log_persistence_active: false,
         db_write_queue_drops: 42,
         services: [makeServiceInfo({ name: "stale-service" })],
@@ -311,7 +293,7 @@ describe("DiagnosticsPage", () => {
   it("separates log-queue drops from DB-write-queue drops", async () => {
     server.use(
       http.get("/api/health", () =>
-        HttpResponse.json(makeSystemStatus({ log_queue_drops: 12, db_write_queue_drops: 4 })),
+        HttpResponse.json(createSystemStatus({ log_queue_drops: 12, db_write_queue_drops: 4 })),
       ),
     );
     const { findByTestId } = renderWithAppState(<DiagnosticsPage />);
@@ -324,7 +306,7 @@ describe("DiagnosticsPage", () => {
   it("keeps log drop counters independent in the stats strip", async () => {
     server.use(
       http.get("/api/health", () =>
-        HttpResponse.json(makeSystemStatus({ log_queue_drops: 12, db_write_queue_drops: 4 })),
+        HttpResponse.json(createSystemStatus({ log_queue_drops: 12, db_write_queue_drops: 4 })),
       ),
     );
     const { findByTestId } = renderWithAppState(<DiagnosticsPage />, {
@@ -347,7 +329,7 @@ describe("DiagnosticsPage", () => {
     server.use(
       http.get("/api/health", () =>
         HttpResponse.json(
-          makeSystemStatus({
+          createSystemStatus({
             services: [
               makeServiceInfo({ name: "db", status: "starting", role: "service", ready_phase: "migrating schema" }),
             ],
@@ -364,7 +346,7 @@ describe("DiagnosticsPage", () => {
     server.use(
       http.get("/api/health", () =>
         HttpResponse.json(
-          makeSystemStatus({
+          createSystemStatus({
             services: [makeServiceInfo({ name: "bus", status: "running", ready_phase: "Bus initialized" })],
           }),
         ),

--- a/frontend/src/test/factories.ts
+++ b/frontend/src/test/factories.ts
@@ -23,6 +23,7 @@ type LogEntryResponse = components["schemas"]["LogEntryResponse"];
 type TelemetryStatusResponse = components["schemas"]["TelemetryStatusResponse"];
 type AppInstanceResponse = components["schemas"]["AppInstanceResponse"];
 type Execution = components["schemas"]["Execution"];
+type SystemStatusResponse = components["schemas"]["SystemStatusResponse"];
 
 export function createInstance(overrides: Partial<AppInstanceResponse> = {}): AppInstanceResponse {
   return {
@@ -259,6 +260,25 @@ export function createTelemetryStatus(overrides: Partial<TelemetryStatusResponse
     error_handler_failures: 0,
     ...overrides,
   } satisfies TelemetryStatusResponse;
+}
+
+/** A fully healthy `/api/health` response: connected, bootstrap released, nothing dropped. */
+export function createSystemStatus(overrides: Partial<SystemStatusResponse> = {}): SystemStatusResponse {
+  return {
+    status: "ok",
+    websocket_connected: true,
+    bootstrap_released: true,
+    uptime_seconds: 120,
+    entity_count: 10,
+    app_count: 2,
+    services: [],
+    version: "1.0.0",
+    boot_issues: [],
+    log_queue_drops: 0,
+    db_write_queue_drops: 0,
+    log_persistence_active: true,
+    ...overrides,
+  } satisfies SystemStatusResponse;
 }
 
 export function createExecution(kind: "handler" | "job", overrides: Partial<Execution> = {}): Execution {

--- a/frontend/src/test/handlers.ts
+++ b/frontend/src/test/handlers.ts
@@ -13,7 +13,7 @@ import { http, HttpResponse } from "msw";
 import type { SetupServer } from "msw/node";
 
 import type { components } from "../api/generated-types";
-import { createManifestList, createSystemConfig } from "./factories";
+import { createManifestList, createSystemConfig, createSystemStatus, createTelemetryStatus } from "./factories";
 
 type SystemStatusResponse = components["schemas"]["SystemStatusResponse"];
 type ManifestListResponse = components["schemas"]["AppManifestListResponse"];
@@ -136,13 +136,7 @@ export const handlers = [
 
   // GET /api/telemetry/status
   http.get("/api/telemetry/status", () => {
-    return HttpResponse.json<TelemetryStatusResponse>({
-      degraded: false,
-      dropped_overflow: 0,
-      dropped_exhausted: 0,
-      dropped_shutdown: 0,
-      error_handler_failures: 0,
-    });
+    return HttpResponse.json<TelemetryStatusResponse>(createTelemetryStatus());
   }),
 
   // GET /api/logs/recent
@@ -183,19 +177,6 @@ export const handlers = [
 
   // GET /api/health
   http.get("/api/health", () => {
-    return HttpResponse.json<SystemStatusResponse>({
-      status: "ok",
-      websocket_connected: true,
-      bootstrap_released: true,
-      uptime_seconds: 120,
-      entity_count: 10,
-      app_count: 2,
-      services: [],
-      version: "1.0.0",
-      boot_issues: [],
-      log_queue_drops: 0,
-      db_write_queue_drops: 0,
-      log_persistence_active: true,
-    });
+    return HttpResponse.json<SystemStatusResponse>(createSystemStatus());
   }),
 ];

--- a/frontend/src/utils/status.ts
+++ b/frontend/src/utils/status.ts
@@ -153,20 +153,6 @@ export function executionStatusKind(status: ExecutionStatus): StatusKind {
   return EXECUTION_STATUS_KIND[status] ?? "err";
 }
 
-const LOG_LEVEL_MAP: ReadonlyMap<string, StatusVariant> = new Map<string, StatusVariant>([
-  ["DEBUG", "neutral"],
-  ["INFO", "success"],
-  ["WARNING", "warning"],
-  ["ERROR", "danger"],
-  ["CRITICAL", "danger"],
-]);
-
-/** Map a log level string to a StatusVariant. Unknown values return "neutral" silently
- * (no console.warn — unlike sibling functions, custom log levels from the wire are expected). */
-export function levelToVariant(level: string): StatusVariant {
-  return LOG_LEVEL_MAP.get(level) ?? "neutral";
-}
-
 /**
  * StatusKind: semantic shape/color for StatusShape SVG indicators.
  * Use StatusKind (via statusToKind) for shape indicators (dots, triangles, squares).
@@ -181,24 +167,11 @@ export function levelToVariant(level: string): StatusVariant {
  * service-health values ("success", "failure", "unknown"). STATUS_KIND_MAP
  * covers both ResourceStatus and ManifestStatus plus the legacy "shutting_down"
  * value and the "unknown" placeholder — use executionStatusKind() for
- * execution results, levelToKind() for log levels. New ResourceStatus or
- * ManifestStatus variants must be added to both maps.
+ * execution results. Log levels are not mapped here at all: they carry their own
+ * styling via LOG_LEVEL_STYLES in components/shared/log-table/constants.ts.
+ * New ResourceStatus or ManifestStatus variants must be added to both maps.
  */
 export type StatusKind = "ok" | "warn" | "err" | "cancel" | "mute";
-
-const LOG_LEVEL_KIND_MAP: ReadonlyMap<string, StatusKind> = new Map<string, StatusKind>([
-  ["DEBUG", "mute"],
-  ["INFO", "mute"],
-  ["WARNING", "warn"],
-  ["ERROR", "err"],
-  ["CRITICAL", "err"],
-]);
-
-/** Map a log level string to a StatusKind for use with StatusShape.
- * Unknown levels return "mute". */
-export function levelToKind(level: string): StatusKind {
-  return LOG_LEVEL_KIND_MAP.get(level) ?? "mute";
-}
 
 type StatusKindMapKey = ResourceStatus | ManifestStatus | ShuttingDownStatus | UnknownStatus;
 


### PR DESCRIPTION
## Summary

Mechanical cleanup of pre-existing code-quality findings in the frontend apps page and status
utilities, surfaced by `/mine-clean-code`. No behavior or rendering changes — this is naming,
dead-code removal, and test-fixture deduplication only.

## What changed

**Dead code removal (`utils/status.ts`)**

- Deleted `levelToVariant` / `levelToKind` and their backing maps. Both were exported with zero
  callers; log-level styling is actually owned by `LOG_LEVEL_STYLES` in the log-table module.
- Updated the `StatusKind` doc comment, which pointed readers at the now-removed `levelToKind()`.
  It now says explicitly that log levels are not mapped here and points at `LOG_LEVEL_STYLES`.

**Naming and structure (`pages/apps.tsx`)**

- Named two magic numbers: `FILTER_SHAPE_SIZE` (filter-menu status glyph) and
  `COMPACT_STATS_COLUMNS` (stats-strip column override below the sidebar breakpoint).
- Extracted the `?filter=` validation ternary into an `isFilterId` type guard, which lets the
  inline `as FilterId` cast go away.
- Moved the duplicated `<colgroup>` percentage layouts into a `COLUMN_WIDTHS` record keyed by
  compact/full, each width paired with the column name it sizes, rendered via inline `style` —
  matching how `handlers.tsx` and `log-table-view.tsx` already do it.
- Split the 600-character `DATA_TABLE_CLASS` into frame / header-cell / body-cell / row groups,
  joined verbatim with `" "` (deliberately not `cn()`, which would reorder and merge the groups).

**Test fixture deduplication**

- Added `createSystemStatus()` to `test/factories.ts` for the `/api/health` shape and used it to
  replace three identical inline copies (`test/handlers.ts`, `diagnostics.test.tsx`,
  `use-websocket.test.ts`).
- Reused the existing `createTelemetryStatus()` for the `/api/telemetry/status` mock handler,
  which had its own inline duplicate.

## Testing

- `uv run nox -s dev` — 7032 passed, 1 skipped, 2 xfailed
- `npm run test -- --run` (frontend) — 1544 passed across 106 files
- `prek -a` — all hooks pass (ruff, eslint, stylelint, tsc, prettier, house-lint, token/breakpoint
  checks)
- `prek pyright -a --stage pre-push` — passes

Verified the `DATA_TABLE_CLASS` split is byte-identical to the original string, so the emitted
`class` attribute is unchanged. The `<colgroup>` change swaps Tailwind's `w-[72%]` for
`style={{ width: "72%" }}`, which compiles to the same `width` declaration.

## Visual evidence

Tagged `no-visual-change`. The two rendering-adjacent edits — the `DATA_TABLE_CLASS` split and the
`<colgroup>` className→style swap — both produce identical CSS, as verified above.

Closes #1602
