### PR TITLE
test: deduplicate CodeTab test setup and remove stale task markers

### DIFF
--- a/frontend/src/components/app-detail/code-tab.test.tsx
+++ b/frontend/src/components/app-detail/code-tab.test.tsx
@@ -3,6 +3,7 @@ import { delay, http, HttpResponse } from "msw";
 import type { ComponentProps } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+import { createListener } from "../../test/factories";
 import { server } from "../../test/server";
 import { CodeTab } from "./code-tab";
 
@@ -47,7 +48,7 @@ describe("CodeTab", () => {
   };
 
   async function renderAndWaitForLoad(props: Partial<ComponentProps<typeof CodeTab>> = {}) {
-    const result = render(<CodeTab appKey="test_app" listeners={[]} {...props} />);
+    const result = render(<CodeTab appKey={defaultSource.app_key} listeners={[]} {...props} />);
     await waitFor(() => {
       expect(screen.getByTestId("code-tab-content")).toBeDefined();
     });
@@ -64,7 +65,7 @@ describe("CodeTab", () => {
   });
 
   it("shows loading spinner initially", () => {
-    render(<CodeTab appKey="test_app" listeners={[]} />);
+    render(<CodeTab appKey={defaultSource.app_key} listeners={[]} />);
     expect(screen.getByRole("status")).toBeDefined();
   });
 
@@ -73,9 +74,8 @@ describe("CodeTab", () => {
   });
 
   it("includes Shiki token color utilities for light and dark themes", async () => {
-    render(<CodeTab appKey="test_app" listeners={[]} />);
-    const codeTab = await screen.findByTestId("code-tab-content");
-    const body = codeTab.lastElementChild;
+    await renderAndWaitForLoad();
+    const body = screen.getByTestId("code-tab-content").lastElementChild;
     expect(body?.className).toContain(
       "[&_.shiki_span:not(.line):not(.line-num)]:text-[var(--shiki-light,var(--ink-1))]",
     );
@@ -97,7 +97,7 @@ describe("CodeTab", () => {
         return HttpResponse.json({ detail: "not found" }, { status: 404 });
       }),
     );
-    render(<CodeTab appKey="test_app" listeners={[]} />);
+    render(<CodeTab appKey={defaultSource.app_key} listeners={[]} />);
     await waitFor(() => {
       expect(screen.getByTestId("code-tab-error")).toBeDefined();
     });
@@ -121,13 +121,9 @@ describe("CodeTab", () => {
 
   it("annotates handler lines with title tooltip on hover", async () => {
     const listeners = [
-      {
-        listener_id: 1,
-        handler_method: "on_state_change",
-        source_location: "test_app.py:2",
-      },
+      createListener({ listener_id: 1, handler_method: "on_state_change", source_location: "test_app.py:2" }),
     ];
-    await renderAndWaitForLoad({ listeners: listeners as never });
+    await renderAndWaitForLoad({ listeners });
     const line2 = screen.getByTestId("code-line-2");
     expect(line2.getAttribute("title")).toContain("on_state_change");
     expect(line2.classList.contains("line--annotated")).toBe(true);
@@ -162,7 +158,7 @@ describe("CodeTab", () => {
       }),
     );
 
-    const { unmount } = render(<CodeTab appKey="test_app" listeners={[]} />);
+    const { unmount } = render(<CodeTab appKey={defaultSource.app_key} listeners={[]} />);
     expect(screen.getByRole("status")).toBeDefined();
 
     // Wait for the request to be initiated

--- a/frontend/src/components/app-detail/code-tab.test.tsx
+++ b/frontend/src/components/app-detail/code-tab.test.tsx
@@ -1,8 +1,10 @@
 import { render, screen, waitFor } from "@testing-library/react";
 import { delay, http, HttpResponse } from "msw";
+import type { ComponentProps } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { server } from "../../test/server";
+import { CodeTab } from "./code-tab";
 
 // Mock shiki to avoid async highlighting in tests
 vi.mock("shiki", () => ({
@@ -33,7 +35,8 @@ vi.mock("../../hooks/use-query-params", () => ({
 // jsdom doesn't implement scrollIntoView — mock it globally
 window.HTMLElement.prototype.scrollIntoView = vi.fn();
 
-import { CodeTab } from "./code-tab";
+// Long enough to observe the request in flight, short enough not to slow the suite.
+const IN_FLIGHT_DELAY_MS = 100;
 
 describe("CodeTab", () => {
   const defaultSource = {
@@ -42,6 +45,14 @@ describe("CodeTab", () => {
     content: "class TestApp:\n    def on_state_change(self):\n        pass\n",
     line_count: 3,
   };
+
+  async function renderAndWaitForLoad(props: Partial<ComponentProps<typeof CodeTab>> = {}) {
+    const result = render(<CodeTab appKey="test_app" listeners={[]} {...props} />);
+    await waitFor(() => {
+      expect(screen.getByTestId("code-tab-content")).toBeDefined();
+    });
+    return result;
+  }
 
   beforeEach(() => {
     mockLineParam = null;
@@ -58,10 +69,7 @@ describe("CodeTab", () => {
   });
 
   it("renders source code after loading", async () => {
-    render(<CodeTab appKey="test_app" listeners={[]} />);
-    await waitFor(() => {
-      expect(screen.getByTestId("code-tab-content")).toBeDefined();
-    });
+    await renderAndWaitForLoad();
   });
 
   it("includes Shiki token color utilities for light and dark themes", async () => {
@@ -77,10 +85,7 @@ describe("CodeTab", () => {
   });
 
   it("renders line numbers in gutter", async () => {
-    render(<CodeTab appKey="test_app" listeners={[]} />);
-    await waitFor(() => {
-      expect(screen.getByTestId("code-tab-content")).toBeDefined();
-    });
+    await renderAndWaitForLoad();
     // Line numbers 1, 2, 3 should appear in gutter
     const gutterLines = screen.getAllByTestId(/^code-line-\d+$/);
     expect(gutterLines.length).toBeGreaterThanOrEqual(1);
@@ -100,27 +105,17 @@ describe("CodeTab", () => {
   });
 
   it("shows line count in header", async () => {
-    render(<CodeTab appKey="test_app" listeners={[]} />);
-    await waitFor(() => {
-      expect(screen.getByTestId("code-tab-content")).toBeDefined();
-    });
-    // "class TestApp:\n    def on_state_change(self):\n        pass\n" = 3 lines
-    expect(screen.getByTestId("code-tab-header").textContent).toContain("3 lines");
+    await renderAndWaitForLoad();
+    expect(screen.getByTestId("code-tab-header").textContent).toContain(`${defaultSource.line_count} lines`);
   });
 
   it("shows read-only label in header", async () => {
-    render(<CodeTab appKey="test_app" listeners={[]} />);
-    await waitFor(() => {
-      expect(screen.getByTestId("code-tab-content")).toBeDefined();
-    });
+    await renderAndWaitForLoad();
     expect(screen.getByTestId("code-tab-header").textContent).toContain("read-only");
   });
 
   it("shows copy path button in header", async () => {
-    render(<CodeTab appKey="test_app" listeners={[]} />);
-    await waitFor(() => {
-      expect(screen.getByTestId("code-tab-content")).toBeDefined();
-    });
+    await renderAndWaitForLoad();
     expect(screen.getByTestId("copy-path-btn")).toBeDefined();
   });
 
@@ -132,22 +127,16 @@ describe("CodeTab", () => {
         source_location: "test_app.py:2",
       },
     ];
-    render(<CodeTab appKey="test_app" listeners={listeners as never} />);
-    await waitFor(() => {
-      expect(screen.getByTestId("code-tab-content")).toBeDefined();
-    });
+    await renderAndWaitForLoad({ listeners: listeners as never });
     const line2 = screen.getByTestId("code-line-2");
     expect(line2.getAttribute("title")).toContain("on_state_change");
     expect(line2.classList.contains("line--annotated")).toBe(true);
   });
 
-  // T03: CodeTab reads ?line= from URL instead of focusLine prop
+  // CodeTab reads ?line= from URL instead of focusLine prop
   it("reads focusLine from ?line= query param and applies line--focus class", async () => {
     mockLineParam = "2";
-    render(<CodeTab appKey="test_app" listeners={[]} />);
-    await waitFor(() => {
-      expect(screen.getByTestId("code-tab-content")).toBeDefined();
-    });
+    await renderAndWaitForLoad();
     // Wait for the focus effect to run
     await waitFor(() => {
       const line2 = screen.getByTestId("code-line-2");
@@ -157,10 +146,7 @@ describe("CodeTab", () => {
 
   it("does not apply line--focus class when ?line= is absent", async () => {
     mockLineParam = null;
-    render(<CodeTab appKey="test_app" listeners={[]} />);
-    await waitFor(() => {
-      expect(screen.getByTestId("code-tab-content")).toBeDefined();
-    });
+    await renderAndWaitForLoad();
     const line1 = screen.getByTestId("code-line-1");
     expect(line1.classList.contains("line--focus")).toBe(false);
   });
@@ -171,7 +157,7 @@ describe("CodeTab", () => {
     server.use(
       http.get("/api/apps/:app_key/source", async ({ request }) => {
         requestSignal = request.signal;
-        await delay(100);
+        await delay(IN_FLIGHT_DELAY_MS);
         return HttpResponse.json(defaultSource);
       }),
     );

--- a/frontend/src/pages/app-detail.tabs.test.tsx
+++ b/frontend/src/pages/app-detail.tabs.test.tsx
@@ -181,7 +181,7 @@ describe("AppDetailPage tabs", () => {
     expect(logsTab.getAttribute("href")).toBe("/apps/test_app/logs");
   });
 
-  // T03: "view in code" navigates to /apps/:key/code?line=N instead of mutating signal
+  // "view in code" navigates to /apps/:key/code?line=N instead of mutating signal
   it("onSwitchToCode navigates to code tab with ?line= param", async () => {
     setupApi(createManifest());
     const { findByTestId } = renderPage({ key: "test_app", tab: "handlers" });


### PR DESCRIPTION
## Summary

Test-file hygiene only — no assertions changed and no production code touched. A quality scan of `frontend/src/components/app-detail/code-tab.test.tsx` surfaced five pre-existing maintainability findings; this cleans up all of them.

## What changed and why

**Repeated render + wait-for-load block (7 of 11 tests).** `render(<CodeTab appKey="test_app" listeners={[]} />)` followed by a `waitFor` on the `code-tab-content` testid appeared near-verbatim at seven sites, so changing the loading contract meant a seven-site find-and-replace. Replaced with a file-local `renderAndWaitForLoad(props?)` helper that takes partial props and returns the render result. The shared `src/test/render-helpers.tsx` only covers Zustand-store-backed renders, so a local helper is the right scope here.

**Line count duplicated in three unsynchronized places.** `defaultSource.line_count: 3`, a comment restating "= 3 lines", and the literal assertion string `"3 lines"` each encoded the same fact independently — editing the fixture content would silently desynchronize them. The assertion now derives from the fixture (`` `${defaultSource.line_count} lines` ``) and the restating comment is gone.

**Stale `T03` task markers.** These referenced a work-package task file that no longer exists (task directories are removed by `cfl archive`), making them unresolvable for a future reader. Dropped the `T03:` prefix in both `code-tab.test.tsx` and `app-detail.tabs.test.tsx`, keeping the descriptive remainder as a plain comment.

**Module-under-test import split from the import block.** The `CodeTab` import sat 30 lines below the others, after the `vi.mock(...)` calls and the `scrollIntoView` prototype assignment, reading as though the ordering were load-bearing. It is not: Vitest hoists `vi.mock` above all imports, and the prototype assignment runs at module-eval time before any test body. Moved it up with the other imports.

**Unexplained `delay(100)`.** Named it `IN_FLIGHT_DELAY_MS` with a one-line comment covering the tradeoff — long enough to observe the request in flight, short enough not to slow the suite.

## Testing

- `npx vitest run src/components/app-detail/code-tab.test.tsx src/pages/app-detail.tabs.test.tsx` — 2 files, 33 tests passed. This confirms the moved import does not break the `vi.mock` hoisting or `scrollIntoView` setup, which was the one change that looked deliberate even though it was not required.
- `uv run nox -s dev` — 7032 passed, 1 skipped, 2 xfailed.
- `prek -a` — all hooks passed, including `tsc`, `eslint`, `prettier`, and `stylelint` for the frontend.
- `prek pyright -a --stage pre-push` — passed.

No visual evidence is included because both changed files are `*.test.tsx`, which `tools/frontend/check_pr_screenshots.py` excludes from the rendered-frontend check.

Closes #1614
