### PR TITLE
test: deduplicate scattered test files via shared fixtures and parametrization

### DIFF
--- a/src/hassette/test_utils/factories.py
+++ b/src/hassette/test_utils/factories.py
@@ -409,15 +409,20 @@ def make_mock_listener(
     instance_index: int = 1,
     topic: str = "hass.event.test",
     handler_name: str = "MyApp.on_event",
+    invoke_side_effect: Any = None,
 ) -> MagicMock:
     """Build a MagicMock stand-in for a Listener with configurable attributes.
 
     Covers command-executor tests (invoke wiring), dispatch tests (db_id routing),
     and registration tests (identity fields).
+
+    Args:
+        invoke_side_effect: Applied to both ``invoke`` and ``invoker.invoke`` — the two entry
+            points a caller may reach, which every failure-path test has to set in lockstep.
     """
     listener = MagicMock()
-    listener.invoke = AsyncMock()
-    listener.invoker.invoke = AsyncMock()
+    listener.invoke = AsyncMock(side_effect=invoke_side_effect)
+    listener.invoker.invoke = AsyncMock(side_effect=invoke_side_effect)
     listener.error_handler = error_handler
     listener.invoker.error_handler = error_handler
     listener.listener_id = listener_id

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -10,8 +10,11 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 from hassette import Hassette
+from hassette.commands import InvokeHandler
 from hassette.config.config import HassetteConfig
+from hassette.core.command_executor import CommandExecutor
 from hassette.core.database_service import DatabaseService
+from hassette.core.execution_record import ExecutionRecord
 from hassette.core.sync_executor import SyncExecutor
 from hassette.test_utils import make_mock_hassette
 from hassette.test_utils.helpers import cleanup_hassette_streams
@@ -114,6 +117,44 @@ async def initialized_db(db_hassette: AsyncMock) -> AsyncIterator[tuple[Database
         yield db_service, session_id
     finally:
         await db_service.on_shutdown()
+
+
+@pytest.fixture
+async def executor(
+    db_hassette: AsyncMock, initialized_db: tuple[DatabaseService, int]
+) -> AsyncIterator[CommandExecutor]:
+    """Create and prepare a CommandExecutor with real DB wired in."""
+    _db_service, _session_id = initialized_db
+    exc = CommandExecutor(db_hassette, parent=db_hassette)
+    await exc.on_initialize()
+    try:
+        yield exc
+    finally:
+        await exc.on_shutdown()
+
+
+def invoke_cmd(listener: MagicMock, *, listener_id: int = 1, effective_timeout: float | None = None) -> InvokeHandler:
+    """Build the InvokeHandler command the executor receives for a bus dispatch."""
+    return InvokeHandler(
+        listener=listener,
+        event=MagicMock(),
+        topic="test",
+        listener_id=listener_id,
+        source_tier="app",
+        effective_timeout=effective_timeout,
+    )
+
+
+def pop_execution_record(executor: CommandExecutor) -> ExecutionRecord:
+    """Pop the record ``executor`` queued for the execution that just ran.
+
+    Asserts the queue is non-empty and the entry is an ``ExecutionRecord`` so callers can go
+    straight to the field they care about.
+    """
+    assert not executor._write_queue.empty()
+    record = executor._write_queue.get_nowait()
+    assert isinstance(record, ExecutionRecord)
+    return record
 
 
 def make_mock_job(

--- a/tests/integration/test_annotation_conversion.py
+++ b/tests/integration/test_annotation_conversion.py
@@ -1,14 +1,15 @@
 # pyright: reportInvalidTypeForm=none
 """Tests for dependency injection type conversion, unions, and complex types."""
 
-from typing import Annotated
+from collections.abc import Callable
+from typing import Annotated, Any
 
 import pytest
 
 from hassette import STATE_REGISTRY, A, D
 from hassette.bus.injection import ParameterInjector
 from hassette.conversion import ANNOTATION_CONVERTER
-from hassette.events import RawStateChangeEvent
+from hassette.events import Event, RawStateChangeEvent
 from hassette.exceptions import DependencyResolutionError
 from hassette.models import states
 from hassette.test_utils import make_full_state_change_event, make_light_state_dict
@@ -23,6 +24,27 @@ def get_random_model(exclude_models: list[type[states.BaseState]]) -> type[state
     return states.BaseState  # Fallback, should not happen in this test
 
 
+def inject(handler: Callable[..., Any], event: Event) -> dict[str, Any]:
+    """Resolve `handler`'s parameters against `event` the way the bus does at dispatch time."""
+    signature = get_typed_signature(handler)
+    injector = ParameterInjector(handler.__name__, signature)
+    return injector.inject_parameters(event)
+
+
+def value_handler(annotation: Any) -> Callable[..., None]:
+    """Build a handler with a single `value` parameter carrying `annotation`.
+
+    The complex-type conversion cases differ only in that annotation, so synthesizing it lets them
+    share one parametrized body instead of one near-identical handler definition each.
+    """
+
+    def handler(value):
+        pass
+
+    handler.__annotations__ = {"value": annotation}
+    return handler
+
+
 class TestDependencyInjectionHandlesTypeConversion:
     """Test that dependency injection handles type conversion correctly."""
 
@@ -33,10 +55,7 @@ class TestDependencyInjectionHandlesTypeConversion:
             def handler(event: RawStateChangeEvent):
                 pass
 
-            signature = get_typed_signature(handler)
-            injector = ParameterInjector(handler.__name__, signature)
-            kwargs = injector.inject_parameters(state_change_event)
-            result = kwargs["event"]
+            result = inject(handler, state_change_event)["event"]
 
             assert result is state_change_event, "Extractor should return the event as-is"
 
@@ -76,9 +95,7 @@ class TestDependencyInjectionHandlesTypeConversion:
             def handler(new_state: D.MaybeStateNew[model]):
                 pass
 
-            signature = get_typed_signature(handler)
-            injector = ParameterInjector(handler.__name__, signature)
-            kwargs = injector.inject_parameters(state_change_event)
+            kwargs = inject(handler, state_change_event)
 
             state = kwargs["new_state"]
             if state_change_event.payload.data.new_state is None:
@@ -96,9 +113,7 @@ class TestDependencyInjectionHandlesTypeConversion:
                 # results.append(new_state)
                 pass
 
-            signature = get_typed_signature(handler)
-            injector = ParameterInjector(handler.__name__, signature)
-            kwargs = injector.inject_parameters(state_change_event)
+            kwargs = inject(handler, state_change_event)
 
             state = kwargs["new_state"]
             if state_change_event.payload.data.new_state is None:
@@ -117,9 +132,7 @@ class TestDependencyInjectionHandlesTypeConversion:
             def handler(new_state: D.StateNew[model], old_state: D.MaybeStateOld[model]):
                 pass
 
-            signature = get_typed_signature(handler)
-            injector = ParameterInjector(handler.__name__, signature)
-            kwargs = injector.inject_parameters(state_change_event)
+            kwargs = inject(handler, state_change_event)
 
             old_state = kwargs["old_state"]
 
@@ -138,9 +151,7 @@ class TestDependencyInjectionHandlesTypeConversion:
             def handler(new_state: D.MaybeStateNew[model], old_state: D.StateOld[model]):
                 pass
 
-            signature = get_typed_signature(handler)
-            injector = ParameterInjector(handler.__name__, signature)
-            kwargs = injector.inject_parameters(state_change_event)
+            kwargs = inject(handler, state_change_event)
 
             new_state = kwargs["new_state"]
             old_state = kwargs["old_state"]
@@ -162,9 +173,7 @@ class TestDependencyInjectionHandlesTypeConversion:
             def handler(new_state: D.StateNew[model], old_state: D.StateOld[model]):
                 pass
 
-            signature = get_typed_signature(handler)
-            injector = ParameterInjector(handler.__name__, signature)
-            kwargs = injector.inject_parameters(state_change_event)
+            kwargs = inject(handler, state_change_event)
 
             new_state = kwargs["new_state"]
             old_state = kwargs["old_state"]
@@ -180,9 +189,7 @@ class TestDependencyInjectionHandlesTypeConversion:
             def handler(event: D.TypedStateChangeEvent[model]):
                 pass
 
-            signature = get_typed_signature(handler)
-            injector = ParameterInjector(handler.__name__, signature)
-            kwargs = injector.inject_parameters(state_change_event)
+            kwargs = inject(handler, state_change_event)
 
             event = kwargs["event"]
             new_state = event.payload.data.new_state
@@ -207,11 +214,8 @@ class TestDependencyInjectionHandlesTypeConversion:
                 pass
 
             for handler in (typed_state_change_handler, new_state_handler):
-                signature = get_typed_signature(handler)
-                injector = ParameterInjector(handler.__name__, signature)
-
                 with pytest.raises(DependencyResolutionError, match=r".*failed to convert parameter.*"):
-                    injector.inject_parameters(state_change_event)
+                    inject(handler, state_change_event)
 
 
 class TestDependencyInjectionTypeConversionHandlesUnions:
@@ -232,11 +236,8 @@ class TestDependencyInjectionTypeConversionHandlesUnions:
                 pass
 
             for handler in (typed_state_change_handler, new_state_handler):
-                signature = get_typed_signature(handler)
-                injector = ParameterInjector(handler.__name__, signature)
-
                 # consider not raising as success
-                injector.inject_parameters(state_change_event)
+                inject(handler, state_change_event)
 
     async def test_typed_annotation_union_with_all_wrong_types_raises(
         self, state_change_events_with_new_state: list[RawStateChangeEvent]
@@ -254,212 +255,116 @@ class TestDependencyInjectionTypeConversionHandlesUnions:
                 pass
 
             for handler in (typed_state_change_handler, new_state_handler):
-                signature = get_typed_signature(handler)
-                injector = ParameterInjector(handler.__name__, signature)
-
                 with pytest.raises(DependencyResolutionError, match=r".* to hassette.models.states.*"):
-                    injector.inject_parameters(state_change_event)
+                    inject(handler, state_change_event)
 
 
 class TestDependencyInjectionTypeConversionHandlesComplexTypes:
-    async def test_typed_annotation_handles_list_of_int(self):
-        """Asserts that when we have a nested type of list[int], the elements are converted to int."""
-        light_state_old = make_light_state_dict(rgb_color=[255, 0, 0])
-        light_state_new = make_light_state_dict(rgb_color=["0", "255", "0"])
+    """Test that nested container annotations convert their elements to the annotated types."""
+
+    @pytest.mark.parametrize(
+        ("old_attrs", "new_attrs", "annotation", "expected"),
+        # dup-ignore-start: rows of one pytest.param table — the repeated shape *is* the table,
+        # and each row is a distinct conversion case. Collapsing rows would delete test cases,
+        # not duplication.
+        [
+            pytest.param(
+                {"rgb_color": [255, 0, 0]},
+                {"rgb_color": ["0", "255", "0"]},
+                Annotated[list[int], A.get_attr_new("rgb_color")],
+                [0, 255, 0],
+                id="list_int_converts_str_elements",
+            ),
+            pytest.param(
+                {"rgb_color": [255, 0, 0]},
+                {"rgb_color": [12345, "67890", "13579"]},
+                Annotated[list[int], A.get_attr_new("rgb_color")],
+                [12345, 67890, 13579],
+                id="list_int_converts_mixed_elements",
+            ),
+            pytest.param(
+                {"rgb_color": [255, 0, 0]},
+                {"rgb_color": [12345, "test", "13579"]},
+                Annotated[list[int | str], A.get_attr_new("rgb_color")],
+                [12345, "test", 13579],
+                id="list_int_or_str_converts_what_it_can",
+            ),
+            pytest.param(
+                {"rgb_color": [255, 0, 0]},
+                {"rgb_color": [12345, "test", "13579"]},
+                Annotated[list[str | int], A.get_attr_new("rgb_color")],
+                ["12345", "test", "13579"],
+                id="list_str_or_int_converts_all_to_str",
+            ),
+            pytest.param(
+                {"rgb_color": None},
+                {"rgb_color": [0, 255, 0]},
+                Annotated[tuple[int], A.get_attr_new("rgb_color")],
+                (0, 255, 0),
+                id="tuple_single_arg_from_list",
+            ),
+            pytest.param(
+                {"rgb_color": None},
+                {"rgb_color": [0, 255, 0]},
+                Annotated[tuple[int, ...], A.get_attr_new("rgb_color")],
+                (0, 255, 0),
+                id="tuple_ellipsis_from_list",
+            ),
+            pytest.param(
+                {"rgb_color": None},
+                {"rgb_color": [0, 255, 0]},
+                Annotated[tuple[int, int, int], A.get_attr_new("rgb_color")],
+                (0, 255, 0),
+                id="tuple_repeated_args_from_list",
+            ),
+            pytest.param(
+                {"rgb_color": None},
+                {"rgb_color": (0, 255, 0)},
+                Annotated[list[int], A.get_attr_new("rgb_color")],
+                [0, 255, 0],
+                id="list_int_from_tuple",
+            ),
+            pytest.param(
+                {"color_temp": 250},
+                {"color_temp": "400"},
+                Annotated[dict[str, int], A.get_attrs_new(["color_temp"])],
+                {"color_temp": 400},
+                id="dict_str_int_converts_values",
+            ),
+            pytest.param(
+                {"color_temp": 250, "effect": None},
+                {"color_temp": "400", "effect": "blink"},
+                Annotated[dict[str, int | str], A.get_attrs_new(["color_temp", "effect"])],
+                {"color_temp": 400, "effect": "blink"},
+                id="dict_str_int_or_str_converts_each_value",
+            ),
+        ],
+        # dup-ignore-end
+    )
+    async def test_nested_annotation_converts_elements(
+        self,
+        old_attrs: dict[str, Any],
+        new_attrs: dict[str, Any],
+        annotation: Any,
+        expected: Any,
+    ):
+        """Elements of a nested container annotation are converted to the annotated element type."""
         light_event = make_full_state_change_event(
-            entity_id="light.kitchen", old_state=light_state_old, new_state=light_state_new
+            entity_id="light.kitchen",
+            old_state=make_light_state_dict(**old_attrs),
+            new_state=make_light_state_dict(**new_attrs),
         )
 
-        def new_state_handler(rgb_color: Annotated[list[int], A.get_attr_new("rgb_color")]):
-            pass
+        assert inject(value_handler(annotation), light_event) == {"value": expected}
 
-        signature = get_typed_signature(new_state_handler)
-        injector = ParameterInjector(new_state_handler.__name__, signature)
-
-        # succeeds if there is no exception
-        kwargs = injector.inject_parameters(light_event)
-        assert kwargs == {"rgb_color": [0, 255, 0]}
-
-    async def test_typed_annotation_handles_dict_str_int(self):
-        """Asserts that when the dict has str keys and int values, the values are converted to int."""
-        light_state_old = make_light_state_dict(color_temp=250)
-        light_state_new = make_light_state_dict(color_temp="400")
+    async def test_nested_annotation_raises_when_an_element_cannot_convert(self):
+        """A list[int] annotation raises when any element is not convertible to int."""
         light_event = make_full_state_change_event(
-            entity_id="light.kitchen", old_state=light_state_old, new_state=light_state_new
+            entity_id="light.kitchen",
+            old_state=make_light_state_dict(rgb_color=[255, 0, 0]),
+            new_state=make_light_state_dict(rgb_color=[12345, "test", "13579"]),
         )
+        handler = value_handler(Annotated[list[int], A.get_attr_new("rgb_color")])
 
-        def new_state_handler(attrs: Annotated[dict[str, int], A.get_attrs_new(["color_temp"])]):
-            pass
-
-        signature = get_typed_signature(new_state_handler)
-        injector = ParameterInjector(new_state_handler.__name__, signature)
-
-        # succeeds if there is no exception
-        kwargs = injector.inject_parameters(light_event)
-        assert kwargs == {"attrs": {"color_temp": 400}}
-
-    async def test_typed_annotation_handles_dict_mixed_type(self):
-        """Asserts that when the dict has mixed types, each value is converted to the correct type."""
-        light_state_old = make_light_state_dict(color_temp=250, effect=None)
-        light_state_new = make_light_state_dict(color_temp="400", effect="blink")
-        light_event = make_full_state_change_event(
-            entity_id="light.kitchen", old_state=light_state_old, new_state=light_state_new
-        )
-
-        def new_state_handler(attrs: Annotated[dict[str, int | str], A.get_attrs_new(["color_temp", "effect"])]):
-            pass
-
-        signature = get_typed_signature(new_state_handler)
-        injector = ParameterInjector(new_state_handler.__name__, signature)
-
-        # succeeds if there is no exception
-        kwargs = injector.inject_parameters(light_event)
-        assert kwargs == {"attrs": {"color_temp": 400, "effect": "blink"}}
-
-    async def test_typed_annotation_handles_incoming_elements_mixed_types(self):
-        """Asserts that when the element type is int and all elements can be converted to int, they are converted."""
-        light_state_old = make_light_state_dict(rgb_color=[255, 0, 0])
-        light_state_new = make_light_state_dict(rgb_color=[12345, "67890", "13579"])
-        light_event = make_full_state_change_event(
-            entity_id="light.kitchen", old_state=light_state_old, new_state=light_state_new
-        )
-
-        def new_state_handler(rgb_color: Annotated[list[int], A.get_attr_new("rgb_color")]):
-            pass
-
-        signature = get_typed_signature(new_state_handler)
-        injector = ParameterInjector(new_state_handler.__name__, signature)
-
-        # succeeds if there is no exception
-        kwargs = injector.inject_parameters(light_event)
-        assert kwargs == {"rgb_color": [12345, 67890, 13579]}
-
-    async def test_typed_annotation_handles_incoming_elements_mixed_types_cannot_convert_raises(self):
-        """Asserts that when the element type is int and not all elements can be converted, raises."""
-        light_state_old = make_light_state_dict(rgb_color=[255, 0, 0])
-        light_state_new = make_light_state_dict(rgb_color=[12345, "test", "13579"])
-        light_event = make_full_state_change_event(
-            entity_id="light.kitchen", old_state=light_state_old, new_state=light_state_new
-        )
-
-        def new_state_handler(rgb_color: Annotated[list[int], A.get_attr_new("rgb_color")]):
-            pass
-
-        signature = get_typed_signature(new_state_handler)
-        injector = ParameterInjector(new_state_handler.__name__, signature)
-
-        # succeeds if there is no exception
-        with pytest.raises(DependencyResolutionError, match=r".*failed to convert parameter 'rgb_color'.*"):
-            injector.inject_parameters(light_event)
-
-    async def test_typed_annotation_handles_incoming_elements_mixed_types_can_convert_converts_successfully(self):
-        """Asserts that when the union starts with int, all elements that can be converted to int are converted."""
-        light_state_old = make_light_state_dict(rgb_color=[255, 0, 0])
-        light_state_new = make_light_state_dict(rgb_color=[12345, "test", "13579"])
-        light_event = make_full_state_change_event(
-            entity_id="light.kitchen", old_state=light_state_old, new_state=light_state_new
-        )
-
-        def new_state_handler(rgb_color: Annotated[list[int | str], A.get_attr_new("rgb_color")]):
-            pass
-
-        signature = get_typed_signature(new_state_handler)
-        injector = ParameterInjector(new_state_handler.__name__, signature)
-
-        # succeeds if there is no exception
-        kwargs = injector.inject_parameters(light_event)
-        assert kwargs == {"rgb_color": [12345, "test", 13579]}
-
-    async def test_typed_annotation_handles_incoming_elements_with_str_annotation_converts_all_to_str(self):
-        """Asserts that when the union starts with str, all elements are converted to str, regardless of other
-        types in the Union.
-        """
-        light_state_old = make_light_state_dict(rgb_color=[255, 0, 0])
-        light_state_new = make_light_state_dict(rgb_color=[12345, "test", "13579"])
-        light_event = make_full_state_change_event(
-            entity_id="light.kitchen", old_state=light_state_old, new_state=light_state_new
-        )
-
-        def new_state_handler(rgb_color: Annotated[list[str | int], A.get_attr_new("rgb_color")]):
-            pass
-
-        signature = get_typed_signature(new_state_handler)
-        injector = ParameterInjector(new_state_handler.__name__, signature)
-
-        # succeeds if there is no exception
-        kwargs = injector.inject_parameters(light_event)
-        assert kwargs == {"rgb_color": ["12345", "test", "13579"]}
-
-    async def test_rgb_color_from_list_int_to_tuple_int_single_t_conversion(self):
-        """Asserts that when we annotated with tuple[int] and receive multiple int elements,
-        we still handle it correctly by converting to a tuple.
-        """
-        light_state_old = make_light_state_dict(rgb_color=None)
-        light_state_new = make_light_state_dict(rgb_color=[0, 255, 0])
-        light_event = make_full_state_change_event(
-            entity_id="light.kitchen", old_state=light_state_old, new_state=light_state_new
-        )
-
-        def new_state_handler(rgb_color: Annotated[tuple[int], A.get_attr_new("rgb_color")]):
-            pass
-
-        signature = get_typed_signature(new_state_handler)
-        injector = ParameterInjector(new_state_handler.__name__, signature)
-
-        # succeeds if there is no exception
-        kwargs = injector.inject_parameters(light_event)
-        assert kwargs == {"rgb_color": (0, 255, 0)}
-
-    async def test_rgb_color_from_list_int_to_tuple_int_ellipses_conversion(self):
-        """Asserts that when we have a nested type of tuple[int, ...], the elements are converted to int."""
-        light_state_old = make_light_state_dict(rgb_color=None)
-        light_state_new = make_light_state_dict(rgb_color=[0, 255, 0])
-        light_event = make_full_state_change_event(
-            entity_id="light.kitchen", old_state=light_state_old, new_state=light_state_new
-        )
-
-        def new_state_handler(rgb_color: Annotated[tuple[int, ...], A.get_attr_new("rgb_color")]):
-            pass
-
-        signature = get_typed_signature(new_state_handler)
-        injector = ParameterInjector(new_state_handler.__name__, signature)
-
-        # succeeds if there is no exception
-        kwargs = injector.inject_parameters(light_event)
-        assert kwargs == {"rgb_color": (0, 255, 0)}
-
-    async def test_rgb_color_from_list_int_to_tuple_int_repeated_conversion(self):
-        """Asserts that when we have a nested type of tuple[int, int, int], the elements are converted to int."""
-        light_state_old = make_light_state_dict(rgb_color=None)
-        light_state_new = make_light_state_dict(rgb_color=[0, 255, 0])
-        light_event = make_full_state_change_event(
-            entity_id="light.kitchen", old_state=light_state_old, new_state=light_state_new
-        )
-
-        def new_state_handler(rgb_color: Annotated[tuple[int, int, int], A.get_attr_new("rgb_color")]):
-            pass
-
-        signature = get_typed_signature(new_state_handler)
-        injector = ParameterInjector(new_state_handler.__name__, signature)
-
-        # succeeds if there is no exception
-        kwargs = injector.inject_parameters(light_event)
-        assert kwargs == {"rgb_color": (0, 255, 0)}
-
-    async def test_rgb_color_from_tuple_int_to_list_int_conversion(self):
-        """Asserts that when we have a nested type of tuple[int, int, int], the elements are converted to int."""
-        light_state_old = make_light_state_dict(rgb_color=None)
-        light_state_new = make_light_state_dict(rgb_color=(0, 255, 0))
-        light_event = make_full_state_change_event(
-            entity_id="light.kitchen", old_state=light_state_old, new_state=light_state_new
-        )
-
-        def new_state_handler(rgb_color: Annotated[list[int], A.get_attr_new("rgb_color")]):
-            pass
-
-        signature = get_typed_signature(new_state_handler)
-        injector = ParameterInjector(new_state_handler.__name__, signature)
-
-        # succeeds if there is no exception
-        kwargs = injector.inject_parameters(light_event)
-        assert kwargs == {"rgb_color": [0, 255, 0]}
+        with pytest.raises(DependencyResolutionError, match=r".*failed to convert parameter 'value'.*"):
+            inject(handler, light_event)

--- a/tests/integration/test_apps.py
+++ b/tests/integration/test_apps.py
@@ -1,6 +1,7 @@
 import asyncio
 import contextlib
 import typing
+from collections.abc import Iterable
 from copy import deepcopy
 from pathlib import Path
 from unittest.mock import patch
@@ -28,6 +29,22 @@ if typing.TYPE_CHECKING:
 TEST_APPS_PATH = Path(__file__).parent.parent / "data" / "apps"
 
 
+def change_set(
+    *,
+    orphans: Iterable[str] = (),
+    new_apps: Iterable[str] = (),
+    reimport_apps: Iterable[str] = (),
+    reload_apps: Iterable[str] = (),
+) -> ChangeSet:
+    """Build a ChangeSet from plain iterables, defaulting every unlisted bucket to empty."""
+    return ChangeSet(
+        orphans=frozenset(orphans),
+        new_apps=frozenset(new_apps),
+        reimport_apps=frozenset(reimport_apps),
+        reload_apps=frozenset(reload_apps),
+    )
+
+
 class TestApps:
     hassette: HassetteHarness
     app_handler: "AppHandler"
@@ -36,6 +53,51 @@ class TestApps:
     def setup(self, hassette_with_app_handler: HassetteHarness):
         self.hassette = hassette_with_app_handler
         self.app_handler = hassette_with_app_handler.app_handler
+
+    async def on_load_completed(self) -> asyncio.Event:
+        """Subscribe to APP_LOAD_COMPLETED and return an Event set the next time it fires."""
+        event = asyncio.Event()
+
+        async def handler(**kwargs):  # noqa
+            self.hassette.task_bucket.post_to_loop(event.set)
+
+        await self.hassette.bus_service.add_listener(
+            create_listener(
+                handler,
+                task_bucket=self.app_handler.task_bucket,
+                owner_id="test",
+                topic=Topic.HASSETTE_EVENT_APP_LOAD_COMPLETED,
+            )
+        )
+        return event
+
+    async def run_change_event(
+        self,
+        changes: ChangeSet,
+        *,
+        new_manifests: dict[str, AppManifest] | None = None,
+        timeout: float = 1,
+    ) -> None:
+        """Force one reconciliation pass with `changes` and wait for APP_LOAD_COMPLETED.
+
+        When `new_manifests` is given, refresh_config is stubbed to return it — the shape the
+        file-watcher path produces — instead of re-reading hassette.toml.
+        """
+        event = await self.on_load_completed()
+
+        with contextlib.ExitStack() as stack:
+            mock_detect = stack.enter_context(
+                patch.object(self.app_handler.lifecycle.change_detector, "detect_changes")
+            )
+            mock_detect.return_value = changes
+
+            if new_manifests is not None:
+                mock_refresh_config = stack.enter_context(patch.object(self.app_handler.lifecycle, "refresh_config"))
+                self.app_handler.registry.set_manifests(new_manifests)
+                mock_refresh_config.return_value = (self.app_handler.registry.manifests, new_manifests)
+
+            await self.app_handler.lifecycle.handle_change_event()
+            await asyncio.wait_for(event.wait(), timeout=timeout)
 
     async def test_apps_are_working(self) -> None:
         """Test actual WebSocket calls against running HA instance."""
@@ -70,13 +132,13 @@ class TestApps:
         """Verify that calling handle_changes() without config modifications preserves all running apps."""
         orig_apps = set(self.app_handler.registry.app_keys())
 
-        event = asyncio.Event()
         results = []
 
         async def handler(**kwargs):
             results.append(kwargs)
             self.hassette.task_bucket.post_to_loop(event.set)
 
+        event = asyncio.Event()
         await self.hassette.bus_service.add_listener(
             create_listener(
                 handler,
@@ -110,33 +172,10 @@ class TestApps:
             "Precondition: my_app config shows enabled"
         )
 
-        event = asyncio.Event()
+        await self.run_change_event(change_set(orphans={"my_app"}))
 
-        async def handler(**kwargs):  # noqa
-            self.hassette.task_bucket.post_to_loop(event.set)
-
-        await self.hassette.bus_service.add_listener(
-            create_listener(
-                handler,
-                task_bucket=self.app_handler.task_bucket,
-                owner_id="test",
-                topic=Topic.HASSETTE_EVENT_APP_LOAD_COMPLETED,
-            )
-        )
-
-        with patch.object(self.app_handler.lifecycle.change_detector, "detect_changes") as mock_detect:
-            mock_detect.return_value = ChangeSet(
-                orphans=frozenset({"my_app"}),
-                new_apps=frozenset(),
-                reimport_apps=frozenset(),
-                reload_apps=frozenset(),
-            )
-
-            await self.app_handler.lifecycle.handle_change_event()
-            await asyncio.wait_for(event.wait(), timeout=1)
-
-            assert "my_app" not in self.app_handler.registry, "my_app should stop after being disabled"
-            assert "my_app_sync" in self.app_handler.registry, "Other enabled apps should continue running"
+        assert "my_app" not in self.app_handler.registry, "my_app should stop after being disabled"
+        assert "my_app_sync" in self.app_handler.registry, "Other enabled apps should continue running"
 
     async def test_handle_changes_enables_app(self) -> None:
         """Verify that editing hassette.toml to enable a disabled app starts the instance."""
@@ -148,38 +187,10 @@ class TestApps:
         new_app_config = deepcopy(self.app_handler.registry.manifests)
         new_app_config["disabled_app"].enabled = True
 
-        event = asyncio.Event()
+        await self.run_change_event(change_set(new_apps={"disabled_app"}), new_manifests=new_app_config)
 
-        async def handler(**kwargs):  # noqa
-            self.hassette.task_bucket.post_to_loop(event.set)
-
-        await self.hassette.bus_service.add_listener(
-            create_listener(
-                handler,
-                task_bucket=self.app_handler.task_bucket,
-                owner_id="test",
-                topic=Topic.HASSETTE_EVENT_APP_LOAD_COMPLETED,
-            )
-        )
-
-        with (
-            patch.object(self.app_handler.lifecycle.change_detector, "detect_changes") as mock_detect,
-            patch.object(self.app_handler.lifecycle, "refresh_config") as mock_refresh_config,
-        ):
-            self.app_handler.registry.set_manifests(new_app_config)
-            mock_refresh_config.return_value = (self.app_handler.registry.manifests, new_app_config)
-            mock_detect.return_value = ChangeSet(
-                orphans=frozenset(),
-                new_apps=frozenset({"disabled_app"}),
-                reimport_apps=frozenset(),
-                reload_apps=frozenset(),
-            )
-
-            await self.app_handler.lifecycle.handle_change_event()
-            await asyncio.wait_for(event.wait(), timeout=1)
-
-            assert "disabled_app" in self.app_handler.registry, "disabled_app should start after being enabled"
-            assert "my_app" in self.app_handler.registry, "Other enabled apps should continue running"
+        assert "disabled_app" in self.app_handler.registry, "disabled_app should start after being enabled"
+        assert "my_app" in self.app_handler.registry, "Other enabled apps should continue running"
 
     async def test_config_changes_are_reflected_after_reload(self) -> None:
         """Verify that editing hassette.toml to change an app's config reloads the instance."""
@@ -195,11 +206,9 @@ class TestApps:
         original_config = deepcopy(self.app_handler.registry.manifests)
         self.app_handler.registry.manifests["my_app"].app_config = {"test_entity": "light.office"}
 
-        change_set = ChangeSet(
-            orphans=frozenset(), new_apps=frozenset(), reimport_apps=frozenset(), reload_apps=frozenset({"my_app"})
-        )
+        changes = change_set(reload_apps={"my_app"})
 
-        await self.app_handler.apply_changes(change_set, original_config, self.app_handler.registry.manifests)
+        await self.app_handler.apply_changes(changes, original_config, self.app_handler.registry.manifests)
         await wait_for(
             lambda: (
                 "my_app" in self.app_handler.registry
@@ -307,124 +316,40 @@ class TestApps:
         """A reload ChangeSet with new_apps containing an autostart=false app leaves it unstarted."""
         assert "no_autostart_app" not in self.app_handler.registry, "Precondition: not running"
 
-        event = asyncio.Event()
-
-        async def handler(**kwargs):  # noqa
-            self.hassette.task_bucket.post_to_loop(event.set)
-
-        await self.hassette.bus_service.add_listener(
-            create_listener(
-                handler,
-                task_bucket=self.app_handler.task_bucket,
-                owner_id="test",
-                topic=Topic.HASSETTE_EVENT_APP_LOAD_COMPLETED,
-            )
-        )
-
         new_app_config = deepcopy(self.app_handler.registry.manifests)
 
-        with (
-            patch.object(self.app_handler.lifecycle.change_detector, "detect_changes") as mock_detect,
-            patch.object(self.app_handler.lifecycle, "refresh_config") as mock_refresh_config,
-        ):
-            self.app_handler.registry.set_manifests(new_app_config)
-            mock_refresh_config.return_value = (self.app_handler.registry.manifests, new_app_config)
-            mock_detect.return_value = ChangeSet(
-                orphans=frozenset(),
-                new_apps=frozenset({"no_autostart_app"}),
-                reimport_apps=frozenset(),
-                reload_apps=frozenset(),
-            )
+        await self.run_change_event(change_set(new_apps={"no_autostart_app"}), new_manifests=new_app_config)
 
-            await self.app_handler.lifecycle.handle_change_event()
-            await asyncio.wait_for(event.wait(), timeout=1)
-
-            assert "no_autostart_app" not in self.app_handler.registry, (
-                "no_autostart_app should remain unstarted after reload with new_apps (autostart=false)"
-            )
+        assert "no_autostart_app" not in self.app_handler.registry, (
+            "no_autostart_app should remain unstarted after reload with new_apps (autostart=false)"
+        )
 
     async def test_unrelated_reload_leaves_manually_started_autostart_false_app_running(self) -> None:
         """A reload that changes an unrelated app leaves an already-running autostart=false app running."""
         await self.app_handler.lifecycle.start_app("no_autostart_app")
         assert "no_autostart_app" in self.app_handler.registry, "Precondition: no_autostart_app is manually running"
 
-        event = asyncio.Event()
-
-        async def handler(**kwargs):  # noqa
-            self.hassette.task_bucket.post_to_loop(event.set)
-
-        await self.hassette.bus_service.add_listener(
-            create_listener(
-                handler,
-                task_bucket=self.app_handler.task_bucket,
-                owner_id="test",
-                topic=Topic.HASSETTE_EVENT_APP_LOAD_COMPLETED,
-            )
-        )
-
         new_app_config = deepcopy(self.app_handler.registry.manifests)
         new_app_config["my_app"].app_config = {"test_entity": "light.some_other_light"}
 
-        with (
-            patch.object(self.app_handler.lifecycle.change_detector, "detect_changes") as mock_detect,
-            patch.object(self.app_handler.lifecycle, "refresh_config") as mock_refresh_config,
-        ):
-            self.app_handler.registry.set_manifests(new_app_config)
-            mock_refresh_config.return_value = (self.app_handler.registry.manifests, new_app_config)
-            mock_detect.return_value = ChangeSet(
-                orphans=frozenset(),
-                new_apps=frozenset(),
-                reimport_apps=frozenset(),
-                reload_apps=frozenset({"my_app"}),
-            )
+        await self.run_change_event(change_set(reload_apps={"my_app"}), new_manifests=new_app_config)
 
-            await self.app_handler.lifecycle.handle_change_event()
-            await asyncio.wait_for(event.wait(), timeout=1)
-
-            assert "no_autostart_app" in self.app_handler.registry, (
-                "no_autostart_app should still be running after an unrelated reload"
-            )
+        assert "no_autostart_app" in self.app_handler.registry, (
+            "no_autostart_app should still be running after an unrelated reload"
+        )
 
     async def test_reload_of_not_running_autostart_false_app_leaves_it_unstarted(self) -> None:
         """A reload with reload_apps containing an autostart=false app that is not running leaves it unstarted."""
         assert "no_autostart_app" not in self.app_handler.registry, "Precondition: not running"
 
-        event = asyncio.Event()
-
-        async def handler(**kwargs):  # noqa
-            self.hassette.task_bucket.post_to_loop(event.set)
-
-        await self.hassette.bus_service.add_listener(
-            create_listener(
-                handler,
-                task_bucket=self.app_handler.task_bucket,
-                owner_id="test",
-                topic=Topic.HASSETTE_EVENT_APP_LOAD_COMPLETED,
-            )
-        )
-
         new_app_config = deepcopy(self.app_handler.registry.manifests)
         new_app_config["no_autostart_app"].app_config = {"test_entity": "light.changed"}
 
-        with (
-            patch.object(self.app_handler.lifecycle.change_detector, "detect_changes") as mock_detect,
-            patch.object(self.app_handler.lifecycle, "refresh_config") as mock_refresh_config,
-        ):
-            self.app_handler.registry.set_manifests(new_app_config)
-            mock_refresh_config.return_value = (self.app_handler.registry.manifests, new_app_config)
-            mock_detect.return_value = ChangeSet(
-                orphans=frozenset(),
-                new_apps=frozenset(),
-                reimport_apps=frozenset(),
-                reload_apps=frozenset({"no_autostart_app"}),
-            )
+        await self.run_change_event(change_set(reload_apps={"no_autostart_app"}), new_manifests=new_app_config)
 
-            await self.app_handler.lifecycle.handle_change_event()
-            await asyncio.wait_for(event.wait(), timeout=1)
-
-            assert "no_autostart_app" not in self.app_handler.registry, (
-                "no_autostart_app should remain unstarted after config change reload (autostart=false, not running)"
-            )
+        assert "no_autostart_app" not in self.app_handler.registry, (
+            "no_autostart_app should remain unstarted after config change reload (autostart=false, not running)"
+        )
 
     async def test_reload_of_running_autostart_false_app_leaves_it_running(self) -> None:
         """A reload of a running autostart=false app that had config changes reloads and keeps it running."""
@@ -436,14 +361,9 @@ class TestApps:
         new_app_config["no_autostart_app"].app_config = {"test_entity": "light.changed"}
         self.app_handler.registry.set_manifests(new_app_config)
 
-        change_set = ChangeSet(
-            orphans=frozenset(),
-            new_apps=frozenset(),
-            reimport_apps=frozenset(),
-            reload_apps=frozenset({"no_autostart_app"}),
-        )
+        changes = change_set(reload_apps={"no_autostart_app"})
 
-        await self.app_handler.apply_changes(change_set, original_app_config, new_app_config)
+        await self.app_handler.apply_changes(changes, original_app_config, new_app_config)
         await wait_for(
             lambda: "no_autostart_app" in self.app_handler.registry,
             desc="no_autostart_app still running after reload",
@@ -558,10 +478,8 @@ class TestPerInstanceSelectiveRestart:
         # Mutate instance 1's config only — instance 0's dict stays identical.
         lifecycle.registry.manifests[app_key].app_config = [{"value": "a"}, {"value": "changed"}]
 
-        change_set = ChangeSet(
-            orphans=frozenset(), new_apps=frozenset(), reimport_apps=frozenset(), reload_apps=frozenset({app_key})
-        )
-        await lifecycle.apply_changes(change_set, original_config, lifecycle.registry.manifests)
+        changes = change_set(reload_apps={app_key})
+        await lifecycle.apply_changes(changes, original_config, lifecycle.registry.manifests)
 
         await wait_for(
             lambda: (
@@ -699,10 +617,8 @@ class TestPerInstanceSelectiveRestart:
         lifecycle._stop_instance_unlocked = instrumented_stop
         lifecycle._create_instance_unlocked = instrumented_create
 
-        change_set = ChangeSet(
-            orphans=frozenset(), new_apps=frozenset(), reimport_apps=frozenset(), reload_apps=frozenset({app_key})
-        )
-        task = asyncio.create_task(lifecycle.apply_changes(change_set, original_config, lifecycle.registry.manifests))
+        changes = change_set(reload_apps={app_key})
+        task = asyncio.create_task(lifecycle.apply_changes(changes, original_config, lifecycle.registry.manifests))
 
         await asyncio.wait_for(index_1_stop_entered.wait(), timeout=1)
         # While index 1's stop of the old, name-colliding "beta" instance is still pending, no

--- a/tests/integration/test_command_executor.py
+++ b/tests/integration/test_command_executor.py
@@ -2,53 +2,61 @@
 
 import asyncio
 import time
-from collections.abc import AsyncIterator
 from unittest.mock import AsyncMock, MagicMock, PropertyMock
 
 import pytest
 
-from hassette.commands import ExecuteJob, InvokeHandler
+from hassette.commands import ExecuteJob
 from hassette.core.command_executor import CommandExecutor
 from hassette.core.database_service import DatabaseService
 from hassette.core.execution_record import ExecutionRecord
 from hassette.exceptions import DependencyError, HassetteError
-from hassette.test_utils.factories import make_job_registration, make_listener_registration, make_mock_listener
+from hassette.test_utils.factories import (
+    make_execution_record,
+    make_job_registration,
+    make_listener_registration,
+    make_mock_listener,
+)
+from hassette.types.types import ExecutionStatus
 from hassette.utils.execution import ExecutionResult
 
-from .conftest import make_mock_job
+from .conftest import invoke_cmd, make_mock_job, pop_execution_record
 
 
-@pytest.fixture
-async def executor(
-    db_hassette: AsyncMock, initialized_db: tuple[DatabaseService, int]
-) -> AsyncIterator[CommandExecutor]:
-    """Create and prepare a CommandExecutor with real DB wired in."""
-    _db_service, _session_id = initialized_db
-    exc = CommandExecutor(db_hassette, parent=db_hassette)
-    await exc.on_initialize()
-    try:
-        yield exc
-    finally:
-        await exc.on_shutdown()
+def queue_record(
+    executor: CommandExecutor,
+    listener_id: int,
+    session_id: int,
+    *,
+    status: ExecutionStatus = "success",
+    duration_ms: float = 10.0,
+) -> None:
+    """Put one handler execution record straight onto the executor's write queue.
+
+    ``execution_id`` stays None so a caller can queue several records without tripping the
+    UNIQUE constraint on that column.
+    """
+    executor._write_queue.put_nowait(
+        make_execution_record(
+            listener_id=listener_id,
+            session_id=session_id,
+            execution_start_ts=time.time(),
+            duration_ms=duration_ms,
+            status=status,
+            execution_id=None,
+        )
+    )
 
 
 async def test_cancelled_error_reraises(executor: CommandExecutor) -> None:
     """CancelledError must be re-raised after queueing a 'cancelled' record."""
-    listener = make_mock_listener()
-    listener.invoke.side_effect = asyncio.CancelledError()
-    listener.invoker.invoke.side_effect = asyncio.CancelledError()
-
-    cmd = InvokeHandler(
-        listener=listener, event=MagicMock(), topic="test", listener_id=1, source_tier="app", effective_timeout=None
-    )
+    listener = make_mock_listener(invoke_side_effect=asyncio.CancelledError())
 
     with pytest.raises(asyncio.CancelledError):
-        await executor.execute(cmd)
+        await executor.execute(invoke_cmd(listener))
 
     # Record should have been queued
-    assert not executor._write_queue.empty()
-    record = executor._write_queue.get_nowait()
-    assert isinstance(record, ExecutionRecord)
+    record = pop_execution_record(executor)
     assert record.status == "cancelled"
     assert record.listener_id == 1
 
@@ -67,15 +75,7 @@ async def test_restart_cancellation_persists_cancelled_row(
 
     listener_id = await executor.register_listener(make_listener_registration())
 
-    record = ExecutionRecord(
-        kind="handler",
-        listener_id=listener_id,
-        session_id=session_id,
-        execution_start_ts=time.time(),
-        duration_ms=10.0,
-        status="cancelled",
-    )
-    executor._write_queue.put_nowait(record)
+    queue_record(executor, listener_id, session_id, status="cancelled")
     await executor.drain_and_persist()
 
     # dup-ignore-start: shares the "fetch one row, assert count then fields" shape with
@@ -93,89 +93,41 @@ async def test_restart_cancellation_persists_cancelled_row(
     # dup-ignore-end
 
 
-async def test_dependency_error_swallowed(executor: CommandExecutor) -> None:
-    """DependencyError must be swallowed (not re-raised) and logged as error."""
-    listener = make_mock_listener()
-    listener.invoke.side_effect = DependencyError("missing dep")
-    listener.invoker.invoke.side_effect = DependencyError("missing dep")
+@pytest.mark.parametrize(
+    ("exc", "expect_traceback"),
+    [
+        pytest.param(DependencyError("missing dep"), False, id="dependency_error"),
+        pytest.param(HassetteError("framework error"), False, id="hassette_error"),
+        pytest.param(ValueError("oops"), True, id="unexpected_error"),
+    ],
+)
+async def test_handler_error_swallowed(executor: CommandExecutor, exc: Exception, expect_traceback: bool) -> None:
+    """Handler errors are swallowed (not re-raised) and recorded with status='error'.
 
-    cmd = InvokeHandler(
-        listener=listener, event=MagicMock(), topic="test", listener_id=1, source_tier="app", effective_timeout=None
-    )
+    Framework errors are logged via logger.error, so they carry no traceback; an unexpected
+    exception goes through logger.exception and stores one.
+    """
+    listener = make_mock_listener(invoke_side_effect=exc)
 
     # Should not raise
-    await executor.execute(cmd)
+    await executor.execute(invoke_cmd(listener))
 
-    assert not executor._write_queue.empty()
-    record = executor._write_queue.get_nowait()
-    assert isinstance(record, ExecutionRecord)
+    record = pop_execution_record(executor)
     assert record.status == "error"
-    assert record.error_type == "DependencyError"
-    assert record.error_message == "missing dep"
-    # DependencyError should NOT include traceback (logger.error, not logger.exception)
-    # We can't easily assert logger call, but we verify the record has no traceback
-    assert record.error_traceback is None
-
-
-async def test_hassette_error_swallowed(executor: CommandExecutor) -> None:
-    """HassetteError must be swallowed and logged without traceback."""
-    listener = make_mock_listener()
-    listener.invoke.side_effect = HassetteError("framework error")
-    listener.invoker.invoke.side_effect = HassetteError("framework error")
-
-    cmd = InvokeHandler(
-        listener=listener, event=MagicMock(), topic="test", listener_id=1, source_tier="app", effective_timeout=None
-    )
-
-    await executor.execute(cmd)
-
-    assert not executor._write_queue.empty()
-    record = executor._write_queue.get_nowait()
-    assert isinstance(record, ExecutionRecord)
-    assert record.status == "error"
-    assert record.error_type == "HassetteError"
-    assert record.error_message == "framework error"
-    assert record.error_traceback is None
-
-
-async def test_unexpected_error_swallowed(executor: CommandExecutor) -> None:
-    """Generic Exception must be swallowed and include traceback."""
-    listener = make_mock_listener()
-    listener.invoke.side_effect = ValueError("oops")
-    listener.invoker.invoke.side_effect = ValueError("oops")
-
-    cmd = InvokeHandler(
-        listener=listener, event=MagicMock(), topic="test", listener_id=1, source_tier="app", effective_timeout=None
-    )
-
-    await executor.execute(cmd)
-
-    assert not executor._write_queue.empty()
-    record = executor._write_queue.get_nowait()
-    assert isinstance(record, ExecutionRecord)
-    assert record.status == "error"
-    assert record.error_type == "ValueError"
-    assert record.error_message == "oops"
-    # logger.exception includes traceback — we verify it was stored
-    assert record.error_traceback is not None
-    assert "ValueError" in record.error_traceback
+    assert record.error_type == type(exc).__name__
+    assert record.error_message == str(exc)
+    if expect_traceback:
+        assert record.error_traceback is not None
+        assert type(exc).__name__ in record.error_traceback
+    else:
+        assert record.error_traceback is None
 
 
 async def test_success_record_queued(executor: CommandExecutor) -> None:
     """Successful invocation must queue a 'success' record."""
-    listener = make_mock_listener()
-    listener.invoke.return_value = None
-    listener.invoker.invoke.return_value = None
+    await executor.execute(invoke_cmd(make_mock_listener()))
 
-    cmd = InvokeHandler(
-        listener=listener, event=MagicMock(), topic="test", listener_id=1, source_tier="app", effective_timeout=None
-    )
-
-    await executor.execute(cmd)
-
-    assert not executor._write_queue.empty()
-    record = executor._write_queue.get_nowait()
-    assert isinstance(record, ExecutionRecord)
+    record = pop_execution_record(executor)
     assert record.status == "success"
     assert record.listener_id == 1
     assert record.error_type is None
@@ -194,34 +146,16 @@ async def test_execute_timeout_fires(executor: CommandExecutor) -> None:
     listener.invoke = slow_handler
     listener.invoker.invoke = slow_handler
 
-    cmd = InvokeHandler(
-        listener=listener, event=MagicMock(), topic="test", listener_id=1, source_tier="app", effective_timeout=0.05
-    )
+    await executor.execute(invoke_cmd(listener, effective_timeout=0.05))
 
-    await executor.execute(cmd)
-
-    assert not executor._write_queue.empty()
-    record = executor._write_queue.get_nowait()
-    assert isinstance(record, ExecutionRecord)
-    assert record.status == "timed_out"
+    assert pop_execution_record(executor).status == "timed_out"
 
 
 async def test_execute_timeout_none_is_noop(executor: CommandExecutor) -> None:
     """effective_timeout=None does not enforce timeout."""
-    listener = make_mock_listener()
-    listener.invoke.return_value = None
-    listener.invoker.invoke.return_value = None
+    await executor.execute(invoke_cmd(make_mock_listener()))
 
-    cmd = InvokeHandler(
-        listener=listener, event=MagicMock(), topic="test", listener_id=1, source_tier="app", effective_timeout=None
-    )
-
-    await executor.execute(cmd)
-
-    assert not executor._write_queue.empty()
-    record = executor._write_queue.get_nowait()
-    assert isinstance(record, ExecutionRecord)
-    assert record.status == "success"
+    assert pop_execution_record(executor).status == "success"
 
 
 async def test_timeout_warning_rate_limited(executor: CommandExecutor) -> None:
@@ -244,15 +178,7 @@ async def test_timeout_warning_rate_limited(executor: CommandExecutor) -> None:
 
     # Fire 3 timeouts with the same listener_id
     for _ in range(3):
-        cmd = InvokeHandler(
-            listener=listener,
-            event=MagicMock(),
-            topic="test",
-            listener_id=1,
-            source_tier="app",
-            effective_timeout=0.01,
-        )
-        await executor.execute(cmd)
+        await executor.execute(invoke_cmd(listener, effective_timeout=0.01))
 
     executor.logger.warning = original_warning  # pyright: ignore[reportAttributeAccessIssue]
 
@@ -275,15 +201,7 @@ async def test_timeout_warning_lazy_eviction(executor: CommandExecutor) -> None:
     executor._timeout_warn_timestamps = {1: time.monotonic() - 120.0}  # pyright: ignore[reportAttributeAccessIssue]
 
     # Fire a timeout for a different listener_id
-    cmd = InvokeHandler(
-        listener=listener,
-        event=MagicMock(),
-        topic="test",
-        listener_id=2,
-        source_tier="app",
-        effective_timeout=0.01,
-    )
-    await executor.execute(cmd)
+    await executor.execute(invoke_cmd(listener, listener_id=2, effective_timeout=0.01))
 
     # Stale entry for listener_id=1 should have been evicted
     assert 1 not in executor._timeout_warn_timestamps
@@ -298,15 +216,7 @@ async def test_serve_drains_queue_to_db(executor: CommandExecutor, initialized_d
     listener_id = await executor.register_listener(reg)
 
     # Queue a success record directly
-    record = ExecutionRecord(
-        kind="handler",
-        listener_id=listener_id,
-        session_id=session_id,
-        execution_start_ts=time.time(),
-        duration_ms=10.0,
-        status="success",
-    )
-    executor._write_queue.put_nowait(record)
+    queue_record(executor, listener_id, session_id)
 
     # Drain without going through serve() loop — call drain_and_persist directly
     await executor.drain_and_persist()
@@ -338,15 +248,7 @@ async def test_flush_queue_on_shutdown(executor: CommandExecutor, initialized_db
 
     # Put two records in the queue
     for _ in range(2):
-        record = ExecutionRecord(
-            kind="handler",
-            listener_id=listener_id,
-            session_id=session_id,
-            execution_start_ts=time.time(),
-            duration_ms=5.0,
-            status="success",
-        )
-        executor._write_queue.put_nowait(record)
+        queue_record(executor, listener_id, session_id, duration_ms=5.0)
 
     await executor.flush_queue()
 
@@ -369,9 +271,7 @@ async def test_execute_job_success_record_queued(executor: CommandExecutor) -> N
     cmd = ExecuteJob(job=job, callable=callable_mock, job_db_id=42, source_tier="app", effective_timeout=None)
     await executor.execute(cmd)
 
-    assert not executor._write_queue.empty()
-    record = executor._write_queue.get_nowait()
-    assert isinstance(record, ExecutionRecord)
+    record = pop_execution_record(executor)
     assert record.kind == "job"
     assert record.status == "success"
     assert record.job_id == 42
@@ -386,9 +286,7 @@ async def test_execute_job_error_swallowed(executor: CommandExecutor) -> None:
     cmd = ExecuteJob(job=job, callable=callable_mock, job_db_id=42, source_tier="app", effective_timeout=None)
     await executor.execute(cmd)
 
-    assert not executor._write_queue.empty()
-    record = executor._write_queue.get_nowait()
-    assert isinstance(record, ExecutionRecord)
+    record = pop_execution_record(executor)
     assert record.kind == "job"
     assert record.status == "error"
     assert record.error_type == "RuntimeError"
@@ -402,11 +300,7 @@ def test_build_record_uses_session_id_directly(db_hassette: AsyncMock) -> None:
     db_hassette.session_id = 99
     db_hassette.try_session_id.return_value = 99
 
-    listener = make_mock_listener()
-
-    cmd = InvokeHandler(
-        listener=listener, event=MagicMock(), topic="test", listener_id=5, source_tier="app", effective_timeout=None
-    )
+    cmd = invoke_cmd(make_mock_listener(), listener_id=5)
     result = ExecutionResult()
     result.status = "success"
     result.duration_ms = 1.0
@@ -431,21 +325,11 @@ async def test_persist_batch_drops_presession_records(
     listener_id = await executor.register_listener(reg)
 
     now = time.time()
-    valid = ExecutionRecord(
-        kind="handler",
-        listener_id=listener_id,
-        session_id=session_id,
-        execution_start_ts=now,
-        duration_ms=5.0,
-        status="success",
+    valid = make_execution_record(
+        listener_id=listener_id, session_id=session_id, execution_start_ts=now, execution_id=None
     )
-    pre_session = ExecutionRecord(
-        kind="handler",
-        listener_id=listener_id,
-        session_id=None,  # pre-session record
-        execution_start_ts=now,
-        duration_ms=3.0,
-        status="success",
+    pre_session = make_execution_record(
+        listener_id=listener_id, session_id=None, execution_start_ts=now, execution_id=None
     )
 
     # Patch try_session_id to return None so the "session not ready" path is triggered

--- a/tests/integration/test_command_executor_error_handler.py
+++ b/tests/integration/test_command_executor_error_handler.py
@@ -1,15 +1,13 @@
 """Integration tests for CommandExecutor error handler invocation paths."""
 
 import asyncio
-from collections.abc import AsyncIterator
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import MagicMock
 
 import pytest
 
 from hassette.bus.error_context import BusErrorContext
 from hassette.commands import ExecuteJob, InvokeHandler
 from hassette.core.command_executor import CommandExecutor
-from hassette.core.database_service import DatabaseService
 from hassette.scheduler.error_context import SchedulerErrorContext
 from hassette.test_utils import wait_for
 from hassette.test_utils.factories import make_mock_listener
@@ -18,20 +16,6 @@ from hassette.test_utils.helpers import settle
 from .conftest import make_mock_job
 
 WAIT_TIMEOUT = 2.0
-
-
-@pytest.fixture
-async def executor(
-    db_hassette: AsyncMock, initialized_db: tuple[DatabaseService, int]
-) -> AsyncIterator[CommandExecutor]:
-    """Create and prepare a CommandExecutor with real DB and TaskBucket wired in."""
-    _db_service, _session_id = initialized_db
-    exc = CommandExecutor(db_hassette, parent=db_hassette)
-    await exc.on_initialize()
-    try:
-        yield exc
-    finally:
-        await exc.on_shutdown()
 
 
 async def test_error_handler_runs_after_framework_log(executor: CommandExecutor) -> None:

--- a/tests/integration/test_service_watcher.py
+++ b/tests/integration/test_service_watcher.py
@@ -5,13 +5,13 @@ Tests use RestartSpec-based per-service configuration rather than global config 
 
 import asyncio
 import time
-from typing import ClassVar
+from typing import ClassVar, NamedTuple
 from unittest.mock import patch
 
 import pytest
 
 from hassette.core.service_watcher import ServiceWatcher
-from hassette.events import HassetteServiceEvent
+from hassette.events import Event, HassetteServiceEvent
 from hassette.events.base import HassettePayload
 from hassette.events.hassette import ServiceStatusPayload
 from hassette.resources.lifecycle import mark_ready
@@ -44,7 +44,7 @@ def make_fast_spec(**overrides: object) -> RestartSpec:
 
 
 @pytest.fixture
-async def get_service_watcher_mock(hassette_with_bus):
+async def watcher(hassette_with_bus):
     """Return a fresh service watcher for each test."""
     hassette = hassette_with_bus.hassette
     watcher = ServiceWatcher(hassette, parent=hassette)
@@ -111,106 +111,120 @@ def get_dummy_service(
     return _Dummy(hassette)
 
 
-async def test_restart_service_cancels_then_starts(get_service_watcher_mock: ServiceWatcher):
-    """Restarting a failed service cancels and reinitializes it."""
-    call_counts = make_call_counts()
+class DummyServiceSetup(NamedTuple):
+    """Everything a ServiceWatcher test needs to drive one dummy service."""
 
-    dummy_service = get_dummy_service(
-        call_counts,
-        get_service_watcher_mock.hassette,
-        restart_spec=make_fast_spec(restart_type=RestartType.TRANSIENT, budget_intensity=5),
+    service: Service
+    calls: dict[str, int]
+    spec: RestartSpec
+    key: str
+    failed_event: HassetteServiceEvent
+
+
+def register_dummy_service(
+    watcher: ServiceWatcher, *, fail: bool = False, **spec_overrides: object
+) -> DummyServiceSetup:
+    """Attach a dummy service to `watcher`'s hassette and pre-build what tests assert against."""
+    calls = make_call_counts()
+    spec = make_fast_spec(**spec_overrides)
+    service = get_dummy_service(calls, watcher.hassette, fail=fail, restart_spec=spec)
+    watcher.hassette.children.append(service)
+    return DummyServiceSetup(
+        service=service,
+        calls=calls,
+        spec=spec,
+        key=watcher.service_key(service.class_name, service.role),
+        failed_event=make_service_failed_event(service),
     )
-    get_service_watcher_mock.hassette.children.append(dummy_service)
 
-    event = make_service_failed_event(dummy_service)
 
-    await get_service_watcher_mock.restart_service(event)
+async def exhaust_budget(watcher: ServiceWatcher, dummy: DummyServiceSetup, restarts: int) -> list[Event]:
+    """Use up `restarts` budget slots, then fire the FAILED event that exhausts the budget.
+
+    Returns the events emitted by that final, over-budget pass — the CRASHED / EXHAUSTED_COOLING
+    / EXHAUSTED_DEAD event whose shape is what each restart type's test asserts on.
+    """
+    for _ in range(restarts):
+        await restart_and_await(watcher, dummy.failed_event)
+
+    with EventCapture.capturing(watcher.hassette) as capture:
+        await watcher.restart_service(dummy.failed_event)
+
+    return capture.events
+
+
+def budget_entries(watcher: ServiceWatcher, key: str) -> int:
+    """Count the live (non-expired) restart-budget entries recorded for `key`."""
+    budget = watcher._budgets.get(key)
+    assert budget is not None, f"No restart budget recorded for {key}"
+    budget.evict_expired()
+    return len(budget._timestamps)
+
+
+async def test_restart_service_cancels_then_starts(watcher: ServiceWatcher):
+    """Restarting a failed service cancels and reinitializes it."""
+    dummy = register_dummy_service(watcher, restart_type=RestartType.TRANSIENT, budget_intensity=5)
+
+    await watcher.restart_service(dummy.failed_event)
 
     await wait_for(
-        lambda: call_counts == {"cancel": 1, "start": 1},
+        lambda: dummy.calls == {"cancel": 1, "start": 1},
         desc="restart_service completed",
     )
 
-    assert call_counts == {"cancel": 1, "start": 1}, (
-        f"Expected cancel and start to be called once each, got {call_counts}"
+    assert dummy.calls == {"cancel": 1, "start": 1}, (
+        f"Expected cancel and start to be called once each, got {dummy.calls}"
     )
 
 
-async def test_always_failing_service_stops_after_max_attempts(get_service_watcher_mock: ServiceWatcher):
+async def test_always_failing_service_stops_after_max_attempts(watcher: ServiceWatcher):
     """A service that always fails on restart stops being restarted after budget exhaustion."""
-    watcher = get_service_watcher_mock
     hassette = watcher.hassette
-    call_counts = make_call_counts()
 
     # budget_intensity=3 means 3 restarts before exhaustion
-    spec = make_fast_spec(restart_type=RestartType.PERMANENT, budget_intensity=3)
-    dummy_service = get_dummy_service(call_counts, hassette, fail=True, restart_spec=spec)
-    hassette.children.append(dummy_service)
-
-    event = make_service_failed_event(dummy_service)
-    key = watcher.service_key(dummy_service.class_name, dummy_service.role)
+    dummy = register_dummy_service(watcher, fail=True, restart_type=RestartType.PERMANENT, budget_intensity=3)
 
     # Each call to restart_service increments budget and spawns a restart task.
     # The service fails on restart but exceptions are caught.
     for _ in range(3):
-        await restart_and_await(watcher, event)
+        await restart_and_await(watcher, dummy.failed_event)
 
-    budget = watcher._budgets.get(key)
-    assert budget is not None
-    budget.evict_expired()
-    assert len(budget._timestamps) == 3
+    assert budget_entries(watcher, dummy.key) == 3
     assert not hassette.shutdown_event.is_set(), "Shutdown should not happen before budget exhausted"
 
     # The 4th call should trigger shutdown (budget exhausted, PERMANENT)
-    await watcher.restart_service(event)
+    await watcher.restart_service(dummy.failed_event)
 
     assert hassette.shutdown_event.is_set(), "Shutdown should be triggered after budget exhausted"
 
 
-async def test_crashed_event_emitted_before_shutdown(get_service_watcher_mock: ServiceWatcher):
+async def test_crashed_event_emitted_before_shutdown(watcher: ServiceWatcher):
     """When budget is exhausted for PERMANENT service, a CRASHED event is emitted before shutdown."""
-    watcher = get_service_watcher_mock
-    hassette = watcher.hassette
-    call_counts = make_call_counts()
+    dummy = register_dummy_service(watcher, fail=True, restart_type=RestartType.PERMANENT, budget_intensity=1)
 
-    spec = make_fast_spec(restart_type=RestartType.PERMANENT, budget_intensity=1)
-    dummy_service = get_dummy_service(call_counts, hassette, fail=True, restart_spec=spec)
-    hassette.children.append(dummy_service)
-
-    event = make_service_failed_event(dummy_service)
-
-    # First call uses the one budget slot
-    await restart_and_await(watcher, event)
-
-    # Second call exceeds budget — should emit CRASHED then shutdown
-    with EventCapture.capturing(hassette) as capture:
-        await watcher.restart_service(event)
+    # The one budget slot is used first, so the second call exceeds it
+    events = await exhaust_budget(watcher, dummy, restarts=1)
 
     # First send_event call should be the CRASHED event (shutdown may emit STOPPED after)
-    assert len(capture.events) >= 1
-    crashed_event = capture.events[0]
+    assert len(events) >= 1
+    crashed_event = events[0]
     assert crashed_event.topic == Topic.HASSETTE_EVENT_SERVICE_STATUS
     assert crashed_event.payload.data.status == ResourceStatus.CRASHED
     assert crashed_event.payload.data.previous_status == ResourceStatus.FAILED
-    assert crashed_event.payload.data.resource_name == dummy_service.class_name
+    assert crashed_event.payload.data.resource_name == dummy.service.class_name
 
 
-async def test_exponential_backoff(get_service_watcher_mock: ServiceWatcher):
+async def test_exponential_backoff(watcher: ServiceWatcher):
     """Backoff delay increases exponentially between restart attempts (using shutdown-safe sleep)."""
-    watcher = get_service_watcher_mock
-    call_counts = make_call_counts()
-
-    spec = make_fast_spec(
+    dummy = register_dummy_service(
+        watcher,
+        fail=True,
         restart_type=RestartType.TRANSIENT,
         budget_intensity=10,
         backoff_base_seconds=1.0,
         backoff_multiplier=2.0,
         backoff_max_seconds=60.0,
     )
-    dummy_service = get_dummy_service(call_counts, watcher.hassette, fail=True, restart_spec=spec)
-    watcher.hassette.children.append(dummy_service)
-
-    event = make_service_failed_event(dummy_service)
 
     sleep_calls: list[float] = []
 
@@ -220,7 +234,7 @@ async def test_exponential_backoff(get_service_watcher_mock: ServiceWatcher):
 
     with patch.object(watcher, "shutdown_safe_sleep", side_effect=mock_shutdown_safe_sleep):
         for _ in range(3):
-            await restart_and_await(watcher, event)
+            await restart_and_await(watcher, dummy.failed_event)
 
     # attempt 1: backoff = 1.0 * 2^0 = 1.0
     # attempt 2: backoff = 1.0 * 2^1 = 2.0
@@ -228,190 +242,138 @@ async def test_exponential_backoff(get_service_watcher_mock: ServiceWatcher):
     assert sleep_calls == [1.0, 2.0, 4.0]
 
 
-async def test_budget_reset_on_recovery(get_service_watcher_mock: ServiceWatcher):
+async def test_budget_reset_on_recovery(watcher: ServiceWatcher):
     """Budget resets when a service transitions to RUNNING and becomes ready."""
-    watcher = get_service_watcher_mock
-    call_counts = make_call_counts()
-
-    spec = make_fast_spec(restart_type=RestartType.TRANSIENT, budget_intensity=5, startup_timeout_seconds=1.0)
-    dummy_service = get_dummy_service(call_counts, watcher.hassette, fail=True, restart_spec=spec)
-    watcher.hassette.children.append(dummy_service)
-
-    event = make_service_failed_event(dummy_service)
-    key = watcher.service_key(dummy_service.class_name, dummy_service.role)
+    dummy = register_dummy_service(
+        watcher, fail=True, restart_type=RestartType.TRANSIENT, budget_intensity=5, startup_timeout_seconds=1.0
+    )
 
     # Accumulate 2 restart attempts
     for _ in range(2):
-        await restart_and_await(watcher, event)
+        await restart_and_await(watcher, dummy.failed_event)
 
-    budget = watcher._budgets[key]
-    budget.evict_expired()
-    assert len(budget._timestamps) == 2
+    assert budget_entries(watcher, dummy.key) == 2
 
     # Mark the service ready, then fire RUNNING event — budget should reset
-    mark_ready(dummy_service, reason="test")
-    await on_running_and_await(watcher, make_service_running_event(dummy_service))
+    mark_ready(dummy.service, reason="test")
+    await on_running_and_await(watcher, make_service_running_event(dummy.service))
 
-    budget.evict_expired()
-    assert len(budget._timestamps) == 0  # budget reset
+    assert budget_entries(watcher, dummy.key) == 0  # budget reset
 
 
-async def test_permanent_exhaustion_triggers_shutdown(get_service_watcher_mock: ServiceWatcher):
+async def test_permanent_exhaustion_triggers_shutdown(watcher: ServiceWatcher):
     """PERMANENT service: exhausting budget triggers hassette.shutdown()."""
-    watcher = get_service_watcher_mock
     hassette = watcher.hassette
-    call_counts = make_call_counts()
-
-    spec = make_fast_spec(restart_type=RestartType.PERMANENT, budget_intensity=2)
-    dummy_service = get_dummy_service(call_counts, hassette, restart_spec=spec)
-    hassette.children.append(dummy_service)
-
-    event = make_service_failed_event(dummy_service)
+    dummy = register_dummy_service(watcher, restart_type=RestartType.PERMANENT, budget_intensity=2)
 
     # Use up budget
-    await restart_and_await(watcher, event)
-    await restart_and_await(watcher, event)
+    await restart_and_await(watcher, dummy.failed_event)
+    await restart_and_await(watcher, dummy.failed_event)
 
     assert not hassette.shutdown_event.is_set(), "Should not shutdown until budget exhausted"
 
     # Exhaust budget (budget check is synchronous — no spawn needed)
-    await watcher.restart_service(event)
+    await watcher.restart_service(dummy.failed_event)
     assert hassette.shutdown_event.is_set()
 
 
-async def test_permanent_exhaustion_records_fatal_reason(get_service_watcher_mock: ServiceWatcher):
+async def test_permanent_exhaustion_records_fatal_reason(watcher: ServiceWatcher):
     """PERMANENT exhaustion records _fatal_shutdown_reason synchronously at the decision site.
 
     Regression test for the reason-race: the CRASHED event is dispatched asynchronously
     (task-per-handler), so the reason must be set synchronously in handle_exhaustion — not
     only in the async shutdown_if_crashed handler — or run_forever() exits 0 on a real crash.
     """
-    watcher = get_service_watcher_mock
     hassette = watcher.hassette
     assert hassette._fatal_shutdown_reason is None
 
-    spec = make_fast_spec(restart_type=RestartType.PERMANENT, budget_intensity=2)
-    dummy_service = get_dummy_service(make_call_counts(), hassette, restart_spec=spec)
-    hassette.children.append(dummy_service)
+    dummy = register_dummy_service(watcher, restart_type=RestartType.PERMANENT, budget_intensity=2)
 
-    event = make_service_failed_event(dummy_service)
-    await restart_and_await(watcher, event)
-    await restart_and_await(watcher, event)
-    await watcher.restart_service(event)  # exhausts → handle_exhaustion (PERMANENT, no spawn)
+    await restart_and_await(watcher, dummy.failed_event)
+    await restart_and_await(watcher, dummy.failed_event)
+    await watcher.restart_service(dummy.failed_event)  # exhausts → handle_exhaustion (PERMANENT, no spawn)
 
     assert hassette._fatal_shutdown_reason is not None
-    assert dummy_service.class_name in hassette._fatal_shutdown_reason
+    assert dummy.service.class_name in hassette._fatal_shutdown_reason
 
 
-async def test_fatal_error_records_fatal_reason(get_service_watcher_mock: ServiceWatcher):
+async def test_fatal_error_records_fatal_reason(watcher: ServiceWatcher):
     """A service raising a configured fatal error records _fatal_shutdown_reason synchronously."""
-    watcher = get_service_watcher_mock
     hassette = watcher.hassette
     assert hassette._fatal_shutdown_reason is None
 
-    spec = make_fast_spec(
+    dummy = register_dummy_service(
+        watcher,
         restart_type=RestartType.TRANSIENT,
         budget_intensity=5,
         fatal_error_names=("RuntimeError",),
     )
-    dummy_service = get_dummy_service(make_call_counts(), hassette, restart_spec=spec)
-    hassette.children.append(dummy_service)
 
-    event = make_service_failed_event(dummy_service, exception=RuntimeError("boom"))
+    event = make_service_failed_event(dummy.service, exception=RuntimeError("boom"))
     await watcher.restart_service(event)  # fatal-error path triggers immediately
 
     assert hassette._fatal_shutdown_reason is not None
     assert "RuntimeError" in hassette._fatal_shutdown_reason
 
 
-async def test_transient_exhaustion_enters_cooldown(get_service_watcher_mock: ServiceWatcher):
+async def test_transient_exhaustion_enters_cooldown(watcher: ServiceWatcher):
     """TRANSIENT service: exhausting budget emits EXHAUSTED_COOLING and schedules cooldown task."""
-    watcher = get_service_watcher_mock
     hassette = watcher.hassette
-    call_counts = make_call_counts()
-
-    spec = make_fast_spec(
+    dummy = register_dummy_service(
+        watcher,
         restart_type=RestartType.TRANSIENT,
         budget_intensity=2,
         cooldown_seconds=999,  # long cooldown so we can verify the task is created
     )
-    dummy_service = get_dummy_service(call_counts, hassette, restart_spec=spec)
-    hassette.children.append(dummy_service)
 
-    event = make_service_failed_event(dummy_service)
-    key = watcher.service_key(dummy_service.class_name, dummy_service.role)
-
-    # Use up budget
-    await restart_and_await(watcher, event)
-    await restart_and_await(watcher, event)
-
-    # Exhaust budget (budget check is synchronous — no spawn needed)
-    with EventCapture.capturing(hassette) as capture:
-        await watcher.restart_service(event)
+    events = await exhaust_budget(watcher, dummy, restarts=2)
 
     assert not hassette.shutdown_event.is_set(), "TRANSIENT exhaustion should NOT trigger shutdown"
-    assert len(capture.events) >= 1
-    cooling_event = capture.events[0]
+    assert len(events) >= 1
+    cooling_event = events[0]
     assert cooling_event.payload.data.status == ResourceStatus.EXHAUSTED_COOLING
     assert cooling_event.payload.data.retry_at is not None
     assert cooling_event.payload.data.retry_at > time.time()
 
     # Cooldown task should be scheduled
-    assert key in watcher._cooldown_tasks
-    assert not watcher._cooldown_tasks[key].done()
+    assert dummy.key in watcher._cooldown_tasks
+    assert not watcher._cooldown_tasks[dummy.key].done()
 
     # Cancel the cooldown task to avoid lingering
-    watcher._cooldown_tasks[key].cancel()
+    watcher._cooldown_tasks[dummy.key].cancel()
 
 
-async def test_temporary_exhaustion_stays_dead(get_service_watcher_mock: ServiceWatcher):
+async def test_temporary_exhaustion_stays_dead(watcher: ServiceWatcher):
     """TEMPORARY service: exhausting budget emits EXHAUSTED_DEAD, no further restarts."""
-    watcher = get_service_watcher_mock
     hassette = watcher.hassette
-    call_counts = make_call_counts()
+    dummy = register_dummy_service(watcher, restart_type=RestartType.TEMPORARY, budget_intensity=2)
 
-    spec = make_fast_spec(restart_type=RestartType.TEMPORARY, budget_intensity=2)
-    dummy_service = get_dummy_service(call_counts, hassette, restart_spec=spec)
-    hassette.children.append(dummy_service)
-
-    event = make_service_failed_event(dummy_service)
-
-    # Use up budget
-    await restart_and_await(watcher, event)
-    await restart_and_await(watcher, event)
-
-    # Exhaust budget (budget check is synchronous — no spawn needed)
-    with EventCapture.capturing(hassette) as capture:
-        await watcher.restart_service(event)
+    events = await exhaust_budget(watcher, dummy, restarts=2)
 
     assert not hassette.shutdown_event.is_set()
-    assert len(capture.events) == 1
-    dead_event = capture.events[0]
+    assert len(events) == 1
+    dead_event = events[0]
     assert dead_event.payload.data.status == ResourceStatus.EXHAUSTED_DEAD
     assert dead_event.payload.data.retry_at is None
 
 
-async def test_fatal_error_triggers_immediate_shutdown(get_service_watcher_mock: ServiceWatcher):
+async def test_fatal_error_triggers_immediate_shutdown(watcher: ServiceWatcher):
     """Service with fatal_error_names: matching exception triggers immediate shutdown, no restart."""
-    watcher = get_service_watcher_mock
     hassette = watcher.hassette
-    call_counts = make_call_counts()
-
-    spec = make_fast_spec(
+    dummy = register_dummy_service(
+        watcher,
         restart_type=RestartType.TRANSIENT,
         fatal_error_names=("FatalDbError", "SchemaVersionError"),
         budget_intensity=5,
     )
-    dummy_service = get_dummy_service(call_counts, hassette, restart_spec=spec)
-    hassette.children.append(dummy_service)
 
     # Create a failed event with exception_type matching a fatal error name
     fatal_event = HassetteServiceEvent(
         topic=Topic.HASSETTE_EVENT_SERVICE_STATUS,
         payload=HassettePayload(
             data=ServiceStatusPayload(
-                resource_name=dummy_service.class_name,
-                role=dummy_service.role,
+                resource_name=dummy.service.class_name,
+                role=dummy.service.role,
                 status=ResourceStatus.FAILED,
                 previous_status=ResourceStatus.RUNNING,
                 exception="fatal db error",
@@ -432,29 +394,25 @@ async def test_fatal_error_triggers_immediate_shutdown(get_service_watcher_mock:
     # First event should be CRASHED
     assert capture.events[0].payload.data.status == ResourceStatus.CRASHED
     # No restart should have been attempted
-    assert call_counts["start"] == 0
+    assert dummy.calls["start"] == 0
 
 
-async def test_non_retryable_error_skips_restart(get_service_watcher_mock: ServiceWatcher):
+async def test_non_retryable_error_skips_restart(watcher: ServiceWatcher):
     """Service with non_retryable_error_names: matching exception skips restart, goes to exhaustion."""
-    watcher = get_service_watcher_mock
     hassette = watcher.hassette
-    call_counts = make_call_counts()
-
-    spec = make_fast_spec(
+    dummy = register_dummy_service(
+        watcher,
         restart_type=RestartType.TEMPORARY,
         non_retryable_error_names=("NonRetryableError",),
         budget_intensity=5,
     )
-    dummy_service = get_dummy_service(call_counts, hassette, restart_spec=spec)
-    hassette.children.append(dummy_service)
 
     nr_event = HassetteServiceEvent(
         topic=Topic.HASSETTE_EVENT_SERVICE_STATUS,
         payload=HassettePayload(
             data=ServiceStatusPayload(
-                resource_name=dummy_service.class_name,
-                role=dummy_service.role,
+                resource_name=dummy.service.class_name,
+                role=dummy.service.role,
                 status=ResourceStatus.FAILED,
                 previous_status=ResourceStatus.RUNNING,
                 exception="non-retryable",
@@ -469,203 +427,149 @@ async def test_non_retryable_error_skips_restart(get_service_watcher_mock: Servi
         await watcher.restart_service(nr_event)
 
     # No restart attempt made
-    assert call_counts["start"] == 0
+    assert dummy.calls["start"] == 0
     # TEMPORARY exhaustion → EXHAUSTED_DEAD emitted
     assert len(capture.events) == 1
     assert capture.events[0].payload.data.status == ResourceStatus.EXHAUSTED_DEAD
 
 
-async def test_in_restart_guard_prevents_double_budget(get_service_watcher_mock: ServiceWatcher):
+async def test_in_restart_guard_prevents_double_budget(watcher: ServiceWatcher):
     """Two FAILED events while restart is in progress only record one budget entry."""
-    watcher = get_service_watcher_mock
-    hassette = watcher.hassette
-    call_counts = make_call_counts()
-
-    spec = make_fast_spec(restart_type=RestartType.TRANSIENT, budget_intensity=10)
-    dummy_service = get_dummy_service(call_counts, hassette, restart_spec=spec)
-    hassette.children.append(dummy_service)
-
-    event = make_service_failed_event(dummy_service)
-    key = watcher.service_key(dummy_service.class_name, dummy_service.role)
+    dummy = register_dummy_service(watcher, restart_type=RestartType.TRANSIENT, budget_intensity=10)
 
     # Manually set the in-restart flag to simulate concurrent restart in progress
-    watcher._restarting.add(key)
+    watcher._restarting.add(dummy.key)
     # Ensure budget exists but has 1 entry (from the first restart)
-    budget = watcher.get_budget(key, spec)
-    budget.record_restart()
+    watcher.get_budget(dummy.key, dummy.spec).record_restart()
 
     # Second FAILED event arrives while restart is in progress — should be dropped
-    await watcher.restart_service(event)
+    await watcher.restart_service(dummy.failed_event)
 
     # Budget should still have only 1 entry
-    budget.evict_expired()
-    assert len(budget._timestamps) == 1, "Second FAILED event should have been dropped by in-restart guard"
+    assert budget_entries(watcher, dummy.key) == 1, "Second FAILED event should have been dropped by in-restart guard"
 
     # Clean up
-    watcher._restarting.discard(key)
+    watcher._restarting.discard(dummy.key)
 
 
-async def test_shutdown_safe_sleep_aborts_on_shutdown(get_service_watcher_mock: ServiceWatcher):
+async def test_shutdown_safe_sleep_aborts_on_shutdown(watcher: ServiceWatcher):
     """Backoff sleep aborts early when shutdown_event is set."""
-    watcher = get_service_watcher_mock
     hassette = watcher.hassette
-    call_counts = make_call_counts()
-
-    spec = make_fast_spec(
+    dummy = register_dummy_service(
+        watcher,
         restart_type=RestartType.TRANSIENT,
         budget_intensity=10,
         backoff_base_seconds=5.0,  # real backoff that would be interrupted
         backoff_multiplier=1.0,
     )
-    dummy_service = get_dummy_service(call_counts, hassette, restart_spec=spec)
-    hassette.children.append(dummy_service)
-
-    event = make_service_failed_event(dummy_service)
-    key = watcher.service_key(dummy_service.class_name, dummy_service.role)
 
     # Set shutdown event to trigger early abort during backoff
     hassette.shutdown_event.set()
 
-    await restart_and_await(watcher, event)
+    await restart_and_await(watcher, dummy.failed_event)
 
     # Service should NOT have been restarted
-    assert call_counts["start"] == 0, "Service should not restart when shutdown is requested during backoff"
+    assert dummy.calls["start"] == 0, "Service should not restart when shutdown is requested during backoff"
     # In-restart flag should be cleared
-    assert key not in watcher._restarting
+    assert dummy.key not in watcher._restarting
 
 
-async def test_budget_reset_on_recovery_confirmed(get_service_watcher_mock: ServiceWatcher):
+async def test_budget_reset_on_recovery_confirmed(watcher: ServiceWatcher):
     """Budget resets when service reaches RUNNING and signals readiness."""
-    watcher = get_service_watcher_mock
-    call_counts = make_call_counts()
-
-    spec = make_fast_spec(restart_type=RestartType.TRANSIENT, budget_intensity=5, startup_timeout_seconds=1.0)
-    dummy_service = get_dummy_service(call_counts, watcher.hassette, fail=True, restart_spec=spec)
-    watcher.hassette.children.append(dummy_service)
-
-    event = make_service_failed_event(dummy_service)
-    key = watcher.service_key(dummy_service.class_name, dummy_service.role)
+    dummy = register_dummy_service(
+        watcher, fail=True, restart_type=RestartType.TRANSIENT, budget_intensity=5, startup_timeout_seconds=1.0
+    )
 
     # Accumulate 2 restart attempts
-    await restart_and_await(watcher, event)
-    await restart_and_await(watcher, event)
+    await restart_and_await(watcher, dummy.failed_event)
+    await restart_and_await(watcher, dummy.failed_event)
 
-    budget = watcher._budgets[key]
-    budget.evict_expired()
-    assert len(budget._timestamps) == 2
+    assert budget_entries(watcher, dummy.key) == 2
 
     # Mark the service ready, then fire RUNNING event — budget should reset
-    mark_ready(dummy_service, reason="test")
-    await on_running_and_await(watcher, make_service_running_event(dummy_service))
+    mark_ready(dummy.service, reason="test")
+    await on_running_and_await(watcher, make_service_running_event(dummy.service))
 
-    budget.evict_expired()
-    assert len(budget._timestamps) == 0  # budget.reset() was called
-    assert key not in watcher._restarting  # in-restart cleared
+    assert budget_entries(watcher, dummy.key) == 0  # budget.reset() was called
+    assert dummy.key not in watcher._restarting  # in-restart cleared
 
 
-async def test_readiness_timeout_no_budget_impact(get_service_watcher_mock: ServiceWatcher):
+async def test_readiness_timeout_no_budget_impact(watcher: ServiceWatcher):
     """Readiness timeout after RUNNING does NOT increment restart budget."""
-    watcher = get_service_watcher_mock
-    call_counts = make_call_counts()
-
-    spec = make_fast_spec(restart_type=RestartType.TRANSIENT, budget_intensity=5, startup_timeout_seconds=0.05)
-    dummy_service = get_dummy_service(call_counts, watcher.hassette, fail=True, restart_spec=spec)
-    watcher.hassette.children.append(dummy_service)
-
-    event = make_service_failed_event(dummy_service)
-    key = watcher.service_key(dummy_service.class_name, dummy_service.role)
+    dummy = register_dummy_service(
+        watcher, fail=True, restart_type=RestartType.TRANSIENT, budget_intensity=5, startup_timeout_seconds=0.05
+    )
 
     # Accumulate 1 restart attempt
-    await restart_and_await(watcher, event)
+    await restart_and_await(watcher, dummy.failed_event)
 
-    budget = watcher._budgets[key]
-    budget.evict_expired()
-    count_before = len(budget._timestamps)
+    count_before = budget_entries(watcher, dummy.key)
 
     # Fire RUNNING event WITHOUT marking ready — timeout will occur, no budget impact
     # on_service_running spawns a readiness task; wait for it to time out
-    await watcher.on_service_running(make_service_running_event(dummy_service))
+    await watcher.on_service_running(make_service_running_event(dummy.service))
     await wait_for(
         lambda: watcher.task_bucket.pending_tasks() == [],
         desc="readiness timeout task completed",
         timeout=AWAIT_TIMEOUT,
     )
 
-    budget.evict_expired()
-    assert len(budget._timestamps) == count_before, "Readiness timeout should not impact restart budget"
+    assert budget_entries(watcher, dummy.key) == count_before, "Readiness timeout should not impact restart budget"
 
 
-async def test_cooldown_then_recovery(get_service_watcher_mock: ServiceWatcher):
+async def test_cooldown_then_recovery(watcher: ServiceWatcher):
     """TRANSIENT exhaustion → cooldown completes → budget reset → restart attempted."""
-    watcher = get_service_watcher_mock
-    hassette = watcher.hassette
-    call_counts = make_call_counts()
-
-    spec = make_fast_spec(
+    dummy = register_dummy_service(
+        watcher,
         restart_type=RestartType.TRANSIENT,
         budget_intensity=1,
         cooldown_seconds=0.05,  # very short cooldown for test speed
     )
-    dummy_service = get_dummy_service(call_counts, hassette, restart_spec=spec)
-    hassette.children.append(dummy_service)
-
-    event = make_service_failed_event(dummy_service)
-    key = watcher.service_key(dummy_service.class_name, dummy_service.role)
 
     # Use up the budget (1 restart)
-    await restart_and_await(watcher, event)
+    await restart_and_await(watcher, dummy.failed_event)
 
     # Exhaust budget — should schedule cooldown task (budget check is synchronous)
-    await watcher.restart_service(event)
+    await watcher.restart_service(dummy.failed_event)
 
-    assert key in watcher._cooldown_tasks
-    cooldown_task = watcher._cooldown_tasks[key]
+    assert dummy.key in watcher._cooldown_tasks
+    cooldown_task = watcher._cooldown_tasks[dummy.key]
 
     # Wait for the cooldown task to complete
     await asyncio.wait_for(asyncio.shield(cooldown_task), timeout=2.0)
 
     # After cooldown, budget should have been reset and restart attempted
-    budget = watcher._budgets.get(key)
-    if budget:
-        budget.evict_expired()
-        # Budget was reset during cooldown
-        assert len(budget._timestamps) == 0 or call_counts["start"] >= 2
+    if watcher._budgets.get(dummy.key):
+        assert budget_entries(watcher, dummy.key) == 0 or dummy.calls["start"] >= 2
 
 
-async def test_max_cooldown_cycles_exceeded(get_service_watcher_mock: ServiceWatcher):
+async def test_max_cooldown_cycles_exceeded(watcher: ServiceWatcher):
     """TRANSIENT with max_cooldown_cycles=1: second exhaustion → EXHAUSTED_DEAD."""
-    watcher = get_service_watcher_mock
     hassette = watcher.hassette
-    call_counts = make_call_counts()
-
-    spec = make_fast_spec(
+    dummy = register_dummy_service(
+        watcher,
         restart_type=RestartType.TRANSIENT,
         budget_intensity=1,
         cooldown_seconds=0.01,
         max_cooldown_cycles=1,
     )
-    dummy_service = get_dummy_service(call_counts, hassette, restart_spec=spec)
-    hassette.children.append(dummy_service)
-
-    key = watcher.service_key(dummy_service.class_name, dummy_service.role)
 
     # Set cycle count to max+1 to simulate exceeding max.
     # Also put the service in EXHAUSTED_COOLING — the valid pre-condition for cooldown_and_retry
     # (in production, handle_exhaustion sets this before spawning the cooldown task).
-    watcher._cooldown_cycles[key] = 2  # already exceeded max_cooldown_cycles=1
-    dummy_service._status = ResourceStatus.EXHAUSTED_COOLING
+    watcher._cooldown_cycles[dummy.key] = 2  # already exceeded max_cooldown_cycles=1
+    dummy.service._status = ResourceStatus.EXHAUSTED_COOLING
 
     # Run cooldown_and_retry directly — should detect exceeded cycles and emit EXHAUSTED_DEAD
     with EventCapture.capturing(hassette) as capture:
-        await watcher.cooldown_and_retry(dummy_service.class_name, dummy_service.role, key, spec)
+        await watcher.cooldown_and_retry(dummy.service.class_name, dummy.service.role, dummy.key, dummy.spec)
 
     assert len(capture.events) == 1
     assert capture.events[0].payload.data.status == ResourceStatus.EXHAUSTED_DEAD
 
 
-async def test_concurrent_failures_independent_budgets(get_service_watcher_mock: ServiceWatcher):
+async def test_concurrent_failures_independent_budgets(watcher: ServiceWatcher):
     """Two services fail simultaneously — each tracked by its own budget."""
-    watcher = get_service_watcher_mock
     hassette = watcher.hassette
 
     counts_a = make_call_counts()
@@ -717,61 +621,35 @@ async def test_concurrent_failures_independent_budgets(get_service_watcher_mock:
     assert key_b in watcher._budgets
 
     # Each should have independent budget with 1 restart recorded
-    budget_a = watcher._budgets[key_a]
-    budget_b = watcher._budgets[key_b]
-    budget_a.evict_expired()
-    budget_b.evict_expired()
-    assert len(budget_a._timestamps) == 1
-    assert len(budget_b._timestamps) == 1
+    assert budget_entries(watcher, key_a) == 1
+    assert budget_entries(watcher, key_b) == 1
 
 
-async def test_restart_exception_caught_no_double_count(get_service_watcher_mock: ServiceWatcher):
+async def test_restart_exception_caught_no_double_count(watcher: ServiceWatcher):
     """on_initialize raises → exception caught and logged, budget not double-counted."""
-    watcher = get_service_watcher_mock
-    hassette = watcher.hassette
-    call_counts = make_call_counts()
+    dummy = register_dummy_service(watcher, fail=True, restart_type=RestartType.TRANSIENT, budget_intensity=10)
 
-    spec = make_fast_spec(restart_type=RestartType.TRANSIENT, budget_intensity=10)
-    dummy_service = get_dummy_service(call_counts, hassette, fail=True, restart_spec=spec)
-    hassette.children.append(dummy_service)
+    await restart_and_await(watcher, dummy.failed_event)
 
-    event = make_service_failed_event(dummy_service)
-    key = watcher.service_key(dummy_service.class_name, dummy_service.role)
-
-    await restart_and_await(watcher, event)
-
-    budget = watcher._budgets.get(key)
-    assert budget is not None
-    budget.evict_expired()
     # Only 1 budget entry recorded (before restart), not 2
-    assert len(budget._timestamps) == 1
+    assert budget_entries(watcher, dummy.key) == 1
 
     # In-restart flag should be cleared after exception
-    assert key not in watcher._restarting
+    assert dummy.key not in watcher._restarting
 
 
-async def test_bus_recovery_reconciliation(get_service_watcher_mock: ServiceWatcher):
+async def test_bus_recovery_reconciliation(watcher: ServiceWatcher):
     """BusService restarts, another service is in FAILED state during blind window → reconciliation picks it up."""
-    watcher = get_service_watcher_mock
-    hassette = watcher.hassette
-    call_counts = make_call_counts()
-
-    spec = make_fast_spec(restart_type=RestartType.TRANSIENT, budget_intensity=5)
-    dummy_service = get_dummy_service(call_counts, hassette, restart_spec=spec)
-    hassette.children.append(dummy_service)
+    dummy = register_dummy_service(watcher, restart_type=RestartType.TRANSIENT, budget_intensity=5)
 
     # Simulate the service being in FAILED state with no budget entry
     # (as if FAILED event was dropped during BusService restart).
     # Use ._status bypass — this is deliberate test fixture setup, not a lifecycle operation.
-    dummy_service._status = ResourceStatus.FAILED
-    key = watcher.service_key(dummy_service.class_name, dummy_service.role)
-    assert key not in watcher._budgets  # no budget entry — dropped during blind window
+    dummy.service._status = ResourceStatus.FAILED
+    assert dummy.key not in watcher._budgets  # no budget entry — dropped during blind window
 
     # Run reconciliation
     await watcher.reconcile_after_bus_recovery()
 
     # Reconciliation should have picked up the FAILED service and entered restart flow
-    budget = watcher._budgets.get(key)
-    assert budget is not None, "Reconciliation should have created a budget entry"
-    budget.evict_expired()
-    assert len(budget._timestamps) == 1, "Reconciliation should have recorded one restart"
+    assert budget_entries(watcher, dummy.key) == 1, "Reconciliation should have recorded one restart"

--- a/tests/integration/test_thread_leaked_observability.py
+++ b/tests/integration/test_thread_leaked_observability.py
@@ -11,12 +11,11 @@ via ``make_mock_hassette()``, not a mock pool.
 import asyncio
 import threading
 import time
-from collections.abc import AsyncIterator
-from unittest.mock import AsyncMock, MagicMock
+from collections.abc import Awaitable, Callable
+from unittest.mock import MagicMock
 
 import pytest
 
-from hassette.commands import InvokeHandler
 from hassette.core.command_executor import CommandExecutor
 from hassette.core.database_service import DatabaseService
 from hassette.core.execution_record import ExecutionRecord
@@ -25,21 +24,36 @@ from hassette.task_bucket.task_bucket import TaskBucket
 from hassette.test_utils.factories import make_listener_registration, make_mock_listener
 from hassette.test_utils.mock_hassette import make_mock_hassette
 
-# Shared fixtures
+from .conftest import invoke_cmd, pop_execution_record
+
+InvokeFn = Callable[[object], Awaitable[None]]
 
 
-@pytest.fixture
-async def executor(
-    db_hassette: AsyncMock, initialized_db: tuple[DatabaseService, int]
-) -> AsyncIterator[CommandExecutor]:
-    """CommandExecutor with real DB wired in (same pattern as test_command_executor.py)."""
-    _db_service, _session_id = initialized_db
-    exc = CommandExecutor(db_hassette, parent=db_hassette)
-    await exc.on_initialize()
-    try:
-        yield exc
-    finally:
-        await exc.on_shutdown()
+def sync_invoker(sync_executor: SyncExecutor, handler: Callable[[object], None]) -> InvokeFn:
+    """Wrap a sync handler in the async adapter the bus uses, so it runs on a pool worker."""
+    adapted = TaskBucket(make_mock_hassette(), sync_executor=sync_executor).make_async_adapter(handler)
+
+    async def invoke(event: object) -> None:
+        await adapted(event)
+
+    return invoke
+
+
+def make_invoker_listener(invoke: InvokeFn) -> MagicMock:
+    """Listener that dispatches to `invoke`, carrying the identity fields the executor reads."""
+    listener = make_mock_listener()
+    listener.invoker.invoke = invoke
+    listener.invoker.error_handler = None
+    listener.identity.app_key = "test_app"
+    listener.identity.instance_index = 0
+    return listener
+
+
+def assert_timed_out(executor: CommandExecutor, *, thread_leaked: bool, reason: str) -> None:
+    """Assert the queued record is a timeout with the expected thread_leaked verdict."""
+    record = pop_execution_record(executor)
+    assert record.status == "timed_out"
+    assert record.thread_leaked is thread_leaked, reason
 
 
 # Not-started sync timeout → thread_leaked=False (handle.thread still None)
@@ -58,8 +72,6 @@ async def test_not_started_sync_timeout_no_false_positive(
     """
     pool_gate = threading.Event()
     started = threading.Barrier(3)
-    hassette_mock = make_mock_hassette()
-    bucket = TaskBucket(hassette_mock, sync_executor=sync_executor)
 
     def pool_filler() -> None:
         started.wait(timeout=2.0)
@@ -78,38 +90,19 @@ async def test_not_started_sync_timeout_no_false_positive(
     def sync_fn(_event: object) -> None:
         pass  # never reached within the test
 
-    adapted = bucket.make_async_adapter(sync_fn)
+    listener = make_invoker_listener(sync_invoker(sync_executor, sync_fn))
 
-    async def invoke(event: object) -> None:
-        await adapted(event)
-
-    listener = make_mock_listener()
-    listener.invoker.invoke = invoke
-    listener.invoker.error_handler = None
-    listener.identity.app_key = "test_app"
-    listener.identity.instance_index = 0
-
-    cmd = InvokeHandler(
-        listener=listener,
-        event=MagicMock(),
-        topic="test",
-        listener_id=4,
-        source_tier="app",
-        effective_timeout=0.01,  # 10ms — fires before pool has a free slot
-    )
-
-    await executor.execute(cmd)
+    # 10ms timeout — fires before the pool has a free slot
+    await executor.execute(invoke_cmd(listener, listener_id=4, effective_timeout=0.01))
 
     # Release the pool fillers so they exit before teardown.
     pool_gate.set()
     await asyncio.gather(filler_f1, filler_f2, return_exceptions=True)
 
-    assert not executor._write_queue.empty()
-    record = executor._write_queue.get_nowait()
-    assert isinstance(record, ExecutionRecord)
-    assert record.status == "timed_out"
-    assert record.thread_leaked is False, (
-        "thread_leaked must be False when worker never dequeued (handle.thread is None)"
+    assert_timed_out(
+        executor,
+        thread_leaked=False,
+        reason="thread_leaked must be False when worker never dequeued (handle.thread is None)",
     )
 
 
@@ -125,8 +118,6 @@ async def test_sync_handler_timeout_sets_thread_leaked(
     The handler sleeps for much longer than the timeout; when asyncio cancels
     the await the worker thread is still alive, so the liveness check fires.
     """
-    bucket = TaskBucket(make_mock_hassette(), sync_executor=sync_executor)
-
     released = threading.Event()
 
     def sync_blocking(_event: object) -> None:
@@ -134,36 +125,19 @@ async def test_sync_handler_timeout_sets_thread_leaked(
         # alive when the asyncio timeout fires.
         released.wait(timeout=5.0)
 
-    adapted = bucket.make_async_adapter(sync_blocking)
+    listener = make_invoker_listener(sync_invoker(sync_executor, sync_blocking))
 
-    async def invoke(event: object) -> None:
-        await adapted(event)
-
-    listener = make_mock_listener()
-    listener.invoker.invoke = invoke
-    listener.invoker.error_handler = None
-    listener.identity.app_key = "test_app"
-    listener.identity.instance_index = 0
-
-    cmd = InvokeHandler(
-        listener=listener,
-        event=MagicMock(),
-        topic="test",
-        listener_id=1,
-        source_tier="app",
-        effective_timeout=0.05,  # 50ms — worker will still be alive
-    )
-
-    await executor.execute(cmd)
+    # 50ms timeout — the worker will still be alive when it fires
+    await executor.execute(invoke_cmd(listener, effective_timeout=0.05))
 
     # Release the worker so it can exit cleanly after the test.
     released.set()
 
-    assert not executor._write_queue.empty()
-    record = executor._write_queue.get_nowait()
-    assert isinstance(record, ExecutionRecord)
-    assert record.status == "timed_out"
-    assert record.thread_leaked is True, "Expected thread_leaked=True for a sync handler still alive after timeout"
+    assert_timed_out(
+        executor,
+        thread_leaked=True,
+        reason="Expected thread_leaked=True for a sync handler still alive after timeout",
+    )
 
 
 # Async handler timeout → thread_leaked=False (no worker thread involved)
@@ -173,30 +147,19 @@ async def test_async_handler_timeout_does_not_set_thread_leaked(
     executor: CommandExecutor,
 ) -> None:
     """An async handler that times out does NOT set thread_leaked (no worker thread)."""
-    listener = make_mock_listener()
 
     async def slow_async(_event: object) -> None:
         await asyncio.sleep(10.0)
 
-    listener.invoker.invoke = slow_async
-    listener.invoker.error_handler = None
+    listener = make_invoker_listener(slow_async)
 
-    cmd = InvokeHandler(
-        listener=listener,
-        event=MagicMock(),
-        topic="test",
-        listener_id=2,
-        source_tier="app",
-        effective_timeout=0.05,
+    await executor.execute(invoke_cmd(listener, listener_id=2, effective_timeout=0.05))
+
+    assert_timed_out(
+        executor,
+        thread_leaked=False,
+        reason="thread_leaked must be False for async handlers (no worker thread)",
     )
-
-    await executor.execute(cmd)
-
-    assert not executor._write_queue.empty()
-    record = executor._write_queue.get_nowait()
-    assert isinstance(record, ExecutionRecord)
-    assert record.status == "timed_out"
-    assert record.thread_leaked is False, "thread_leaked must be False for async handlers (no worker thread)"
 
 
 # Thread-leaked distinguishable from clean timeout (thread finishes before check)
@@ -215,29 +178,15 @@ async def test_pure_async_timeout_no_handle_no_thread_leaked(
     async def async_slow(_event: object) -> None:
         await asyncio.sleep(10.0)
 
-    listener = make_mock_listener()
-    listener.invoker.invoke = async_slow
-    listener.invoker.error_handler = None
-    listener.identity.app_key = "test_app"
-    listener.identity.instance_index = 0
+    listener = make_invoker_listener(async_slow)
 
-    cmd = InvokeHandler(
-        listener=listener,
-        event=MagicMock(),
-        topic="test",
-        listener_id=3,
-        source_tier="app",
-        effective_timeout=0.05,
+    await executor.execute(invoke_cmd(listener, listener_id=3, effective_timeout=0.05))
+
+    assert_timed_out(
+        executor,
+        thread_leaked=False,
+        reason="No worker thread — handle is None, so thread_leaked must be False",
     )
-
-    await executor.execute(cmd)
-
-    assert not executor._write_queue.empty()
-    record = executor._write_queue.get_nowait()
-    assert isinstance(record, ExecutionRecord)
-    assert record.status == "timed_out"
-    # No worker thread — handle is None, so thread_leaked must be False
-    assert record.thread_leaked is False
 
 
 # Completed sync handler with user-code TimeoutError → thread_leaked=False
@@ -256,121 +205,65 @@ async def test_completed_sync_handler_no_false_thread_leaked(
     would cause a false thread_leaked=True.  The active flag — cleared by _call's finally
     block when the handler returns/raises — prevents this false positive.
     """
-    bucket = TaskBucket(make_mock_hassette(), sync_executor=sync_executor)
 
     def sync_raises_timeout(_event: object) -> None:
         raise TimeoutError("user-code timeout")
 
-    adapted = bucket.make_async_adapter(sync_raises_timeout)
+    listener = make_invoker_listener(sync_invoker(sync_executor, sync_raises_timeout))
 
-    async def invoke(event: object) -> None:
-        await adapted(event)
+    # No framework timeout — the TimeoutError comes from user code
+    await executor.execute(invoke_cmd(listener, listener_id=5))
 
-    listener = make_mock_listener()
-    listener.invoker.invoke = invoke
-    listener.invoker.error_handler = None
-    listener.identity.app_key = "test_app"
-    listener.identity.instance_index = 0
-
-    cmd = InvokeHandler(
-        listener=listener,
-        event=MagicMock(),
-        topic="test",
-        listener_id=5,
-        source_tier="app",
-        effective_timeout=None,  # no framework timeout — the TimeoutError is from user code
-    )
-
-    await executor.execute(cmd)
-
-    assert not executor._write_queue.empty()
-    record = executor._write_queue.get_nowait()
-    assert isinstance(record, ExecutionRecord)
-    assert record.status == "timed_out"
-    assert record.thread_leaked is False, (
-        "thread_leaked must be False when the sync handler completed (active=False) "
-        "even though the pool thread is still alive"
+    assert_timed_out(
+        executor,
+        thread_leaked=False,
+        reason=(
+            "thread_leaked must be False when the sync handler completed (active=False) "
+            "even though the pool thread is still alive"
+        ),
     )
 
 
 # Round-trip persistence — thread_leaked column survives write+read back
 
 
-async def test_thread_leaked_persists_to_db(
+@pytest.mark.parametrize("thread_leaked", [True, False], ids=["leaked", "not_leaked"])
+async def test_thread_leaked_round_trips_through_db(
     executor: CommandExecutor,
     initialized_db: tuple[DatabaseService, int],
+    thread_leaked: bool,
 ) -> None:
-    """thread_leaked=True on an execution record persists to the DB and reads back correctly.
+    """The thread_leaked flag persists to the DB and reads back as 1/0.
 
-    Verifies the 004.sql migration column is wired end-to-end: build_record →
-    execution_insert_params → INSERT → SELECT.
+    Verifies the 004.sql migration column is wired end-to-end: execution_insert_params →
+    INSERT → SELECT. The record is built directly rather than via build_record, because
+    build_record with a MagicMock event would try to bind a MagicMock origin to SQLite.
     """
-    db_service, _session_id = initialized_db
+    db_service, session_id = initialized_db
 
     # Register the listener so the FK constraint is satisfied.
-    reg = make_listener_registration(topic="test")
-    listener_id = await executor.register_listener(reg)
+    listener_id = await executor.register_listener(make_listener_registration(topic="test"))
 
-    # Build the record directly so we avoid calling build_record with a MagicMock event
-    # (cmd.event.payload.origin would be a MagicMock and SQLite can't bind it).
-    # The persistence path is independent of how the flag is set — we're testing the
-    # execution_insert_params → INSERT → SELECT round-trip, not build_record itself.
+    execution_id = f"test-exec-thread-leaked-{thread_leaked}"
     record = ExecutionRecord(
         kind="handler",
         listener_id=listener_id,
-        session_id=_session_id,
+        session_id=session_id,
         execution_start_ts=time.time(),
         duration_ms=55.0,
         status="timed_out",
-        thread_leaked=True,
+        thread_leaked=thread_leaked,
         error_type="TimeoutError",
         error_message="execution timed out",
-        execution_id="test-exec-thread-leaked",
+        execution_id=execution_id,
     )
-    assert record.thread_leaked is True
 
-    # Persist and read back.
     await executor.persist_batch([record])
 
     cursor = await db_service.db.execute(
         "SELECT thread_leaked FROM executions WHERE execution_id = ?",
-        ("test-exec-thread-leaked",),
+        (execution_id,),
     )
     row = await cursor.fetchone()
     assert row is not None, "execution row not found after persist"
-    assert row[0] == 1, f"Expected thread_leaked=1, got {row[0]}"
-
-
-async def test_thread_leaked_false_persists_as_zero(
-    executor: CommandExecutor,
-    initialized_db: tuple[DatabaseService, int],
-) -> None:
-    """thread_leaked=False (default) persists as 0 in the DB."""
-    db_service, _session_id = initialized_db
-
-    reg = make_listener_registration(topic="test", name="test_app.on_event_false")
-    listener_id = await executor.register_listener(reg)
-
-    record = ExecutionRecord(
-        kind="handler",
-        listener_id=listener_id,
-        session_id=_session_id,
-        execution_start_ts=time.time(),
-        duration_ms=50.0,
-        status="timed_out",
-        thread_leaked=False,
-        error_type="TimeoutError",
-        error_message="execution timed out",
-        execution_id="test-exec-no-leak",
-    )
-    assert record.thread_leaked is False
-
-    await executor.persist_batch([record])
-
-    cursor = await db_service.db.execute(
-        "SELECT thread_leaked FROM executions WHERE execution_id = ?",
-        ("test-exec-no-leak",),
-    )
-    row = await cursor.fetchone()
-    assert row is not None
-    assert row[0] == 0, f"Expected thread_leaked=0, got {row[0]}"
+    assert row[0] == int(thread_leaked)

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -8,7 +8,11 @@ import logging
 import logging.handlers
 import queue
 import sys
+import threading
+import time
 import warnings
+from collections.abc import Callable
+from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass
 from io import StringIO
 from typing import TYPE_CHECKING
@@ -35,6 +39,7 @@ from hassette.logging_ import (
 )
 from hassette.models.entities.light import LightEntity
 from hassette.models.states import LightState
+from hassette.task_bucket.interruptible_executor import InterruptibleThreadPoolExecutor
 from hassette.test_utils.factories import make_mock_parent
 
 if TYPE_CHECKING:
@@ -47,6 +52,9 @@ TEST_TOKEN = "test-token"
 #: Shared timezone for tests that build fixed ZonedDateTime instances — America/Chicago
 #: covers DST transitions in a way UTC doesn't, so most scheduler/trigger tests use it.
 TZ = "America/Chicago"
+
+#: Upper bound on how long a submitted worker may take to signal that it is running.
+WORKER_READY_TIMEOUT = 2.0
 
 
 def make_sync_executor_config(
@@ -324,3 +332,115 @@ def drain_forgotten_await_handles():
     with warnings.catch_warnings():
         warnings.simplefilter("ignore", HassetteForgottenAwaitWarning)
         gc.collect()
+
+
+def await_worker_ready(ready: threading.Event) -> None:
+    """Block until a submitted worker signals that it is actually running."""
+    assert ready.wait(timeout=WORKER_READY_TIMEOUT), "worker did not signal ready in time"
+
+
+def busy_loop_worker(
+    ready: threading.Event,
+    *,
+    terminated: threading.Event | None = None,
+    reraise: bool = False,
+) -> Callable[[], None]:
+    """Build a Python-level busy loop that signals `ready`, then spins until interrupted.
+
+    Only Python bytecode runs in the loop, so ``async_raise`` lands on the next instruction —
+    the property the shutdown-interrupt tests rely on. SystemExit is swallowed by default so
+    pytest's threadexception plugin does not treat the interrupted worker as a test failure;
+    `reraise` keeps it propagating for tests asserting that the executor suppresses it.
+    `terminated` is set when the interrupt is observed.
+
+    Keep the loop body a bare ``pass``. Giving it any other shape (an ``if`` on a closure
+    variable, for instance) makes CPython 3.14 deliver the async SystemExit at a point the
+    frame's exception table does not route to this handler, so it escapes the thread instead
+    of being caught — verified empirically, not a theoretical concern.
+    """
+
+    def run() -> None:
+        ready.set()
+        try:
+            while True:
+                pass
+        except SystemExit:
+            if terminated is not None:
+                terminated.set()
+            if reraise:
+                raise
+
+    return run
+
+
+def sleeping_loop_worker(ready: threading.Event, interval: float = 0.01) -> Callable[[], None]:
+    """Build a loop of short C sleeps that signals `ready`, then runs until interrupted.
+
+    Unlike `busy_loop_worker`, the worker yields between iterations; each sleep returns to
+    Python promptly, so ``async_raise`` still reaches it. SystemExit is swallowed.
+    """
+
+    def run() -> None:
+        ready.set()
+        try:
+            while True:
+                time.sleep(interval)
+        except SystemExit:
+            pass
+
+    return run
+
+
+def c_blocked_worker(ready: threading.Event, seconds: float = 60.0) -> Callable[[], None]:
+    """Build a worker that signals `ready`, then blocks in a C-level sleep.
+
+    ``async_raise`` cannot interrupt this until the call returns to Python, so shutdown must
+    abandon the thread at budget expiry instead of waiting for it.
+    """
+
+    def run() -> None:
+        ready.set()
+        time.sleep(seconds)
+
+    return run
+
+
+def start_busy_thread(*, name: str | None = None, terminated: threading.Event | None = None) -> threading.Thread:
+    """Start a daemon thread running `busy_loop_worker` and wait until it is spinning."""
+    ready = threading.Event()
+    thread = threading.Thread(target=busy_loop_worker(ready, terminated=terminated), name=name, daemon=True)
+    thread.start()
+    await_worker_ready(ready)
+    return thread
+
+
+def start_sleeping_thread(interval: float = 0.01) -> threading.Thread:
+    """Start a daemon thread running `sleeping_loop_worker` and wait until it is looping."""
+    ready = threading.Event()
+    thread = threading.Thread(target=sleeping_loop_worker(ready, interval), daemon=True)
+    thread.start()
+    await_worker_ready(ready)
+    return thread
+
+
+def submit_busy_worker(
+    executor: ThreadPoolExecutor, *, terminated: threading.Event | None = None, reraise: bool = False
+) -> None:
+    """Submit a Python busy-loop worker to `executor` and wait until it is spinning."""
+    ready = threading.Event()
+    executor.submit(busy_loop_worker(ready, terminated=terminated, reraise=reraise))
+    await_worker_ready(ready)
+
+
+def submit_c_blocked_worker(executor: ThreadPoolExecutor, seconds: float = 60.0) -> None:
+    """Submit a C-blocked worker to `executor` and wait until it is blocked."""
+    ready = threading.Event()
+    executor.submit(c_blocked_worker(ready, seconds))
+    await_worker_ready(ready)
+
+
+def timed_shutdown(executor: InterruptibleThreadPoolExecutor, budget: float) -> float:
+    """Shut `executor` down through the join/interrupt loop; return elapsed wall-clock seconds."""
+    wall_start = time.monotonic()
+    executor.shutdown(join_threads_or_timeout=True, timeout=budget)
+    return time.monotonic() - wall_start

--- a/tests/unit/task_bucket/test_interruptible_executor.py
+++ b/tests/unit/task_bucket/test_interruptible_executor.py
@@ -28,8 +28,25 @@ from hassette.task_bucket.interruptible_executor import (
     async_raise,
     join_or_interrupt_threads,
 )
+from tests.unit.conftest import (
+    await_worker_ready,
+    start_busy_thread,
+    start_sleeping_thread,
+    submit_busy_worker,
+    submit_c_blocked_worker,
+    timed_shutdown,
+)
 
 _EXECUTOR_LOGGER = "hassette.task_bucket.interruptible_executor"
+
+
+def interrupt_and_join(thread: threading.Thread) -> None:
+    """Interrupt `thread` with async_raise(SystemExit) and assert it actually exits."""
+    assert thread.ident is not None  # the thread has started, so ident is set
+    async_raise(thread.ident, SystemExit)
+    thread.join(timeout=3.0)
+    assert not thread.is_alive(), "Thread should have been terminated by async_raise"
+
 
 # async_raise(SystemExit) into a worker stuck in a C-level call (time.sleep) deadlocks under
 # coverage's settrace tracer on Python 3.11. Python 3.12+ trace via sys.monitoring (PEP 669)
@@ -132,12 +149,8 @@ class TestAsyncRaise:
         t.start()
         time.sleep(0.05)  # let it spin up
 
-        assert t.ident is not None
-        async_raise(t.ident, SystemExit)
-
         # Thread must stop within a generous but bounded time.
-        t.join(timeout=3.0)
-        assert not t.is_alive(), "Thread should have been terminated by async_raise"
+        interrupt_and_join(t)
         assert done.is_set(), "Thread should have received SystemExit"
 
 
@@ -177,28 +190,14 @@ class TestJoinOrInterruptThreads:
 
         t = threading.Thread(target=short_work, daemon=True)
         t.start()
-        assert started.wait(timeout=2.0), "worker did not signal start in time"
+        await_worker_ready(started)
 
         joined = join_or_interrupt_threads({t}, timeout=2.0, log=False)
         assert t in joined
 
     def test_logs_straggler_name_before_interrupt(self) -> None:
         """When log=True, the straggler's name and stack must be logged before async_raise."""
-        ready = threading.Event()
-
-        def busy_loop() -> None:
-            ready.set()
-            try:
-                while True:
-                    pass
-            except SystemExit:
-                # Swallow SystemExit so the thread exits cleanly without triggering
-                # pytest's threadexception plugin.
-                pass
-
-        t = threading.Thread(target=busy_loop, name="test-straggler-thread", daemon=True)
-        t.start()
-        assert ready.wait(timeout=2.0), "worker did not signal ready in time"
+        t = start_busy_thread(name="test-straggler-thread")
 
         with capture_warnings() as records:
             join_or_interrupt_threads({t}, timeout=0.05, log=True)
@@ -231,21 +230,7 @@ class TestJoinOrInterruptThreads:
 
     def test_suppresses_system_error_from_async_raise(self) -> None:
         """SystemError from async_raise must be suppressed, not propagated."""
-        ready = threading.Event()
-
-        def loop() -> None:
-            ready.set()
-            try:
-                while True:
-                    pass
-            except SystemExit:
-                # Swallow SystemExit so the thread exits cleanly without triggering
-                # pytest's threadexception plugin.
-                pass
-
-        t = threading.Thread(target=loop, daemon=True)
-        t.start()
-        assert ready.wait(timeout=2.0), "worker did not signal ready in time"
+        t = start_busy_thread()
 
         with patch(
             "hassette.task_bucket.interruptible_executor.async_raise",
@@ -255,9 +240,7 @@ class TestJoinOrInterruptThreads:
             join_or_interrupt_threads({t}, timeout=0.05, log=False)
 
         # Clean up — t is still running because async_raise was patched to raise SystemError
-        assert t.ident is not None
-        async_raise(t.ident, SystemExit)
-        t.join(timeout=2.0)
+        interrupt_and_join(t)
 
 
 # InterruptibleThreadPoolExecutor.shutdown — integration-level tests
@@ -275,19 +258,10 @@ class TestInterruptibleThreadPoolExecutorShutdown:
         within the budget.
         """
         executor = InterruptibleThreadPoolExecutor(max_workers=1)
-        started = threading.Event()
-
-        def c_blocked() -> None:
-            started.set()
-            time.sleep(60)  # long C-level sleep
-
-        executor.submit(c_blocked)
-        assert started.wait(timeout=2.0), "worker did not signal start in time"
+        submit_c_blocked_worker(executor)
 
         budget = 1.0
-        wall_start = time.monotonic()
-        executor.shutdown(join_threads_or_timeout=True, timeout=budget)
-        elapsed = time.monotonic() - wall_start
+        elapsed = timed_shutdown(executor, budget)
 
         # Allow a 20% margin over budget for scheduling jitter.
         assert elapsed < budget * 1.2, f"shutdown() took {elapsed:.2f}s, expected < {budget * 1.2:.2f}s"
@@ -295,15 +269,7 @@ class TestInterruptibleThreadPoolExecutorShutdown:
     def test_shutdown_does_not_raise(self) -> None:
         """shutdown() must never propagate an exception from the interrupt loop."""
         executor = InterruptibleThreadPoolExecutor(max_workers=2)
-        ready = threading.Event()
-
-        def busy() -> None:
-            ready.set()
-            while True:
-                pass
-
-        executor.submit(busy)
-        assert ready.wait(timeout=2.0), "worker did not signal ready in time"
+        submit_busy_worker(executor)
 
         # Must not raise — benign errors are suppressed
         executor.shutdown(join_threads_or_timeout=True, timeout=0.5)
@@ -313,20 +279,8 @@ class TestInterruptibleThreadPoolExecutorShutdown:
         within the shutdown budget.
         """
         executor = InterruptibleThreadPoolExecutor(max_workers=1)
-        ready = threading.Event()
         terminated = threading.Event()
-
-        def busy_loop() -> None:
-            ready.set()
-            try:
-                while True:
-                    pass
-            except SystemExit:
-                terminated.set()
-                raise
-
-        executor.submit(busy_loop)
-        assert ready.wait(timeout=2.0), "worker did not signal ready in time"
+        submit_busy_worker(executor, terminated=terminated, reraise=True)
 
         budget = 2.0
         executor.shutdown(join_threads_or_timeout=True, timeout=budget)
@@ -336,18 +290,7 @@ class TestInterruptibleThreadPoolExecutorShutdown:
     def test_stack_logged_for_python_straggler(self) -> None:
         """Straggler thread name and stack must be logged before interrupt."""
         executor = InterruptibleThreadPoolExecutor(max_workers=1, thread_name_prefix="test-worker")
-        ready = threading.Event()
-
-        def busy_loop() -> None:
-            ready.set()
-            try:
-                while True:
-                    pass
-            except SystemExit:
-                raise
-
-        executor.submit(busy_loop)
-        assert ready.wait(timeout=2.0), "worker did not signal ready in time"
+        submit_busy_worker(executor, reraise=True)
 
         with capture_warnings() as records:
             executor.shutdown(join_threads_or_timeout=True, timeout=2.0)
@@ -360,14 +303,7 @@ class TestInterruptibleThreadPoolExecutorShutdown:
     def test_shutdown_without_join_skips_interrupt_loop(self) -> None:
         """shutdown(join_threads_or_timeout=False) must skip the join/interrupt loop."""
         executor = InterruptibleThreadPoolExecutor(max_workers=1)
-        ready = threading.Event()
-
-        def busy() -> None:
-            ready.set()
-            time.sleep(30)
-
-        executor.submit(busy)
-        assert ready.wait(timeout=2.0), "worker did not signal ready in time"
+        submit_c_blocked_worker(executor, seconds=30)
 
         # Should return immediately (no join attempt)
         wall_start = time.monotonic()
@@ -424,19 +360,7 @@ class TestInterruptibleThreadPoolExecutorShutdown:
         and its mocked ValueError actually fires (a dead thread would join first and
         async_raise would never run — a vacuous test).
         """
-        ready = threading.Event()
-
-        def busy_loop() -> None:
-            ready.set()
-            try:
-                while True:
-                    time.sleep(0.01)
-            except SystemExit:
-                pass  # swallow so pytest's threadexception plugin doesn't flag it
-
-        t = threading.Thread(target=busy_loop, daemon=True)
-        t.start()
-        assert ready.wait(timeout=2.0), "worker did not signal ready in time"
+        t = start_sleeping_thread()
 
         with patch(
             "hassette.task_bucket.interruptible_executor.async_raise",
@@ -446,26 +370,12 @@ class TestInterruptibleThreadPoolExecutorShutdown:
             join_or_interrupt_threads({t}, timeout=0.05, log=False)
 
         # Clean up: actually stop the live thread now that the real async_raise is back.
-        assert t.ident is not None  # thread has started, so ident is set
-        async_raise(t.ident, SystemExit)
-        t.join(timeout=2.0)
-        assert not t.is_alive()
+        interrupt_and_join(t)
 
     def test_res_greater_than_one_suppressed_during_shutdown(self) -> None:
         """SystemError from async_raise (res>1 path) must be suppressed at shutdown."""
         executor = InterruptibleThreadPoolExecutor(max_workers=1)
-        ready = threading.Event()
-
-        def busy() -> None:
-            ready.set()
-            try:
-                while True:
-                    pass
-            except SystemExit:
-                raise
-
-        executor.submit(busy)
-        assert ready.wait(timeout=2.0), "worker did not signal ready in time"
+        submit_busy_worker(executor, reraise=True)
 
         with patch(
             "hassette.task_bucket.interruptible_executor.async_raise",

--- a/tests/unit/test_autodetect_apps.py
+++ b/tests/unit/test_autodetect_apps.py
@@ -12,7 +12,26 @@ import pytest
 from hassette import context
 from hassette.config.config import HassetteConfig
 from hassette.config.defaults import AUTODETECT_EXCLUDE_DIRS_DEFAULT
+from hassette.types.types import AppDict
 from hassette.utils.app_utils import autodetect_apps
+
+
+def write_app(app_dir: Path, filename: str, source: str) -> Path:
+    """Write `source` as a module inside `app_dir`, creating the directory if needed."""
+    app_dir.mkdir(parents=True, exist_ok=True)
+    path = app_dir / filename
+    path.write_text(dedent(source))
+    return path
+
+
+def detect(app_dir: Path, known_paths: set[Path] | None = None) -> dict[str, AppDict]:
+    """Run autodetect_apps over `app_dir` with the production exclude list."""
+    return autodetect_apps(app_dir, known_paths or set(), set(AUTODETECT_EXCLUDE_DIRS_DEFAULT))
+
+
+def assert_detected(result: dict[str, AppDict], *app_keys: str) -> None:
+    """Assert the detected app keys are exactly `app_keys` — nothing missing, nothing extra."""
+    assert sorted(result) == sorted(app_keys), f"Expected {sorted(app_keys)}, got {sorted(result)}"
 
 
 class TestAutoDetectAppsCurrDir:
@@ -30,61 +49,45 @@ class TestAutoDetectAppsCurrDir:
 
     def test_autodetect_in_current_directory(self, tmp_path: Path):
         """Test auto-detection of apps in the current directory."""
-        # Create a simple app file in the temp directory
-        app_file = tmp_path / "current_dir_app.py"
-        app_file.write_text(
-            dedent("""
+        write_app(
+            tmp_path,
+            "current_dir_app.py",
+            """
             from hassette import App, AppConfig
 
             class CurrentDirApp(App[AppConfig]): ...
-        """)
+        """,
         )
-        expected = f"{tmp_path.name}.current_dir_app.CurrentDirApp"
 
-        known_paths = set()
-        result = autodetect_apps(tmp_path, known_paths, set(AUTODETECT_EXCLUDE_DIRS_DEFAULT))
-        assert len(result) == 1, f"Expected 1 app, got {len(result)}"
-        assert expected in result, f"Expected to find '{expected}' in detected apps"
+        assert_detected(detect(tmp_path), f"{tmp_path.name}.current_dir_app.CurrentDirApp")
 
     def test_autodetect_ignores_venv_directory(self, tmp_path: Path):
         """Test that auto-detection ignores .venv directory."""
-        # Create a .venv directory with an app file
-        venv_dir = tmp_path / ".venv"
-        venv_dir.mkdir()
-
-        app_file = venv_dir / "venv_app.py"
-        app_file.write_text(
-            dedent("""
+        write_app(
+            tmp_path / ".venv",
+            "venv_app.py",
+            """
             from hassette import App, AppConfig
 
             class VenvApp(App[AppConfig]): ...
-        """)
+        """,
         )
 
-        known_paths = set()
-        result = autodetect_apps(tmp_path, known_paths, set(AUTODETECT_EXCLUDE_DIRS_DEFAULT))
-        assert len(result) == 0, f"Expected 0 apps, got {len(result)}"
-        assert "venv_app.VenvApp" not in result, "Did not expect to find 'venv_app.VenvApp' in detected apps"
+        assert_detected(detect(tmp_path))
 
     def test_autodetect_ignores_hidden_directories(self, tmp_path: Path):
         """Test that auto-detection ignores hidden directories."""
-        # Create a hidden directory with an app file
-        hidden_dir = tmp_path / ".hidden"
-        hidden_dir.mkdir()
-
-        app_file = hidden_dir / "hidden_app.py"
-        app_file.write_text(
-            dedent("""
+        write_app(
+            tmp_path / ".hidden",
+            "hidden_app.py",
+            """
             from hassette import App, AppConfig
 
             class HiddenApp(App[AppConfig]): ...
-        """)
+        """,
         )
 
-        known_paths = set()
-        result = autodetect_apps(tmp_path, known_paths, set(AUTODETECT_EXCLUDE_DIRS_DEFAULT))
-        assert len(result) == 0, f"Expected 0 apps, got {len(result)}"
-        assert "hidden_app.HiddenApp" not in result, "Did not expect to find 'hidden_app.HiddenApp' in detected apps"
+        assert_detected(detect(tmp_path))
 
 
 class TestAutoDetectApps:
@@ -98,73 +101,59 @@ class TestAutoDetectApps:
     def test_autodetect_simple_app(self, tmp_path: Path):
         """Test auto-detection of a simple app in the root directory."""
         app_dir = tmp_path / "apps"
-        app_dir.mkdir()
-
-        # Create a simple app file
-        app_file = app_dir / "simple_app.py"
-        app_file.write_text(
-            dedent("""
+        write_app(
+            app_dir,
+            "simple_app.py",
+            """
             from hassette import App, AppConfig
 
             class SimpleAppConfig(AppConfig):
                 message: str = "Hello"
 
             class SimpleApp(App[SimpleAppConfig]): ...
-        """)
+        """,
         )
 
-        known_paths = set()
-        result = autodetect_apps(app_dir, known_paths, set(AUTODETECT_EXCLUDE_DIRS_DEFAULT))
-
-        assert len(result) == 1
-        assert "apps.simple_app.SimpleApp" in result
+        result = detect(app_dir)
+        assert_detected(result, "apps.simple_app.SimpleApp")
 
         app_dict = result["apps.simple_app.SimpleApp"]
-        assert app_dict["filename"] == "simple_app.py", f"Expected 'simple_app.py', got '{app_dict['filename']}'"
-        assert app_dict["class_name"] == "SimpleApp", f"Expected 'SimpleApp', got '{app_dict['class_name']}'"
-        assert app_dict["app_dir"] == app_dir, f"Expected '{app_dir}', got '{app_dict['app_dir']}'"
-        assert app_dict["app_key"] == "apps.simple_app.SimpleApp", (
-            f"Expected 'apps.simple_app.SimpleApp', got '{app_dict['app_key']}'"
-        )
-        assert app_dict["enabled"] is True, f"Expected 'True', got '{app_dict['enabled']}'"
+        assert app_dict["filename"] == "simple_app.py"
+        assert app_dict["class_name"] == "SimpleApp"
+        assert app_dict["app_dir"] == app_dir
+        assert app_dict["app_key"] == "apps.simple_app.SimpleApp"
+        assert app_dict["enabled"] is True
 
     def test_autodetect_sync_app(self, tmp_path: Path):
         """Test auto-detection of a sync app."""
         app_dir = tmp_path / "apps"
-        app_dir.mkdir()
-
-        # Create a sync app file
-        app_file = app_dir / "sync_app.py"
-        app_file.write_text(
-            dedent("""
+        write_app(
+            app_dir,
+            "sync_app.py",
+            """
             from hassette import AppSync, AppConfig
 
             class SyncAppConfig(AppConfig):
                 interval: int = 60
 
             class MySyncApp(AppSync[SyncAppConfig]): ...
-        """)
+        """,
         )
 
-        known_paths = set()
-        result = autodetect_apps(app_dir, known_paths, set(AUTODETECT_EXCLUDE_DIRS_DEFAULT))
-
-        assert len(result) == 1
-        assert "apps.sync_app.MySyncApp" in result, "Expected to find 'apps.sync_app.MySyncApp' in detected apps"
+        result = detect(app_dir)
+        assert_detected(result, "apps.sync_app.MySyncApp")
 
         app_dict = result["apps.sync_app.MySyncApp"]
-        assert app_dict["filename"] == "sync_app.py", f"Expected 'sync_app.py', got '{app_dict['filename']}'"
-        assert app_dict["class_name"] == "MySyncApp", f"Expected 'MySyncApp', got '{app_dict['class_name']}'"
+        assert app_dict["filename"] == "sync_app.py"
+        assert app_dict["class_name"] == "MySyncApp"
 
     def test_autodetect_multiple_apps_in_file(self, tmp_path: Path):
         """Test auto-detection when multiple app classes exist in one file."""
         app_dir = tmp_path / "apps"
-        app_dir.mkdir()
-
-        # Create a file with multiple app classes
-        app_file = app_dir / "multi_apps.py"
-        app_file.write_text(
-            dedent("""
+        write_app(
+            app_dir,
+            "multi_apps.py",
+            """
             from hassette import App, AppSync, AppConfig
 
             class SharedConfig(AppConfig):
@@ -173,90 +162,62 @@ class TestAutoDetectApps:
             class FirstApp(App[SharedConfig]): ...
 
             class SecondApp(AppSync[SharedConfig]): ...
-        """)
+        """,
         )
 
-        known_paths = set()
-        result = autodetect_apps(app_dir, known_paths, set(AUTODETECT_EXCLUDE_DIRS_DEFAULT))
+        result = detect(app_dir)
+        assert_detected(result, "apps.multi_apps.FirstApp", "apps.multi_apps.SecondApp")
 
-        assert len(result) == 2, f"Expected 2 apps, got {len(result)}"
-        assert "apps.multi_apps.FirstApp" in result, "Expected to find 'apps.multi_apps.FirstApp' in detected apps"
-        assert "apps.multi_apps.SecondApp" in result, "Expected to find 'apps.multi_apps.SecondApp' in detected apps"
-
-        first_app_dict = result["apps.multi_apps.FirstApp"]
-        assert first_app_dict["class_name"] == "FirstApp", f"Expected 'FirstApp', got '{first_app_dict['class_name']}'"
-
-        second_app_dict = result["apps.multi_apps.SecondApp"]
-        assert second_app_dict["class_name"] == "SecondApp", (
-            f"Expected 'SecondApp', got '{second_app_dict['class_name']}'"
-        )
+        assert result["apps.multi_apps.FirstApp"]["class_name"] == "FirstApp"
+        assert result["apps.multi_apps.SecondApp"]["class_name"] == "SecondApp"
 
     def test_autodetect_nested_directory(self, tmp_path: Path):
         """Test auto-detection of apps in nested directories."""
         app_dir = tmp_path / "apps"
         app_dir.mkdir()
-
-        # Create nested directory structure
-        notifications_dir = app_dir / "notifications"
-        notifications_dir.mkdir()
-
-        app_file = notifications_dir / "email_notifier.py"
-        app_file.write_text(
-            dedent("""
+        write_app(
+            app_dir / "notifications",
+            "email_notifier.py",
+            """
             from hassette import App, AppConfig
 
             class EmailConfig(AppConfig):
                 smtp_server: str = "localhost"
 
             class EmailNotifier(App[EmailConfig]): ...
-        """)
+        """,
         )
 
-        known_paths = set()
-        result = autodetect_apps(app_dir, known_paths, set(AUTODETECT_EXCLUDE_DIRS_DEFAULT))
-
-        assert len(result) == 1, f"Expected 1 app, got {len(result)}"
-        assert "apps.notifications.email_notifier.EmailNotifier" in result, (
-            "Expected to find 'apps.notifications.email_notifier.EmailNotifier' in detected apps"
-        )
+        result = detect(app_dir)
+        assert_detected(result, "apps.notifications.email_notifier.EmailNotifier")
 
         app_dict = result["apps.notifications.email_notifier.EmailNotifier"]
-        assert app_dict["filename"] == "email_notifier.py", (
-            f"Expected 'email_notifier.py', got '{app_dict['filename']}'"
-        )
-        assert app_dict["class_name"] == "EmailNotifier", f"Expected 'EmailNotifier', got '{app_dict['class_name']}'"
-        assert app_dict["app_key"] == "apps.notifications.email_notifier.EmailNotifier", (
-            f"Expected 'apps.notifications.email_notifier.EmailNotifier', got '{app_dict['app_key']}'"
-        )
+        assert app_dict["filename"] == "email_notifier.py"
+        assert app_dict["class_name"] == "EmailNotifier"
+        assert app_dict["app_key"] == "apps.notifications.email_notifier.EmailNotifier"
 
     def test_autodetect_skips_known_paths(self, tmp_path: Path):
         """Test that auto-detection skips already configured apps."""
         app_dir = tmp_path / "apps"
-        app_dir.mkdir()
-
-        app_file = app_dir / "configured_app.py"
-        app_file.write_text(
-            dedent("""
+        app_file = write_app(
+            app_dir,
+            "configured_app.py",
+            """
             from hassette import App, AppConfig
 
             class ConfiguredApp(App[AppConfig]): ...
-        """)
+        """,
         )
 
-        # Include this file in known_paths
-        known_paths = {app_file.resolve()}
-        result = autodetect_apps(app_dir, known_paths, set(AUTODETECT_EXCLUDE_DIRS_DEFAULT))
-
-        assert len(result) == 0, "Expected no apps to be detected since the only app is in known_paths"
+        assert_detected(detect(app_dir, known_paths={app_file.resolve()}))
 
     def test_autodetect_ignores_base_classes(self, tmp_path: Path):
         """Test that auto-detection ignores the base App and AppSync classes."""
         app_dir = tmp_path / "apps"
-        app_dir.mkdir()
-
-        app_file = app_dir / "base_classes.py"
-        app_file.write_text(
-            dedent("""
+        write_app(
+            app_dir,
+            "base_classes.py",
+            """
             from hassette import App, AppSync, AppConfig
 
             # These should not be detected
@@ -264,103 +225,75 @@ class TestAutoDetectApps:
             AppSync = AppSync
 
             class RealApp(App[AppConfig]): ...
-        """)
+        """,
         )
 
-        known_paths = set()
-        result = autodetect_apps(app_dir, known_paths, set(AUTODETECT_EXCLUDE_DIRS_DEFAULT))
-
-        # Should only find RealApp, not App or AppSync
-        assert len(result) == 1, f"Expected 1 app, got {len(result)}"
-        assert "apps.base_classes.RealApp" in result, "Expected to find 'apps.base_classes.RealApp' in detected apps"
+        assert_detected(detect(app_dir), "apps.base_classes.RealApp")
 
     def test_autodetect_ignores_imported_classes(self, tmp_path: Path):
         """Test that auto-detection ignores classes imported from other modules."""
         app_dir = tmp_path / "apps"
-        app_dir.mkdir()
-
-        # Create a module with an app class
-        module_file = app_dir / "my_module.py"
-        module_file.write_text(
-            dedent("""
+        write_app(
+            app_dir,
+            "my_module.py",
+            """
             from hassette import App, AppConfig
 
             class ModuleApp(App[AppConfig]): ...
-        """)
+        """,
         )
-
-        # Create another file that imports the class
-        import_file = app_dir / "importer.py"
-        import_file.write_text(
-            dedent("""
+        write_app(
+            app_dir,
+            "importer.py",
+            """
             from my_module import ModuleApp
             from hassette import App, AppConfig
 
             class LocalApp(App[AppConfig]): ...
-        """)
+        """,
         )
 
-        known_paths = set()
-        result = autodetect_apps(app_dir, known_paths, set(AUTODETECT_EXCLUDE_DIRS_DEFAULT))
-
-        # Should find both apps, but each in their own module
-        assert len(result) == 2, f"Expected 2 apps, got {len(result)}"
-        assert "apps.my_module.ModuleApp" in result, "Expected to find 'apps.my_module.ModuleApp' in detected apps"
-        assert "apps.importer.LocalApp" in result, "Expected to find 'apps.importer.LocalApp' in detected apps"
-        # ModuleApp should NOT be detected in importer.py
-        assert "apps.importer.ModuleApp" not in result, (
-            "Did not expect to find 'apps.importer.ModuleApp' in detected apps"
-        )
+        # Each app is detected in its own module; ModuleApp must NOT appear under importer.py
+        assert_detected(detect(app_dir), "apps.my_module.ModuleApp", "apps.importer.LocalApp")
 
     def test_autodetect_handles_import_errors(self, tmp_path: Path):
         """Test that auto-detection gracefully handles files with import errors."""
         app_dir = tmp_path / "apps"
-        app_dir.mkdir()
-
-        # Create a file with import errors
-        bad_file = app_dir / "broken_app.py"
-        bad_file.write_text(
-            dedent("""
+        write_app(
+            app_dir,
+            "broken_app.py",
+            """
             from nonexistent_module import SomethingThatDoesntExist
             from hassette import App, AppConfig
 
             class BrokenApp(App[AppConfig]): ...
-        """)
+        """,
         )
-
-        # Create a good file
-        good_file = app_dir / "good_app.py"
-        good_file.write_text(
-            dedent("""
+        write_app(
+            app_dir,
+            "good_app.py",
+            """
             from hassette import App, AppConfig
 
             class GoodApp(App[AppConfig]): ...
-        """)
+        """,
         )
 
-        known_paths = set()
-        result = autodetect_apps(app_dir, known_paths, set(AUTODETECT_EXCLUDE_DIRS_DEFAULT))
+        # The broken module is skipped rather than aborting the whole scan
+        result = detect(app_dir)
+        assert_detected(result, "apps.good_app.GoodApp")
 
-        # Should only find the good app, not the broken one - this is the key functional test
-        assert len(result) == 1, f"Expected 1 app, got {len(result)}"
-        assert "apps.good_app.GoodApp" in result, "Expected to find 'apps.good_app.GoodApp' in detected apps"
-        assert "apps.broken_app.BrokenApp" not in result, (
-            "Did not expect to find 'apps.broken_app.BrokenApp' in detected apps"
-        )
-
-        # Verify the detected app has correct properties
         good_app_dict = result["apps.good_app.GoodApp"]
-        assert good_app_dict["filename"] == "good_app.py", f"Expected 'good_app.py', got '{good_app_dict['filename']}'"
-        assert good_app_dict["class_name"] == "GoodApp", f"Expected 'GoodApp', got '{good_app_dict['class_name']}'"
+        assert good_app_dict["filename"] == "good_app.py"
+        assert good_app_dict["class_name"] == "GoodApp"
 
     def test_autodetect_ignores_non_app_classes(self, tmp_path: Path):
         """Test that auto-detection ignores classes that don't inherit from App/AppSync."""
         app_dir = tmp_path / "apps"
-        app_dir.mkdir()
-
-        app_file = app_dir / "mixed_classes.py"
-        app_file.write_text(
-            dedent("""
+        write_app(
+            app_dir,
+            "mixed_classes.py",
+            """
             from hassette import App, AppConfig
 
             class RegularClass:
@@ -371,14 +304,7 @@ class TestAutoDetectApps:
                     pass
 
             class ActualApp(App[AppConfig]): ...
-        """)
+        """,
         )
 
-        known_paths = set()
-        result = autodetect_apps(app_dir, known_paths, set(AUTODETECT_EXCLUDE_DIRS_DEFAULT))
-
-        # Should only find the actual app class
-        assert len(result) == 1, f"Expected 1 app, got {len(result)}"
-        assert "apps.mixed_classes.ActualApp" in result, (
-            "Expected to find 'apps.mixed_classes.ActualApp' in detected apps"
-        )
+        assert_detected(detect(app_dir), "apps.mixed_classes.ActualApp")

--- a/tests/unit/test_model_types.py
+++ b/tests/unit/test_model_types.py
@@ -4,6 +4,8 @@ Every field with an enumerated value set uses a constrained type that rejects
 values outside that set at validation time.
 """
 
+from typing import Any
+
 import pytest
 from pydantic import ValidationError
 
@@ -25,41 +27,187 @@ from hassette.web.models import (
 
 STANDARD_LOG_LEVELS = ("DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL")
 
+# Every builder below sets *only* the model's required fields and passes overrides straight
+# through, so a test can both feed an out-of-range value to the constrained type and read an
+# untouched optional field's default. The shared src/hassette/test_utils/web_*_helpers.py
+# factories fill optional fields with realistic values, which would mask exactly those defaults.
+
+
+def _build(model: Any, defaults: dict[str, Any], overrides: dict[str, Any]) -> Any:
+    """Instantiate `model` from `defaults`, with `overrides` replacing any of them."""
+    return model(**(defaults | overrides))
+
+
+def minimal_execution(**overrides: Any) -> Execution:
+    """Execution with only its required fields set."""
+    return _build(
+        Execution,
+        {
+            "kind": "handler",
+            "execution_start_ts": 1.0,
+            "duration_ms": 10.0,
+            "status": "success",
+            "error_type": None,
+            "error_message": None,
+        },
+        overrides,
+    )
+
+
+def minimal_manifest_response(**overrides: Any) -> AppManifestResponse:
+    """AppManifestResponse with only its required fields set."""
+    return _build(
+        AppManifestResponse,
+        {
+            "app_key": "my_app",
+            "class_name": "MyApp",
+            "display_name": "My App",
+            "filename": "my_app.py",
+            "enabled": True,
+            "auto_loaded": False,
+            "status": "stopped",
+        },
+        overrides,
+    )
+
+
+def minimal_grid_entry(**overrides: Any) -> DashboardAppGridEntry:
+    """DashboardAppGridEntry with only its required fields set."""
+    return _build(
+        DashboardAppGridEntry,
+        {
+            "app_key": "my_app",
+            "status": "running",
+            "display_name": "My App",
+            "handler_count": 0,
+            "job_count": 0,
+            "total_invocations": 0,
+            "total_errors": 0,
+            "total_executions": 0,
+            "total_job_errors": 0,
+            "avg_duration_ms": 0.0,
+            "last_activity_ts": None,
+            "health_status": "excellent",
+            "error_rate": 0.0,
+            "error_rate_class": "good",
+        },
+        overrides,
+    )
+
+
+def minimal_instance_response(**overrides: Any) -> AppInstanceResponse:
+    """AppInstanceResponse with only its required fields set."""
+    return _build(
+        AppInstanceResponse,
+        {
+            "app_key": "my_app",
+            "index": 0,
+            "instance_name": "MyApp[0]",
+            "class_name": "MyApp",
+            "status": ResourceStatus.RUNNING,
+        },
+        overrides,
+    )
+
+
+def minimal_health_response(**overrides: Any) -> AppHealthResponse:
+    """AppHealthResponse with only its required fields set."""
+    return _build(
+        AppHealthResponse,
+        {
+            "error_rate": 0.0,
+            "error_rate_class": "good",
+            "handler_avg_duration": 0.0,
+            "job_avg_duration": 0.0,
+            "last_activity_ts": None,
+            "health_status": "excellent",
+        },
+        overrides,
+    )
+
+
+def minimal_listener_with_summary(**overrides: Any) -> ListenerWithSummary:
+    """ListenerWithSummary with only its required fields set."""
+    return _build(
+        ListenerWithSummary,
+        {
+            "listener_id": 1,
+            "app_key": "my_app",
+            "topic": "state_changed.light.kitchen",
+            "handler_method": "on_light",
+            "total_invocations": 0,
+            "successful": 0,
+            "failed": 0,
+            "di_failures": 0,
+            "cancelled": 0,
+        },
+        overrides,
+    )
+
+
+def minimal_log_record(**overrides: Any) -> LogRecord:
+    """LogRecord with only its required fields set."""
+    return _build(
+        LogRecord,
+        {"id": 1, "seq": 1, "timestamp": 1.0, "level": "INFO", "logger_name": "test", "message": "test"},
+        overrides,
+    )
+
+
+def minimal_log_entry_response(**overrides: Any) -> LogEntryResponse:
+    """LogEntryResponse with only its required fields set."""
+    return _build(
+        LogEntryResponse,
+        {
+            "seq": 1,
+            "timestamp": 1.0,
+            "level": "INFO",
+            "logger_name": "test",
+            "func_name": "fn",
+            "lineno": 1,
+            "message": "test",
+        },
+        overrides,
+    )
+
+
+def minimal_execution_completed_data(**overrides: Any) -> ExecutionCompletedData:
+    """ExecutionCompletedData with only its required fields set."""
+    return _build(
+        ExecutionCompletedData,
+        {"kind": "handler", "app_key": "my_app", "instance_index": 0, "status": "success", "duration_ms": 10.0},
+        overrides,
+    )
+
+
+def minimal_system_status(**overrides: Any) -> SystemStatusResponse:
+    """SystemStatusResponse with only its required fields set."""
+    return _build(
+        SystemStatusResponse,
+        {
+            "status": "ok",
+            "websocket_connected": True,
+            "bootstrap_released": True,
+            "uptime_seconds": 0.0,
+            "entity_count": 0,
+            "app_count": 0,
+        },
+        overrides,
+    )
+
 
 class TestExecutionStatus:
     def test_rejects_bogus_status(self) -> None:
         with pytest.raises(ValidationError):
-            Execution(
-                kind="handler",
-                execution_start_ts=1.0,
-                duration_ms=10.0,
-                status="bogus",
-                error_type=None,
-                error_message=None,
-            )
+            minimal_execution(status="bogus")
 
     def test_accepts_all_valid_values(self) -> None:
         for value in ("success", "error", "cancelled", "timed_out", "skipped"):
-            obj = Execution(
-                kind="handler",
-                execution_start_ts=1.0,
-                duration_ms=10.0,
-                status=value,
-                error_type=None,
-                error_message=None,
-            )
-            assert obj.status == ExecutionStatus(value)
+            assert minimal_execution(status=value).status == ExecutionStatus(value)
 
     def test_rejects_bogus_on_job_execution(self) -> None:
         with pytest.raises(ValidationError):
-            Execution(
-                kind="job",
-                execution_start_ts=1.0,
-                duration_ms=10.0,
-                status="pending",
-                error_type=None,
-                error_message=None,
-            )
+            minimal_execution(kind="job", status="pending")
 
     def test_rejects_bogus_on_activity_feed_entry(self) -> None:
         with pytest.raises(ValidationError):
@@ -74,15 +222,7 @@ class TestExecutionStatus:
             )
 
     def test_serialises_to_plain_string(self) -> None:
-        obj = Execution(
-            kind="handler",
-            execution_start_ts=1.0,
-            duration_ms=10.0,
-            status="success",
-            error_type=None,
-            error_message=None,
-        )
-        data = obj.model_dump()
+        data = minimal_execution().model_dump()
         assert data["status"] == "success"
         assert isinstance(data["status"], str)
 
@@ -90,28 +230,11 @@ class TestExecutionStatus:
 class TestManifestStatus:
     def test_rejects_value_outside_six_value_set(self) -> None:
         with pytest.raises(ValidationError):
-            AppManifestResponse(
-                app_key="my_app",
-                class_name="MyApp",
-                display_name="My App",
-                filename="my_app.py",
-                enabled=True,
-                auto_loaded=False,
-                status="unknown",
-            )
+            minimal_manifest_response(status="unknown")
 
     def test_accepts_all_six_values(self) -> None:
         for value in ManifestStatus:
-            obj = AppManifestResponse(
-                app_key="my_app",
-                class_name="MyApp",
-                display_name="My App",
-                filename="my_app.py",
-                enabled=True,
-                auto_loaded=False,
-                status=value,
-            )
-            assert obj.status == value
+            assert minimal_manifest_response(status=value).status == value
 
     def test_is_str_enum_with_expected_members(self) -> None:
         assert set(ManifestStatus) == {
@@ -127,134 +250,33 @@ class TestManifestStatus:
 
     def test_rejects_on_dashboard_grid_entry(self) -> None:
         with pytest.raises(ValidationError):
-            DashboardAppGridEntry(
-                app_key="my_app",
-                status="active",  # not a valid ManifestStatus
-                display_name="My App",
-                handler_count=0,
-                job_count=0,
-                total_invocations=0,
-                total_errors=0,
-                total_executions=0,
-                total_job_errors=0,
-                avg_duration_ms=0.0,
-                last_activity_ts=None,
-                health_status="excellent",
-                error_rate=0.0,
-                error_rate_class="good",
-            )
+            minimal_grid_entry(status="active")  # not a valid ManifestStatus
 
     def test_autostart_defaults_to_true_when_omitted(self) -> None:
-        obj = AppManifestResponse(
-            app_key="my_app",
-            class_name="MyApp",
-            display_name="My App",
-            filename="my_app.py",
-            enabled=True,
-            auto_loaded=False,
-            status="stopped",
-        )
-        assert obj.autostart is True
+        assert minimal_manifest_response().autostart is True
 
     def test_autostart_round_trips_false(self) -> None:
-        obj = AppManifestResponse(
-            app_key="my_app",
-            class_name="MyApp",
-            display_name="My App",
-            filename="my_app.py",
-            enabled=True,
-            auto_loaded=False,
-            status="stopped",
-            autostart=False,
-        )
-        assert obj.autostart is False
+        assert minimal_manifest_response(autostart=False).autostart is False
 
 
 class TestInCurrentConfig:
     def test_app_manifest_response_defaults_to_true(self) -> None:
-        obj = AppManifestResponse(
-            app_key="my_app",
-            class_name="MyApp",
-            display_name="My App",
-            filename="my_app.py",
-            enabled=True,
-            auto_loaded=False,
-            status="stopped",
-        )
-        assert obj.in_current_config is True
+        assert minimal_manifest_response().in_current_config is True
 
     def test_app_manifest_response_round_trips_false(self) -> None:
-        obj = AppManifestResponse(
-            app_key="my_app",
-            class_name="MyApp",
-            display_name="My App",
-            filename="my_app.py",
-            enabled=True,
-            auto_loaded=False,
-            status="stopped",
-            in_current_config=False,
-        )
-        assert obj.in_current_config is False
+        assert minimal_manifest_response(in_current_config=False).in_current_config is False
 
     def test_dashboard_app_grid_entry_defaults_to_true(self) -> None:
-        obj = DashboardAppGridEntry(
-            app_key="my_app",
-            status="running",
-            display_name="My App",
-            handler_count=0,
-            job_count=0,
-            total_invocations=0,
-            total_errors=0,
-            total_executions=0,
-            total_job_errors=0,
-            avg_duration_ms=0.0,
-            last_activity_ts=None,
-            health_status="excellent",
-            error_rate=0.0,
-            error_rate_class="good",
-        )
-        assert obj.in_current_config is True
+        assert minimal_grid_entry().in_current_config is True
 
     def test_dashboard_app_grid_entry_round_trips_false(self) -> None:
-        obj = DashboardAppGridEntry(
-            app_key="my_app",
-            status="running",
-            display_name="My App",
-            handler_count=0,
-            job_count=0,
-            total_invocations=0,
-            total_errors=0,
-            total_executions=0,
-            total_job_errors=0,
-            avg_duration_ms=0.0,
-            last_activity_ts=None,
-            health_status="excellent",
-            error_rate=0.0,
-            error_rate_class="good",
-            in_current_config=False,
-        )
-        assert obj.in_current_config is False
+        assert minimal_grid_entry(in_current_config=False).in_current_config is False
 
 
 class TestDashboardAppGridEntryManifestFields:
     def test_manifest_metadata_fields_have_defaults(self) -> None:
         """DashboardAppGridEntry must be constructible without any manifest metadata fields."""
-        obj = DashboardAppGridEntry(
-            app_key="my_app",
-            status="running",
-            display_name="My App",
-            handler_count=0,
-            job_count=0,
-            total_invocations=0,
-            total_errors=0,
-            total_executions=0,
-            total_job_errors=0,
-            avg_duration_ms=0.0,
-            last_activity_ts=None,
-            health_status="excellent",
-            error_rate=0.0,
-            error_rate_class="good",
-        )
+        obj = minimal_grid_entry()
         assert obj.class_name == ""
         assert obj.filename == ""
         assert obj.enabled is True
@@ -266,38 +288,8 @@ class TestDashboardAppGridEntryManifestFields:
         assert obj.error_traceback is None
 
     def test_manifest_metadata_fields_round_trip(self) -> None:
-        # dup-ignore-start: same ("my_app", index=0, "MyApp[0]", "MyApp", RUNNING) literal shape
-        # used by tests/unit/core/test_runtime_query_service.py and tests/e2e/mock_fixtures/manifests.py —
-        # different test tiers/directories building unrelated fixture/response data;
-        # src/hassette/test_utils/web_manifest_helpers.py's make_app_instance_info() factory
-        # builds the schemas.app_snapshots.AppInstanceInfo used elsewhere, not this Pydantic
-        # response model (web.models.AppInstanceResponse), so it doesn't directly apply here;
-        # adopting a shared builder across all these call sites is out of scope for this cluster,
-        # which is marker-only per this task's file classification (see
-        # design/specs/099-dedupe-tests-unit-core/design.md, Group B row).
-        instance = AppInstanceResponse(
-            app_key="my_app",
-            index=0,
-            instance_name="MyApp[0]",
-            class_name="MyApp",
-            status=ResourceStatus.RUNNING,
-        )
-        # dup-ignore-end
-        obj = DashboardAppGridEntry(
-            app_key="my_app",
-            status="running",
-            display_name="My App",
-            handler_count=0,
-            job_count=0,
-            total_invocations=0,
-            total_errors=0,
-            total_executions=0,
-            total_job_errors=0,
-            avg_duration_ms=0.0,
-            last_activity_ts=None,
-            health_status="excellent",
-            error_rate=0.0,
-            error_rate_class="good",
+        instance = minimal_instance_response()
+        obj = minimal_grid_entry(
             class_name="MyApp",
             filename="my_app.py",
             enabled=False,
@@ -322,32 +314,11 @@ class TestDashboardAppGridEntryManifestFields:
 class TestResourceStatus:
     def test_accepts_all_nine_resource_status_values(self) -> None:
         for value in ResourceStatus:
-            # dup-ignore-start: same ("my_app", index=0, "MyApp[0]", "MyApp", <status>) literal
-            # shape as test_manifest_metadata_fields_round_trip() above — see that dup-ignore
-            # comment for the full cross-file/cross-tier rationale.
-            obj = AppInstanceResponse(
-                app_key="my_app",
-                index=0,
-                instance_name="MyApp[0]",
-                class_name="MyApp",
-                status=value,
-            )
-            # dup-ignore-end
-            assert obj.status == value
+            assert minimal_instance_response(status=value).status == value
 
     def test_rejects_value_not_in_resource_status(self) -> None:
         with pytest.raises(ValidationError):
-            # dup-ignore-start: same ("my_app", index=0, "MyApp[0]", "MyApp", <status>) literal
-            # shape as test_manifest_metadata_fields_round_trip() above — see that dup-ignore
-            # comment for the full cross-file/cross-tier rationale.
-            AppInstanceResponse(
-                app_key="my_app",
-                index=0,
-                instance_name="MyApp[0]",
-                class_name="MyApp",
-                status="active",
-            )
-            # dup-ignore-end
+            minimal_instance_response(status="active")
 
     def test_rejects_value_not_in_resource_status_on_service_info(self) -> None:
         with pytest.raises(ValidationError):
@@ -364,266 +335,92 @@ class TestResourceStatus:
             ResourceStatus.STOPPING,
             ResourceStatus.EXHAUSTED_COOLING,
         ):
-            # dup-ignore-start: same ("my_app", index=0, "MyApp[0]", "MyApp", <status>) literal
-            # shape as test_manifest_metadata_fields_round_trip() above — see that dup-ignore
-            # comment for the full cross-file/cross-tier rationale.
-            obj = AppInstanceResponse(
-                app_key="my_app",
-                index=0,
-                instance_name="MyApp[0]",
-                class_name="MyApp",
-                status=value,
-            )
-            # dup-ignore-end
-            assert obj.status == value
+            assert minimal_instance_response(status=value).status == value
 
 
 class TestHealthStatus:
     def test_rejects_unknown(self) -> None:
         with pytest.raises(ValidationError):
-            AppHealthResponse(
-                error_rate=0.0,
-                error_rate_class="good",
-                handler_avg_duration=0.0,
-                job_avg_duration=0.0,
-                last_activity_ts=None,
-                health_status="unknown",
-            )
+            minimal_health_response(health_status="unknown")
 
     def test_accepts_all_four_values(self) -> None:
         for value in ("excellent", "good", "warning", "critical"):
-            obj = AppHealthResponse(
-                error_rate=0.0,
-                error_rate_class="good",
-                handler_avg_duration=0.0,
-                job_avg_duration=0.0,
-                last_activity_ts=None,
-                health_status=value,
-            )
-            assert obj.health_status == value
+            assert minimal_health_response(health_status=value).health_status == value
 
     def test_rejects_on_dashboard_grid_entry(self) -> None:
         with pytest.raises(ValidationError):
-            DashboardAppGridEntry(
-                app_key="my_app",
-                status="running",
-                display_name="My App",
-                handler_count=0,
-                job_count=0,
-                total_invocations=0,
-                total_errors=0,
-                total_executions=0,
-                total_job_errors=0,
-                avg_duration_ms=0.0,
-                last_activity_ts=None,
-                health_status="unknown",
-                error_rate=0.0,
-                error_rate_class="good",
-            )
+            minimal_grid_entry(health_status="unknown")
 
 
 class TestErrorRateClass:
     def test_rejects_ok(self) -> None:
         with pytest.raises(ValidationError):
-            AppHealthResponse(
-                error_rate=0.0,
-                error_rate_class="ok",  # not in the 3-value set
-                handler_avg_duration=0.0,
-                job_avg_duration=0.0,
-                last_activity_ts=None,
-                health_status="excellent",
-            )
+            minimal_health_response(error_rate_class="ok")  # not in the 3-value set
 
     def test_accepts_all_three_values(self) -> None:
         for value in ("good", "warn", "bad"):
-            obj = AppHealthResponse(
-                error_rate=0.0,
-                error_rate_class=value,
-                handler_avg_duration=0.0,
-                job_avg_duration=0.0,
-                last_activity_ts=None,
-                health_status="excellent",
-            )
-            assert obj.error_rate_class == value
+            assert minimal_health_response(error_rate_class=value).error_rate_class == value
 
     def test_rejects_ok_on_dashboard_grid_entry(self) -> None:
         with pytest.raises(ValidationError):
-            DashboardAppGridEntry(
-                app_key="my_app",
-                status="running",
-                display_name="My App",
-                handler_count=0,
-                job_count=0,
-                total_invocations=0,
-                total_errors=0,
-                total_executions=0,
-                total_job_errors=0,
-                avg_duration_ms=0.0,
-                last_activity_ts=None,
-                health_status="excellent",
-                error_rate=0.0,
-                error_rate_class="ok",
-            )
+            minimal_grid_entry(error_rate_class="ok")
 
 
 class TestListenerKind:
     def test_rejects_custom(self) -> None:
         with pytest.raises(ValidationError):
-            ListenerWithSummary(
-                listener_id=1,
-                app_key="my_app",
-                topic="state_changed.light.kitchen",
-                listener_kind="custom",  # not in the 3-value set
-                handler_method="on_light",
-                total_invocations=0,
-                successful=0,
-                failed=0,
-                di_failures=0,
-                cancelled=0,
-            )
+            minimal_listener_with_summary(listener_kind="custom")  # not in the 3-value set
 
     def test_accepts_all_three_values(self) -> None:
         for value in ("state change", "service call", "event"):
-            obj = ListenerWithSummary(
-                listener_id=1,
-                app_key="my_app",
-                topic="state_changed.light.kitchen",
-                listener_kind=value,
-                handler_method="on_light",
-                total_invocations=0,
-                successful=0,
-                failed=0,
-                di_failures=0,
-                cancelled=0,
-            )
-            assert obj.listener_kind == value
+            assert minimal_listener_with_summary(listener_kind=value).listener_kind == value
 
     def test_default_is_event(self) -> None:
-        obj = ListenerWithSummary(
-            listener_id=1,
-            app_key="my_app",
-            topic="some.custom.topic",
-            handler_method="on_event",
-            total_invocations=0,
-            successful=0,
-            failed=0,
-            di_failures=0,
-            cancelled=0,
-        )
-        assert obj.listener_kind == "event"
+        assert minimal_listener_with_summary(topic="some.custom.topic").listener_kind == "event"
 
 
 class TestLogLevelType:
     def test_rejects_warn_non_standard(self) -> None:
+        # non-standard; valid Python levels use "WARNING"
         with pytest.raises(ValidationError):
-            LogRecord(
-                id=1,
-                seq=1,
-                timestamp=1.0,
-                level="WARN",  # non-standard; valid Python levels use "WARNING"
-                logger_name="test",
-                message="test",
-            )
+            minimal_log_record(level="WARN")
 
     def test_accepts_all_five_standard_levels_on_log_record(self) -> None:
         for level in STANDARD_LOG_LEVELS:
-            obj = LogRecord(
-                id=1,
-                seq=1,
-                timestamp=1.0,
-                level=level,
-                logger_name="test",
-                message="test",
-            )
-            assert obj.level == level
+            assert minimal_log_record(level=level).level == level
 
     def test_rejects_warn_on_log_entry_response(self) -> None:
         with pytest.raises(ValidationError):
-            LogEntryResponse(
-                seq=1,
-                timestamp=1.0,
-                level="WARN",
-                logger_name="test",
-                func_name="fn",
-                lineno=1,
-                message="test",
-            )
+            minimal_log_entry_response(level="WARN")
 
     def test_rejects_bogus_source_tier_on_log_entry_response(self) -> None:
         with pytest.raises(ValidationError):
-            LogEntryResponse(
-                seq=1,
-                timestamp=1.0,
-                level="INFO",
-                logger_name="test",
-                func_name="fn",
-                lineno=1,
-                message="test",
-                source_tier="bogus",
-            )
+            minimal_log_entry_response(source_tier="bogus")
 
     def test_accepts_valid_source_tiers_on_log_entry_response(self) -> None:
         for tier in ("app", "framework", None):
-            obj = LogEntryResponse(
-                seq=1,
-                timestamp=1.0,
-                level="INFO",
-                logger_name="test",
-                func_name="fn",
-                lineno=1,
-                message="test",
-                source_tier=tier,
-            )
-            assert obj.source_tier == tier
+            assert minimal_log_entry_response(source_tier=tier).source_tier == tier
 
     def test_accepts_all_five_standard_levels_on_log_entry_response(self) -> None:
         for level in STANDARD_LOG_LEVELS:
-            obj = LogEntryResponse(
-                seq=1,
-                timestamp=1.0,
-                level=level,
-                logger_name="test",
-                func_name="fn",
-                lineno=1,
-                message="test",
-            )
-            assert obj.level == level
+            assert minimal_log_entry_response(level=level).level == level
 
 
 class TestWebSocketPayloadStatus:
     def test_execution_completed_data_rejects_bogus_kind(self) -> None:
         """Kind must be 'handler' or 'job'."""
         with pytest.raises(ValidationError):
-            ExecutionCompletedData(
-                kind="unknown",  # pyright: ignore[reportArgumentType]
-                app_key="my_app",
-                instance_index=0,
-                status="success",
-                duration_ms=10.0,
-            )
+            minimal_execution_completed_data(kind="unknown")
 
     def test_execution_completed_data_handler_kind(self) -> None:
-        obj = ExecutionCompletedData(
-            kind="handler",
-            listener_id=1,
-            app_key="my_app",
-            instance_index=0,
-            status="success",
-            duration_ms=10.0,
-        )
+        obj = minimal_execution_completed_data(listener_id=1)
         assert obj.kind == "handler"
         assert obj.listener_id == 1
         assert obj.job_id is None
 
     def test_execution_completed_data_job_kind(self) -> None:
-        obj = ExecutionCompletedData(
-            kind="job",
-            job_id=7,
-            app_key="my_app",
-            instance_index=0,
-            status="error",
-            duration_ms=99.0,
-            error_type="TimeoutError",
+        obj = minimal_execution_completed_data(
+            kind="job", job_id=7, status="error", duration_ms=99.0, error_type="TimeoutError"
         )
         assert obj.kind == "job"
         assert obj.job_id == 7
@@ -634,23 +431,8 @@ class TestWebSocketPayloadStatus:
 class TestSystemHealthStatus:
     def test_rejects_value_outside_three_value_set(self) -> None:
         with pytest.raises(ValidationError):
-            SystemStatusResponse(
-                status="healthy",  # not in ("ok", "degraded", "starting")
-                websocket_connected=True,
-                bootstrap_released=True,
-                uptime_seconds=0.0,
-                entity_count=0,
-                app_count=0,
-            )
+            minimal_system_status(status="healthy")  # not in ("ok", "degraded", "starting")
 
     def test_accepts_all_three_values(self) -> None:
         for value in ("ok", "degraded", "starting"):
-            obj = SystemStatusResponse(
-                status=value,
-                websocket_connected=True,
-                bootstrap_released=True,
-                uptime_seconds=0.0,
-                entity_count=0,
-                app_count=0,
-            )
-            assert obj.status == value
+            assert minimal_system_status(status=value).status == value

--- a/tests/unit/test_model_types.py
+++ b/tests/unit/test_model_types.py
@@ -33,14 +33,14 @@ STANDARD_LOG_LEVELS = ("DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL")
 # factories fill optional fields with realistic values, which would mask exactly those defaults.
 
 
-def _build(model: Any, defaults: dict[str, Any], overrides: dict[str, Any]) -> Any:
+def build(model: Any, defaults: dict[str, Any], overrides: dict[str, Any]) -> Any:
     """Instantiate `model` from `defaults`, with `overrides` replacing any of them."""
     return model(**(defaults | overrides))
 
 
 def minimal_execution(**overrides: Any) -> Execution:
     """Execution with only its required fields set."""
-    return _build(
+    return build(
         Execution,
         {
             "kind": "handler",
@@ -56,7 +56,7 @@ def minimal_execution(**overrides: Any) -> Execution:
 
 def minimal_manifest_response(**overrides: Any) -> AppManifestResponse:
     """AppManifestResponse with only its required fields set."""
-    return _build(
+    return build(
         AppManifestResponse,
         {
             "app_key": "my_app",
@@ -73,7 +73,7 @@ def minimal_manifest_response(**overrides: Any) -> AppManifestResponse:
 
 def minimal_grid_entry(**overrides: Any) -> DashboardAppGridEntry:
     """DashboardAppGridEntry with only its required fields set."""
-    return _build(
+    return build(
         DashboardAppGridEntry,
         {
             "app_key": "my_app",
@@ -97,7 +97,7 @@ def minimal_grid_entry(**overrides: Any) -> DashboardAppGridEntry:
 
 def minimal_instance_response(**overrides: Any) -> AppInstanceResponse:
     """AppInstanceResponse with only its required fields set."""
-    return _build(
+    return build(
         AppInstanceResponse,
         {
             "app_key": "my_app",
@@ -112,7 +112,7 @@ def minimal_instance_response(**overrides: Any) -> AppInstanceResponse:
 
 def minimal_health_response(**overrides: Any) -> AppHealthResponse:
     """AppHealthResponse with only its required fields set."""
-    return _build(
+    return build(
         AppHealthResponse,
         {
             "error_rate": 0.0,
@@ -128,7 +128,7 @@ def minimal_health_response(**overrides: Any) -> AppHealthResponse:
 
 def minimal_listener_with_summary(**overrides: Any) -> ListenerWithSummary:
     """ListenerWithSummary with only its required fields set."""
-    return _build(
+    return build(
         ListenerWithSummary,
         {
             "listener_id": 1,
@@ -147,7 +147,7 @@ def minimal_listener_with_summary(**overrides: Any) -> ListenerWithSummary:
 
 def minimal_log_record(**overrides: Any) -> LogRecord:
     """LogRecord with only its required fields set."""
-    return _build(
+    return build(
         LogRecord,
         {"id": 1, "seq": 1, "timestamp": 1.0, "level": "INFO", "logger_name": "test", "message": "test"},
         overrides,
@@ -156,7 +156,7 @@ def minimal_log_record(**overrides: Any) -> LogRecord:
 
 def minimal_log_entry_response(**overrides: Any) -> LogEntryResponse:
     """LogEntryResponse with only its required fields set."""
-    return _build(
+    return build(
         LogEntryResponse,
         {
             "seq": 1,
@@ -173,7 +173,7 @@ def minimal_log_entry_response(**overrides: Any) -> LogEntryResponse:
 
 def minimal_execution_completed_data(**overrides: Any) -> ExecutionCompletedData:
     """ExecutionCompletedData with only its required fields set."""
-    return _build(
+    return build(
         ExecutionCompletedData,
         {"kind": "handler", "app_key": "my_app", "instance_index": 0, "status": "success", "duration_ms": 10.0},
         overrides,
@@ -182,7 +182,7 @@ def minimal_execution_completed_data(**overrides: Any) -> ExecutionCompletedData
 
 def minimal_system_status(**overrides: Any) -> SystemStatusResponse:
     """SystemStatusResponse with only its required fields set."""
-    return _build(
+    return build(
         SystemStatusResponse,
         {
             "status": "ok",

--- a/tests/unit/test_sync_executor_service_saturation.py
+++ b/tests/unit/test_sync_executor_service_saturation.py
@@ -21,6 +21,7 @@ import os
 import sys
 import threading
 import time
+from collections.abc import Iterator
 from typing import Any
 from unittest.mock import patch
 
@@ -39,7 +40,26 @@ from hassette.core.sync_executor import (  # pyright: ignore[reportPrivateUsage]
 from hassette.core.sync_executor_service import SyncExecutorService
 from hassette.task_bucket.interruptible_executor import InterruptibleThreadPoolExecutor
 from hassette.task_bucket.task_bucket import TaskBucket
-from tests.unit.conftest import TEST_TOKEN, make_service, make_sync_executor_hassette
+from tests.unit.conftest import (
+    TEST_TOKEN,
+    make_service,
+    make_sync_executor_hassette,
+    submit_busy_worker,
+    submit_c_blocked_worker,
+    timed_shutdown,
+)
+
+
+def shutdown_pool(svc: SyncExecutorService) -> None:
+    """Tear down the service's pool without the join/interrupt loop — teardown, not under test."""
+    svc.sync_executor.executor.shutdown(join_threads_or_timeout=False)
+
+
+async def cancel_serve_task(task: "asyncio.Task[None]") -> None:
+    """Cancel a serve() task the way the framework does and wait for it to settle."""
+    task.cancel()
+    with contextlib.suppress(asyncio.CancelledError, TimeoutError):
+        await asyncio.gather(task, return_exceptions=True)
 
 
 def _capture_saturation_warnings(sync_executor: SyncExecutor) -> list[tuple]:
@@ -53,6 +73,25 @@ def _capture_saturation_warnings(sync_executor: SyncExecutor) -> list[tuple]:
     calls: list[tuple] = []
     sync_executor.logger.warning = lambda msg, *a: calls.append((msg, *a))  # pyright: ignore[reportAttributeAccessIssue]
     return calls
+
+
+@contextlib.contextmanager
+def saturation_probe(
+    max_workers: int, outstanding: int = 0, **pool_kwargs: Any
+) -> Iterator[tuple[SyncExecutor, list[tuple]]]:
+    """Yield a SyncExecutor with `outstanding` submissions simulated, plus its captured warnings.
+
+    Occupancy is set through the counter rather than real submissions — the probe only reads
+    that counter, and blocking real workers would make the test slower and flakier. The pool is
+    torn down on exit.
+    """
+    sync_executor = SyncExecutor()
+    sync_executor.rebuild_pool(max_workers=max_workers, **pool_kwargs)
+    sync_executor._outstanding_submissions = outstanding
+    try:
+        yield sync_executor, _capture_saturation_warnings(sync_executor)
+    finally:
+        sync_executor.executor.shutdown(join_threads_or_timeout=False)
 
 
 # async_raise(SystemExit) into a worker stuck in a C-level call (time.sleep) deadlocks under
@@ -215,112 +254,73 @@ class TestSubmissionTimeSaturationWarning:
 
     def test_warning_not_fired_below_threshold(self) -> None:
         """No WARNING is emitted when pool occupancy is below 75%."""
-        sync_executor = SyncExecutor()
-        sync_executor.rebuild_pool(max_workers=4)
-        # active_workers=0, max_workers=4 → 0% occupancy (well below 75%)
-        warning_calls = _capture_saturation_warnings(sync_executor)
-
-        sync_executor.log_saturation_rate_limited()
+        # 0/4 → 0% occupancy, well below the 75% threshold
+        with saturation_probe(max_workers=4) as (sync_executor, warning_calls):
+            sync_executor.log_saturation_rate_limited()
 
         assert not any("approaching saturation" in str(c) for c in warning_calls), (
             "No WARNING expected when pool is below threshold"
         )
-        sync_executor.executor.shutdown(join_threads_or_timeout=False)
 
     def test_warning_not_fired_just_below_threshold(self) -> None:
-        """No WARNING at exactly 74% occupancy (3/4 workers on max_workers=4 pool)."""
-        sync_executor = SyncExecutor()
-        sync_executor.rebuild_pool(max_workers=4)
-        # 3/4 = 75% — but threshold is strictly >=0.75, so 3/4 = 0.75 should fire.
-        # Test the boundary below: 2/4 = 50% must NOT fire.
-        sync_executor._outstanding_submissions = 2  # 50% occupancy — below threshold
-
-        warning_calls = _capture_saturation_warnings(sync_executor)
-
-        sync_executor.log_saturation_rate_limited()
+        """No WARNING at 50% occupancy — the boundary case just under the 75% threshold."""
+        # The threshold check is >=0.75, so 3/4 fires; 2/4 = 50% must not.
+        with saturation_probe(max_workers=4, outstanding=2) as (sync_executor, warning_calls):
+            sync_executor.log_saturation_rate_limited()
 
         assert not any("approaching saturation" in str(c) for c in warning_calls), (
             "No WARNING expected at 50% occupancy (below 75% threshold)"
         )
-        sync_executor.executor.shutdown(join_threads_or_timeout=False)
 
     def test_warning_fires_at_exact_threshold(self) -> None:
         """WARNING fires at exactly 75% occupancy (3/4 workers on max_workers=4 pool)."""
-        sync_executor = SyncExecutor()
-        sync_executor.rebuild_pool(max_workers=4)
-        sync_executor._outstanding_submissions = 3  # 3/4 = 75% — exactly at threshold
-
-        warning_calls = _capture_saturation_warnings(sync_executor)
-
-        sync_executor.log_saturation_rate_limited()
+        with saturation_probe(max_workers=4, outstanding=3) as (sync_executor, warning_calls):
+            sync_executor.log_saturation_rate_limited()
 
         assert any("approaching saturation" in str(c) for c in warning_calls), (
             "WARNING must fire at exactly 75% occupancy (at-threshold case)"
         )
-        sync_executor.executor.shutdown(join_threads_or_timeout=False)
 
     def test_warning_rate_limited_not_spammed(self) -> None:
         """Saturation WARNING is rate-limited: second call within window is suppressed."""
-        sync_executor = SyncExecutor()
-        sync_executor.rebuild_pool(max_workers=1)
-        sync_executor._outstanding_submissions = 1  # 100% — above threshold
+        with saturation_probe(max_workers=1, outstanding=1) as (sync_executor, warning_calls):
+            # First call — should log
+            sync_executor.log_saturation_rate_limited()
+            first_count = len(warning_calls)
+            assert first_count >= 1, "Expected at least one WARNING on first call"
 
-        warning_calls = _capture_saturation_warnings(sync_executor)
-
-        # First call — should log
-        sync_executor.log_saturation_rate_limited()
-        first_count = len(warning_calls)
-        assert first_count >= 1, "Expected at least one WARNING on first call"
-
-        # Second call immediately — should be suppressed by rate-limit
-        sync_executor.log_saturation_rate_limited()
-        second_count = len(warning_calls)
+            # Second call immediately — should be suppressed by rate-limit
+            sync_executor.log_saturation_rate_limited()
+            second_count = len(warning_calls)
 
         assert second_count == first_count, (
             f"Second call within rate-limit window should be suppressed; got {second_count - first_count} extra calls"
         )
 
-        sync_executor.executor.shutdown(join_threads_or_timeout=False)
-
     def test_warning_fires_again_after_window_expires(self) -> None:
         """After the rate-limit window expires, the WARNING fires again."""
-        sync_executor = SyncExecutor()
-        sync_executor.rebuild_pool(max_workers=1)
-        sync_executor._outstanding_submissions = 1  # 100% — above threshold
+        with saturation_probe(max_workers=1, outstanding=1) as (sync_executor, warning_calls):
+            sync_executor.log_saturation_rate_limited()
+            first_count = len(warning_calls)
 
-        warning_calls = _capture_saturation_warnings(sync_executor)
+            # Manually expire the rate-limit window
+            sync_executor._last_saturation_warn_ts = (
+                time.monotonic() - sync_executor.saturation_warn_rate_limit_seconds - 1.0
+            )
 
-        sync_executor.log_saturation_rate_limited()
-        first_count = len(warning_calls)
-
-        # Manually expire the rate-limit window
-        sync_executor._last_saturation_warn_ts = (
-            time.monotonic() - sync_executor.saturation_warn_rate_limit_seconds - 1.0
-        )
-
-        sync_executor.log_saturation_rate_limited()
-        second_count = len(warning_calls)
+            sync_executor.log_saturation_rate_limited()
+            second_count = len(warning_calls)
 
         assert second_count > first_count, "WARNING should fire again after the rate-limit window expires"
 
-        sync_executor.executor.shutdown(join_threads_or_timeout=False)
-
     def test_warning_includes_worker_and_queue_counts(self) -> None:
         """The WARNING message includes active worker count and queue depth."""
-        sync_executor = SyncExecutor()
-        sync_executor.rebuild_pool(max_workers=1)
-        sync_executor._outstanding_submissions = 1  # 100% — above threshold
-
-        warning_calls: list[str] = []
-        sync_executor.logger.warning = lambda msg, *a: warning_calls.append(msg % a if a else msg)  # pyright: ignore[reportAttributeAccessIssue]
-
-        sync_executor.log_saturation_rate_limited()
+        with saturation_probe(max_workers=1, outstanding=1) as (sync_executor, warning_calls):
+            sync_executor.log_saturation_rate_limited()
 
         assert warning_calls, "Expected at least one saturation WARNING"
         msg = str(warning_calls[0])
         assert "outstanding submissions" in msg or "1/1" in msg, f"Expected saturation detail in WARNING; got: {msg}"
-
-        sync_executor.executor.shutdown(join_threads_or_timeout=False)
 
     def test_probe_fires_when_pool_saturated_and_no_submissions(self) -> None:
         """Periodic probe emits saturation WARNING even when no submissions arrive.
@@ -337,26 +337,15 @@ class TestSubmissionTimeSaturationWarning:
         loop — see TestPeriodicSaturationProbe below for the serve()-loop tests
         that remain on SyncExecutorService.
         """
-        sync_executor = SyncExecutor()
-        sync_executor.rebuild_pool(max_workers=2)
-
-        try:
-            # Simulate fully-saturated pool via the active counter (no real submissions needed).
-            sync_executor._outstanding_submissions = 2
-
+        with saturation_probe(max_workers=2, outstanding=2) as (sync_executor, warning_calls):
             # Pre-expire the rate-limit so the probe can fire immediately
             sync_executor._last_saturation_warn_ts = 0.0
 
-            warning_calls = _capture_saturation_warnings(sync_executor)
-
             sync_executor.log_saturation_rate_limited()
 
-            assert any("approaching saturation" in str(c) for c in warning_calls), (
-                "Probe must fire saturation WARNING when pool is fully saturated"
-            )
-
-        finally:
-            sync_executor.executor.shutdown(join_threads_or_timeout=False)
+        assert any("approaching saturation" in str(c) for c in warning_calls), (
+            "Probe must fire saturation WARNING when pool is fully saturated"
+        )
 
 
 class TestPeriodicSaturationProbe:
@@ -385,12 +374,10 @@ class TestPeriodicSaturationProbe:
 
             # Simulate framework shutdown: set the service-level shutdown_event then cancel.
             svc.shutdown_event.set()
-            serve_task.cancel()
-            with contextlib.suppress(asyncio.CancelledError, TimeoutError):
-                await asyncio.gather(serve_task, return_exceptions=True)
+            await cancel_serve_task(serve_task)
             assert serve_task.done()
 
-        svc.sync_executor.executor.shutdown(join_threads_or_timeout=False)
+        shutdown_pool(svc)
 
     @pytest.mark.anyio
     async def test_serve_calls_probe_on_each_cycle(self, caplog: pytest.LogCaptureFixture) -> None:
@@ -423,9 +410,7 @@ class TestPeriodicSaturationProbe:
                 # Wait long enough for at least 2 probe cycles
                 await asyncio.sleep(0.2)
                 # Cancel the task (how the framework shuts down serve())
-                serve_task.cancel()
-                with contextlib.suppress(asyncio.CancelledError, TimeoutError):
-                    await asyncio.gather(serve_task, return_exceptions=True)
+                await cancel_serve_task(serve_task)
 
             assert len(probe_calls) >= 1, (
                 f"serve() must call log_saturation_rate_limited() on each cycle; got {len(probe_calls)} calls"
@@ -433,7 +418,7 @@ class TestPeriodicSaturationProbe:
 
         finally:
             gate.set()
-            svc.sync_executor.executor.shutdown(join_threads_or_timeout=False)
+            shutdown_pool(svc)
 
 
 class TestShutdownInterruptsPythonWorker:
@@ -446,25 +431,11 @@ class TestShutdownInterruptsPythonWorker:
         shutdown boundary, then shutdown runs with join_threads_or_timeout=True.
         """
         executor = InterruptibleThreadPoolExecutor(max_workers=1, thread_name_prefix="test-sync")
-        ready = threading.Event()
         terminated = threading.Event()
-
-        def busy_loop() -> None:
-            ready.set()
-            try:
-                while True:
-                    pass
-            except SystemExit:
-                terminated.set()
-                raise
-
-        executor.submit(busy_loop)
-        ready.wait(timeout=2)
+        submit_busy_worker(executor, terminated=terminated, reraise=True)
 
         budget = 3.0
-        wall_start = time.monotonic()
-        executor.shutdown(join_threads_or_timeout=True, timeout=budget)
-        elapsed = time.monotonic() - wall_start
+        elapsed = timed_shutdown(executor, budget)
 
         assert terminated.is_set(), "Worker must have received SystemExit at shutdown"
         assert elapsed < budget * 1.5, f"Shutdown took {elapsed:.2f}s — expected < {budget * 1.5:.2f}s"
@@ -476,19 +447,8 @@ class TestShutdownInterruptsPythonWorker:
         ordering sensitivity (project uses structlog, which bypasses caplog).
         """
         executor = InterruptibleThreadPoolExecutor(max_workers=1, thread_name_prefix="hassette-sync")
-        ready = threading.Event()
         log_calls: list[tuple] = []
-
-        def busy_loop() -> None:
-            ready.set()
-            try:
-                while True:
-                    pass
-            except SystemExit:
-                raise
-
-        executor.submit(busy_loop)
-        ready.wait(timeout=2)
+        submit_busy_worker(executor, reraise=True)
 
         def capture_log(name: str, ident: int) -> None:
             log_calls.append((name, ident))
@@ -504,18 +464,7 @@ class TestShutdownInterruptsPythonWorker:
     def test_shutdown_does_not_raise(self) -> None:
         """Shutdown never propagates an exception from the interrupt loop."""
         executor = InterruptibleThreadPoolExecutor(max_workers=1)
-        ready = threading.Event()
-
-        def busy_loop() -> None:
-            ready.set()
-            try:
-                while True:
-                    pass
-            except SystemExit:
-                raise
-
-        executor.submit(busy_loop)
-        ready.wait(timeout=2)
+        submit_busy_worker(executor, reraise=True)
 
         # Must not raise — all interruption exceptions are suppressed
         executor.shutdown(join_threads_or_timeout=True, timeout=1.0)
@@ -524,20 +473,8 @@ class TestShutdownInterruptsPythonWorker:
     async def test_on_shutdown_with_busy_worker_completes(self, caplog: pytest.LogCaptureFixture) -> None:
         """SyncExecutorService.on_shutdown() completes with a Python busy-loop worker."""
         svc = make_service(max_workers=1, shutdown_timeout=3.0)
-        ready = threading.Event()
         terminated = threading.Event()
-
-        def busy_loop() -> None:
-            ready.set()
-            try:
-                while True:
-                    pass
-            except SystemExit:
-                terminated.set()
-                raise
-
-        svc.sync_executor.executor.submit(busy_loop)
-        ready.wait(timeout=2)
+        submit_busy_worker(svc.sync_executor.executor, terminated=terminated, reraise=True)
 
         # on_shutdown runs executor.shutdown in a thread so the event loop stays live
         await asyncio.wait_for(svc.on_shutdown(), timeout=5.0)
@@ -552,19 +489,10 @@ class TestShutdownCBlockedWorker:
     def test_c_blocked_worker_shutdown_completes_within_budget(self) -> None:
         """Shutdown returns within budget even when a worker is blocked in time.sleep."""
         executor = InterruptibleThreadPoolExecutor(max_workers=1)
-        ready = threading.Event()
-
-        def c_blocked() -> None:
-            ready.set()
-            time.sleep(60)  # C-level — not interruptible by async_raise
-
-        executor.submit(c_blocked)
-        ready.wait(timeout=2)
+        submit_c_blocked_worker(executor)
 
         budget = 1.0
-        wall_start = time.monotonic()
-        executor.shutdown(join_threads_or_timeout=True, timeout=budget)
-        elapsed = time.monotonic() - wall_start
+        elapsed = timed_shutdown(executor, budget)
 
         # Allow 30% margin for scheduling jitter
         assert elapsed < budget * 1.3, (
@@ -574,14 +502,7 @@ class TestShutdownCBlockedWorker:
     def test_c_blocked_worker_does_not_raise(self) -> None:
         """Shutdown with a C-blocked worker must not propagate any exception."""
         executor = InterruptibleThreadPoolExecutor(max_workers=1)
-        ready = threading.Event()
-
-        def c_blocked() -> None:
-            ready.set()
-            time.sleep(60)
-
-        executor.submit(c_blocked)
-        ready.wait(timeout=2)
+        submit_c_blocked_worker(executor)
 
         # Must not raise — C-blocked thread is abandoned, not errored
         executor.shutdown(join_threads_or_timeout=True, timeout=0.5)
@@ -589,15 +510,8 @@ class TestShutdownCBlockedWorker:
     def test_c_blocked_worker_straggler_is_logged(self) -> None:
         """C-blocked worker that survives the budget is logged at shutdown."""
         executor = InterruptibleThreadPoolExecutor(max_workers=1, thread_name_prefix="hassette-sync")
-        ready = threading.Event()
         log_calls: list[tuple] = []
-
-        def c_blocked() -> None:
-            ready.set()
-            time.sleep(60)
-
-        executor.submit(c_blocked)
-        ready.wait(timeout=2)
+        submit_c_blocked_worker(executor)
 
         def capture_log(name: str, ident: int) -> None:
             log_calls.append((name, ident))
@@ -614,14 +528,7 @@ class TestShutdownCBlockedWorker:
     async def test_on_shutdown_c_blocked_completes_within_budget(self) -> None:
         """SyncExecutorService.on_shutdown() completes within budget with a C-blocked worker."""
         svc = make_service(max_workers=1, shutdown_timeout=1.0)
-        ready = threading.Event()
-
-        def c_blocked() -> None:
-            ready.set()
-            time.sleep(60)
-
-        svc.sync_executor.executor.submit(c_blocked)
-        ready.wait(timeout=2)
+        submit_c_blocked_worker(svc.sync_executor.executor)
 
         wall_start = time.monotonic()
         # on_shutdown budget = min(sync_executor_shutdown_timeout_seconds, resource_shutdown_timeout_seconds)
@@ -640,7 +547,7 @@ class TestConfigBehavior:
         """Executor uses the configured max_workers ceiling."""
         svc = make_service(max_workers=3)
         assert svc.sync_executor.executor._max_workers == 3  # pyright: ignore[reportAttributeAccessIssue]
-        svc.sync_executor.executor.shutdown(join_threads_or_timeout=False)
+        shutdown_pool(svc)
 
     def test_default_max_workers_is_reasonable(self) -> None:
         """Default max_workers is min(32, cpu_count + 4) — a reasonable pool ceiling."""
@@ -695,21 +602,20 @@ class TestConfigBehavior:
         svc = make_service(max_workers=2, saturation_warn_threshold=0.5, saturation_warn_rate_limit_seconds=10.0)
         assert svc.sync_executor.saturation_warn_threshold == 0.5
         assert svc.sync_executor.saturation_warn_rate_limit_seconds == 10.0
-        svc.sync_executor.executor.shutdown(join_threads_or_timeout=False)
+        shutdown_pool(svc)
 
     def test_lowered_threshold_fires_warning_earlier(self) -> None:
         """A lower configured threshold fires a WARNING at an occupancy that the default would not."""
-        sync_executor = SyncExecutor()
-        sync_executor.rebuild_pool(max_workers=4, saturation_warn_threshold=0.5)
-        sync_executor._outstanding_submissions = 2  # 50% occupancy — below the 0.75 default
-
-        warning_calls = _capture_saturation_warnings(sync_executor)
-        sync_executor.log_saturation_rate_limited()
+        # 2/4 = 50% occupancy — below the 0.75 default, at the configured 0.5 threshold
+        with saturation_probe(max_workers=4, outstanding=2, saturation_warn_threshold=0.5) as (
+            sync_executor,
+            warning_calls,
+        ):
+            sync_executor.log_saturation_rate_limited()
 
         assert any("approaching saturation" in str(c) for c in warning_calls), (
             "WARNING must fire at 50% occupancy when threshold is configured to 0.5"
         )
-        sync_executor.executor.shutdown(join_threads_or_timeout=False)
 
     def test_validator_rejects_threshold_outside_unit_interval(self) -> None:
         """sync_executor_saturation_warn_threshold must be within [0, 1]."""
@@ -790,4 +696,4 @@ class TestTrackSubmission:
         assert len(track_calls) >= 1, "run_in_thread must call track_submission after submitting"
 
         await asyncio.wrap_future(future)
-        svc.sync_executor.executor.shutdown(join_threads_or_timeout=False)
+        shutdown_pool(svc)


### PR DESCRIPTION
## Summary

The `duplicate-code` CI job (PMD CPD via `tools/check_duplicate_code.py`) flagged repeated
blocks across 11 scattered backend test files. This removes those clusters by extracting the
repeated boilerplate into shared `conftest.py` fixtures and helpers, and by collapsing parallel
test bodies into parametrized cases.

Net effect: **-850 lines** across the test suite with slightly *more* test cases than before.

## What changed

**New shared helpers**

- `tests/unit/conftest.py` — worker/thread lifecycle helpers used by the `task_bucket` tests
  (`await_worker_ready`, `busy_loop_worker`, `start_busy_thread`, `start_sleeping_thread`,
  `submit_busy_worker`, `submit_c_blocked_worker`, `timed_shutdown`) plus the
  `WORKER_READY_TIMEOUT` constant.
- `tests/integration/conftest.py` — shared setup for the command-executor and service-watcher
  integration tests.
- `src/hassette/test_utils/factories.py` — small extension to the shared factory surface so
  test files import a canonical builder rather than redefining one locally.

**Deduplicated files**

`tests/unit/task_bucket/test_interruptible_executor.py`, `tests/unit/test_model_types.py`,
`tests/unit/test_autodetect_apps.py`, `tests/unit/test_sync_executor_service_saturation.py`,
`tests/integration/test_thread_leaked_observability.py`,
`tests/integration/test_command_executor.py`,
`tests/integration/test_command_executor_error_handler.py`,
`tests/integration/test_service_watcher.py`,
`tests/integration/test_annotation_conversion.py`, `tests/integration/test_apps.py`.

One cluster is annotated rather than extracted — a `pytest.param` table where the repeated
shape *is* the table, and collapsing it would hurt readability. It carries a specific
`# dup-ignore-start:` reason as the issue requires.

## Testing

- `uv run nox -s dev` — **7034 passed, 1 skipped, 2 xfailed** (0 failures)
- `prek -a` — all 28 hooks pass
- `prek run pyright -a --stage pre-push` — passes
- `uv run python tools/check_duplicate_code.py` — **zero clusters remain in all 11 scoped
  files**. The tool still exits non-zero on out-of-scope files; that is the known
  `continue-on-error` baseline on `main`, not something this branch introduces.

**Coverage preserved:** `main` collects 7032 unit+integration tests; this branch collects 7037.
Test count went up, not down — the parametrization expanded a couple of cases rather than
dropping any. Restructuring only; no production code behavior changed.

Closes #1621
