### PR TITLE
test: name shared config-timeout constant and unify dedup test helper naming

### DIFF
--- a/src/hassette/test_utils/config.py
+++ b/src/hassette/test_utils/config.py
@@ -52,6 +52,12 @@ WAIT_FOR_READY_TIMEOUT_SECONDS: float = 5.0
 # documented in CLAUDE.md.
 TEST_TOTAL_TIMEOUT_SECONDS = 30
 
+# Matches the production default shared by LifecycleConfig.event_handler_timeout_seconds and
+# SchedulerConfig.job_timeout_seconds. Bus- and scheduler-dispatch tests use it as the stand-in
+# "config default" their per-listener/per-job overrides are resolved against, so the value is
+# named once instead of repeated as a bare literal across those files.
+TEST_CONFIG_TIMEOUT_SECONDS = 600.0
+
 # Early-drop retry tuning shared by tests/integration/websocket/test_reconnect.py and
 # tests/unit/core/test_ws_connection_state.py. Small backoff values keep the retry loop fast
 # and deterministic in CI. Tests that need a different value for the specific behavior under

--- a/src/hassette/test_utils/helpers.py
+++ b/src/hassette/test_utils/helpers.py
@@ -49,6 +49,10 @@ STATE_DICT_KEYS = frozenset({"last_changed", "last_updated", "last_reported", "c
 SETTLE_SECONDS = 0.05
 """Default settle window: seconds to let a stray extra handler call land before a negative assertion."""
 
+PLACEHOLDER_SERVICE_NAME = "TestService"
+"""Stand-in resource_name for the service-lifecycle event factories below. Tests that don't
+assert on the name should take this default rather than inventing another placeholder."""
+
 
 class FakeStateReader:
     """Minimal dict-backed implementation of the StateReader protocol.
@@ -504,7 +508,7 @@ def make_service_running_event(service: "Service") -> HassetteServiceEvent:
 
 
 def make_crashed_event(
-    resource_name: str = "TestService",
+    resource_name: str = PLACEHOLDER_SERVICE_NAME,
     exception_type: str | None = "RuntimeError",
     exception: str | None = "something broke",
     exception_traceback: str | None = "Traceback ...",

--- a/tests/unit/bus/test_invocation.py
+++ b/tests/unit/bus/test_invocation.py
@@ -13,6 +13,7 @@ from hassette.bus.error_context import BusErrorContext
 from hassette.bus.invocation import build_tracked_invoke_fn
 from hassette.bus.listeners import Listener
 from hassette.commands import InvokeHandler
+from hassette.test_utils.config import TEST_CONFIG_TIMEOUT_SECONDS
 from hassette.test_utils.factories import make_mock_event, make_mock_executor
 from hassette.test_utils.helpers import create_listener
 
@@ -60,7 +61,7 @@ async def invoke_and_get_cmd(
 class TestTimeoutResolution:
     async def test_timeout_disabled_returns_none(self) -> None:
         """listener.timeout_disabled=True → effective_timeout=None, config_resolver not called."""
-        config_resolver = MagicMock(return_value=600.0)
+        config_resolver = MagicMock(return_value=TEST_CONFIG_TIMEOUT_SECONDS)
         listener = create_listener(topic="test.topic", timeout_disabled=True)
 
         cmd = await invoke_and_get_cmd(listener=listener, config_resolver=config_resolver)
@@ -70,7 +71,7 @@ class TestTimeoutResolution:
 
     async def test_per_listener_timeout_used_when_set(self) -> None:
         """listener.timeout=5 → effective_timeout=5.0, config_resolver not called."""
-        config_resolver = MagicMock(return_value=600.0)
+        config_resolver = MagicMock(return_value=TEST_CONFIG_TIMEOUT_SECONDS)
         listener = create_listener(topic="test.topic", timeout=5.0)
 
         cmd = await invoke_and_get_cmd(listener=listener, config_resolver=config_resolver)
@@ -148,10 +149,8 @@ class TestInvokeHandlerConstruction:
         # Set db_id after building the invoke_fn (simulates async registration completing)
         listener.db_id = 42
 
-        # dup-ignore-start: Bus-layer fire-and-extract-cmd tail mirrors the BusService-level
-        # dispatch tests in tests/unit/core/test_bus_service_error_handler.py and
-        # test_bus_service_timeout.py — same build_tracked_invoke_fn behavior verified at two
-        # integration points (Bus vs BusService) by design, not copy-paste.
+        # dup-ignore-start: fire-and-extract-cmd tail — see the matching comment in
+        # invoke_and_get_cmd above.
         await invoke_fn()
 
         cmd = executor.execute.call_args[0][0]

--- a/tests/unit/core/conftest.py
+++ b/tests/unit/core/conftest.py
@@ -26,6 +26,7 @@ from hassette.core.service_watcher import ServiceWatcher
 from hassette.core.telemetry.repository import TelemetryRepository
 from hassette.resources.restart import RestartSpec
 from hassette.resources.service import Service
+from hassette.test_utils.config import TEST_CONFIG_TIMEOUT_SECONDS
 from hassette.test_utils.factories import make_execution_record
 from hassette.test_utils.helpers import block_until_cancelled
 from hassette.test_utils.mock_hassette import make_mock_hassette
@@ -472,7 +473,9 @@ def make_watcher(hassette: MagicMock) -> ServiceWatcher:
     return watcher
 
 
-def make_bus_service(*, config_timeout: float | None = 600.0, max_concurrent_dispatches: int = 50) -> BusService:
+def make_bus_service(
+    *, config_timeout: float | None = TEST_CONFIG_TIMEOUT_SECONDS, max_concurrent_dispatches: int = 50
+) -> BusService:
     """Create a BusService with mocked internals, bypassing Resource.__init__."""
     svc = BusService.__new__(BusService)
     svc.hassette = MagicMock()
@@ -516,7 +519,7 @@ def make_bus_service(*, config_timeout: float | None = 600.0, max_concurrent_dis
 
 def make_scheduler_service(
     *,
-    config_timeout: float | None = 600.0,
+    config_timeout: float | None = TEST_CONFIG_TIMEOUT_SECONDS,
     behind_schedule_threshold: float = 60,
 ) -> SchedulerService:
     """Create a SchedulerService with mocked internals, bypassing Resource.__init__."""

--- a/tests/unit/core/test_bus_service_error_handler.py
+++ b/tests/unit/core/test_bus_service_error_handler.py
@@ -2,6 +2,7 @@
 
 from hassette.bus.invocation import build_tracked_invoke_fn
 from hassette.commands import InvokeHandler
+from hassette.test_utils.config import TEST_CONFIG_TIMEOUT_SECONDS
 from hassette.test_utils.factories import make_mock_event, make_mock_executor
 from hassette.test_utils.helpers import create_listener
 
@@ -20,7 +21,9 @@ class TestDispatchCarriesAppLevelHandler:
         # behavior verified at two integration points (Bus vs BusService) by design, not copy-paste.
         listener = create_listener(topic="test.topic", app_error_handler_resolver=lambda: app_handler)
 
-        invoke_fn = build_tracked_invoke_fn(listener, event, "test.topic", executor, lambda: 600.0)
+        invoke_fn = build_tracked_invoke_fn(
+            listener, event, "test.topic", executor, lambda: TEST_CONFIG_TIMEOUT_SECONDS
+        )
         await invoke_fn()
 
         cmd = executor.execute.call_args[0][0]
@@ -33,12 +36,13 @@ class TestDispatchCarriesAppLevelHandler:
         executor = make_mock_executor()
         event = make_mock_event()
 
-        # dup-ignore-start: BusService-level dispatch test mirrors tests/unit/bus/test_invocation.py's
-        # Bus-layer coverage of build_tracked_invoke_fn's app_level_error_handler resolution — same
-        # behavior verified at two integration points (Bus vs BusService) by design, not copy-paste.
+        # dup-ignore-start: build-and-fire tail mirroring the Bus-layer coverage — see the matching
+        # comment in test_dispatch_carries_app_level_handler above.
         listener = create_listener(topic="test.topic")
 
-        invoke_fn = build_tracked_invoke_fn(listener, event, "test.topic", executor, lambda: 600.0)
+        invoke_fn = build_tracked_invoke_fn(
+            listener, event, "test.topic", executor, lambda: TEST_CONFIG_TIMEOUT_SECONDS
+        )
         await invoke_fn()
 
         cmd = executor.execute.call_args[0][0]
@@ -51,12 +55,13 @@ class TestDispatchCarriesAppLevelHandler:
         executor = make_mock_executor()
         event = make_mock_event()
 
-        # dup-ignore-start: BusService-level dispatch test mirrors tests/unit/bus/test_invocation.py's
-        # Bus-layer coverage of build_tracked_invoke_fn's app_level_error_handler resolution — same
-        # behavior verified at two integration points (Bus vs BusService) by design, not copy-paste.
+        # dup-ignore-start: build-and-fire tail mirroring the Bus-layer coverage — see the matching
+        # comment in test_dispatch_carries_app_level_handler above.
         listener = create_listener(topic="test.topic", app_error_handler_resolver=lambda: None)
 
-        invoke_fn = build_tracked_invoke_fn(listener, event, "test.topic", executor, lambda: 600.0)
+        invoke_fn = build_tracked_invoke_fn(
+            listener, event, "test.topic", executor, lambda: TEST_CONFIG_TIMEOUT_SECONDS
+        )
         await invoke_fn()
 
         cmd = executor.execute.call_args[0][0]
@@ -69,21 +74,27 @@ class TestDispatchCarriesAppLevelHandler:
         executor = make_mock_executor()
         event = make_mock_event()
 
-        current_handler = [None]
+        # Rebinding this local is visible to the resolver lambda below, which closes over the
+        # variable rather than its value — no mutable cell needed to swap the handler mid-test.
+        current_handler = None
 
         async def handler_v2(ctx) -> None:
             pass
 
-        listener = create_listener(topic="test.topic", app_error_handler_resolver=lambda: current_handler[0])
+        listener = create_listener(topic="test.topic", app_error_handler_resolver=lambda: current_handler)
 
-        invoke_fn = build_tracked_invoke_fn(listener, event, "test.topic", executor, lambda: 600.0)
+        invoke_fn = build_tracked_invoke_fn(
+            listener, event, "test.topic", executor, lambda: TEST_CONFIG_TIMEOUT_SECONDS
+        )
         await invoke_fn()
         cmd = executor.execute.call_args[0][0]
         assert cmd.app_level_error_handler is None
 
-        current_handler[0] = handler_v2
+        current_handler = handler_v2
 
-        invoke_fn = build_tracked_invoke_fn(listener, event, "test.topic", executor, lambda: 600.0)
+        invoke_fn = build_tracked_invoke_fn(
+            listener, event, "test.topic", executor, lambda: TEST_CONFIG_TIMEOUT_SECONDS
+        )
         await invoke_fn()
         cmd = executor.execute.call_args[0][0]
         assert cmd.app_level_error_handler is handler_v2

--- a/tests/unit/core/test_bus_service_timeout.py
+++ b/tests/unit/core/test_bus_service_timeout.py
@@ -4,6 +4,7 @@ from unittest.mock import MagicMock
 
 from hassette.bus.invocation import build_tracked_invoke_fn
 from hassette.commands import InvokeHandler
+from hassette.test_utils.config import TEST_CONFIG_TIMEOUT_SECONDS
 from hassette.test_utils.factories import make_mock_event, make_mock_executor
 from hassette.test_utils.helpers import create_listener
 
@@ -14,14 +15,15 @@ class TestDispatchResolvesEffectiveTimeout:
     async def test_dispatch_resolves_effective_timeout_from_listener(self) -> None:
         """listener.timeout=5 -> effective_timeout=5."""
         executor = make_mock_executor()
-        config_timeout = 600.0
         # dup-ignore-start: BusService-level dispatch test mirrors tests/unit/bus/test_invocation.py's
         # Bus-layer coverage of build_tracked_invoke_fn's timeout resolution — same behavior verified
         # at two integration points (Bus vs BusService) by design, not copy-paste.
         listener = create_listener(topic="test.topic", timeout=5.0)
         event = make_mock_event()
 
-        invoke_fn = build_tracked_invoke_fn(listener, event, "test.topic", executor, lambda: config_timeout)
+        invoke_fn = build_tracked_invoke_fn(
+            listener, event, "test.topic", executor, lambda: TEST_CONFIG_TIMEOUT_SECONDS
+        )
         await invoke_fn()
 
         cmd = executor.execute.call_args[0][0]
@@ -32,32 +34,32 @@ class TestDispatchResolvesEffectiveTimeout:
     async def test_dispatch_resolves_effective_timeout_from_config(self) -> None:
         """listener.timeout=None -> uses config default."""
         executor = make_mock_executor()
-        config_timeout = 600.0
-        # dup-ignore-start: BusService-level dispatch test mirrors tests/unit/bus/test_invocation.py's
-        # Bus-layer coverage of build_tracked_invoke_fn's timeout resolution — same behavior verified
-        # at two integration points (Bus vs BusService) by design, not copy-paste.
+        # dup-ignore-start: build-and-fire tail mirroring the Bus-layer coverage — see the matching
+        # comment in test_dispatch_resolves_effective_timeout_from_listener above.
         listener = create_listener(topic="test.topic")
         event = make_mock_event()
 
-        invoke_fn = build_tracked_invoke_fn(listener, event, "test.topic", executor, lambda: config_timeout)
+        invoke_fn = build_tracked_invoke_fn(
+            listener, event, "test.topic", executor, lambda: TEST_CONFIG_TIMEOUT_SECONDS
+        )
         await invoke_fn()
 
         cmd = executor.execute.call_args[0][0]
         assert isinstance(cmd, InvokeHandler)
-        assert cmd.effective_timeout == 600.0
+        assert cmd.effective_timeout == TEST_CONFIG_TIMEOUT_SECONDS
         # dup-ignore-end
 
     async def test_dispatch_resolves_timeout_disabled(self) -> None:
         """listener.timeout_disabled=True -> effective_timeout=None."""
         executor = make_mock_executor()
-        config_timeout = 600.0
-        # dup-ignore-start: BusService-level dispatch test mirrors tests/unit/bus/test_invocation.py's
-        # Bus-layer coverage of build_tracked_invoke_fn's timeout resolution — same behavior verified
-        # at two integration points (Bus vs BusService) by design, not copy-paste.
+        # dup-ignore-start: build-and-fire tail mirroring the Bus-layer coverage — see the matching
+        # comment in test_dispatch_resolves_effective_timeout_from_listener above.
         listener = create_listener(topic="test.topic", timeout_disabled=True)
         event = make_mock_event()
 
-        invoke_fn = build_tracked_invoke_fn(listener, event, "test.topic", executor, lambda: config_timeout)
+        invoke_fn = build_tracked_invoke_fn(
+            listener, event, "test.topic", executor, lambda: TEST_CONFIG_TIMEOUT_SECONDS
+        )
         await invoke_fn()
 
         cmd = executor.execute.call_args[0][0]
@@ -67,7 +69,7 @@ class TestDispatchResolvesEffectiveTimeout:
 
     async def test_once_listener_removed_after_dispatch(self) -> None:
         """once=True handler is removed from the bus after dispatch regardless of execution outcome."""
-        svc = make_bus_service(config_timeout=600.0)
+        svc = make_bus_service(config_timeout=TEST_CONFIG_TIMEOUT_SECONDS)
         listener = create_listener(topic="test.topic", timeout=0.001, once=True)
         event = make_mock_event()
 

--- a/tests/unit/core/test_scheduler_service_error_handler.py
+++ b/tests/unit/core/test_scheduler_service_error_handler.py
@@ -5,7 +5,7 @@ from unittest.mock import AsyncMock, MagicMock
 import hassette.utils.date_utils as date_utils
 
 from .conftest import make_scheduler_service
-from .test_scheduler_service_timeout import get_executed_cmd
+from .test_scheduler_service_timeout import run_job_and_get_cmd
 
 
 def make_job(  # factory-local: returns MagicMock, not ScheduledJob
@@ -41,9 +41,9 @@ class TestSchedulerServiceCarriesAppLevelHandler:
 
         job = make_job(scheduler=MagicMock())
         job.app_error_handler_resolver = lambda: app_handler
-        await svc.run_job(job)
 
-        cmd = get_executed_cmd(svc)
+        cmd = await run_job_and_get_cmd(svc, job)
+
         assert cmd.app_level_error_handler is app_handler
 
     async def test_dispatch_no_handler_when_resolver_returns_none(self) -> None:
@@ -52,9 +52,9 @@ class TestSchedulerServiceCarriesAppLevelHandler:
 
         job = make_job(scheduler=MagicMock())
         job.app_error_handler_resolver = lambda: None
-        await svc.run_job(job)
 
-        cmd = get_executed_cmd(svc)
+        cmd = await run_job_and_get_cmd(svc, job)
+
         assert cmd.app_level_error_handler is None
 
     async def test_dispatch_no_handler_when_no_resolver(self) -> None:
@@ -63,7 +63,7 @@ class TestSchedulerServiceCarriesAppLevelHandler:
 
         job = make_job(scheduler=None)
         job.app_error_handler_resolver = None
-        await svc.run_job(job)
 
-        cmd = get_executed_cmd(svc)
+        cmd = await run_job_and_get_cmd(svc, job)
+
         assert cmd.app_level_error_handler is None

--- a/tests/unit/core/test_scheduler_service_timeout.py
+++ b/tests/unit/core/test_scheduler_service_timeout.py
@@ -1,22 +1,29 @@
 """Tests for SchedulerService.run_job() effective timeout resolution."""
 
+from typing import Any
 from unittest.mock import AsyncMock
 
 from hassette.commands import ExecuteJob
 from hassette.core.scheduler_service import SchedulerService
+from hassette.test_utils.config import TEST_CONFIG_TIMEOUT_SECONDS
 from hassette.test_utils.factories import make_scheduled_job
 
 from .conftest import make_scheduler_service
 
 
-def get_executed_cmd(svc: SchedulerService) -> ExecuteJob:
-    """Return the ExecuteJob command dispatched via ``svc._executor.execute``.
+async def run_job_and_get_cmd(svc: SchedulerService, job: Any, **run_job_kwargs: Any) -> ExecuteJob:
+    """Run ``svc.run_job(job, ...)`` and return the ExecuteJob it dispatched via ``svc._executor.execute``.
 
     Shared across the scheduler_service test files (timeout, error_handler, trigger) that all
-    assert on the same "run_job dispatched an ExecuteJob" shape. Kept local to this file rather
-    than promoted to conftest.py, which is shared write-target scope across unrelated test
-    groups (see design/specs/098-dedup-core-service-tests/design.md).
+    assert on the same "run_job dispatched an ExecuteJob" shape. Named to match the fire-then-extract
+    helpers covering the same pattern elsewhere — ``invoke_and_get_cmd`` in
+    tests/unit/bus/test_invocation.py and ``execute_handler_and_get_record`` in
+    test_command_executor_execution_id.py. Kept local to this file rather than promoted to
+    conftest.py, which is shared write-target scope across unrelated test groups (see
+    design/specs/098-dedup-core-service-tests/design.md).
     """
+    await svc.run_job(job, **run_job_kwargs)
+
     cmd = svc._executor.execute.call_args[0][0]
     assert isinstance(cmd, ExecuteJob)
     return cmd
@@ -25,32 +32,29 @@ def get_executed_cmd(svc: SchedulerService) -> ExecuteJob:
 class TestRunJobResolvesEffectiveTimeout:
     async def test_run_job_resolves_effective_timeout_from_job(self) -> None:
         """job.timeout=5 takes precedence over config default."""
-        svc = make_scheduler_service(config_timeout=600.0)
+        svc = make_scheduler_service(config_timeout=TEST_CONFIG_TIMEOUT_SECONDS)
         job = make_scheduled_job(timeout=5.0)
 
-        await svc.run_job(job)
+        cmd = await run_job_and_get_cmd(svc, job)
 
-        cmd = get_executed_cmd(svc)
         assert cmd.effective_timeout == 5.0
 
     async def test_run_job_resolves_effective_timeout_from_config(self) -> None:
         """job.timeout=None falls through to config default."""
-        svc = make_scheduler_service(config_timeout=600.0)
+        svc = make_scheduler_service(config_timeout=TEST_CONFIG_TIMEOUT_SECONDS)
         job = make_scheduled_job(timeout=None)
 
-        await svc.run_job(job)
+        cmd = await run_job_and_get_cmd(svc, job)
 
-        cmd = get_executed_cmd(svc)
-        assert cmd.effective_timeout == 600.0
+        assert cmd.effective_timeout == TEST_CONFIG_TIMEOUT_SECONDS
 
     async def test_run_job_resolves_timeout_disabled(self) -> None:
         """job.timeout_disabled=True sets effective_timeout=None."""
-        svc = make_scheduler_service(config_timeout=600.0)
+        svc = make_scheduler_service(config_timeout=TEST_CONFIG_TIMEOUT_SECONDS)
         job = make_scheduled_job(timeout_disabled=True)
 
-        await svc.run_job(job)
+        cmd = await run_job_and_get_cmd(svc, job)
 
-        cmd = get_executed_cmd(svc)
         assert cmd.effective_timeout is None
 
     async def test_run_job_does_not_raise_on_timeout(self) -> None:
@@ -63,7 +67,6 @@ class TestRunJobResolvesEffectiveTimeout:
         job = make_scheduled_job(timeout=0.001)
 
         svc._executor.execute = AsyncMock()
-        await svc.run_job(job)  # must not raise
+        cmd = await run_job_and_get_cmd(svc, job)  # the run_job() call inside must not raise
 
-        cmd = get_executed_cmd(svc)
         assert cmd.effective_timeout == 0.001

--- a/tests/unit/core/test_scheduler_service_trigger.py
+++ b/tests/unit/core/test_scheduler_service_trigger.py
@@ -19,12 +19,13 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 import hassette.utils.date_utils as date_utils
+from hassette.commands import ExecuteJob
 from hassette.exceptions import JobRemovedError
 from hassette.test_utils.web_job_helpers import make_real_job
 from hassette.types.enums import ExecutionMode
 
 from .conftest import make_scheduler_service
-from .test_scheduler_service_timeout import get_executed_cmd
+from .test_scheduler_service_timeout import run_job_and_get_cmd
 
 
 def _make_trigger_service():
@@ -49,10 +50,9 @@ class TestRunJobTriggerMode:
         svc = _make_trigger_service()
         job = make_real_job()
 
-        await svc.run_job(job, trigger_mode="manual")
+        cmd = await run_job_and_get_cmd(svc, job, trigger_mode="manual")
 
         svc._executor.execute.assert_called_once()
-        cmd = get_executed_cmd(svc)
         assert cmd.trigger_mode == "manual"
 
     async def test_run_job_defaults_trigger_mode_to_none(self) -> None:
@@ -60,9 +60,8 @@ class TestRunJobTriggerMode:
         svc = _make_trigger_service()
         job = make_real_job()
 
-        await svc.run_job(job)
+        cmd = await run_job_and_get_cmd(svc, job)
 
-        cmd = get_executed_cmd(svc)
         assert cmd.trigger_mode is None
 
 
@@ -170,7 +169,10 @@ class TestSubmitJob:
         await asyncio.wait_for(spawned[0], timeout=1)
 
         svc._executor.execute.assert_called_once()
-        cmd = get_executed_cmd(svc)
+        # Extracted inline rather than via run_job_and_get_cmd: the dispatch under test came from
+        # submit_job()'s spawned task, already awaited above, not from a direct run_job() call.
+        cmd = svc._executor.execute.call_args[0][0]
+        assert isinstance(cmd, ExecuteJob)
         assert cmd.trigger_mode == "manual", "manual submission must record trigger_mode='manual' telemetry"
 
     async def test_submit_job_raises_when_never_registered(self) -> None:

--- a/tests/unit/core/test_service_watcher_coverage.py
+++ b/tests/unit/core/test_service_watcher_coverage.py
@@ -16,7 +16,7 @@ from hassette.events import HassetteServiceEvent
 from hassette.resources.lifecycle import mark_ready
 from hassette.resources.restart import RestartSpec
 from hassette.test_utils import make_mock_hassette, make_service_failed_event, make_service_running_event, wait_for
-from hassette.test_utils.helpers import make_crashed_event
+from hassette.test_utils.helpers import PLACEHOLDER_SERVICE_NAME, make_crashed_event
 from hassette.types import ResourceStatus, Topic
 from hassette.types.enums import ResourceRole, RestartType
 
@@ -82,7 +82,9 @@ class TestRegisterInternalEventListeners:
         assert registered_by_name["hassette.service_watcher.on_bus_service_running"].get("where") is not None
 
 
-def make_running_event(previous_status: ResourceStatus, resource_name: str = "SomeService") -> HassetteServiceEvent:
+def make_running_event(
+    previous_status: ResourceStatus, resource_name: str = PLACEHOLDER_SERVICE_NAME
+) -> HassetteServiceEvent:
     """Build a RUNNING HassetteServiceEvent with a given previous_status, for log_service_event tests."""
     return HassetteServiceEvent.from_service_status(
         resource_name=resource_name,
@@ -299,14 +301,12 @@ class TestShutdownIfCrashed:
         hassette.record_fatal_reason = Mock()
         watcher = make_watcher(hassette)
 
-        event = make_crashed_event(
-            resource_name="SomeService", exception=None, exception_type=None, exception_traceback=None
-        )
+        event = make_crashed_event(exception=None, exception_type=None, exception_traceback=None)
 
         with patch("hassette.core.service_watcher.request_shutdown"):
             await watcher.shutdown_if_crashed(event)
 
-        hassette.record_fatal_reason.assert_called_once_with("service 'SomeService' crashed")
+        hassette.record_fatal_reason.assert_called_once_with(f"service '{PLACEHOLDER_SERVICE_NAME}' crashed")
 
     async def test_reraises_on_unexpected_internal_failure(self) -> None:
         """If record_fatal_reason itself raises, shutdown_if_crashed logs and re-raises."""
@@ -314,9 +314,7 @@ class TestShutdownIfCrashed:
         hassette.record_fatal_reason = Mock(side_effect=RuntimeError("state corrupted"))
         watcher = make_watcher(hassette)
 
-        event = make_crashed_event(
-            resource_name="SomeService", exception="boom", exception_type="RuntimeError", exception_traceback=None
-        )
+        event = make_crashed_event(exception="boom", exception_type="RuntimeError", exception_traceback=None)
 
         with patch("hassette.core.service_watcher.request_shutdown") as mock_request_shutdown:
             with pytest.raises(RuntimeError, match="state corrupted"):


### PR DESCRIPTION
## Summary

Follow-up hygiene pass on the #1616 dedup effort. That effort ran as four independently-executed task groups (command_executor, bus_service, scheduler_service, service_watcher), and a `nitpicker` clean-code review caught the naming and constant drift that accumulated across those parallel groups. This PR closes that drift.

Test-infrastructure only — no `src/` behavior changes. The two `src/hassette/test_utils/` edits are additions to the shared test-helper surface, not framework code.

## What changed

**Named the repeated config-timeout literal.** Added `TEST_CONFIG_TIMEOUT_SECONDS` to `test_utils/config.py` and imported it in place of the 14 bare `600.0` literals across the bus/scheduler dispatch tests, plus the `make_bus_service`/`make_scheduler_service` conftest factories. The constant's docstring records *why* the value is 600.0 — it matches the production default shared by `LifecycleConfig.event_handler_timeout_seconds` and `SchedulerConfig.job_timeout_seconds`, which is the fact a bare literal was hiding.

**Unified the "fire dispatch, extract result" helper naming.** Renamed `get_executed_cmd()` to `run_job_and_get_cmd()` and folded the `run_job()` call into it, so all three helpers share one `<action>_and_get_<result>` template alongside `invoke_and_get_cmd()` and `execute_handler_and_get_record()`. The one `submit_job()` call site that can't use the helper extracts inline with a comment saying why.

**Named the placeholder service name.** `make_crashed_event()`'s `"TestService"` default is now `PLACEHOLDER_SERVICE_NAME`, and the local `make_running_event()` plus the two `"SomeService"` overrides in `test_service_watcher_coverage.py` reuse it instead of inventing a second placeholder.

**Deduplicated the `dup-ignore` rationale comments.** Each file now states its rationale once and cross-references it from later occurrences, matching the pattern already used in `test_command_executor_pipeline_serve.py`.

**Dropped the mutable-cell workaround.** `current_handler = [None]` is now a plain local. The resolver lambda closes over the variable rather than its value, so rebinding is already visible — the single-element-list cell was never needed.

## Testing

- `uv run nox -s dev` — 7034 passed, 1 skipped, 2 xfailed
- `prek -a` — all 28 hooks pass (frontend hooks required `npm install` in this worktree first)
- `prek pyright -a --stage pre-push` — passes

Each acceptance criterion was also grep-verified against the working tree: no bare `600.0` remains in the four listed files, all three helpers match the shared naming template, no `"SomeService"` literals remain, and the mutable cell is gone.

Closes #1632
