### PR TITLE
test: adopt shared factory and name magic literals in e2e mock_fixtures

### DIFF
--- a/tests/e2e/mock_fixtures/__init__.py
+++ b/tests/e2e/mock_fixtures/__init__.py
@@ -10,7 +10,7 @@ sessions/config) to stay under the repo's file-size threshold; this
 from ``tests.e2e.mock_fixtures`` without caring about the internal layout.
 """
 
-from tests.e2e.mock_fixtures.constants import MANUAL_JOB_ID
+from tests.e2e.mock_fixtures.constants import APP_KEY_MY_APP, MANUAL_JOB_ID
 from tests.e2e.mock_fixtures.manifests import (
     build_manifests,
     build_old_snapshot,
@@ -35,6 +35,7 @@ from tests.e2e.mock_fixtures.telemetry import (
 )
 
 __all__ = [
+    "APP_KEY_MY_APP",
     "JOB_MY_APP_1_TOTAL_EXECUTIONS",
     "JOB_MY_APP_2_TOTAL_EXECUTIONS",
     "LISTENER_MY_APP_1_TOTAL_INVOCATIONS",
@@ -71,7 +72,7 @@ __all__ = [
 _listeners = build_listener_telemetry()
 _jobs = build_job_telemetry()
 
-LISTENER_MY_APP_1_TOTAL_INVOCATIONS: int = _listeners["my_app"][0].total_invocations
-LISTENER_MY_APP_2_TOTAL_INVOCATIONS: int = _listeners["my_app"][1].total_invocations
-JOB_MY_APP_1_TOTAL_EXECUTIONS: int = _jobs["my_app"][0].total_executions
-JOB_MY_APP_2_TOTAL_EXECUTIONS: int = _jobs["my_app"][1].total_executions
+LISTENER_MY_APP_1_TOTAL_INVOCATIONS: int = _listeners[APP_KEY_MY_APP][0].total_invocations
+LISTENER_MY_APP_2_TOTAL_INVOCATIONS: int = _listeners[APP_KEY_MY_APP][1].total_invocations
+JOB_MY_APP_1_TOTAL_EXECUTIONS: int = _jobs[APP_KEY_MY_APP][0].total_executions
+JOB_MY_APP_2_TOTAL_EXECUTIONS: int = _jobs[APP_KEY_MY_APP][1].total_executions

--- a/tests/e2e/mock_fixtures/constants.py
+++ b/tests/e2e/mock_fixtures/constants.py
@@ -1,9 +1,28 @@
-"""Shared timestamp and id constants for e2e mock fixtures."""
+"""Shared app-key, timestamp, and id constants for e2e mock fixtures."""
+
+# App keys for the seeded apps. Every fixture module keys its per-app data off these, so a
+# rename lands in one place instead of across the manifest, telemetry, and scheduler seeds.
+APP_KEY_MY_APP = "my_app"
+APP_KEY_OTHER_APP = "other_app"
+APP_KEY_BROKEN_APP = "broken_app"
+APP_KEY_DISABLED_APP = "disabled_app"
+APP_KEY_NOSOURCE_APP = "nosource_app"
+APP_KEY_MULTI_APP = "multi_app"
 
 TS_BASE = 1_704_067_200.0
 TS_RECENT = 1_704_067_100.0
 TS_OLDER = 1_704_067_050.0
 TS_OLDEST = 1_704_067_000.0
+
+# Start/stop timestamps for the two finished sessions on the sessions page. Session 1 is still
+# running, so it uses TS_BASE as its start and has no stop.
+TS_SESSION_2_STARTED = 1_704_060_000.0
+TS_SESSION_2_STOPPED = 1_704_063_600.0
+TS_SESSION_3_STARTED = 1_704_050_000.0
+TS_SESSION_3_STOPPED = 1_704_053_600.0
+
+# duration_seconds reported for every seeded session, running or finished.
+SESSION_DURATION_SECONDS = 3600.0
 
 # job_id of the manual-only job seeded so it's discoverable and submittable through the live
 # UI. Shared between the DB telemetry row and the trigger stub.

--- a/tests/e2e/mock_fixtures/manifests.py
+++ b/tests/e2e/mock_fixtures/manifests.py
@@ -4,42 +4,39 @@ from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
-from hassette.schemas.app_snapshots import AppInstanceInfo, AppManifestInfo, AppStatusSnapshot
-from hassette.test_utils.web_manifest_helpers import make_manifest, make_manifest_db_row
+from hassette.schemas.app_snapshots import AppManifestInfo, AppStatusSnapshot
+from hassette.test_utils.web_manifest_helpers import make_app_instance_info, make_manifest, make_manifest_db_row
 from hassette.types.enums import ManifestStatus, ResourceStatus
+from tests.e2e.mock_fixtures.constants import (
+    APP_KEY_BROKEN_APP,
+    APP_KEY_DISABLED_APP,
+    APP_KEY_MULTI_APP,
+    APP_KEY_MY_APP,
+    APP_KEY_NOSOURCE_APP,
+    APP_KEY_OTHER_APP,
+)
+
+BROKEN_APP_ERROR = "Init error: bad config"
+BROKEN_APP_TRACEBACK = (
+    'Traceback (most recent call last):\n  File "broken_app.py", line 10, in on_initialize\n'
+    '    raise ValueError("bad config")\nValueError: bad config\n'
+)
 
 
 def build_manifests() -> list[AppManifestInfo]:
     """Build a rich set of app manifests for e2e tests."""
     return [
         make_manifest(
-            app_key="my_app",
+            app_key=APP_KEY_MY_APP,
             class_name="MyApp",
             display_name="My App",
             filename="my_app.py",
             status=ManifestStatus.RUNNING,
             instance_count=1,
-            instances=[
-                # dup-ignore-start: same AppInstanceInfo("my_app", index=0, ...) literal shape used
-                # by tests/unit/core/test_runtime_query_service.py and tests/unit/test_model_types.py
-                # — different test tiers/directories building unrelated fixture data;
-                # src/hassette/test_utils/web_manifest_helpers.py's make_app_instance_info() factory
-                # already covers this shape, but adopting it across all three call sites is out of
-                # scope for this cluster, which is marker-only per this task's file classification
-                # (see design/specs/099-dedupe-tests-unit-core/design.md, Group B row).
-                AppInstanceInfo(
-                    app_key="my_app",
-                    index=0,
-                    instance_name="MyApp[0]",
-                    class_name="MyApp",
-                    status=ResourceStatus.RUNNING,
-                    owner_id="MyApp.MyApp[0]",
-                )
-                # dup-ignore-end
-            ],
+            instances=[make_app_instance_info(app_key=APP_KEY_MY_APP, owner_id="MyApp.MyApp[0]")],
         ),
         make_manifest(
-            app_key="other_app",
+            app_key=APP_KEY_OTHER_APP,
             class_name="OtherApp",
             display_name="Other App",
             filename="other_app.py",
@@ -47,34 +44,26 @@ def build_manifests() -> list[AppManifestInfo]:
             instance_count=0,
         ),
         make_manifest(
-            app_key="broken_app",
+            app_key=APP_KEY_BROKEN_APP,
             class_name="BrokenApp",
             display_name="Broken App",
             filename="broken_app.py",
             status=ManifestStatus.FAILED,
             instance_count=1,
             instances=[
-                AppInstanceInfo(
-                    app_key="broken_app",
-                    index=0,
-                    instance_name="BrokenApp[0]",
+                make_app_instance_info(
+                    app_key=APP_KEY_BROKEN_APP,
                     class_name="BrokenApp",
                     status=ResourceStatus.FAILED,
-                    error_message="Init error: bad config",
-                    error_traceback=(
-                        'Traceback (most recent call last):\n  File "broken_app.py", line 10, in '
-                        'on_initialize\n    raise ValueError("bad config")\nValueError: bad config\n'
-                    ),
+                    error_message=BROKEN_APP_ERROR,
+                    error_traceback=BROKEN_APP_TRACEBACK,
                 )
             ],
-            error_message="Init error: bad config",
-            error_traceback=(
-                'Traceback (most recent call last):\n  File "broken_app.py", line 10, in on_initialize\n'
-                '    raise ValueError("bad config")\nValueError: bad config\n'
-            ),
+            error_message=BROKEN_APP_ERROR,
+            error_traceback=BROKEN_APP_TRACEBACK,
         ),
         make_manifest(
-            app_key="disabled_app",
+            app_key=APP_KEY_DISABLED_APP,
             class_name="DisabledApp",
             display_name="Disabled App",
             filename="disabled_app.py",
@@ -83,55 +72,35 @@ def build_manifests() -> list[AppManifestInfo]:
             instance_count=0,
         ),
         make_manifest(
-            app_key="nosource_app",
+            app_key=APP_KEY_NOSOURCE_APP,
             class_name="NoSourceApp",
             display_name="No Source App",
             filename="nosource_app.py",
             status=ManifestStatus.RUNNING,
             instance_count=1,
             instances=[
-                AppInstanceInfo(
-                    app_key="nosource_app",
-                    index=0,
-                    instance_name="NoSourceApp[0]",
+                make_app_instance_info(
+                    app_key=APP_KEY_NOSOURCE_APP,
                     class_name="NoSourceApp",
-                    status=ResourceStatus.RUNNING,
                     owner_id="NoSourceApp.NoSourceApp[0]",
                 ),
             ],
         ),
         make_manifest(
-            app_key="multi_app",
+            app_key=APP_KEY_MULTI_APP,
             class_name="MultiApp",
             display_name="Multi App",
             filename="multi_app.py",
             status=ManifestStatus.RUNNING,
             instance_count=3,
             instances=[
-                AppInstanceInfo(
-                    app_key="multi_app",
-                    index=0,
-                    instance_name="MultiApp[0]",
+                make_app_instance_info(
+                    app_key=APP_KEY_MULTI_APP,
+                    index=index,
                     class_name="MultiApp",
-                    status=ResourceStatus.RUNNING,
-                    owner_id="MultiApp.MultiApp[0]",
-                ),
-                AppInstanceInfo(
-                    app_key="multi_app",
-                    index=1,
-                    instance_name="MultiApp[1]",
-                    class_name="MultiApp",
-                    status=ResourceStatus.RUNNING,
-                    owner_id="MultiApp.MultiApp[1]",
-                ),
-                AppInstanceInfo(
-                    app_key="multi_app",
-                    index=2,
-                    instance_name="MultiApp[2]",
-                    class_name="MultiApp",
-                    status=ResourceStatus.RUNNING,
-                    owner_id="MultiApp.MultiApp[2]",
-                ),
+                    owner_id=f"MultiApp.MultiApp[{index}]",
+                )
+                for index in range(3)
             ],
         ),
     ]
@@ -141,38 +110,18 @@ def build_old_snapshot() -> AppStatusSnapshot:
     """Build the legacy AppStatusSnapshot used to seed mock_hassette."""
     return AppStatusSnapshot(
         instances=[
-            # dup-ignore-start: same AppInstanceInfo("my_app", index=0, ...) literal shape used by
-            # tests/unit/core/test_runtime_query_service.py and tests/unit/test_model_types.py —
-            # different test tiers/directories building unrelated fixture data;
-            # src/hassette/test_utils/web_manifest_helpers.py's make_app_instance_info() factory
-            # already covers this shape, but adopting it across all three call sites is out of
-            # scope for this cluster, which is marker-only per this task's file classification
-            # (see design/specs/099-dedupe-tests-unit-core/design.md, Group B row).
-            AppInstanceInfo(
-                app_key="my_app",
-                index=0,
-                instance_name="MyApp[0]",
-                class_name="MyApp",
-                status=ResourceStatus.RUNNING,
-                owner_id="MyApp.MyApp[0]",
-            ),
-            # dup-ignore-end
-            AppInstanceInfo(
-                app_key="nosource_app",
-                index=0,
-                instance_name="NoSourceApp[0]",
+            make_app_instance_info(app_key=APP_KEY_MY_APP, owner_id="MyApp.MyApp[0]"),
+            make_app_instance_info(
+                app_key=APP_KEY_NOSOURCE_APP,
                 class_name="NoSourceApp",
-                status=ResourceStatus.RUNNING,
                 owner_id="NoSourceApp.NoSourceApp[0]",
             ),
-            AppInstanceInfo(
-                app_key="broken_app",
-                index=0,
-                instance_name="BrokenApp[0]",
+            make_app_instance_info(
+                app_key=APP_KEY_BROKEN_APP,
                 class_name="BrokenApp",
                 status=ResourceStatus.FAILED,
-                error_message="Init error: bad config",
-                error=Exception("Init error: bad config"),
+                error_message=BROKEN_APP_ERROR,
+                error=Exception(BROKEN_APP_ERROR),
             ),
         ],
     )
@@ -195,16 +144,16 @@ def wire_app_manifest_lookups(hassette, manifests: list[AppManifestInfo]) -> Non
     # Build a stub AppManifest for each manifest — source endpoint reads full_path and app_dir.
     # We create a temp-like path pointing to a real file to avoid 404 errors in source tests;
     # for the "nosource_app" we deliberately point at a non-existent path.
-    _stubs: dict[str, MagicMock] = {}
+    stubs: dict[str, MagicMock] = {}
 
-    for m in manifests:
+    for manifest in manifests:
         stub = MagicMock()
-        stub.app_key = m.app_key
-        stub.filename = m.filename
-        stub.class_name = m.class_name
-        stub.enabled = m.enabled
+        stub.app_key = manifest.app_key
+        stub.filename = manifest.filename
+        stub.class_name = manifest.class_name
+        stub.enabled = manifest.enabled
         # Use a real Python file for apps that should have source, None path for nosource_app.
-        if m.app_key == "nosource_app":
+        if manifest.app_key == APP_KEY_NOSOURCE_APP:
             stub.full_path.resolve.return_value = Path("/nonexistent/nosource_app.py")
             stub.app_dir.resolve.return_value = Path("/nonexistent")
             stub.full_path.exists.return_value = False
@@ -216,27 +165,27 @@ def wire_app_manifest_lookups(hassette, manifests: list[AppManifestInfo]) -> Non
             stub.full_path.resolve.return_value = real_path
             stub.app_dir.resolve.return_value = real_path.parent
             stub.full_path.exists.return_value = True
-        stub.app_config = {"instance_name": f"{m.class_name}.0", "env_prefix": m.app_key + "_"}
-        stub.autostart = m.autostart
-        _stubs[m.app_key] = stub
+        stub.app_config = {"instance_name": f"{manifest.class_name}.0", "env_prefix": manifest.app_key + "_"}
+        stub.autostart = manifest.autostart
+        stubs[manifest.app_key] = stub
 
-    hassette._app_handler.registry.get_manifest.side_effect = lambda app_key: _stubs.get(app_key)
+    hassette._app_handler.registry.get_manifest.side_effect = lambda app_key: stubs.get(app_key)
 
-    _manifest_info_by_key = {m.app_key: m for m in manifests}
+    manifest_info_by_key = {manifest.app_key: manifest for manifest in manifests}
 
     # DB spine mocks — /apps/manifests and the dashboard grid both call
     # telemetry.get_all_app_manifests(); /apps/{key}/manifest calls telemetry.get_app_manifest().
     db_rows_by_key = {
-        m.app_key: make_manifest_db_row(
-            app_key=m.app_key,
-            class_name=m.class_name,
-            display_name=m.display_name,
-            filename=m.filename,
-            enabled=int(m.enabled),
-            autostart=int(m.autostart),
-            auto_loaded=int(m.auto_loaded),
+        manifest.app_key: make_manifest_db_row(
+            app_key=manifest.app_key,
+            class_name=manifest.class_name,
+            display_name=manifest.display_name,
+            filename=manifest.filename,
+            enabled=int(manifest.enabled),
+            autostart=int(manifest.autostart),
+            auto_loaded=int(manifest.auto_loaded),
         )
-        for m in manifests
+        for manifest in manifests
     }
     hassette._telemetry_query_service.get_all_app_manifests = AsyncMock(return_value=list(db_rows_by_key.values()))
     hassette._telemetry_query_service.get_app_manifest = AsyncMock(side_effect=db_rows_by_key.get)
@@ -245,8 +194,8 @@ def wire_app_manifest_lookups(hassette, manifests: list[AppManifestInfo]) -> Non
     # registry.manifests.get(app_key) is not None, then calls registry.build_manifest_info()
     # to derive status/instances. The value stored per key is never read (build_manifest_info
     # is stubbed below to ignore it) — its presence is what matters.
-    hassette._app_handler.registry.manifests = dict(_manifest_info_by_key)
-    hassette._app_handler.registry.build_manifest_info.side_effect = lambda app_key, _manifest: _manifest_info_by_key[
+    hassette._app_handler.registry.manifests = dict(manifest_info_by_key)
+    hassette._app_handler.registry.build_manifest_info.side_effect = lambda app_key, _manifest: manifest_info_by_key[
         app_key
     ]
 
@@ -257,5 +206,5 @@ def wire_owner_resolution(hassette) -> None:
         0: SimpleNamespace(unique_name="MyApp.MyApp[0]"),
     }
     hassette._app_handler.registry.get.side_effect = lambda app_key, index=0: (
-        SimpleNamespace(unique_name="MyApp.MyApp[0]") if app_key == "my_app" and index == 0 else None
+        SimpleNamespace(unique_name="MyApp.MyApp[0]") if app_key == APP_KEY_MY_APP and index == 0 else None
     )

--- a/tests/e2e/mock_fixtures/scheduler.py
+++ b/tests/e2e/mock_fixtures/scheduler.py
@@ -4,19 +4,20 @@ from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
 from hassette.test_utils.web_job_helpers import make_job
+from tests.e2e.mock_fixtures.constants import APP_KEY_MY_APP
 
 
 def build_scheduler_jobs() -> list[SimpleNamespace]:
     """Build scheduler job stubs for e2e seed data."""
     return [
-        make_job(trigger_detail="PT30S", app_key="my_app", instance_index=0),
+        make_job(trigger_detail="PT30S", app_key=APP_KEY_MY_APP, instance_index=0),
         make_job(
             job_id="job-2",
             name="morning_routine",
             next_run="2024-01-01T07:00:00",
             trigger_type="cron",
             trigger_detail="0 7 * * * 0",
-            app_key="my_app",
+            app_key=APP_KEY_MY_APP,
             instance_index=0,
         ),
     ]

--- a/tests/e2e/mock_fixtures/sessions_config.py
+++ b/tests/e2e/mock_fixtures/sessions_config.py
@@ -5,7 +5,14 @@ from unittest.mock import AsyncMock, MagicMock
 from hassette.config import HassetteConfig
 from hassette.config.models import DEFAULT_WEB_API_PORT
 from hassette.schemas.summary_models import SessionRecord
-from tests.e2e.mock_fixtures.constants import TS_BASE
+from tests.e2e.mock_fixtures.constants import (
+    SESSION_DURATION_SECONDS,
+    TS_BASE,
+    TS_SESSION_2_STARTED,
+    TS_SESSION_2_STOPPED,
+    TS_SESSION_3_STARTED,
+    TS_SESSION_3_STOPPED,
+)
 
 
 def build_session_list() -> list[SessionRecord]:
@@ -18,25 +25,25 @@ def build_session_list() -> list[SessionRecord]:
             status="running",
             error_type=None,
             error_message=None,
-            duration_seconds=3600.0,
+            duration_seconds=SESSION_DURATION_SECONDS,
         ),
         SessionRecord(
             id=2,
-            started_at=1704060000.0,
-            stopped_at=1704063600.0,
+            started_at=TS_SESSION_2_STARTED,
+            stopped_at=TS_SESSION_2_STOPPED,
             status="success",
             error_type=None,
             error_message=None,
-            duration_seconds=3600.0,
+            duration_seconds=SESSION_DURATION_SECONDS,
         ),
         SessionRecord(
             id=3,
-            started_at=1704050000.0,
-            stopped_at=1704053600.0,
+            started_at=TS_SESSION_3_STARTED,
+            stopped_at=TS_SESSION_3_STOPPED,
             status="failure",
             error_type="RuntimeError",
             error_message="WebSocket connection lost",
-            duration_seconds=3600.0,
+            duration_seconds=SESSION_DURATION_SECONDS,
         ),
     ]
 

--- a/tests/e2e/mock_fixtures/telemetry.py
+++ b/tests/e2e/mock_fixtures/telemetry.py
@@ -29,6 +29,7 @@ T = TypeVar("T")
 # source_tier values the telemetry routes pass through to the query service.
 FRAMEWORK_TIER = "framework"
 APP_TIER = "app"
+ALL_TIER = "all"
 
 # get_error_counts() returns (handler_errors, job_errors); these are the non-framework totals.
 DEFAULT_ERROR_COUNTS = (3, 6)
@@ -470,7 +471,7 @@ def wire_error_telemetry(
     hassette._telemetry_query_service.get_recent_errors = AsyncMock(
         side_effect=by_tier(
             {FRAMEWORK_TIER: framework_tier_errors, APP_TIER: app_tier_errors},
-            default_tier="all",
+            default_tier=ALL_TIER,
             fallback=app_tier_errors + framework_tier_errors,
         )
     )

--- a/tests/e2e/mock_fixtures/telemetry.py
+++ b/tests/e2e/mock_fixtures/telemetry.py
@@ -5,13 +5,62 @@ one telemetry surface end-to-end (build the data, then wire it onto the mock que
 reads top-to-bottom without jumping across the file.
 """
 
+from collections.abc import Callable, Mapping
+from typing import TypeVar
 from unittest.mock import AsyncMock
 
 from hassette.schemas.execution_models import Execution
 from hassette.schemas.job_models import JobErrorRecord, JobGlobalStats, JobSummary
 from hassette.schemas.listener_models import HandlerErrorRecord, ListenerGlobalStats, ListenerSummary
 from hassette.schemas.summary_models import AppHealthSummary, GlobalSummary
-from tests.e2e.mock_fixtures.constants import MANUAL_JOB_ID, TS_BASE, TS_OLDER, TS_OLDEST, TS_RECENT
+from tests.e2e.mock_fixtures.constants import (
+    APP_KEY_BROKEN_APP,
+    APP_KEY_MY_APP,
+    APP_KEY_NOSOURCE_APP,
+    MANUAL_JOB_ID,
+    TS_BASE,
+    TS_OLDER,
+    TS_OLDEST,
+    TS_RECENT,
+)
+
+T = TypeVar("T")
+
+# source_tier values the telemetry routes pass through to the query service.
+FRAMEWORK_TIER = "framework"
+APP_TIER = "app"
+
+# get_error_counts() returns (handler_errors, job_errors); these are the non-framework totals.
+DEFAULT_ERROR_COUNTS = (3, 6)
+
+
+def by_app_key_or_all(items_by_app: Mapping[str, list[T]]) -> Callable[..., list[T]]:
+    """Build a side effect that filters per-app telemetry rows by ``app_key``.
+
+    Mirrors what the real query services do: no ``app_key`` means every app's rows, a known
+    ``app_key`` means only that app's, and an unknown one means an empty list.
+    """
+    all_items = [item for items in items_by_app.values() for item in items]
+
+    def side_effect(app_key: str | None = None, **_) -> list[T]:
+        if app_key is None:
+            return all_items
+        return items_by_app.get(app_key, [])
+
+    return side_effect
+
+
+def by_tier(values: Mapping[str, T], *, default_tier: str, fallback: T) -> Callable[..., T]:
+    """Build a side effect that routes on ``source_tier``.
+
+    ``values`` maps a tier name to the rows served for it; any tier without an entry (including
+    ``default_tier``, when the caller omits ``source_tier`` entirely) gets ``fallback``.
+    """
+
+    def side_effect(source_tier: str = default_tier, **_) -> T:
+        return values.get(source_tier, fallback)
+
+    return side_effect
 
 
 def build_listener_telemetry() -> dict[str, list[ListenerSummary]]:
@@ -21,7 +70,7 @@ def build_listener_telemetry() -> dict[str, list[ListenerSummary]]:
             listener_id=1,
             handler_method="on_light_change",
             topic="state_changed.light.kitchen",
-            app_key="my_app",
+            app_key=APP_KEY_MY_APP,
             instance_index=0,
             debounce=0.5,
             throttle=None,
@@ -49,7 +98,7 @@ def build_listener_telemetry() -> dict[str, list[ListenerSummary]]:
             listener_id=2,
             handler_method="on_temp_update",
             topic="state_changed.sensor.temperature",
-            app_key="my_app",
+            app_key=APP_KEY_MY_APP,
             instance_index=0,
             debounce=None,
             throttle=1.0,
@@ -79,7 +128,7 @@ def build_listener_telemetry() -> dict[str, list[ListenerSummary]]:
             listener_id=3,
             handler_method="on_door_open",
             topic="state_changed.binary_sensor.door",
-            app_key="broken_app",
+            app_key=APP_KEY_BROKEN_APP,
             instance_index=0,
             debounce=None,
             throttle=None,
@@ -109,7 +158,7 @@ def build_listener_telemetry() -> dict[str, list[ListenerSummary]]:
             listener_id=100,
             handler_method="on_event",
             topic="state_changed.switch.fan",
-            app_key="nosource_app",
+            app_key=APP_KEY_NOSOURCE_APP,
             instance_index=0,
             debounce=None,
             throttle=None,
@@ -134,22 +183,15 @@ def build_listener_telemetry() -> dict[str, list[ListenerSummary]]:
         ),
     ]
     return {
-        "my_app": telemetry_listeners_my_app,
-        "broken_app": telemetry_listeners_broken_app,
-        "nosource_app": telemetry_listeners_nosource_app,
+        APP_KEY_MY_APP: telemetry_listeners_my_app,
+        APP_KEY_BROKEN_APP: telemetry_listeners_broken_app,
+        APP_KEY_NOSOURCE_APP: telemetry_listeners_nosource_app,
     }
 
 
 def wire_listener_telemetry(hassette, listeners_by_app: dict[str, list[ListenerSummary]]) -> None:
     """Wire listener summary side effects onto the mock telemetry query service."""
-    all_listeners = [ls for app_listeners in listeners_by_app.values() for ls in app_listeners]
-
-    def _listener_side_effect(app_key=None, **_):
-        if app_key is None:
-            return all_listeners
-        return listeners_by_app.get(app_key, [])
-
-    hassette._telemetry_query_service.get_listener_summary = AsyncMock(side_effect=_listener_side_effect)
+    hassette._telemetry_query_service.get_listener_summary = AsyncMock(side_effect=by_app_key_or_all(listeners_by_app))
 
 
 def build_job_telemetry() -> dict[str, list[JobSummary]]:
@@ -157,7 +199,7 @@ def build_job_telemetry() -> dict[str, list[JobSummary]]:
     telemetry_jobs_my_app = [
         JobSummary(
             job_id=1,
-            app_key="my_app",
+            app_key=APP_KEY_MY_APP,
             instance_index=0,
             job_name="check_lights",
             handler_method="check_lights",
@@ -175,7 +217,7 @@ def build_job_telemetry() -> dict[str, list[JobSummary]]:
         ),
         JobSummary(
             job_id=2,
-            app_key="my_app",
+            app_key=APP_KEY_MY_APP,
             instance_index=0,
             job_name="morning_routine",
             handler_method="morning_routine",
@@ -195,7 +237,7 @@ def build_job_telemetry() -> dict[str, list[JobSummary]]:
         # submission is wired via `wire_scheduler_trigger()` in mock_fixtures/scheduler.py.
         JobSummary(
             job_id=MANUAL_JOB_ID,
-            app_key="my_app",
+            app_key=APP_KEY_MY_APP,
             instance_index=0,
             job_name="send_notification",
             handler_method="send_notification",
@@ -216,7 +258,7 @@ def build_job_telemetry() -> dict[str, list[JobSummary]]:
     telemetry_jobs_broken_app = [
         JobSummary(
             job_id=3,
-            app_key="broken_app",
+            app_key=APP_KEY_BROKEN_APP,
             instance_index=0,
             job_name="retry_connection",
             handler_method="retry_connection",
@@ -237,7 +279,7 @@ def build_job_telemetry() -> dict[str, list[JobSummary]]:
     telemetry_jobs_nosource_app = [
         JobSummary(
             job_id=100,
-            app_key="nosource_app",
+            app_key=APP_KEY_NOSOURCE_APP,
             instance_index=0,
             job_name="poll_sensor",
             handler_method="poll_sensor",
@@ -255,22 +297,15 @@ def build_job_telemetry() -> dict[str, list[JobSummary]]:
         ),
     ]
     return {
-        "my_app": telemetry_jobs_my_app,
-        "broken_app": telemetry_jobs_broken_app,
-        "nosource_app": telemetry_jobs_nosource_app,
+        APP_KEY_MY_APP: telemetry_jobs_my_app,
+        APP_KEY_BROKEN_APP: telemetry_jobs_broken_app,
+        APP_KEY_NOSOURCE_APP: telemetry_jobs_nosource_app,
     }
 
 
 def wire_job_telemetry(hassette, jobs_by_app: dict[str, list[JobSummary]]) -> None:
     """Wire job summary side effects onto the mock telemetry query service."""
-    all_jobs = [j for app_jobs in jobs_by_app.values() for j in app_jobs]
-
-    def _job_side_effect(app_key=None, **_):
-        if app_key is None:
-            return all_jobs
-        return jobs_by_app.get(app_key, [])
-
-    hassette._telemetry_query_service.get_job_summary = AsyncMock(side_effect=_job_side_effect)
+    hassette._telemetry_query_service.get_job_summary = AsyncMock(side_effect=by_app_key_or_all(jobs_by_app))
 
 
 def build_executions() -> list[Execution]:
@@ -365,7 +400,7 @@ def build_error_records() -> tuple[list[HandlerErrorRecord | JobErrorRecord], li
     """
     app_tier_errors = [
         HandlerErrorRecord(
-            app_key="my_app",
+            app_key=APP_KEY_MY_APP,
             listener_id=42,
             handler_method="on_light_change",
             topic="state_changed.light.kitchen",
@@ -376,7 +411,7 @@ def build_error_records() -> tuple[list[HandlerErrorRecord | JobErrorRecord], li
             error_message="Bad state value",
         ),
         JobErrorRecord(
-            app_key="my_app",
+            app_key=APP_KEY_MY_APP,
             job_id=7,
             handler_method="check_lights",
             job_name="check_lights",
@@ -387,7 +422,7 @@ def build_error_records() -> tuple[list[HandlerErrorRecord | JobErrorRecord], li
             error_message="Light service unavailable",
         ),
         HandlerErrorRecord(
-            app_key="broken_app",
+            app_key=APP_KEY_BROKEN_APP,
             listener_id=43,
             handler_method="on_door_open",
             topic="state_changed.binary_sensor.door",
@@ -432,16 +467,12 @@ def wire_error_telemetry(
     framework_tier_errors: list[HandlerErrorRecord],
 ) -> None:
     """Wire error records with source_tier routing onto the mock telemetry query service."""
-
-    def _make_errors_side_effect(source_tier: str = "all", **_kwargs):
-        if source_tier == "framework":
-            return framework_tier_errors
-        if source_tier == "app":
-            return app_tier_errors
-        return app_tier_errors + framework_tier_errors
-
     hassette._telemetry_query_service.get_recent_errors = AsyncMock(
-        side_effect=lambda **kwargs: _make_errors_side_effect(**kwargs)
+        side_effect=by_tier(
+            {FRAMEWORK_TIER: framework_tier_errors, APP_TIER: app_tier_errors},
+            default_tier="all",
+            fallback=app_tier_errors + framework_tier_errors,
+        )
     )
 
 
@@ -493,14 +524,12 @@ def wire_global_summary(
     framework_tier_errors: list[HandlerErrorRecord] | None = None,
 ) -> None:
     """Wire global summary and error count side effects onto the mock telemetry query service."""
-
-    def _make_summary_side_effect(source_tier: str = "app", **_kwargs):
-        if source_tier == "framework":
-            return framework_global_summary
-        return default_global_summary
-
     hassette._telemetry_query_service.get_global_summary = AsyncMock(
-        side_effect=lambda **kwargs: _make_summary_side_effect(**kwargs)
+        side_effect=by_tier(
+            {FRAMEWORK_TIER: framework_global_summary},
+            default_tier=APP_TIER,
+            fallback=default_global_summary,
+        )
     )
 
     fw_errors = framework_tier_errors or []
@@ -508,21 +537,19 @@ def wire_global_summary(
         sum(1 for e in fw_errors if isinstance(e, HandlerErrorRecord)),
         sum(1 for e in fw_errors if isinstance(e, JobErrorRecord)),
     )
-
-    def _make_error_counts_side_effect(source_tier: str = "app", **_kwargs) -> tuple[int, int]:
-        if source_tier == "framework":
-            return framework_error_counts
-        return (3, 6)
-
     hassette._telemetry_query_service.get_error_counts = AsyncMock(
-        side_effect=lambda **kwargs: _make_error_counts_side_effect(**kwargs)
+        side_effect=by_tier(
+            {FRAMEWORK_TIER: framework_error_counts},
+            default_tier=APP_TIER,
+            fallback=DEFAULT_ERROR_COUNTS,
+        )
     )
 
 
 def build_app_health_summaries() -> dict[str, AppHealthSummary]:
     """Build per-app health summaries for e2e tests."""
     return {
-        "my_app": AppHealthSummary(
+        APP_KEY_MY_APP: AppHealthSummary(
             handler_count=2,
             job_count=2,
             total_invocations=30,
@@ -532,7 +559,7 @@ def build_app_health_summaries() -> dict[str, AppHealthSummary]:
             avg_duration_ms=2.0,
             last_activity_ts=TS_BASE,
         ),
-        "broken_app": AppHealthSummary(
+        APP_KEY_BROKEN_APP: AppHealthSummary(
             handler_count=1,
             job_count=1,
             total_invocations=3,

--- a/tests/unit/core/test_runtime_query_service.py
+++ b/tests/unit/core/test_runtime_query_service.py
@@ -13,11 +13,11 @@ from hassette.events.hassette import (
     HassetteExecutionCompletedEvent,
     HassetteServiceEvent,
 )
-from hassette.schemas.app_snapshots import AppFullSnapshot, AppInstanceInfo, AppStatusSnapshot
+from hassette.schemas.app_snapshots import AppFullSnapshot, AppStatusSnapshot
 from hassette.schemas.domain_models import SystemStatus
 from hassette.test_utils import create_app_manifest
 from hassette.test_utils.mock_hassette import make_mock_hassette
-from hassette.test_utils.web_manifest_helpers import make_manifest_db_row
+from hassette.test_utils.web_manifest_helpers import make_app_instance_info, make_manifest_db_row
 from hassette.types.enums import BlockReason, ResourceRole, ResourceStatus
 
 WS_QUEUE_MAX = 256
@@ -82,21 +82,7 @@ def mock_hassette():
     hassette._websocket_service.is_ready = Mock(return_value=True)
 
     # Mock app handler — sync methods need explicit Mock (parent is AsyncMock)
-    # dup-ignore-start: same AppInstanceInfo("my_app", index=0, ...) literal shape used by
-    # tests/e2e/mock_fixtures/manifests.py and tests/unit/test_model_types.py — different test tiers/
-    # directories (e2e fixtures, top-level unit tests) building unrelated fixture data;
-    # src/hassette/test_utils/web_manifest_helpers.py's make_app_instance_info() factory already
-    # covers this shape, but adopting it across all three call sites is out of scope for this
-    # cluster, which is marker-only per this task's file classification (see
-    # design/specs/099-dedupe-tests-unit-core/design.md, Group B row).
-    instance = AppInstanceInfo(
-        app_key="my_app",
-        index=0,
-        instance_name="MyApp[0]",
-        class_name="MyApp",
-        status=ResourceStatus.RUNNING,
-    )
-    # dup-ignore-end
+    instance = make_app_instance_info(app_key="my_app")
     hassette._app_handler.get_status_snapshot = Mock(return_value=AppStatusSnapshot(instances=[instance]))
     hassette._app_handler.registry.get_full_snapshot = Mock(return_value=AppFullSnapshot(manifests=[]))
 

--- a/tests/unit/test_model_types.py
+++ b/tests/unit/test_model_types.py
@@ -266,15 +266,14 @@ class TestDashboardAppGridEntryManifestFields:
         assert obj.error_traceback is None
 
     def test_manifest_metadata_fields_round_trip(self) -> None:
-        # dup-ignore-start: same ("my_app", index=0, "MyApp[0]", "MyApp", RUNNING) literal shape
-        # used by tests/unit/core/test_runtime_query_service.py and tests/e2e/mock_fixtures/manifests.py —
-        # different test tiers/directories building unrelated fixture/response data;
+        # dup-ignore-start: same ("my_app", index=0, "MyApp[0]", "MyApp", <status>) literal shape
+        # as the other AppInstanceResponse constructions in TestResourceStatus below.
         # src/hassette/test_utils/web_manifest_helpers.py's make_app_instance_info() factory
         # builds the schemas.app_snapshots.AppInstanceInfo used elsewhere, not this Pydantic
-        # response model (web.models.AppInstanceResponse), so it doesn't directly apply here;
-        # adopting a shared builder across all these call sites is out of scope for this cluster,
-        # which is marker-only per this task's file classification (see
-        # design/specs/099-dedupe-tests-unit-core/design.md, Group B row).
+        # response model (web.models.AppInstanceResponse), so it doesn't apply here — and the
+        # copies are each a one-line-different assertion of this file's own
+        # subject (the response model's field/validation behavior), so a local builder would
+        # hide the very literals under test.
         instance = AppInstanceResponse(
             app_key="my_app",
             index=0,
@@ -324,7 +323,7 @@ class TestResourceStatus:
         for value in ResourceStatus:
             # dup-ignore-start: same ("my_app", index=0, "MyApp[0]", "MyApp", <status>) literal
             # shape as test_manifest_metadata_fields_round_trip() above — see that dup-ignore
-            # comment for the full cross-file/cross-tier rationale.
+            # comment for the full rationale.
             obj = AppInstanceResponse(
                 app_key="my_app",
                 index=0,
@@ -339,7 +338,7 @@ class TestResourceStatus:
         with pytest.raises(ValidationError):
             # dup-ignore-start: same ("my_app", index=0, "MyApp[0]", "MyApp", <status>) literal
             # shape as test_manifest_metadata_fields_round_trip() above — see that dup-ignore
-            # comment for the full cross-file/cross-tier rationale.
+            # comment for the full rationale.
             AppInstanceResponse(
                 app_key="my_app",
                 index=0,
@@ -366,7 +365,7 @@ class TestResourceStatus:
         ):
             # dup-ignore-start: same ("my_app", index=0, "MyApp[0]", "MyApp", <status>) literal
             # shape as test_manifest_metadata_fields_round_trip() above — see that dup-ignore
-            # comment for the full cross-file/cross-tier rationale.
+            # comment for the full rationale.
             obj = AppInstanceResponse(
                 app_key="my_app",
                 index=0,


### PR DESCRIPTION
## Summary

Mechanical cleanup of the pre-existing code-quality findings that the clean-code review of #1642 surfaced in the `tests/e2e/mock_fixtures/` package. Every finding was moved verbatim from the old single-file `mock_fixtures.py` and predates the decomposition PR — none of it is new code.

No behavior change. This is test-fixture hygiene only; no `src/` file is touched.

## What changed

**Adopt the shared `make_app_instance_info()` factory.** Three sites hand-built the same `AppInstanceInfo("my_app", index=0, ...)` literal, each carrying a copy-pasted 7-line "dup-ignore" comment explaining why the duplication was being left in place. Rather than dedupe the *rationale prose*, the duplication itself is gone: all three sites now call the existing `hassette.test_utils.web_manifest_helpers.make_app_instance_info()` factory, and the comments are deleted outright. The `multi_app` instance list also collapses from three near-identical literals into a `range(3)` comprehension. `tests/unit/test_model_types.py` keeps a hand-built literal — the factory returns `AppInstanceInfo`, not the `AppInstanceResponse` that file needs — so its now-stale cross-file reference is refreshed to say so rather than removed.

**Collapse five near-identical closures in `telemetry.py`** behind two shared helpers: `by_app_key_or_all()` (the `app_key`-filtering side effect used by `wire_listener_telemetry`/`wire_job_telemetry`) and `by_tier()` (the `source_tier`-routing side effect used by `wire_error_telemetry`/`wire_global_summary`). Both carry docstrings describing which real query-service behavior they mirror.

**Name the magic literals.** `sessions_config.py`'s session 2/3 start-stop timestamps join the existing `TS_*` pattern in `constants.py`, and the `3600.0` repeated across all three sessions becomes `SESSION_DURATION_SECONDS`. The seeded app-key strings (`"my_app"` 22x, `"broken_app"` 9x, `"nosource_app"` 9x, plus `other_app`/`disabled_app`/`multi_app`) are centralized as `APP_KEY_*` constants, so an app rename lands in one place instead of across the manifest, telemetry, and scheduler seeds. The `broken_app` error message and traceback, previously written out twice in `manifests.py`, become module constants.

**Naming consistency.** `**_kwargs` unified to `**_` for the swallow-remaining-kwargs role, the leading underscore dropped from the read-later locals `_stubs`/`_manifest_info_by_key` to match their non-underscored siblings in the same function, and the loop variable `m` spelled `manifest`.

## Testing

- `uv run nox -s dev` — 7034 passed, 1 skipped, 2 xfailed.
  - One run flagged `test_scheduler_entity_time.py::test_waiting_job_removed_from_heap_but_stays_registered`, which passed both in isolation (19/19 in that file) and on a clean full re-run. It is a pre-existing timing flake under `-n 4` parallelism, in a scheduler test this diff does not touch — no `src/` file changed here at all.
- `uv run nox -s e2e` — 174 passed on each of Python 3.11 / 3.12 / 3.13 / 3.14. This is the suite that actually exercises the changed fixtures; `nox -s dev` deselects `e2e`, so the dev run alone would not have covered the bulk of this diff.
- `prek -a` — all 28 hooks pass.
- `prek pyright -a --stage pre-push` — clean.

Beyond the suites, the equivalence claim was checked directly by replaying the old and new builders plus every wired side effect side by side across all `app_key`/`source_tier` branches: manifest output, snapshot output, and all routed query results are identical.

Closes #1643
