### PR TITLE
test: normalize event variable naming in test_runtime_query_service

### DIFF
--- a/tests/unit/core/test_runtime_query_service.py
+++ b/tests/unit/core/test_runtime_query_service.py
@@ -371,10 +371,10 @@ class TestCompletionPayloadEnrichment:
     async def test_handler_payload_carries_app_identity(self, runtime: RuntimeQueryService) -> None:
         """app_key and instance_index from a handler execution are stored in the pending dict."""
         runtime.broadcast = AsyncMock()
-        ev = HassetteExecutionCompletedEvent.from_record(
+        event = HassetteExecutionCompletedEvent.from_record(
             kind="handler", listener_id=42, status="success", duration_ms=5.0, app_key="lights", instance_index=1
         )
-        await runtime.on_execution_completed(ev)
+        await runtime.on_execution_completed(event)
         assert runtime._pending_completions[0]["app_key"] == "lights"
         assert runtime._pending_completions[0]["instance_index"] == 1
         assert runtime._pending_completions[0]["kind"] == "handler"
@@ -383,10 +383,10 @@ class TestCompletionPayloadEnrichment:
     async def test_job_payload_carries_app_identity(self, runtime: RuntimeQueryService) -> None:
         """app_key and instance_index from a job execution are stored in the pending dict."""
         runtime.broadcast = AsyncMock()
-        ev = HassetteExecutionCompletedEvent.from_record(
+        event = HassetteExecutionCompletedEvent.from_record(
             kind="job", job_id=99, status="success", duration_ms=8.0, app_key="climate", instance_index=2
         )
-        await runtime.on_execution_completed(ev)
+        await runtime.on_execution_completed(event)
         assert runtime._pending_completions[0]["app_key"] == "climate"
         assert runtime._pending_completions[0]["instance_index"] == 2
         assert runtime._pending_completions[0]["kind"] == "job"
@@ -395,10 +395,10 @@ class TestCompletionPayloadEnrichment:
     async def test_payload_defaults_to_empty_app_key(self, runtime: RuntimeQueryService) -> None:
         """Events without app_key default to empty string and zero index."""
         runtime.broadcast = AsyncMock()
-        ev = HassetteExecutionCompletedEvent.from_record(
+        event = HassetteExecutionCompletedEvent.from_record(
             kind="handler", listener_id=999, status="success", duration_ms=5.0
         )
-        await runtime.on_execution_completed(ev)
+        await runtime.on_execution_completed(event)
         assert runtime._pending_completions[0]["app_key"] == ""
         assert runtime._pending_completions[0]["instance_index"] == 0
 
@@ -415,10 +415,10 @@ class TestCompletionBatching:
 
         runtime.broadcast = fake_broadcast
 
-        ev1 = HassetteExecutionCompletedEvent.from_record(
+        event1 = HassetteExecutionCompletedEvent.from_record(
             kind="handler", listener_id=1, status="success", duration_ms=10.0, app_key="my_app", instance_index=0
         )
-        ev2 = HassetteExecutionCompletedEvent.from_record(
+        event2 = HassetteExecutionCompletedEvent.from_record(
             kind="handler",
             listener_id=2,
             status="failed",
@@ -428,8 +428,8 @@ class TestCompletionBatching:
             error_type="ValueError",
         )
 
-        await runtime.on_execution_completed(ev1)
-        await runtime.on_execution_completed(ev2)
+        await runtime.on_execution_completed(event1)
+        await runtime.on_execution_completed(event2)
 
         # Flush should not have fired yet (still in the same tick)
         assert len(broadcast_calls) == 0
@@ -452,15 +452,15 @@ class TestCompletionBatching:
 
         runtime.broadcast = fake_broadcast
 
-        ev1 = HassetteExecutionCompletedEvent.from_record(
+        event1 = HassetteExecutionCompletedEvent.from_record(
             kind="job", job_id=10, status="success", duration_ms=50.0, app_key="scheduler_app", instance_index=0
         )
-        ev2 = HassetteExecutionCompletedEvent.from_record(
+        event2 = HassetteExecutionCompletedEvent.from_record(
             kind="job", job_id=11, status="success", duration_ms=30.0, app_key="scheduler_app", instance_index=0
         )
 
-        await runtime.on_execution_completed(ev1)
-        await runtime.on_execution_completed(ev2)
+        await runtime.on_execution_completed(event1)
+        await runtime.on_execution_completed(event2)
 
         assert len(broadcast_calls) == 0
         msg = await assert_flushed_single_message(runtime, broadcast_calls)
@@ -471,10 +471,10 @@ class TestCompletionBatching:
         """After flush, _pending_completions is empty."""
         runtime.broadcast = AsyncMock()
 
-        ev = HassetteExecutionCompletedEvent.from_record(
+        event = HassetteExecutionCompletedEvent.from_record(
             kind="handler", listener_id=3, status="success", duration_ms=1.0, app_key="app", instance_index=0
         )
-        await runtime.on_execution_completed(ev)
+        await runtime.on_execution_completed(event)
         assert len(runtime._pending_completions) == 1
 
         await runtime.flush_completions()
@@ -495,15 +495,15 @@ class TestCompletionBatching:
 
         runtime.broadcast = fake_broadcast
 
-        handler_ev = HassetteExecutionCompletedEvent.from_record(
+        handler_event = HassetteExecutionCompletedEvent.from_record(
             kind="handler", listener_id=1, status="success", duration_ms=5.0, app_key="my_app", instance_index=0
         )
-        job_ev = HassetteExecutionCompletedEvent.from_record(
+        job_event = HassetteExecutionCompletedEvent.from_record(
             kind="job", job_id=10, status="success", duration_ms=8.0, app_key="my_app", instance_index=0
         )
 
-        await runtime.on_execution_completed(handler_ev)
-        await runtime.on_execution_completed(job_ev)
+        await runtime.on_execution_completed(handler_event)
+        await runtime.on_execution_completed(job_event)
 
         # Single message containing both handler and job entries
         msg = await assert_flushed_single_message(runtime, broadcast_calls)


### PR DESCRIPTION
## Summary

`tests/unit/core/test_runtime_query_service.py` used four different names for the same
concept — the event object under test being fed into `RuntimeQueryService`. `ev`, `ev1`/`ev2`,
`event`, and `handler_ev`/`job_ev` all coexisted in one file, which makes the tests harder to
scan and gives a reader no signal about whether the different spellings mean different things.
They don't.

This normalizes all of them on the fully-spelled form, which was already in use in
`TestConcurrentAppHandlerTeardown` and `TestServiceStatusMapping`:

| Before | After |
|---|---|
| `ev` | `event` |
| `ev1` / `ev2` | `event1` / `event2` |
| `handler_ev` / `job_ev` | `handler_event` / `job_event` |

Purely mechanical — a rename confined to local variables inside one test file. No assertions,
fixtures, or production code were touched.

## Testing

- `uv run nox -s dev` — 7034 passed, 1 skipped, 2 xfailed
- `prek -a` — all hooks pass (ruff, prettier, eslint, stylelint, tsc, and the repo's custom checks)
- `prek pyright -a --stage pre-push` — passes
- Grepped the file afterward to confirm no `ev` / `ev1` / `ev2` / `handler_ev` / `job_ev`
  occurrences remain

Closes #1644
