### PR TITLE
fix: derive detail-header status pill test id from kind prop

### DIFF
--- a/frontend/src/components/app-detail/detail-header.test.tsx
+++ b/frontend/src/components/app-detail/detail-header.test.tsx
@@ -18,6 +18,11 @@ describe("DetailHeader", () => {
     expect(getByTestId("handler-status-pill").textContent).toBe("failing");
   });
 
+  it("names the failing badge test id after the kind", () => {
+    const { getByTestId } = render(<DetailHeader name="broken_job" kindLabel="cron" statusKind="err" kind="job" />);
+    expect(getByTestId("job-status-pill").textContent).toBe("failing");
+  });
+
   it("hides the failing badge when statusKind is 'ok'", () => {
     const { queryByTestId } = render(
       <DetailHeader name="healthy_listener" kindLabel="listener" statusKind="ok" kind="handler" />,

--- a/frontend/src/components/app-detail/detail-header.tsx
+++ b/frontend/src/components/app-detail/detail-header.tsx
@@ -32,7 +32,7 @@ export function DetailHeader({ name, kindLabel, statusKind, kind, subtitle, head
       <div className="mb-3 flex flex-wrap items-baseline gap-2">
         <h2 className="font-mono text-[length:var(--text-h2)] font-semibold text-foreground">{name}</h2>
         {isFailing && (
-          <Badge variant="danger" size="sm" data-testid="handler-status-pill">
+          <Badge variant="danger" size="sm" data-testid={`${kind}-status-pill`}>
             failing
           </Badge>
         )}

--- a/frontend/src/components/app-detail/handlers-tab.job.test.tsx
+++ b/frontend/src/components/app-detail/handlers-tab.job.test.tsx
@@ -206,7 +206,7 @@ describe("HandlersTab job detail", () => {
     });
     const { getByTestId } = renderHandlersTab([], [job], "job/44");
     await waitFor(() => getByTestId("job-detail-44"));
-    expect(getByTestId("handler-status-pill").textContent).toBe("failing");
+    expect(getByTestId("job-status-pill").textContent).toBe("failing");
   });
 
   it("job detail: shows mode chip for every job", async () => {


### PR DESCRIPTION
## Summary

The failing-status badge in `DetailHeader` rendered a hardcoded `data-testid="handler-status-pill"` even though the component is shared between the handler and job detail views and already accepts a `kind: "handler" | "job"` prop. When `job-detail.tsx` rendered it with `kind="job"`, the test ID still claimed "handler", making job-detail selectors misleading.

## What changed

- `detail-header.tsx` — the badge's test ID is now derived from the `kind` prop (`data-testid={`${kind}-status-pill`}`), matching the pattern the subtitle on line 47 already used (`${kind}-human-description`).
- `handlers-tab.job.test.tsx` — the job-detail assertion now queries `job-status-pill` instead of the stale `handler-status-pill`.
- `detail-header.test.tsx` — added a case rendering with `kind="job"` so both branches of the derived test ID are covered, not just the handler one that happens to keep its old value.

No rendered output changes — this only touches a `data-testid` attribute, so there is no visual diff to screenshot.

## Testing

- `npm run test -- --run` (frontend) — 1548 passed across 107 files
- `uv run nox -s dev` (backend) — 7034 passed, 1 skipped, 2 xfailed
- `prek -a` — all hooks passed
- `prek pyright -a --stage pre-push` — passed
- Grepped for remaining `handler-status-pill` references across `.tsx`/`.ts`/`.py` (including e2e tests); the only survivors are in `detail-header.test.tsx`, where the component is rendered with `kind="handler"` and the value is correct.

Closes #1646
