### PR TITLE
test: consolidate duplicated _propagate_hassette_logger fixture into tests/unit/web/conftest.py

### DIFF
--- a/tests/integration/web_api/test_auth.py
+++ b/tests/integration/web_api/test_auth.py
@@ -48,6 +48,11 @@ def _propagate_hassette_logger() -> None:
     Some other test in the session may have left `propagate` set to False (e.g. via
     `enable_basic_logging()`) -- caplog relies on propagation to the root logger. Same
     workaround as `tests/unit/web/conftest.py`.
+
+    Kept as a local copy rather than hoisted into this directory's conftest: the unit-side
+    consolidation covers `tests/unit/web/` only, and this is the one module here that needs
+    the workaround, so a directory-wide autouse fixture would apply it to every integration
+    web-api module to serve a single caller.
     """
     logging.getLogger("hassette").propagate = True
 

--- a/tests/integration/web_api/test_auth.py
+++ b/tests/integration/web_api/test_auth.py
@@ -47,7 +47,7 @@ def _propagate_hassette_logger() -> None:
 
     Some other test in the session may have left `propagate` set to False (e.g. via
     `enable_basic_logging()`) -- caplog relies on propagation to the root logger. Same
-    workaround as `tests/unit/web/test_auth.py`.
+    workaround as `tests/unit/web/conftest.py`.
     """
     logging.getLogger("hassette").propagate = True
 

--- a/tests/unit/web/conftest.py
+++ b/tests/unit/web/conftest.py
@@ -12,5 +12,10 @@ def _propagate_hassette_logger() -> None:
     Some other test in the session may have left ``propagate`` set to False (e.g. via
     ``enable_basic_logging()``); caplog relies on propagation to the root logger. Same
     workaround as ``tests/unit/test_validate_apps.py``.
+
+    Living here rather than in the five caplog-using modules that used to each carry a copy
+    means it is autouse for every module in this directory, including ones that never touch
+    caplog. That is deliberate and inert: it forces the logger back to Python's own default,
+    so a module that does not read log records cannot observe the difference.
     """
     logging.getLogger("hassette").propagate = True

--- a/tests/unit/web/conftest.py
+++ b/tests/unit/web/conftest.py
@@ -1,0 +1,16 @@
+"""Shared fixtures for web unit tests."""
+
+import logging
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _propagate_hassette_logger() -> None:
+    """Ensure the "hassette" logger propagates so caplog can see records.
+
+    Some other test in the session may have left ``propagate`` set to False (e.g. via
+    ``enable_basic_logging()``); caplog relies on propagation to the root logger. Same
+    workaround as ``tests/unit/test_validate_apps.py``.
+    """
+    logging.getLogger("hassette").propagate = True

--- a/tests/unit/web/test_auth.py
+++ b/tests/unit/web/test_auth.py
@@ -3,11 +3,9 @@ precedence between a presented bearer token, trusted-peer match, and a session c
 """
 
 import ipaddress
-import logging
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
-import pytest
 from starlette.datastructures import Headers
 
 from hassette.web.auth import authorize_ws
@@ -48,17 +46,6 @@ def _make_websocket(
     ws.cookies = cookies or {}
     ws.client = SimpleNamespace(host=client_host) if client_host is not None else None
     return ws
-
-
-@pytest.fixture(autouse=True)
-def _propagate_hassette_logger() -> None:
-    """Ensure the "hassette" logger propagates so caplog can see records.
-
-    Some other test in the session may have left ``propagate`` set to False (e.g. via
-    ``enable_basic_logging()``); caplog relies on propagation to the root logger. Same
-    workaround as ``tests/unit/test_validate_apps.py``.
-    """
-    logging.getLogger("hassette").propagate = True
 
 
 class TestAuthorizeWsPrecedence:

--- a/tests/unit/web/test_auth_session.py
+++ b/tests/unit/web/test_auth_session.py
@@ -3,10 +3,8 @@ HMAC-derived cookie mint/verify with TTL enforcement, the cookie ``Secure``-flag
 (reusing the trusted-peer matcher), and the sliding-renewal predicate.
 """
 
-import logging
 from unittest.mock import patch
 
-import pytest
 from starlette.datastructures import Headers
 
 from hassette.web.auth.session import (
@@ -18,17 +16,6 @@ from hassette.web.auth.session import (
     verify_session_cookie,
 )
 from hassette.web.auth.trusted_proxies import resolve_trusted_proxies
-
-
-@pytest.fixture(autouse=True)
-def _propagate_hassette_logger() -> None:
-    """Ensure the "hassette" logger propagates so caplog can see records.
-
-    Some other test in the session may have left ``propagate`` set to False (e.g. via
-    ``enable_basic_logging()``); caplog relies on propagation to the root logger. Same
-    workaround as ``tests/unit/test_validate_apps.py``.
-    """
-    logging.getLogger("hassette").propagate = True
 
 
 class TestCheckBearerToken:

--- a/tests/unit/web/test_auth_tokens.py
+++ b/tests/unit/web/test_auth_tokens.py
@@ -20,17 +20,6 @@ def _make_config(**overrides: Any) -> WebApiConfig:
     return WebApiConfig.model_validate(overrides)
 
 
-@pytest.fixture(autouse=True)
-def _propagate_hassette_logger() -> None:
-    """Ensure the "hassette" logger propagates so caplog can see records.
-
-    Some other test in the session may have left ``propagate`` set to False (e.g. via
-    ``enable_basic_logging()``); caplog relies on propagation to the root logger. Same
-    workaround as ``tests/unit/test_validate_apps.py``.
-    """
-    logging.getLogger("hassette").propagate = True
-
-
 class TestResolveAuthTokenExplicitConfig:
     def test_uses_configured_token_without_touching_disk(
         self, tmp_path: Path, caplog: pytest.LogCaptureFixture

--- a/tests/unit/web/test_auth_trusted_proxies.py
+++ b/tests/unit/web/test_auth_trusted_proxies.py
@@ -3,7 +3,6 @@ periodic refresh, and the peer-match function's header-free signature.
 """
 
 import asyncio
-import logging
 import re
 import socket
 from typing import Any
@@ -14,17 +13,6 @@ import pytest
 from hassette.exceptions import TrustedProxyConfigError
 from hassette.test_utils import make_addrinfo, patch_loop_getaddrinfo
 from hassette.web.auth.trusted_proxies import is_trusted_peer, refresh_trusted_proxies, resolve_trusted_proxies
-
-
-@pytest.fixture(autouse=True)
-def _propagate_hassette_logger() -> None:
-    """Ensure the "hassette" logger propagates so caplog can see records.
-
-    Some other test in the session may have left ``propagate`` set to False (e.g. via
-    ``enable_basic_logging()``); caplog relies on propagation to the root logger. Same
-    workaround as ``tests/unit/test_validate_apps.py``.
-    """
-    logging.getLogger("hassette").propagate = True
 
 
 class TestResolveTrustedProxiesLiteral:

--- a/tests/unit/web/test_middleware.py
+++ b/tests/unit/web/test_middleware.py
@@ -31,17 +31,6 @@ from hassette.web.middleware import (
 )
 
 
-@pytest.fixture(autouse=True)
-def _propagate_hassette_logger() -> None:
-    """Ensure the "hassette" logger propagates so caplog can see records.
-
-    Some other test in the session may have left ``propagate`` set to False (e.g. via
-    ``enable_basic_logging()``); caplog relies on propagation to the root logger. Same
-    workaround as ``tests/unit/web/test_auth.py``.
-    """
-    logging.getLogger("hassette").propagate = True
-
-
 class _FakeClock:
     """Deterministic stand-in for :func:`time.monotonic`, injected into ``_FailedAuthTracker``.
 


### PR DESCRIPTION
## Summary

The `_propagate_hassette_logger` autouse fixture was copy-pasted verbatim across five files in `tests/unit/web/` — identical body, near-identical docstrings. This moves it into a single directory-scoped `tests/unit/web/conftest.py` and deletes the duplicates.

The issue listed four files; a fifth (`test_middleware.py`) carried the same copy and is included here.

## Changes

- **Added** `tests/unit/web/conftest.py` with one autouse `_propagate_hassette_logger` fixture. This matches the per-subdirectory conftest convention already used by `tests/unit/{bus,core,resources,scheduler,tools,cli}/`.
- **Removed** the five duplicated definitions from `test_auth.py`, `test_auth_session.py`, `test_auth_tokens.py`, `test_auth_trusted_proxies.py`, and `test_middleware.py`, along with the imports each deletion orphaned.
- **Repointed** the docstring cross-reference in `tests/integration/web_api/test_auth.py`, which named `tests/unit/web/test_auth.py` as the canonical copy — that copy no longer exists.

`tests/integration/web_api/test_auth.py` keeps its own definition. It sits in a separate test tree with no shared conftest to dedupe into, so consolidating it would mean inventing a cross-tree fixture home for a single consumer.

## Testing

- `uv run nox -s dev` — 7035 passed, 1 skipped, 2 xfailed
- `prek -a` — all hooks pass
- `prek pyright -a --stage pre-push` — passes

Test-only change; no source, docs, or frontend surface is affected.

Closes #1652
