### PR TITLE
test: unprefix CLI client test helpers and parametrize credential-attachment tests

### DIFF
--- a/tests/unit/cli/test_client.py
+++ b/tests/unit/cli/test_client.py
@@ -59,7 +59,7 @@ def make_transport(
     return httpx.MockTransport(_fixed_response)
 
 
-def _make_host_port_config(host: str = "127.0.0.1", port: int = 8126) -> HassetteConfig:
+def make_host_port_config(host: str = "127.0.0.1", port: int = 8126) -> HassetteConfig:
     """Bare host/port config for base-URL construction tests.
 
     Narrower than the shared ``make_cli_config()`` (from ``conftest.py``) — no ``cli``/``data_dir``
@@ -69,7 +69,8 @@ def _make_host_port_config(host: str = "127.0.0.1", port: int = 8126) -> Hassett
     return HassetteConfig(token=None, web_api=WebApiConfig(host=host, port=port))
 
 
-def _make_manifest_list(instances: list[AppInstanceResponse], app_key: str = "my_app"):
+def make_manifest_list(instances: list[AppInstanceResponse], app_key: str = "my_app"):
+    """Wrap ``instances`` in a single-app manifest list, as ``/api/apps/manifests`` returns it."""
     manifest = make_manifest_response(app_key=app_key, instance_count=len(instances), instances=instances)
     return make_manifest_list_response(manifests=[manifest])
 
@@ -83,7 +84,7 @@ def url_capturing_client() -> tuple[HassetteCLIClient, list[str]]:
         return httpx.Response(200, content=b"[]", headers={"content-type": "application/json"})
 
     transport = httpx.MockTransport(handler)
-    return HassetteCLIClient(_make_host_port_config(), json_mode=False, transport=transport), captured_urls
+    return HassetteCLIClient(make_host_port_config(), json_mode=False, transport=transport), captured_urls
 
 
 def route_listeners(client: HassetteCLIClient, **kwargs: Any) -> Any:
@@ -139,27 +140,41 @@ def stderr_for_successful_get(config: HassetteConfig, **client_kwargs: Any) -> s
     return buf.getvalue()
 
 
+def stderr_for_connect_error(config: HassetteConfig, **client_kwargs: Any) -> str:
+    """Return what a client built from ``config`` writes to stderr when the server is unreachable.
+
+    The connect-error path is the sibling of ``stderr_for_successful_get`` — the address echo, the
+    full-base-URL report, and the TLS-verification warning all have to appear here too, so only the
+    config/flags that produced the client ever vary between these tests.
+    """
+    client = HassetteCLIClient(
+        config, json_mode=False, transport=make_transport(raise_exc=httpx.ConnectError), **client_kwargs
+    )
+    _code, stderr = get_expecting_exit(client)
+    return stderr
+
+
 # Base URL construction & address substitution
 
 
 class TestBaseUrl:
     def test_default_address(self) -> None:
-        config = _make_host_port_config("127.0.0.1", 8126)
+        config = make_host_port_config()
         client = HassetteCLIClient(config, json_mode=False)
         assert client.base_url == "http://127.0.0.1:8126"
 
     def test_bind_all_ipv4_substituted(self) -> None:
-        config = _make_host_port_config("0.0.0.0", 8126)
+        config = make_host_port_config("0.0.0.0", 8126)
         client = HassetteCLIClient(config, json_mode=False)
         assert client.base_url == "http://127.0.0.1:8126"
 
     def test_bind_all_ipv6_substituted(self) -> None:
-        config = _make_host_port_config("::", 8080)
+        config = make_host_port_config("::", 8080)
         client = HassetteCLIClient(config, json_mode=False)
         assert client.base_url == "http://[::1]:8080"
 
     def test_non_default_host_port(self) -> None:
-        config = _make_host_port_config("192.168.1.5", 9000)
+        config = make_host_port_config("192.168.1.5", 9000)
         client = HassetteCLIClient(config, json_mode=False)
         assert client.base_url == "http://192.168.1.5:9000"
 
@@ -169,7 +184,7 @@ class TestBaseUrl:
 
 class TestSuccessfulRequests:
     def test_returns_deserialized_pydantic_model(self) -> None:
-        config = _make_host_port_config()
+        config = make_host_port_config()
         transport = make_transport(200, {"value": "hello"})
         client = HassetteCLIClient(config, json_mode=False, transport=transport)
         result = client.get("/test", SimpleModel)
@@ -177,7 +192,7 @@ class TestSuccessfulRequests:
         assert result.value == "hello"
 
     def test_returns_dict_for_dict_response(self) -> None:
-        config = _make_host_port_config()
+        config = make_host_port_config()
         body = {"web_api": {"port": 8126}}
         transport = make_transport(200, body)
         client = HassetteCLIClient(config, json_mode=False, transport=transport)
@@ -191,7 +206,7 @@ class TestSuccessfulRequests:
 
 class TestTolerate503:
     def test_503_deserializes_body_when_tolerated(self) -> None:
-        config = _make_host_port_config()
+        config = make_host_port_config()
         transport = make_transport(503, {"value": "degraded"})
         client = HassetteCLIClient(config, json_mode=False, transport=transport)
         result = client.get(TELEMETRY_STATUS_ENDPOINT, SimpleModel, tolerate_503=True)
@@ -199,7 +214,7 @@ class TestTolerate503:
         assert result.value == "degraded"
 
     def test_503_still_exits_when_not_tolerated(self) -> None:
-        config = _make_host_port_config()
+        config = make_host_port_config()
         transport = make_transport(503, {"value": "degraded"})
         client = HassetteCLIClient(config, json_mode=False, transport=transport)
         with pytest.raises(SystemExit) as exc_info:
@@ -207,7 +222,7 @@ class TestTolerate503:
         assert exc_info.value.code == 1
 
     def test_500_still_exits_even_when_503_tolerated(self) -> None:
-        config = _make_host_port_config()
+        config = make_host_port_config()
         transport = make_transport(500, {"detail": "boom"})
         client = HassetteCLIClient(config, json_mode=False, transport=transport)
         with pytest.raises(SystemExit) as exc_info:
@@ -216,7 +231,7 @@ class TestTolerate503:
 
     def test_503_with_non_json_body_exits_instead_of_crashing(self) -> None:
         """A tolerated 503 from a proxy/LB (HTML body, not JSON) exits cleanly, not a traceback."""
-        config = _make_host_port_config()
+        config = make_host_port_config()
 
         def handler(_req: httpx.Request) -> httpx.Response:
             return httpx.Response(503, content=b"<html>503 Service Unavailable</html>")
@@ -228,7 +243,7 @@ class TestTolerate503:
 
     def test_503_with_wrong_shape_json_exits_instead_of_crashing(self) -> None:
         """A tolerated 503 whose JSON doesn't match the model exits cleanly, not a traceback."""
-        config = _make_host_port_config()
+        config = make_host_port_config()
         transport = make_transport(503, {"unexpected": "shape"})
         client = HassetteCLIClient(config, json_mode=False, transport=transport)
         with pytest.raises(SystemExit) as exc_info:
@@ -241,7 +256,7 @@ class TestTolerate503:
 
 class TestHttpErrorsHumanMode:
     def test_404_exits_with_code_1(self, capsys: pytest.CaptureFixture[str]) -> None:
-        config = _make_host_port_config()
+        config = make_host_port_config()
         transport = make_transport(404, {"detail": "Not found"})
         client = HassetteCLIClient(config, json_mode=False, transport=transport)
         with pytest.raises(SystemExit) as exc_info:
@@ -249,14 +264,14 @@ class TestHttpErrorsHumanMode:
         assert exc_info.value.code == 1
 
     def test_404_prints_to_stderr(self) -> None:
-        config = _make_host_port_config()
+        config = make_host_port_config()
         transport = make_transport(404, {"detail": "Not found"})
         client = HassetteCLIClient(config, json_mode=False, transport=transport)
         _code, stderr = get_expecting_exit(client, MISSING_ENDPOINT)
         assert len(stderr) > 0
 
     def test_500_exits_with_code_1(self) -> None:
-        config = _make_host_port_config()
+        config = make_host_port_config()
         transport = make_transport(500, {"detail": "Internal server error"})
         client = HassetteCLIClient(config, json_mode=False, transport=transport)
         with pytest.raises(SystemExit) as exc_info:
@@ -264,7 +279,7 @@ class TestHttpErrorsHumanMode:
         assert exc_info.value.code == 1
 
     def test_nothing_on_stdout_for_http_error_human_mode(self, capsys: pytest.CaptureFixture[str]) -> None:
-        config = _make_host_port_config()
+        config = make_host_port_config()
         transport = make_transport(503, {"detail": "Service unavailable"})
         client = HassetteCLIClient(config, json_mode=False, transport=transport)
         with pytest.raises(SystemExit):
@@ -278,7 +293,7 @@ class TestHttpErrorsHumanMode:
 
 class TestHttpErrorsJsonMode:
     def test_404_json_error_structure(self, capsys: pytest.CaptureFixture[str]) -> None:
-        config = _make_host_port_config()
+        config = make_host_port_config()
         transport = make_transport(404, {"detail": "Not found"})
         client = HassetteCLIClient(config, json_mode=True, transport=transport)
         parsed = get_json_error(client, capsys, MISSING_ENDPOINT, expect_code=1)
@@ -287,7 +302,7 @@ class TestHttpErrorsJsonMode:
         assert "detail" in parsed
 
     def test_json_mode_error_nothing_on_stderr(self, capsys: pytest.CaptureFixture[str]) -> None:
-        config = _make_host_port_config()
+        config = make_host_port_config()
         transport = make_transport(500, {"detail": "boom"})
         client = HassetteCLIClient(config, json_mode=True, transport=transport)
         # In json mode, error goes to stdout only
@@ -300,7 +315,7 @@ class TestHttpErrorsJsonMode:
 
 class TestNetworkErrors:
     def test_connection_refused_exits_code_2(self) -> None:
-        config = _make_host_port_config()
+        config = make_host_port_config()
         transport = make_transport(raise_exc=httpx.ConnectError)
         client = HassetteCLIClient(config, json_mode=False, transport=transport)
         with pytest.raises(SystemExit) as exc_info:
@@ -308,14 +323,11 @@ class TestNetworkErrors:
         assert exc_info.value.code == 2
 
     def test_connection_refused_mentions_address_stderr(self) -> None:
-        config = _make_host_port_config("127.0.0.1", 8126)
-        transport = make_transport(raise_exc=httpx.ConnectError)
-        client = HassetteCLIClient(config, json_mode=False, transport=transport)
-        _code, stderr = get_expecting_exit(client)
+        stderr = stderr_for_connect_error(make_host_port_config())
         assert "127.0.0.1" in stderr or "8126" in stderr
 
     def test_timeout_exits_code_2(self) -> None:
-        config = _make_host_port_config()
+        config = make_host_port_config()
         transport = make_transport(raise_exc=httpx.TimeoutException)
         client = HassetteCLIClient(config, json_mode=False, transport=transport)
         with pytest.raises(SystemExit) as exc_info:
@@ -323,7 +335,7 @@ class TestNetworkErrors:
         assert exc_info.value.code == 2
 
     def test_timeout_json_mode_null_status(self, capsys: pytest.CaptureFixture[str]) -> None:
-        config = _make_host_port_config()
+        config = make_host_port_config()
         transport = make_transport(raise_exc=httpx.TimeoutException)
         client = HassetteCLIClient(config, json_mode=True, transport=transport)
         parsed = get_json_error(client, capsys)
@@ -332,7 +344,7 @@ class TestNetworkErrors:
         assert "detail" in parsed
 
     def test_connection_refused_json_mode_null_status(self, capsys: pytest.CaptureFixture[str]) -> None:
-        config = _make_host_port_config()
+        config = make_host_port_config()
         transport = make_transport(raise_exc=httpx.ConnectError)
         client = HassetteCLIClient(config, json_mode=True, transport=transport)
         parsed = get_json_error(client, capsys)
@@ -365,7 +377,7 @@ class TestInstanceRouting:
         assert any("instance_index=1" in u for u in captured_urls)
 
     def test_name_instance_resolves_to_index(self) -> None:
-        config = _make_host_port_config()
+        config = make_host_port_config()
         call_count = 0
         instances = [
             AppInstanceResponse(
@@ -375,7 +387,7 @@ class TestInstanceRouting:
                 app_key="my_app", index=1, instance_name="office", class_name="MyApp", status="running"
             ),
         ]
-        manifest_list = _make_manifest_list(instances)
+        manifest_list = make_manifest_list(instances)
 
         def handler(request: httpx.Request) -> httpx.Response:
             nonlocal call_count
@@ -400,13 +412,13 @@ class TestInstanceRouting:
         assert any("instance_index=1" in u for u in captured_urls)
 
     def test_unknown_instance_name_exits_nonzero(self) -> None:
-        config = _make_host_port_config()
+        config = make_host_port_config()
         instances = [
             AppInstanceResponse(
                 app_key="my_app", index=0, instance_name="default", class_name="MyApp", status="running"
             ),
         ]
-        manifest_list = _make_manifest_list(instances)
+        manifest_list = make_manifest_list(instances)
 
         def handler(request: httpx.Request) -> httpx.Response:
             if MANIFESTS_ENDPOINT in str(request.url):
@@ -427,7 +439,7 @@ class TestInstanceRouting:
         assert "default" in buf.getvalue()
 
     def test_instance_without_app_exits_nonzero(self) -> None:
-        config = _make_host_port_config()
+        config = make_host_port_config()
         transport = make_transport(200, [])
         client = HassetteCLIClient(config, json_mode=False, transport=transport)
         with capture_stderr() as buf, pytest.raises(SystemExit) as exc_info:
@@ -441,7 +453,7 @@ class TestInstanceRouting:
 
 class TestDebugMode:
     def test_debug_human_mode_shows_url_and_body(self) -> None:
-        config = _make_host_port_config()
+        config = make_host_port_config()
         transport = make_transport(500, {"detail": "Internal server error"})
         client = HassetteCLIClient(config, json_mode=False, debug_mode=True, transport=transport)
         _code, stderr = get_expecting_exit(client, CRASH_ENDPOINT)
@@ -450,7 +462,7 @@ class TestDebugMode:
         assert "Internal server error" in stderr
 
     def test_debug_json_mode_includes_debug_key(self, capsys: pytest.CaptureFixture[str]) -> None:
-        config = _make_host_port_config()
+        config = make_host_port_config()
         transport = make_transport(500, {"detail": "boom"})
         client = HassetteCLIClient(config, json_mode=True, debug_mode=True, transport=transport)
         parsed = get_json_error(client, capsys, CRASH_ENDPOINT)
@@ -461,14 +473,14 @@ class TestDebugMode:
         assert "boom" in parsed["debug"]["body"]
 
     def test_no_debug_human_mode_omits_url(self) -> None:
-        config = _make_host_port_config()
+        config = make_host_port_config()
         transport = make_transport(500, {"detail": "Internal server error"})
         client = HassetteCLIClient(config, json_mode=False, debug_mode=False, transport=transport)
         _code, stderr = get_expecting_exit(client, CRASH_ENDPOINT)
         assert "URL:" not in stderr
 
     def test_no_debug_json_mode_omits_debug_key(self, capsys: pytest.CaptureFixture[str]) -> None:
-        config = _make_host_port_config()
+        config = make_host_port_config()
         transport = make_transport(500, {"detail": "boom"})
         client = HassetteCLIClient(config, json_mode=True, debug_mode=False, transport=transport)
         parsed = get_json_error(client, capsys, CRASH_ENDPOINT)
@@ -480,7 +492,7 @@ class TestDebugMode:
 
 class TestRedirectResponse:
     def test_302_mentions_redirect_forward_auth_and_docs(self) -> None:
-        config = _make_host_port_config()
+        config = make_host_port_config()
         transport = make_transport(302, {"detail": "Found"})
         client = HassetteCLIClient(config, json_mode=False, transport=transport)
         code, stderr = get_expecting_exit(client)
@@ -490,7 +502,7 @@ class TestRedirectResponse:
         assert "cli configuration docs" in stderr.lower()
 
     def test_302_json_mode_mentions_redirect(self, capsys: pytest.CaptureFixture[str]) -> None:
-        config = _make_host_port_config()
+        config = make_host_port_config()
         transport = make_transport(302, {"detail": "Found"})
         client = HassetteCLIClient(config, json_mode=True, transport=transport)
         parsed = get_json_error(client, capsys)
@@ -502,10 +514,7 @@ class TestRedirectResponse:
 
 class TestFullBaseUrlInErrorMessages:
     def test_network_error_reports_full_base_url(self, tmp_path: Path) -> None:
-        config = make_cli_config(data_dir=tmp_path, cli_server_url=REMOTE_SERVER_URL)
-        transport = make_transport(raise_exc=httpx.ConnectError)
-        client = HassetteCLIClient(config, json_mode=False, transport=transport)
-        _code, stderr = get_expecting_exit(client)
+        stderr = stderr_for_connect_error(make_cli_config(data_dir=tmp_path, cli_server_url=REMOTE_SERVER_URL))
         assert REMOTE_SERVER_URL in stderr
 
     def test_http_error_reports_full_base_url(self, tmp_path: Path) -> None:
@@ -526,7 +535,7 @@ class TestTargetEcho:
         assert REMOTE_SERVER_URL in stderr
 
     def test_loopback_success_omits_target(self) -> None:
-        config = _make_host_port_config()
+        config = make_host_port_config()
         stderr = stderr_for_successful_get(config)
         assert stderr == ""
 
@@ -547,7 +556,7 @@ class TestTargetEcho:
         assert parsed["target"] == REMOTE_SERVER_URL
 
     def test_loopback_401_json_mode_omits_target(self, capsys: pytest.CaptureFixture[str]) -> None:
-        config = _make_host_port_config()
+        config = make_host_port_config()
         transport = make_transport(401, {"detail": "Unauthorized"})
         client = HassetteCLIClient(config, json_mode=True, transport=transport)
         parsed = get_json_error(client, capsys)

--- a/tests/unit/cli/test_client_credentials.py
+++ b/tests/unit/cli/test_client_credentials.py
@@ -10,7 +10,6 @@ import os
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
-import httpx2 as httpx
 import pytest
 from pydantic_settings import BaseSettings, PydanticBaseSettingsSource
 
@@ -21,10 +20,11 @@ from hassette.web.auth.tokens import TOKEN_FILENAME
 from tests.unit.cli.conftest import REMOTE_SERVER_URL, CLIClientFactory, make_cli_config
 from tests.unit.cli.test_client import (
     HEALTH_ENDPOINT,
-    _make_host_port_config,
     get_expecting_exit,
     get_json_error,
+    make_host_port_config,
     make_transport,
+    stderr_for_connect_error,
     stderr_for_successful_get,
 )
 
@@ -43,11 +43,38 @@ CLI_AUTH_TOKEN_ENV = "HASSETTE__CLI__AUTH_TOKEN"
 class TestCredentialAttachment:
     """The CLI resolves a web API bearer token and attaches it to outgoing requests."""
 
-    def test_config_auth_token_attaches_bearer_header(self, tmp_path: Path) -> None:
-        factory = CLIClientFactory(make_cli_config(data_dir=tmp_path, web_api_auth_token="config-token"))
+    # (config token, token file contents, expected Authorization header)
+    #
+    # The blank/empty rows are the load-bearing ones: an empty-string config token (e.g. an unset
+    # env var interpolated by docker-compose as ``HASSETTE__WEB_API__AUTH_TOKEN=""``) and a
+    # whitespace-only one must both be treated as unset, mirroring ``resolve_auth_token()``'s
+    # server-side handling — suppressed *and* falling through to the token file, so the CLI can't
+    # resolve a different credential than the service actually validates against.
+    @pytest.mark.parametrize(
+        ("config_token", "token_file", "expected_header"),
+        [
+            pytest.param("config-token", None, "Bearer config-token", id="config-token"),
+            pytest.param(None, "file-token", "Bearer file-token", id="token-file-fallback"),
+            pytest.param("config-token", "file-token", "Bearer config-token", id="config-token-beats-file"),
+            pytest.param(None, "", None, id="empty-token-file"),
+            pytest.param("", None, None, id="empty-config-token"),
+            pytest.param("  ", "file-token", "Bearer file-token", id="blank-config-token-falls-back-to-file"),
+        ],
+    )
+    def test_resolved_credential_attaches_expected_header(
+        self,
+        tmp_path: Path,
+        config_token: str | None,
+        token_file: str | None,
+        expected_header: str | None,
+    ) -> None:
+        if token_file is not None:
+            (tmp_path / TOKEN_FILENAME).write_text(token_file, encoding="utf-8")
+
+        factory = CLIClientFactory(make_cli_config(data_dir=tmp_path, web_api_auth_token=config_token))
         client, captured_headers = factory.build_capturing_headers()
         client.get(HEALTH_ENDPOINT, dict)
-        assert captured_headers[0]["authorization"] == "Bearer config-token"
+        assert captured_headers[0].get("authorization") == expected_header
 
     def test_env_var_populates_config_and_attaches_bearer_header(
         self,
@@ -99,33 +126,6 @@ class TestCredentialAttachment:
         client.get(HEALTH_ENDPOINT, dict)
         assert captured_headers[0]["authorization"] == "Bearer env-token"
 
-    def test_falls_back_to_token_file_when_config_value_absent(self, tmp_path: Path) -> None:
-        (tmp_path / TOKEN_FILENAME).write_text("file-token", encoding="utf-8")
-        factory = CLIClientFactory(make_cli_config(data_dir=tmp_path))
-        client, captured_headers = factory.build_capturing_headers()
-        client.get(HEALTH_ENDPOINT, dict)
-        assert captured_headers[0]["authorization"] == "Bearer file-token"
-
-    def test_config_value_takes_precedence_over_token_file(self, tmp_path: Path) -> None:
-        (tmp_path / TOKEN_FILENAME).write_text("file-token", encoding="utf-8")
-        factory = CLIClientFactory(make_cli_config(data_dir=tmp_path, web_api_auth_token="config-token"))
-        client, captured_headers = factory.build_capturing_headers()
-        client.get(HEALTH_ENDPOINT, dict)
-        assert captured_headers[0]["authorization"] == "Bearer config-token"
-
-    def test_no_config_value_and_no_token_file_sends_no_authorization_header(self, tmp_path: Path) -> None:
-        factory = CLIClientFactory(make_cli_config(data_dir=tmp_path))
-        client, captured_headers = factory.build_capturing_headers()
-        client.get(HEALTH_ENDPOINT, dict)
-        assert "authorization" not in captured_headers[0]
-
-    def test_empty_token_file_treated_as_no_token(self, tmp_path: Path) -> None:
-        (tmp_path / TOKEN_FILENAME).write_text("", encoding="utf-8")
-        factory = CLIClientFactory(make_cli_config(data_dir=tmp_path))
-        client, captured_headers = factory.build_capturing_headers()
-        client.get(HEALTH_ENDPOINT, dict)
-        assert "authorization" not in captured_headers[0]
-
     def test_missing_token_never_calls_generating_resolver(self, tmp_path: Path) -> None:
         """No token configured, no token file — the CLI must not mint its own token.
 
@@ -154,29 +154,6 @@ class TestCredentialAttachment:
         client = factory.build(transport)
         _code, stderr = get_expecting_exit(client)
         assert "has hassette been started" not in stderr
-
-    def test_empty_string_config_token_sends_no_authorization_header(self, tmp_path: Path) -> None:
-        """An empty-string config token (e.g. an unset env var interpolated by docker-compose
-        as ``HASSETTE__WEB_API__AUTH_TOKEN=""``) must be treated the same as no token at all:
-        no Authorization header is attached.
-        """
-        factory = CLIClientFactory(make_cli_config(data_dir=tmp_path, web_api_auth_token=""))
-        client, captured_headers = factory.build_capturing_headers()
-        client.get(HEALTH_ENDPOINT, dict)
-        assert "authorization" not in captured_headers[0]
-
-    def test_blank_config_token_falls_back_to_token_file(self, tmp_path: Path) -> None:
-        """A blank configured token must mirror resolve_auth_token()'s server-side handling:
-        treated as unset and falling through to the token file, not just suppressed. Otherwise
-        the CLI could resolve a different (missing) credential than the service actually
-        validates against, once the service falls back to a generated token for the same blank
-        config value.
-        """
-        (tmp_path / TOKEN_FILENAME).write_text("file-token", encoding="utf-8")
-        factory = CLIClientFactory(make_cli_config(data_dir=tmp_path, web_api_auth_token="  "))
-        client, captured_headers = factory.build_capturing_headers()
-        client.get(HEALTH_ENDPOINT, dict)
-        assert captured_headers[0]["authorization"] == "Bearer file-token"
 
     def test_empty_string_config_token_401_gives_clear_hint(self, tmp_path: Path) -> None:
         """An empty-string config token must not attach a header and must not resolve as
@@ -220,7 +197,7 @@ class TestNoLiteralWebApiTokenArgument:
 
 class TestVerifySslPassthrough:
     def test_verify_true_by_default(self) -> None:
-        config = _make_host_port_config()
+        config = make_host_port_config()
         with patch("hassette.cli.client.httpx.Client") as mock_client_cls:
             mock_client_cls.return_value = MagicMock()
             HassetteCLIClient(config, json_mode=False)
@@ -324,16 +301,9 @@ class TestVerifySslWarning:
         not only when the failure happens to be an HTTP error response.
         """
         config = make_cli_config(data_dir=tmp_path, cli_server_url=REMOTE_SERVER_URL, cli_verify_ssl=False)
-        transport = make_transport(raise_exc=httpx.ConnectError)
-        client = HassetteCLIClient(config, json_mode=False, transport=transport)
-        _code, stderr = get_expecting_exit(client)
-        assert "TLS verification is disabled" in stderr
+        assert "TLS verification is disabled" in stderr_for_connect_error(config)
 
     def test_flag_sourced_insecure_does_not_warn_on_network_error_path(self, tmp_path: Path) -> None:
         config = make_cli_config(data_dir=tmp_path, cli_server_url=REMOTE_SERVER_URL, cli_verify_ssl=False)
-        transport = make_transport(raise_exc=httpx.ConnectError)
-        client = HassetteCLIClient(
-            config, json_mode=False, transport=transport, verify_ssl_flag=False, server_url_flag=None
-        )
-        _code, stderr = get_expecting_exit(client)
+        stderr = stderr_for_connect_error(config, verify_ssl_flag=False, server_url_flag=None)
         assert "TLS verification is disabled" not in stderr

--- a/tests/unit/cli/test_client_credentials.py
+++ b/tests/unit/cli/test_client_credentials.py
@@ -50,6 +50,10 @@ class TestCredentialAttachment:
     # whitespace-only one must both be treated as unset, mirroring ``resolve_auth_token()``'s
     # server-side handling — suppressed *and* falling through to the token file, so the CLI can't
     # resolve a different credential than the service actually validates against.
+    #
+    # The neither-source-set case (no config token, no token file) is deliberately not a row here:
+    # ``test_missing_token_never_calls_generating_resolver`` below already pins it, asserting the
+    # same header absence plus the stronger invariant that the CLI never mints a token of its own.
     @pytest.mark.parametrize(
         ("config_token", "token_file", "expected_header"),
         [


### PR DESCRIPTION
## Summary

Test-only cleanup of `tests/unit/cli/test_client.py` and `tests/unit/cli/test_client_credentials.py`, addressing the three nitpicker findings in #1654. All of these predate the decompose-oversized-test-files batch (#1578–#1583) — that branch only moved the affected classes verbatim.

## What changed

**Naming drift.** `_make_host_port_config` and `_make_manifest_list` were the only underscore-prefixed module-level helpers in `test_client.py`; every sibling of identical scope (`make_transport`, `url_capturing_client`, `get_expecting_exit`, …) has no prefix. The module-private signal never held anyway — `test_client_credentials.py` imports `_make_host_port_config` across files. Both are renamed without the prefix, and `make_manifest_list` picked up the docstring it was missing.

**Redundant explicit defaults.** Two `make_host_port_config("127.0.0.1", 8126)` call sites passed the function's own default values; they now call `make_host_port_config()`.

**Duplicated test shape.** Eight of `TestCredentialAttachment`'s twelve methods repeated the same three-line body, varying only the `make_cli_config` kwargs and the final header assertion. They collapse into one parametrized `(config_token, token_file, expected_header)` table. The no-credential-anywhere case folds into `test_missing_token_never_calls_generating_resolver`, which already asserted the same header absence plus the stronger no-minted-token invariant. The two blank-token rows carry a comment explaining why they are load-bearing rather than filler — they pin the CLI's empty/whitespace handling to `resolve_auth_token()`'s server-side behavior, so the CLI can't resolve a different credential than the service validates against.

**One follow-on extraction.** Simplifying the redundant-default call sites left three connect-error test bodies token-identical, which `tools/check_duplicate_code.py` would then flag as a new cluster. Those are extracted into `stderr_for_connect_error()`, the sibling of the existing `stderr_for_successful_get()`. This also made `test_client_credentials.py`'s `httpx` import unused, so it's dropped.

No production code, no behavior change, no assertion weakened — every previously-asserted condition still has a test asserting it.

## Testing

- `uv run nox -s dev` — 7033 passed, 1 skipped, 2 xfailed
- `prek -a` — all hooks pass (including `check_duplicate_code`, `check_test_factories`, ruff, eslint, tsc)
- `prek pyright -a --stage pre-push` — passes

Closes #1654
