### PR TITLE
test: reference BATCH_SIZE instead of literals in test_logging_persistence

### DIFF
--- a/tests/unit/test_logging_persistence.py
+++ b/tests/unit/test_logging_persistence.py
@@ -9,11 +9,11 @@ import asyncio
 import logging
 import queue
 import time
-from collections.abc import Coroutine
+from collections.abc import Callable, Coroutine
 from typing import Any
 from unittest.mock import MagicMock
 
-from hassette.logging_ import HassetteQueueListener, LogPersistenceHandler
+from hassette.logging_ import DEQUEUE_TIMEOUT_SECONDS, HassetteQueueListener, LogPersistenceHandler
 
 
 def _enqueue_returning_false(coro: Coroutine[Any, Any, Any]) -> bool:
@@ -28,11 +28,17 @@ def _enqueue_raising_runtime_error(coro: Coroutine[Any, Any, Any]) -> bool:
     raise RuntimeError("DB shut down")
 
 
-def _make_dropping_db_service() -> MagicMock:
-    """Return a db_service mock whose enqueue() always returns False (simulates full queue)."""
+def _make_dropping_db_service(
+    enqueue_side_effect: Callable[[Coroutine[Any, Any, Any]], bool] = _enqueue_returning_false,
+) -> MagicMock:
+    """Return a db_service mock whose enqueue() refuses coroutines, so emitted records are dropped.
+
+    Defaults to simulating a full queue (enqueue returns False). Pass
+    _enqueue_raising_runtime_error to simulate a shut-down service instead.
+    """
     db_service = MagicMock()
     db_service._insert_log_records = MagicMock(return_value=MagicMock())
-    db_service.enqueue = MagicMock(side_effect=_enqueue_returning_false)
+    db_service.enqueue = MagicMock(side_effect=enqueue_side_effect)
     return db_service
 
 
@@ -57,7 +63,7 @@ class TestLogPersistenceHandlerBatching:
             loop.close()
 
     def test_batch_does_not_flush_below_threshold(self) -> None:
-        """Batch accumulates below BATCH_SIZE without flushing."""
+        """Batch accumulates at one record below BATCH_SIZE without flushing."""
         loop = asyncio.new_event_loop()
         db_service = MagicMock()
         db_service.enqueue = MagicMock(return_value=True)
@@ -162,9 +168,7 @@ class TestLogPersistenceDropCountWithDB:
     def test_db_write_queue_drops_increments_on_enqueue_failure(self) -> None:
         """When enqueue() returns False (queue full), db_write_queue_drops increases."""
         loop = asyncio.new_event_loop()
-        db_service = MagicMock()
-        db_service._insert_log_records = MagicMock(return_value=MagicMock())
-        db_service.enqueue = MagicMock(side_effect=_enqueue_returning_false)
+        db_service = _make_dropping_db_service()
         handler = LogPersistenceHandler(db_service, loop, persistence_level=logging.DEBUG)
         try:
             for i in range(LogPersistenceHandler.BATCH_SIZE):
@@ -180,9 +184,7 @@ class TestLogPersistenceDropCountWithDB:
     def test_db_write_queue_drops_increments_on_db_shutdown_runtime_error(self) -> None:
         """When enqueue() raises RuntimeError (DB shut down), db_write_queue_drops increases."""
         loop = asyncio.new_event_loop()
-        db_service = MagicMock()
-        db_service._insert_log_records = MagicMock(return_value=MagicMock())
-        db_service.enqueue = MagicMock(side_effect=_enqueue_raising_runtime_error)
+        db_service = _make_dropping_db_service(_enqueue_raising_runtime_error)
         handler = LogPersistenceHandler(db_service, loop, persistence_level=logging.DEBUG)
         try:
             for i in range(LogPersistenceHandler.BATCH_SIZE):
@@ -200,7 +202,7 @@ class TestDequeueTimeoutFlush:
     """HassetteQueueListener dequeue-timeout triggers flush_if_pending on idle."""
 
     def test_dequeue_timeout_triggers_flush_if_pending(self) -> None:
-        """After 200ms idle, the listener thread calls flush_if_pending on handlers."""
+        """After DEQUEUE_TIMEOUT_SECONDS idle, the listener thread calls flush_if_pending on handlers."""
         q: queue.Queue[logging.LogRecord] = queue.Queue()
         loop = asyncio.new_event_loop()
         db_service = _make_dropping_db_service()
@@ -213,8 +215,8 @@ class TestDequeueTimeoutFlush:
         record = logging.LogRecord("test", logging.WARNING, "", 0, "timeout test", (), None)
         q.put(record)
 
-        # Wait for the dequeue-timeout cycle to flush (200ms timeout + processing)
-        time.sleep(0.5)
+        # Wait for the dequeue-timeout cycle to flush, with margin for thread scheduling
+        time.sleep(DEQUEUE_TIMEOUT_SECONDS + 0.3)
 
         listener.stop()
         loop.run_until_complete(asyncio.sleep(0))

--- a/tests/unit/test_logging_persistence.py
+++ b/tests/unit/test_logging_persistence.py
@@ -16,35 +16,42 @@ from unittest.mock import MagicMock
 from hassette.logging_ import HassetteQueueListener, LogPersistenceHandler
 
 
+def _enqueue_returning_false(coro: Coroutine[Any, Any, Any]) -> bool:
+    """Stand in for a full DB write queue: refuse the coroutine and report the drop."""
+    coro.close()
+    return False
+
+
+def _enqueue_raising_runtime_error(coro: Coroutine[Any, Any, Any]) -> bool:
+    """Stand in for a shut-down DB service: refuse the coroutine and raise."""
+    coro.close()
+    raise RuntimeError("DB shut down")
+
+
 def _make_dropping_db_service() -> MagicMock:
     """Return a db_service mock whose enqueue() always returns False (simulates full queue)."""
     db_service = MagicMock()
     db_service._insert_log_records = MagicMock(return_value=MagicMock())
-
-    def drop_enqueue(coro: Coroutine[Any, Any, Any]) -> bool:
-        coro.close()
-        return False
-
-    db_service.enqueue = MagicMock(side_effect=drop_enqueue)
+    db_service.enqueue = MagicMock(side_effect=_enqueue_returning_false)
     return db_service
 
 
 class TestLogPersistenceHandlerBatching:
     """LogPersistenceHandler batches records and flushes at threshold."""
 
-    def test_batch_flushes_at_50_records(self) -> None:
-        """Batch is flushed when it reaches BATCH_SIZE (50)."""
+    def test_batch_flushes_at_batch_size_records(self) -> None:
+        """Batch is flushed when it reaches BATCH_SIZE."""
         loop = asyncio.new_event_loop()
         db_service = _make_dropping_db_service()
         handler = LogPersistenceHandler(db_service, loop, persistence_level=logging.DEBUG)
         try:
-            for i in range(50):
+            for i in range(LogPersistenceHandler.BATCH_SIZE):
                 record = logging.LogRecord("test", logging.INFO, "", 0, f"msg{i}", (), None)
                 handler.emit(record)
 
-            # enqueue() returns False → all 50 dropped after flush
+            # enqueue() returns False → the whole batch is dropped after flush
             loop.run_until_complete(asyncio.sleep(0))
-            assert handler.db_write_queue_drops == 50
+            assert handler.db_write_queue_drops == LogPersistenceHandler.BATCH_SIZE
             assert len(handler._batch) == 0
         finally:
             loop.close()
@@ -57,12 +64,12 @@ class TestLogPersistenceHandlerBatching:
         db_service._insert_log_records = MagicMock(return_value=MagicMock())
         handler = LogPersistenceHandler(db_service, loop, persistence_level=logging.DEBUG)
         try:
-            for i in range(49):
+            for i in range(LogPersistenceHandler.BATCH_SIZE - 1):
                 record = logging.LogRecord("test", logging.INFO, "", 0, f"msg{i}", (), None)
                 handler.emit(record)
 
             assert handler.db_write_queue_drops == 0
-            assert len(handler._batch) == 49
+            assert len(handler._batch) == LogPersistenceHandler.BATCH_SIZE - 1
         finally:
             loop.close()
 
@@ -152,31 +159,21 @@ class TestLogPersistenceHandlerBatching:
 class TestLogPersistenceDropCountWithDB:
     """LogPersistenceHandler counts drops caused by DB queue-full backpressure."""
 
-    @staticmethod
-    def enqueue_returning_false(coro: Coroutine[Any, Any, Any]) -> bool:
-        coro.close()
-        return False
-
-    @staticmethod
-    def enqueue_raising_runtime_error(coro: Coroutine[Any, Any, Any]) -> bool:
-        coro.close()
-        raise RuntimeError("DB shut down")
-
     def test_db_write_queue_drops_increments_on_enqueue_failure(self) -> None:
         """When enqueue() returns False (queue full), db_write_queue_drops increases."""
         loop = asyncio.new_event_loop()
         db_service = MagicMock()
         db_service._insert_log_records = MagicMock(return_value=MagicMock())
-        db_service.enqueue = MagicMock(side_effect=self.enqueue_returning_false)
+        db_service.enqueue = MagicMock(side_effect=_enqueue_returning_false)
         handler = LogPersistenceHandler(db_service, loop, persistence_level=logging.DEBUG)
         try:
-            for i in range(50):
+            for i in range(LogPersistenceHandler.BATCH_SIZE):
                 record = logging.LogRecord("test", logging.INFO, "", 0, f"msg{i}", (), None)
                 handler.emit(record)
 
             loop.run_until_complete(asyncio.sleep(0))
 
-            assert handler.db_write_queue_drops == 50
+            assert handler.db_write_queue_drops == LogPersistenceHandler.BATCH_SIZE
         finally:
             loop.close()
 
@@ -185,16 +182,16 @@ class TestLogPersistenceDropCountWithDB:
         loop = asyncio.new_event_loop()
         db_service = MagicMock()
         db_service._insert_log_records = MagicMock(return_value=MagicMock())
-        db_service.enqueue = MagicMock(side_effect=self.enqueue_raising_runtime_error)
+        db_service.enqueue = MagicMock(side_effect=_enqueue_raising_runtime_error)
         handler = LogPersistenceHandler(db_service, loop, persistence_level=logging.DEBUG)
         try:
-            for i in range(50):
+            for i in range(LogPersistenceHandler.BATCH_SIZE):
                 record = logging.LogRecord("test", logging.INFO, "", 0, f"msg{i}", (), None)
                 handler.emit(record)
 
             loop.run_until_complete(asyncio.sleep(0))
 
-            assert handler.db_write_queue_drops == 50
+            assert handler.db_write_queue_drops == LogPersistenceHandler.BATCH_SIZE
         finally:
             loop.close()
 


### PR DESCRIPTION
## Summary

Removes the hardcoded `50` / `49` literals from `tests/unit/test_logging_persistence.py` and settles the file on a single helper-declaration convention. Test-only change — no production code or behavior is touched.

## What changed

**Magic number → source constant.** Four call sites used bare `range(50)` / `range(49)` (and matching assertions) to exercise the `LogPersistenceHandler` batch-flush threshold, duplicating `LogPersistenceHandler.BATCH_SIZE` from `src/hassette/logging_.py`. They now reference the constant directly, including the off-by-one "just below threshold" case as `BATCH_SIZE - 1`.

Why this matters: with the literal, changing `BATCH_SIZE` would leave these tests passing while quietly no longer testing the threshold boundary at all — the 49-record test would stop being "one below the flush point" and become an arbitrary count. Referencing the constant makes the tests track the boundary, and fail loudly if the relationship ever breaks.

`test_batch_flushes_at_50_records` is renamed to `test_batch_flushes_at_batch_size_records` so the test name doesn't re-encode the same literal it just stopped hardcoding.

**One helper convention.** `TestLogPersistenceDropCountWithDB` declared two `@staticmethod` helpers invoked via `self.<name>`, while the rest of the file used plain module-level functions (`_make_dropping_db_service`). Both are now module-level `_enqueue_returning_false` / `_enqueue_raising_runtime_error`, and `_make_dropping_db_service` reuses `_enqueue_returning_false` instead of redefining the same logic as a local closure. Both helpers gained docstrings explaining which failure mode they simulate (full queue vs. shut-down service).

## Testing

- `uv run nox -s dev` — 7034 passed, 1 skipped, 2 xfailed
- `prek -a` — all hooks pass
- `prek pyright -a --stage pre-push` — passes

Closes #1655
