### PR TITLE
test: assert observable state in command-executor pipeline tests

### DIFF
--- a/tests/unit/core/test_command_executor_pipeline_persist.py
+++ b/tests/unit/core/test_command_executor_pipeline_persist.py
@@ -109,8 +109,8 @@ async def test_flush_queue_handles_db_closed():
     # flush_queue must NOT raise — shutdown must complete
     await executor.flush_queue()
 
-    # Should have logged something (error/warning about dropped records)
-    assert executor.logger.error.called or executor.logger.warning.called
+    # The queue is fully drained: shutdown made its best-effort persist attempt and moved on
+    assert executor._write_queue.empty()
 
 
 async def test_persist_execution_batch_includes_source_tier():

--- a/tests/unit/core/test_command_executor_pipeline_persist.py
+++ b/tests/unit/core/test_command_executor_pipeline_persist.py
@@ -94,8 +94,12 @@ async def test_flush_queue_handles_db_closed():
     inv = make_invocation(listener_id=5, session_id=1)
     executor._write_queue.put_nowait(inv)
 
+    submit_attempts = 0
+
     # Make submit raise RuntimeError (simulating closed DB) — close the coro to avoid leak
     async def fail_submit(coro):
+        nonlocal submit_attempts
+        submit_attempts += 1
         coro.close()  # prevent "coroutine was never awaited" warning
         raise RuntimeError("database is closed")
 
@@ -109,7 +113,10 @@ async def test_flush_queue_handles_db_closed():
     # flush_queue must NOT raise — shutdown must complete
     await executor.flush_queue()
 
-    # The queue is fully drained: shutdown made its best-effort persist attempt and moved on
+    # flush_queue drains the queue *before* it attempts to persist, so an empty queue alone
+    # proves nothing. Pin the persist attempt itself — this fails if flush_queue ever dequeues
+    # and returns early, which is the regression the empty-queue check cannot see.
+    assert submit_attempts == 1, "flush_queue must make its best-effort persist attempt"
     assert executor._write_queue.empty()
 
 

--- a/tests/unit/core/test_command_executor_pipeline_queue.py
+++ b/tests/unit/core/test_command_executor_pipeline_queue.py
@@ -126,11 +126,11 @@ async def test_enqueue_record_capacity_warning_respects_configured_rate_limit() 
     assert executor._last_capacity_warn_ts is None
 
     executor.enqueue_record(rec)  # current_size=1 before put — at threshold, fires
-    first_warn_ts = executor._last_capacity_warn_ts
-    assert first_warn_ts is not None
+    first_capacity_warn_ts = executor._last_capacity_warn_ts
+    assert first_capacity_warn_ts is not None
 
     executor.enqueue_record(rec)  # current_size=2 before put — still at/above threshold
-    assert executor._last_capacity_warn_ts == first_warn_ts, (
+    assert executor._last_capacity_warn_ts == first_capacity_warn_ts, (
         "second warning should be suppressed by rate-limit, leaving the window timestamp untouched"
     )
 
@@ -234,9 +234,12 @@ async def test_data_error_drops_immediately():
 
     await CommandExecutor.persist_batch(executor, [inv])  # pyright: ignore[reportArgumentType]
 
-    # No re-enqueue, and not counted as a retry-exhausted drop
+    # No re-enqueue, and none of the three counted drop paths were taken — a DataError is
+    # dropped where it is raised, so it is neither an overflow, a retry-exhausted drop, nor a
+    # shutdown-flush drop. Together these are what separate this branch from the sibling
+    # OperationalError path, which re-enqueues and eventually increments dropped_exhausted.
     assert executor._write_queue.empty()
-    assert executor._dropped_exhausted == 0
+    assert executor.get_drop_counters() == (0, 0, 0)
 
 
 async def test_integrity_error_row_by_row_fallback():

--- a/tests/unit/core/test_command_executor_pipeline_queue.py
+++ b/tests/unit/core/test_command_executor_pipeline_queue.py
@@ -13,7 +13,6 @@ Tests cover:
 - RetryableBatch.not_before backoff deferral (#656)
 """
 
-import asyncio
 import sqlite3
 import time
 from collections.abc import Callable, Coroutine
@@ -76,43 +75,42 @@ def wire_raising_persist(executor: CommandExecutor, exc: BaseException) -> None:
 
 
 async def test_bounded_queue_drops_on_full():
-    """Filling a queue beyond maxsize triggers QueueFull; _dropped_overflow is incremented."""
+    """enqueue_record drops the record and increments _dropped_overflow once the queue is full."""
     executor = init_executor(queue_max=3)
 
     rec = make_invocation()
 
-    # Fill queue to max
+    # Fill queue to max through the real enqueue path
     for _ in range(3):
-        executor._write_queue.put_nowait(rec)
+        executor.enqueue_record(rec)
 
-    # Next put_nowait should raise QueueFull — simulate what execute() does
-    try:
-        executor._write_queue.put_nowait(rec)
-        # Should have raised — if not, test the catch path manually
-    except asyncio.QueueFull:
-        executor._dropped_overflow += 1
-        executor.logger.error("Queue full — dropping record")
+    assert executor._write_queue.qsize() == 3
+    assert executor._dropped_overflow == 0
+
+    # Queue is full — this record must be dropped rather than raising
+    executor.enqueue_record(rec)
 
     assert executor._dropped_overflow == 1
     assert executor._write_queue.qsize() == 3
 
 
 async def test_enqueue_record_warns_at_configured_capacity_threshold() -> None:
-    """enqueue_record logs a capacity WARNING once occupancy *before* the enqueue reaches the
-    configured threshold, using lifecycle.command_executor_capacity_warn_threshold (#1041).
+    """enqueue_record opens the capacity rate-limit window once occupancy *before* the enqueue
+    reaches the configured lifecycle.command_executor_capacity_warn_threshold (#1041).
     """
     executor = init_executor(queue_max=4)
     executor.hassette.config.lifecycle.command_executor_capacity_warn_threshold = 0.5  # 2/4
 
     rec = make_invocation()
     executor.enqueue_record(rec)  # current_size=0 before put — below threshold
-    assert executor.logger.warning.call_count == 0
+    assert executor._last_capacity_warn_ts is None
 
     executor.enqueue_record(rec)  # current_size=1 before put — still below threshold
-    assert executor.logger.warning.call_count == 0
+    assert executor._last_capacity_warn_ts is None
 
     executor.enqueue_record(rec)  # current_size=2 before put — at threshold
-    assert executor.logger.warning.call_count == 1
+    assert executor._last_capacity_warn_ts is not None
+    assert executor._write_queue.qsize() == 3
 
 
 async def test_enqueue_record_capacity_warning_respects_configured_rate_limit() -> None:
@@ -125,13 +123,16 @@ async def test_enqueue_record_capacity_warning_respects_configured_rate_limit() 
 
     rec = make_invocation()
     executor.enqueue_record(rec)  # current_size=0 before put — below threshold
-    assert executor.logger.warning.call_count == 0
+    assert executor._last_capacity_warn_ts is None
 
     executor.enqueue_record(rec)  # current_size=1 before put — at threshold, fires
-    assert executor.logger.warning.call_count == 1
+    first_warn_ts = executor._last_capacity_warn_ts
+    assert first_warn_ts is not None
 
     executor.enqueue_record(rec)  # current_size=2 before put — still at/above threshold
-    assert executor.logger.warning.call_count == 1, "second warning should be suppressed by rate-limit"
+    assert executor._last_capacity_warn_ts == first_warn_ts, (
+        "second warning should be suppressed by rate-limit, leaving the window timestamp untouched"
+    )
 
 
 async def test_retryable_batch_expanded_in_drain():
@@ -224,7 +225,7 @@ async def test_max_retries_drops_batch():
 
 
 async def test_data_error_drops_immediately():
-    """DataError from persist_execution_batch → drop immediately + REGRESSION log, no re-enqueue."""
+    """DataError from persist_execution_batch → drop immediately, no re-enqueue and no retry."""
     executor = init_executor()
 
     inv = make_invocation(listener_id=5, session_id=1)
@@ -233,12 +234,9 @@ async def test_data_error_drops_immediately():
 
     await CommandExecutor.persist_batch(executor, [inv])  # pyright: ignore[reportArgumentType]
 
-    # No re-enqueue
+    # No re-enqueue, and not counted as a retry-exhausted drop
     assert executor._write_queue.empty()
-
-    # REGRESSION log
-    error_calls = [str(c) for c in executor.logger.error.call_args_list]
-    assert any("REGRESSION" in c or "DataError" in c or "non-retryable" in c.lower() for c in error_calls)
+    assert executor._dropped_exhausted == 0
 
 
 async def test_integrity_error_row_by_row_fallback():


### PR DESCRIPTION
## Summary

Two test files in the command-executor pipeline suite had assertions that did not actually
constrain the code under test. This replaces them with assertions on observable state.

`test_bounded_queue_drops_on_full` never called `enqueue_record()`. It filled
`executor._write_queue` with `put_nowait()` directly and then re-implemented the overflow
branch — the `try`/`except asyncio.QueueFull`, the `_dropped_overflow += 1`, the error log —
inside the test body. The assertions that followed were checking the test's own inline copy of
the logic, so the test would have stayed green if `enqueue_record()` stopped catching
`QueueFull` or stopped incrementing the counter. It now fills the queue through the real
`enqueue_record()` path and drives the overflow through it too.

The neighbouring capacity-warning, rate-limit, `DataError`, and DB-closed-shutdown tests
asserted on `executor.logger.warning` / `executor.logger.error` mock call counts and error
payloads. That is the pattern this repo's own "No Log Capture Tests" convention rules out —
test the behavior that produces the log, not the log output. Those now assert the rate-limit
window timestamp (`_last_capacity_warn_ts`), queue size, and the drop counters
(`_dropped_overflow`, `_dropped_exhausted`) instead.

Test-only change — no production code touched.

## Changes

- `tests/unit/core/test_command_executor_pipeline_queue.py`
  - `test_bounded_queue_drops_on_full` drives both the fill and the overflow through
    `enqueue_record()`, and asserts `_dropped_overflow` and queue size.
  - Capacity-threshold and rate-limit tests assert `_last_capacity_warn_ts` (unset, then set,
    then unchanged across a suppressed warning) plus queue size.
  - `test_data_error_drops_immediately` drops the error-log payload substring match, keeping
    the no-re-enqueue assertion and adding `_dropped_exhausted == 0` to confirm the drop was
    not counted as retry exhaustion.
- `tests/unit/core/test_command_executor_pipeline_persist.py`
  - `test_flush_queue_handles_db_closed` asserts the queue is drained rather than that some
    logger method was called.

## Testing

- `uv run nox -s dev` — 7034 passed, 1 skipped, 2 xfailed
- `prek -a` — all hooks pass
- `prek pyright -a --stage pre-push` — passes

Closes #1657
