### PR TITLE
test: exercise real app discovery in autodetect and validate-apps tests

### DIFF
--- a/src/hassette/test_utils/__init__.py
+++ b/src/hassette/test_utils/__init__.py
@@ -65,6 +65,7 @@ from .helpers import make_task_bucket as make_task_bucket
 from .helpers import patch_loop_getaddrinfo as patch_loop_getaddrinfo
 from .helpers import wire_up_app_running_listener as wire_up_app_running_listener
 from .helpers import wire_up_app_state_listener as wire_up_app_state_listener
+from .helpers import write_app as write_app
 from .helpers import write_app_toml as write_app_toml
 from .helpers import write_test_app_with_decorator as write_test_app_with_decorator
 from .mock_hassette import make_mock_hassette as make_mock_hassette

--- a/src/hassette/test_utils/helpers.py
+++ b/src/hassette/test_utils/helpers.py
@@ -454,7 +454,7 @@ def write_app(app_dir: Path, filename: str, source: str) -> Path:
     """Write `source` as a module inside `app_dir`, creating the directory if needed.
 
     For app files whose exact source matters (auto-detect discovery, import behavior). Use
-    :func:`write_test_app_with_decorator` instead when a canned App subclass is enough.
+    `write_test_app_with_decorator` instead when a canned App subclass is enough.
     """
     app_dir.mkdir(parents=True, exist_ok=True)
     path = app_dir / filename

--- a/src/hassette/test_utils/helpers.py
+++ b/src/hassette/test_utils/helpers.py
@@ -450,6 +450,18 @@ def write_app_toml(
         tomli_w.dump(toml_dict, f)
 
 
+def write_app(app_dir: Path, filename: str, source: str) -> Path:
+    """Write `source` as a module inside `app_dir`, creating the directory if needed.
+
+    For app files whose exact source matters (auto-detect discovery, import behavior). Use
+    :func:`write_test_app_with_decorator` instead when a canned App subclass is enough.
+    """
+    app_dir.mkdir(parents=True, exist_ok=True)
+    path = app_dir / filename
+    path.write_text(textwrap.dedent(source))
+    return path
+
+
 def write_test_app_with_decorator(
     app_file: Path,
     class_name: str,

--- a/tests/unit/test_autodetect_apps.py
+++ b/tests/unit/test_autodetect_apps.py
@@ -48,7 +48,7 @@ class TestAutoDetectAppsCurrDir:
             from hassette import App, AppConfig
 
             class CurrentDirApp(App[AppConfig]): ...
-        """,
+            """,
         )
 
         assert_detected(detect(tmp_path), f"{tmp_path.name}.current_dir_app.CurrentDirApp")
@@ -62,7 +62,7 @@ class TestAutoDetectAppsCurrDir:
             from hassette import App, AppConfig
 
             class VenvApp(App[AppConfig]): ...
-        """,
+            """,
         )
 
         assert_detected(detect(tmp_path))
@@ -76,7 +76,7 @@ class TestAutoDetectAppsCurrDir:
             from hassette import App, AppConfig
 
             class HiddenApp(App[AppConfig]): ...
-        """,
+            """,
         )
 
         assert_detected(detect(tmp_path))
@@ -103,7 +103,7 @@ class TestAutoDetectApps:
                 message: str = "Hello"
 
             class SimpleApp(App[SimpleAppConfig]): ...
-        """,
+            """,
         )
 
         result = detect(app_dir)
@@ -129,7 +129,7 @@ class TestAutoDetectApps:
                 interval: int = 60
 
             class MySyncApp(AppSync[SyncAppConfig]): ...
-        """,
+            """,
         )
 
         result = detect(app_dir)
@@ -154,7 +154,7 @@ class TestAutoDetectApps:
             class FirstApp(App[SharedConfig]): ...
 
             class SecondApp(AppSync[SharedConfig]): ...
-        """,
+            """,
         )
 
         result = detect(app_dir)
@@ -177,7 +177,7 @@ class TestAutoDetectApps:
                 smtp_server: str = "localhost"
 
             class EmailNotifier(App[EmailConfig]): ...
-        """,
+            """,
         )
 
         result = detect(app_dir)
@@ -198,7 +198,7 @@ class TestAutoDetectApps:
             from hassette import App, AppConfig
 
             class ConfiguredApp(App[AppConfig]): ...
-        """,
+            """,
         )
 
         assert_detected(detect(app_dir, known_paths={app_file.resolve()}))
@@ -217,7 +217,7 @@ class TestAutoDetectApps:
             AppSync = AppSync
 
             class RealApp(App[AppConfig]): ...
-        """,
+            """,
         )
 
         assert_detected(detect(app_dir), "apps.base_classes.RealApp")
@@ -232,7 +232,7 @@ class TestAutoDetectApps:
             from hassette import App, AppConfig
 
             class ModuleApp(App[AppConfig]): ...
-        """,
+            """,
         )
         write_app(
             app_dir,
@@ -242,7 +242,7 @@ class TestAutoDetectApps:
             from hassette import App, AppConfig
 
             class LocalApp(App[AppConfig]): ...
-        """,
+            """,
         )
 
         # Each app is detected in its own module; ModuleApp must NOT appear under importer.py
@@ -259,7 +259,7 @@ class TestAutoDetectApps:
             from hassette import App, AppConfig
 
             class BrokenApp(App[AppConfig]): ...
-        """,
+            """,
         )
         write_app(
             app_dir,
@@ -268,7 +268,7 @@ class TestAutoDetectApps:
             from hassette import App, AppConfig
 
             class GoodApp(App[AppConfig]): ...
-        """,
+            """,
         )
 
         # The broken module is skipped rather than aborting the whole scan
@@ -296,7 +296,7 @@ class TestAutoDetectApps:
                     pass
 
             class ActualApp(App[AppConfig]): ...
-        """,
+            """,
         )
 
         assert_detected(detect(app_dir), "apps.mixed_classes.ActualApp")

--- a/tests/unit/test_autodetect_apps.py
+++ b/tests/unit/test_autodetect_apps.py
@@ -5,23 +5,15 @@ Complements test_validate_apps.py (TestValidateApps) and test_autodetect_apps_in
 """
 
 from pathlib import Path
-from textwrap import dedent
 
 import pytest
 
 from hassette import context
 from hassette.config.config import HassetteConfig
 from hassette.config.defaults import AUTODETECT_EXCLUDE_DIRS_DEFAULT
+from hassette.test_utils import write_app
 from hassette.types.types import AppDict
 from hassette.utils.app_utils import autodetect_apps
-
-
-def write_app(app_dir: Path, filename: str, source: str) -> Path:
-    """Write `source` as a module inside `app_dir`, creating the directory if needed."""
-    app_dir.mkdir(parents=True, exist_ok=True)
-    path = app_dir / filename
-    path.write_text(dedent(source))
-    return path
 
 
 def detect(app_dir: Path, known_paths: set[Path] | None = None) -> dict[str, AppDict]:

--- a/tests/unit/test_autodetect_apps_integration.py
+++ b/tests/unit/test_autodetect_apps_integration.py
@@ -7,12 +7,12 @@ Complements `test_autodetect_apps.py` (TestAutoDetectAppsCurrDir, TestAutoDetect
 
 from collections.abc import Iterator
 from pathlib import Path
-from textwrap import dedent
 
 import pytest
 
 from hassette import context
 from hassette.config.config import HassetteConfig
+from hassette.test_utils import write_app
 from hassette.test_utils.config import TEST_TOKEN
 
 
@@ -28,15 +28,14 @@ class TestAutoDetectIntegration:
         """Test that autodetect_apps is enabled by default in HassetteConfig."""
         # Create a temporary app directory with an app
         app_dir = tmp_path / "apps"
-        app_dir.mkdir()
-
-        app_file = app_dir / "test_app.py"
-        app_file.write_text(
-            dedent("""
+        write_app(
+            app_dir,
+            "test_app.py",
+            """
             from hassette import App, AppConfig
 
             class TestApp(App[AppConfig]): ...
-        """)
+            """,
         )
 
         # Create config with the temp app directory
@@ -55,15 +54,14 @@ class TestAutoDetectIntegration:
         """Test that autodetect_apps can be disabled in HassetteConfig."""
         # Create a temporary app directory with an app
         app_dir = tmp_path / "apps"
-        app_dir.mkdir()
-
-        app_file = app_dir / "test_app.py"
-        app_file.write_text(
-            dedent("""
+        write_app(
+            app_dir,
+            "test_app.py",
+            """
             from hassette import App, AppConfig
 
             class TestApp(App[AppConfig]): ...
-        """)
+            """,
         )
 
         # Create config with auto-detect disabled
@@ -90,18 +88,17 @@ class TestAutoDetectIntegration:
         """
         # Create a temporary app directory with an app
         app_dir = tmp_path / "apps"
-        app_dir.mkdir()
-
-        app_file = app_dir / "priority_app.py"
-        app_file.write_text(
-            dedent("""
+        write_app(
+            app_dir,
+            "priority_app.py",
+            """
             from hassette import App, AppConfig
 
             class MyConfig(AppConfig):
                 custom: str = "auto-app"
 
             class AutoDetectedApp(App[AppConfig]): ...
-        """)
+            """,
         )
 
         # Create config with manual app configuration that conflicts
@@ -137,15 +134,14 @@ class TestAutoDetectIntegration:
         """Test that manually configured apps take precedence over auto-detected ones."""
         # Create a temporary app directory with an app
         app_dir = tmp_path / "apps"
-        app_dir.mkdir()
-
-        app_file = app_dir / "priority_app.py"
-        app_file.write_text(
-            dedent("""
+        write_app(
+            app_dir,
+            "priority_app.py",
+            """
             from hassette import App, AppConfig
 
             class AutoDetectedApp(App[AppConfig]): ...
-        """)
+            """,
         )
 
         # Create config with manual app configuration that conflicts
@@ -183,26 +179,27 @@ class TestAutoDetectIntegration:
         """Test that HassetteConfig combines manual and auto-detected apps correctly."""
         # Create a temporary app directory with multiple apps
         app_dir = tmp_path / "apps"
-        app_dir.mkdir()
 
         # Auto-detected app
-        auto_file = app_dir / "auto_app.py"
-        auto_file.write_text(
-            dedent("""
+        write_app(
+            app_dir,
+            "auto_app.py",
+            """
             from hassette import App, AppConfig
 
             class AutoApp(App[AppConfig]): ...
-        """)
+            """,
         )
 
         # Manually configured app
-        manual_file = app_dir / "manual_app.py"
-        manual_file.write_text(
-            dedent("""
+        write_app(
+            app_dir,
+            "manual_app.py",
+            """
             from hassette import App, AppConfig
 
             class ManualApp(App[AppConfig]): ...
-        """)
+            """,
         )
 
         # Create config with one manual app

--- a/tests/unit/test_autodetect_apps_integration.py
+++ b/tests/unit/test_autodetect_apps_integration.py
@@ -73,8 +73,12 @@ class TestAutoDetectIntegration:
             cli_parse_args=False,
         )
 
+        # `autodetect` is only evaluated inside set_validated_app_manifests(), so the assertion
+        # has to run after it — and against `manifests`, which is what discovery populates.
+        config.set_validated_app_manifests()
+
         # Should not auto-detect any apps (no manual apps configured either)
-        assert len(config.apps.apps) == 0, f"Expected 0 apps, got {len(config.apps.apps)}"
+        assert len(config.apps.manifests) == 0, f"Expected 0 manifests, got {sorted(config.apps.manifests)}"
 
     @pytest.mark.parametrize("ext", [".py", ""])
     def test_defined_filename_without_extension_is_handled(self, tmp_path: Path, ext: str) -> None:

--- a/tests/unit/test_validate_apps.py
+++ b/tests/unit/test_validate_apps.py
@@ -121,8 +121,11 @@ class TestValidateApps:
             f"Expected app_key to be 'valid_app', got {result['valid_app'].app_key}"
         )
 
-    def test_validate_apps_calls_autodetect(self, tmp_path: Path) -> None:
+    def test_validate_apps_merges_autodetected_and_manual_apps(self, tmp_path: Path) -> None:
         """Real discovery runs when autodetect=True and merges with manually configured apps."""
+        # `app_dir.name` is load-bearing, not scaffolding: autodetect_apps() passes it as the
+        # package name, so a discovered app's key is "{app_dir.name}.{module_stem}.{class_name}"
+        # — the literals asserted below change if this directory is renamed.
         app_dir = tmp_path / "test_apps"
         write_app(
             app_dir,
@@ -184,6 +187,7 @@ class TestValidateApps:
         a manually configured file is excluded from discovery via known_paths, so pointing both
         at the same file would never reach the key-conflict branch.
         """
+        # Same "{app_dir.name}.{module_stem}.{class_name}" key format as the test above.
         app_dir = tmp_path / "test_apps"
         write_app(
             app_dir,

--- a/tests/unit/test_validate_apps.py
+++ b/tests/unit/test_validate_apps.py
@@ -8,12 +8,13 @@ Complements `test_autodetect_apps.py` (TestAutoDetectAppsCurrDir, TestAutoDetect
 import logging
 from pathlib import Path
 from typing import Any
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 import pytest
 
 from hassette import context
 from hassette.config.config import HassetteConfig
+from hassette.test_utils import write_app
 from hassette.test_utils.config import make_test_config
 
 
@@ -120,22 +121,27 @@ class TestValidateApps:
             f"Expected app_key to be 'valid_app', got {result['valid_app'].app_key}"
         )
 
-    @patch("hassette.config.config.autodetect_apps")
-    def test_validate_apps_calls_autodetect(self, mock_autodetect: MagicMock, tmp_path: Path) -> None:
-        """Test that validate_apps calls autodetect_app_manifests when autodetect=True."""
+    def test_validate_apps_calls_autodetect(self, tmp_path: Path) -> None:
+        """Real discovery runs when autodetect=True and merges with manually configured apps."""
         app_dir = tmp_path / "test_apps"
-        app_dir.mkdir(parents=True, exist_ok=True)
+        write_app(
+            app_dir,
+            "validate_auto_app.py",
+            """
+            from hassette import App, AppConfig
 
-        # Mock the auto-detection to return a detected app
-        mock_app_dict = {
-            "filename": "auto.py",
-            "class_name": "AutoApp",
-            "app_dir": app_dir,
-            "app_key": "auto.AutoApp",
-            "enabled": True,
-            "full_path": app_dir / "auto.py",
-        }
-        mock_autodetect.return_value = {"auto.AutoApp": mock_app_dict}
+            class ValidateAutoApp(App[AppConfig]): ...
+            """,
+        )
+        write_app(
+            app_dir,
+            "validate_manual_app.py",
+            """
+            from hassette import App, AppConfig
+
+            class ValidateManualApp(App[AppConfig]): ...
+            """,
+        )
 
         config = self.make_config(
             tmp_path,
@@ -143,8 +149,8 @@ class TestValidateApps:
             directory=app_dir,
             apps={
                 "manual_app": {
-                    "filename": "manual.py",
-                    "class_name": "ManualApp",
+                    "filename": "validate_manual_app.py",
+                    "class_name": "ValidateManualApp",
                 }
             },
         )
@@ -153,44 +159,60 @@ class TestValidateApps:
             config.set_validated_app_manifests()
         result = config.apps.manifests
 
-        # Should have both manual and auto-detected apps
-        assert len(result) == 2, f"Expected 2 apps, got {len(result)}"
-        assert "manual_app" in result, "Expected to find 'manual_app' in detected apps"
-        assert "auto.AutoApp" in result, "Expected to find 'auto.AutoApp' in detected apps"
+        autodetected_key = "test_apps.validate_auto_app.ValidateAutoApp"
+        assert sorted(result) == sorted(["manual_app", autodetected_key]), (
+            f"Expected the manual app plus the auto-detected one, got {sorted(result)}"
+        )
 
-        # Check that autodetect_app_manifests was called with correct parameters
-        mock_autodetect.assert_called_once()
-        args, _ = mock_autodetect.call_args
-        assert args[0] == app_dir, f"Expected app_dir to be {app_dir}, got {args[0]}"
-        # Should include the path of the manual app in known_paths
-        known_paths = args[1]
-        expected_path = (app_dir / "manual.py").resolve()
-        assert expected_path in known_paths, f"Expected known_paths to include {expected_path}, got {known_paths}"
+        # Discovery ran against the configured app directory.
+        auto_manifest = result[autodetected_key]
+        assert auto_manifest.app_dir == app_dir, f"Expected app_dir to be {app_dir}, got {auto_manifest.app_dir}"
+        assert auto_manifest.filename == "validate_auto_app.py", (
+            f"Expected filename to be 'validate_auto_app.py', got {auto_manifest.filename}"
+        )
 
-    @patch("hassette.config.config.autodetect_apps")
-    def test_validate_apps_skips_conflicting_autodetected(self, mock_autodetect: MagicMock, tmp_path: Path) -> None:
-        """Test that validate_apps skips auto-detected apps that conflict with manual ones."""
+        # The manually configured file is handed to discovery as a known path, so it is not
+        # detected a second time under its derived key.
+        assert "test_apps.validate_manual_app.ValidateManualApp" not in result, (
+            f"Expected the manually configured file to be skipped by discovery, got {sorted(result)}"
+        )
+
+    def test_validate_apps_skips_conflicting_autodetected(self, tmp_path: Path) -> None:
+        """Auto-detected apps whose key is already claimed by a manual app are dropped.
+
+        The manual entry deliberately points at a *different* file than the one discovery finds:
+        a manually configured file is excluded from discovery via known_paths, so pointing both
+        at the same file would never reach the key-conflict branch.
+        """
         app_dir = tmp_path / "test_apps"
-        app_dir.mkdir(parents=True, exist_ok=True)
+        write_app(
+            app_dir,
+            "validate_conflict_app.py",
+            """
+            from hassette import App, AppConfig
 
-        # Mock auto-detection to return an app with the same key
-        mock_app_dict = {
-            "filename": "my_app.py",
-            "class_name": "MyApp",
-            "app_dir": app_dir,
-            "app_key": "my_app",
-            "enabled": True,
-        }
-        mock_autodetect.return_value = {"my_app": mock_app_dict}
+            class ValidateConflictApp(App[AppConfig]): ...
+            """,
+        )
+        write_app(
+            app_dir,
+            "validate_override_app.py",
+            """
+            from hassette import App, AppConfig
 
+            class ValidateOverrideApp(App[AppConfig]): ...
+            """,
+        )
+
+        conflicting_key = "test_apps.validate_conflict_app.ValidateConflictApp"
         config = self.make_config(
             tmp_path,
             autodetect=True,
             directory=app_dir,
             apps={
-                "my_app": {
-                    "filename": "my_app.py",
-                    "class_name": "MyApp",
+                conflicting_key: {
+                    "filename": "validate_override_app.py",
+                    "class_name": "ValidateOverrideApp",
                 }
             },
         )
@@ -199,21 +221,16 @@ class TestValidateApps:
             config.set_validated_app_manifests()
         result = config.apps.manifests
 
-        # Should only have the manual app, not the auto-detected one
-        assert len(result) == 1, f"Expected 1 app, got {len(result)}"
-        assert "my_app" in result, "Expected to find 'my_app' in detected apps"
-        # Should be the original manual config, not the auto-detected one
-        assert result["my_app"].filename == "my_app.py", (
-            f"Expected filename to be 'my_app.py', got {result['my_app'].filename}"
+        # Only the manual app survives — the auto-detected app that resolved to the same key
+        # is skipped rather than overwriting it.
+        assert sorted(result) == [conflicting_key], f"Expected only {conflicting_key!r}, got {sorted(result)}"
+        manifest = result[conflicting_key]
+        assert manifest.filename == "validate_override_app.py", (
+            f"Expected filename to be 'validate_override_app.py', got {manifest.filename}"
         )
-        assert result["my_app"].class_name == "MyApp", (
-            f"Expected class_name to be 'MyApp', got {result['my_app'].class_name}"
+        assert manifest.class_name == "ValidateOverrideApp", (
+            f"Expected class_name to be 'ValidateOverrideApp', got {manifest.class_name}"
         )
-
-        # The behavior is that auto-detected apps with conflicting keys are simply not added
-        # Let's verify that autodetect_app_manifests was called and the result is correct
-        mock_autodetect.assert_called_once()
-        # The important thing is that the result only contains the manual app
 
     def test_validate_apps_skips_autodetect_when_disabled(self, tmp_path: Path) -> None:
         """Test that validate_apps skips auto-detection when autodetect=False."""


### PR DESCRIPTION
## Summary

Three tests in the app auto-detection suite asserted on things that could not fail. This
replaces the mocks and the wrong assertion target with real app discovery, so the tests now
exercise the contract `HassetteConfig.set_validated_app_manifests()` actually has to preserve.

## What changed

**`test_hassette_config_autodetect_can_be_disabled`** (`tests/unit/test_autodetect_apps_integration.py`)

The test never called `set_validated_app_manifests()` — the one place `autodetect` is
evaluated — and asserted on `config.apps.apps`, which is never populated by discovery either
way. It passed whether or not discovery ran. It now calls that method and asserts
`config.apps.manifests` is empty.

**`test_validate_apps_calls_autodetect`** and **`test_validate_apps_skips_conflicting_autodetected`**
(`tests/unit/test_validate_apps.py`)

Both patched `hassette.config.config.autodetect_apps` and asserted against the mock's return
value, so the real discovery path was never touched. Both now write real app modules under the
configured app directory and assert on the resulting manifests.

The call-argument coverage the mocks provided is preserved behaviorally rather than by
inspecting call args:

- `test_validate_apps_calls_autodetect` asserts the manually configured file is *not* detected
  a second time under its derived key — which is only true if its resolved path was passed to
  discovery in `known_paths`.
- `test_validate_apps_skips_conflicting_autodetected` points its manual entry at a *different*
  file than the one discovery finds. Because a manually configured file is excluded from
  discovery via `known_paths`, aiming both at the same file could never reach the key-conflict
  branch; pointing them at different files is the only way to hit it through real discovery.

**`write_app` hoisted into `hassette.test_utils.helpers`**

Both test modules needed it, so the local copy in `tests/unit/test_autodetect_apps.py` moved to
the shared helpers module per the repo's test-factory convention.

## Testing

- `uv run nox -s dev` — 7034 passed, 1 skipped, 2 xfailed
- `prek -a` — all hooks pass
- `prek pyright -a --stage pre-push` — passes

No source behavior changed; this is test-only.

Closes #1658
