### PR TITLE
refactor(ui): decompose ActionButtons and ExecutionTable render functions

### DIFF
--- a/frontend/src/components/shared/action-buttons.tsx
+++ b/frontend/src/components/shared/action-buttons.tsx
@@ -23,6 +23,10 @@ import { IconPlay, IconRefresh, IconSquare } from "./icons";
 type ManifestStatus = components["schemas"]["ManifestStatus"];
 type ResourceStatus = components["schemas"]["ResourceStatus"];
 
+// "unknown" is a defensive placeholder the app-detail page passes while a status hasn't
+// loaded yet (see `AppDetailPage`'s `liveStatus` selector) — not a backend enum value.
+type AppStatus = ManifestStatus | ResourceStatus | "unknown";
+
 // `verb` reads as "Failed to <verb>", `outcome` as "App "<key>" <outcome>".
 const ACTIONS = {
   start: { request: startApp, verb: "start", outcome: "started" },
@@ -44,11 +48,115 @@ interface ActionButtonSpec {
   onClick: () => void;
 }
 
+// The request returns 202 — the toast confirms the action was accepted, the
+// resulting status change arrives later over the WebSocket.
+async function performAction(appKey: string, name: ActionName) {
+  const { request, verb, outcome } = ACTIONS[name];
+  try {
+    await request(appKey);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    toast.error(`Failed to ${verb} "${appKey}": ${message}`);
+    throw err;
+  }
+  toast.success(`App "${appKey}" ${outcome}`);
+}
+
+function buildButtonSpecs(status: AppStatus, onClick: Record<ActionName, () => void>): ActionButtonSpec[] {
+  return [
+    {
+      action: "start",
+      visible: CAN_START[status],
+      iconVariant: "success-ghost",
+      textVariant: "success",
+      icon: <IconPlay />,
+      label: "Start",
+      ariaLabel: "Start app",
+      onClick: onClick.start,
+    },
+    {
+      action: "reload",
+      visible: status !== "unknown" && isReloadableStatus(status),
+      iconVariant: "info-ghost",
+      textVariant: "outline",
+      icon: <IconRefresh />,
+      label: "Reload",
+      ariaLabel: "Reload app",
+      onClick: onClick.reload,
+    },
+    {
+      action: "stop",
+      visible: CAN_STOP[status],
+      iconVariant: "warning-ghost",
+      textVariant: "danger",
+      icon: <IconSquare />,
+      label: "Stop",
+      ariaLabel: "Stop app",
+      onClick: onClick.stop,
+    },
+  ];
+}
+
+interface ActionButtonProps {
+  spec: ActionButtonSpec;
+  appKey: string;
+  isIcon: boolean;
+  disabled: boolean;
+}
+
+function ActionButton({ spec, appKey, isIcon, disabled }: ActionButtonProps) {
+  return (
+    <Button
+      variant={isIcon ? spec.iconVariant : spec.textVariant}
+      size={isIcon ? "icon" : "sm"}
+      data-testid={`btn-${spec.action}-${appKey}`}
+      disabled={disabled}
+      onClick={spec.onClick}
+      title={isIcon ? spec.label : undefined}
+      aria-label={spec.ariaLabel}
+    >
+      {isIcon ? (
+        spec.icon
+      ) : (
+        <>
+          {spec.icon} {spec.label}
+        </>
+      )}
+    </Button>
+  );
+}
+
+interface StopConfirmDialogProps {
+  appKey: string;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onConfirm: () => void;
+}
+
+function StopConfirmDialog({ appKey, open, onOpenChange, onConfirm }: StopConfirmDialogProps) {
+  return (
+    <AlertDialog open={open} onOpenChange={onOpenChange}>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>Stop app?</AlertDialogTitle>
+          <AlertDialogDescription>
+            Stop &quot;{appKey}&quot;? It will stop processing events until restarted.
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel>Cancel</AlertDialogCancel>
+          <AlertDialogAction variant="destructive" data-testid="confirm-btn-danger" onClick={onConfirm}>
+            Stop
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}
+
 interface Props {
   appKey: string;
-  // "unknown" is a defensive placeholder the app-detail page passes while a status hasn't
-  // loaded yet (see `AppDetailPage`'s `liveStatus` selector) — not a backend enum value.
-  status: ManifestStatus | ResourceStatus | "unknown";
+  status: AppStatus;
   variant?: "icon" | "text";
   confirmStop?: boolean;
 }
@@ -57,25 +165,7 @@ export function ActionButtons({ appKey, status, variant = "icon", confirmStop = 
   const { loading, run } = useAsyncAction();
   const [showStopConfirm, setShowStopConfirm] = useState(false);
 
-  // The request returns 202 — the toast confirms the action was accepted, the
-  // resulting status change arrives later over the WebSocket.
-  const exec = (name: ActionName) => {
-    const { request, verb, outcome } = ACTIONS[name];
-    return run(async () => {
-      try {
-        await request(appKey);
-      } catch (err) {
-        const message = err instanceof Error ? err.message : String(err);
-        toast.error(`Failed to ${verb} "${appKey}": ${message}`);
-        throw err;
-      }
-      toast.success(`App "${appKey}" ${outcome}`);
-    });
-  };
-
-  const canStart = CAN_START[status];
-  const canStop = CAN_STOP[status];
-  const canReload = status !== "unknown" && isReloadableStatus(status);
+  const exec = (name: ActionName) => run(() => performAction(appKey, name));
 
   const handleStop = () => {
     if (confirmStop) {
@@ -86,39 +176,11 @@ export function ActionButtons({ appKey, status, variant = "icon", confirmStop = 
   };
 
   const isIcon = variant === "icon";
-
-  const buttons: ActionButtonSpec[] = [
-    {
-      action: "start",
-      visible: canStart,
-      iconVariant: "success-ghost",
-      textVariant: "success",
-      icon: <IconPlay />,
-      label: "Start",
-      ariaLabel: "Start app",
-      onClick: () => void exec("start"),
-    },
-    {
-      action: "reload",
-      visible: canReload,
-      iconVariant: "info-ghost",
-      textVariant: "outline",
-      icon: <IconRefresh />,
-      label: "Reload",
-      ariaLabel: "Reload app",
-      onClick: () => void exec("reload"),
-    },
-    {
-      action: "stop",
-      visible: canStop,
-      iconVariant: "warning-ghost",
-      textVariant: "danger",
-      icon: <IconSquare />,
-      label: "Stop",
-      ariaLabel: "Stop app",
-      onClick: handleStop,
-    },
-  ];
+  const buttons = buildButtonSpecs(status, {
+    start: () => void exec("start"),
+    reload: () => void exec("reload"),
+    stop: handleStop,
+  });
 
   return (
     <>
@@ -126,50 +188,19 @@ export function ActionButtons({ appKey, status, variant = "icon", confirmStop = 
         {buttons.map(
           (btn) =>
             btn.visible && (
-              <Button
-                key={btn.action}
-                variant={isIcon ? btn.iconVariant : btn.textVariant}
-                size={isIcon ? "icon" : "sm"}
-                data-testid={`btn-${btn.action}-${appKey}`}
-                disabled={loading}
-                onClick={btn.onClick}
-                title={isIcon ? btn.label : undefined}
-                aria-label={btn.ariaLabel}
-              >
-                {isIcon ? (
-                  btn.icon
-                ) : (
-                  <>
-                    {btn.icon} {btn.label}
-                  </>
-                )}
-              </Button>
+              <ActionButton key={btn.action} spec={btn} appKey={appKey} isIcon={isIcon} disabled={loading} />
             ),
         )}
       </div>
       {confirmStop && (
-        <AlertDialog open={showStopConfirm} onOpenChange={setShowStopConfirm}>
-          <AlertDialogContent>
-            <AlertDialogHeader>
-              <AlertDialogTitle>Stop app?</AlertDialogTitle>
-              <AlertDialogDescription>
-                Stop &quot;{appKey}&quot;? It will stop processing events until restarted.
-              </AlertDialogDescription>
-            </AlertDialogHeader>
-            <AlertDialogFooter>
-              <AlertDialogCancel>Cancel</AlertDialogCancel>
-              <AlertDialogAction
-                variant="destructive"
-                data-testid="confirm-btn-danger"
-                onClick={() => {
-                  void exec("stop");
-                }}
-              >
-                Stop
-              </AlertDialogAction>
-            </AlertDialogFooter>
-          </AlertDialogContent>
-        </AlertDialog>
+        <StopConfirmDialog
+          appKey={appKey}
+          open={showStopConfirm}
+          onOpenChange={setShowStopConfirm}
+          onConfirm={() => {
+            void exec("stop");
+          }}
+        />
       )}
     </>
   );

--- a/frontend/src/components/shared/action-buttons.tsx
+++ b/frontend/src/components/shared/action-buttons.tsx
@@ -15,17 +15,10 @@ import {
 import { Button } from "@/components/ui/button";
 
 import { reloadApp, startApp, stopApp } from "../../api/endpoints";
-import type { components } from "../../api/generated-types";
 import { useAsyncAction } from "../../hooks/use-async-action";
+import type { ActionButtonStatusKey } from "../../utils/status";
 import { CAN_START, CAN_STOP, isReloadableStatus } from "../../utils/status";
 import { IconPlay, IconRefresh, IconSquare } from "./icons";
-
-type ManifestStatus = components["schemas"]["ManifestStatus"];
-type ResourceStatus = components["schemas"]["ResourceStatus"];
-
-// "unknown" is a defensive placeholder the app-detail page passes while a status hasn't
-// loaded yet (see `AppDetailPage`'s `liveStatus` selector) — not a backend enum value.
-type AppStatus = ManifestStatus | ResourceStatus | "unknown";
 
 // `verb` reads as "Failed to <verb>", `outcome` as "App "<key>" <outcome>".
 const ACTIONS = {
@@ -62,7 +55,7 @@ async function performAction(appKey: string, name: ActionName) {
   toast.success(`App "${appKey}" ${outcome}`);
 }
 
-function buildButtonSpecs(status: AppStatus, onClick: Record<ActionName, () => void>): ActionButtonSpec[] {
+function buildButtonSpecs(status: ActionButtonStatusKey, handlers: Record<ActionName, () => void>): ActionButtonSpec[] {
   return [
     {
       action: "start",
@@ -72,7 +65,7 @@ function buildButtonSpecs(status: AppStatus, onClick: Record<ActionName, () => v
       icon: <IconPlay />,
       label: "Start",
       ariaLabel: "Start app",
-      onClick: onClick.start,
+      onClick: handlers.start,
     },
     {
       action: "reload",
@@ -82,7 +75,7 @@ function buildButtonSpecs(status: AppStatus, onClick: Record<ActionName, () => v
       icon: <IconRefresh />,
       label: "Reload",
       ariaLabel: "Reload app",
-      onClick: onClick.reload,
+      onClick: handlers.reload,
     },
     {
       action: "stop",
@@ -92,7 +85,7 @@ function buildButtonSpecs(status: AppStatus, onClick: Record<ActionName, () => v
       icon: <IconSquare />,
       label: "Stop",
       ariaLabel: "Stop app",
-      onClick: onClick.stop,
+      onClick: handlers.stop,
     },
   ];
 }
@@ -156,7 +149,9 @@ function StopConfirmDialog({ appKey, open, onOpenChange, onConfirm }: StopConfir
 
 interface Props {
   appKey: string;
-  status: AppStatus;
+  // `unknown` is a defensive placeholder the app-detail page passes while a status hasn't
+  // loaded yet (see `AppDetailPage`'s `liveStatus` selector) — not a backend enum value.
+  status: ActionButtonStatusKey;
   variant?: "icon" | "text";
   confirmStop?: boolean;
 }

--- a/frontend/src/components/shared/execution-table.test.tsx
+++ b/frontend/src/components/shared/execution-table.test.tsx
@@ -213,6 +213,7 @@ describe("ExecutionTable", () => {
     await user.click(row);
     expect(mockNavigate).not.toHaveBeenCalled();
   });
+
   it("moves the roving tabindex between rows with arrow keys", async () => {
     const user = userEvent.setup();
     const records = [

--- a/frontend/src/components/shared/execution-table.test.tsx
+++ b/frontend/src/components/shared/execution-table.test.tsx
@@ -213,4 +213,44 @@ describe("ExecutionTable", () => {
     await user.click(row);
     expect(mockNavigate).not.toHaveBeenCalled();
   });
+  it("moves the roving tabindex between rows with arrow keys", async () => {
+    const user = userEvent.setup();
+    const records = [
+      createExecution("job", { execution_start_ts: 1700000001 }),
+      createExecution("job", { execution_start_ts: 1700000002 }),
+    ];
+    const { container } = render(<ExecutionTable records={records} kind="job" tableId="t" />);
+    const rows = container.querySelectorAll<HTMLElement>("[data-testid='execution-row']");
+
+    expect(rows[0].tabIndex).toBe(0);
+    expect(rows[1].tabIndex).toBe(-1);
+
+    rows[0].focus();
+    await user.keyboard("{ArrowDown}");
+
+    expect(rows[0].tabIndex).toBe(-1);
+    expect(rows[1].tabIndex).toBe(0);
+    expect(document.activeElement).toBe(rows[1]);
+  });
+
+  it("activating a row with the keyboard navigates to execution detail page", async () => {
+    const user = userEvent.setup();
+    mockNavigate.mockClear();
+    const execId = "abc12345-6789-abcd-ef01-234567890abc";
+    const { getByTestId } = render(
+      <ExecutionTable
+        records={[createExecution("job", { execution_id: execId })]}
+        kind="job"
+        tableId="t"
+        appKey="my_app"
+        handlerKind="job"
+        handlerId={1}
+      />,
+    );
+
+    getByTestId("execution-row").focus();
+    await user.keyboard("{Enter}");
+
+    expect(mockNavigate).toHaveBeenCalledWith(`/apps/my_app/handlers/job/1/exec/${execId}`);
+  });
 });

--- a/frontend/src/components/shared/execution-table.tsx
+++ b/frontend/src/components/shared/execution-table.tsx
@@ -1,4 +1,12 @@
-import { type ColumnDef, flexRender, getCoreRowModel, useReactTable } from "@tanstack/react-table";
+import {
+  type Cell,
+  type ColumnDef,
+  flexRender,
+  getCoreRowModel,
+  type Row,
+  type Table as TanStackTable,
+  useReactTable,
+} from "@tanstack/react-table";
 import { useState } from "react";
 import { useLocation } from "wouter";
 
@@ -31,6 +39,11 @@ type ExecutionStatus = components["schemas"]["ExecutionStatus"];
 
 const INITIAL_ROWS = 5;
 
+const HEAD_CLASS =
+  "sticky top-0 z-[var(--z-table-head)] bg-muted px-2 py-1 font-mono text-xs font-medium uppercase tracking-[var(--text-label-tracking)] text-muted-foreground";
+
+const CELL_CLASS = "px-2 py-1 max-mobile:px-1 max-mobile:text-xs";
+
 const STATUS_LABEL: Record<StatusKind, string> = {
   ok: "ok",
   err: "failed",
@@ -51,16 +64,6 @@ export interface ExecutionRecord {
   trigger_origin?: string | null;
   trigger_mode?: string | null;
   thread_leaked: boolean;
-}
-
-interface ExecutionTableProps {
-  records: ExecutionRecord[];
-  kind: "handler" | "job";
-  tableId: string;
-  appKey?: string;
-  handlerKind?: HandlerKind;
-  handlerId?: number;
-  instanceQs?: string;
 }
 
 function statusLabelClass(kind: StatusKind): string {
@@ -139,10 +142,163 @@ const columns: ColumnDef<ExecutionRecord, unknown>[] = [
     id: "detail",
     header: () => <span className="sr-only">Details</span>,
     meta: { headerClassName: "w-8", cellClassName: "text-center align-middle text-muted-foreground transition-colors" },
-    // No `cell` — the row render loop below special-cases `column.id === "detail"` and never calls
-    // flexRender for it (it needs appKey/handlerKind/handlerId, not available at column-definition time).
+    // No `cell` — `ExecutionCell` below special-cases `column.id === "detail"` and never calls
+    // flexRender for it (it needs the row's resolved href, not available at column-definition time).
   },
 ];
+
+type ExecutionKind = "handler" | "job";
+
+interface ExecutionTableProps {
+  records: ExecutionRecord[];
+  kind: ExecutionKind;
+  tableId: string;
+  appKey?: string;
+  handlerKind?: HandlerKind;
+  handlerId?: number;
+  instanceQs?: string;
+}
+
+type DetailTarget = Pick<ExecutionTableProps, "appKey" | "handlerKind" | "handlerId" | "instanceQs">;
+
+// A row links to its execution detail page only when every part of the route is known.
+// Returns null when it isn't — which also drives the row's hover/keyboard affordances.
+function detailHref(record: ExecutionRecord, target: DetailTarget): string | null {
+  const { appKey, handlerKind, handlerId, instanceQs } = target;
+  if (!appKey || !handlerKind || handlerId === undefined || !record.execution_id) {
+    return null;
+  }
+  return executionPath(appKey, handlerKind, handlerId, record.execution_id) + (instanceQs ?? "");
+}
+
+function ExecutionEmptyState({ kind }: { kind: ExecutionKind }) {
+  if (kind === "handler") {
+    return (
+      <EmptyState
+        icon="◌"
+        title="no invocations recorded"
+        body="this handler hasn't been called yet in the current time window."
+      />
+    );
+  }
+  return <EmptyState title="no executions recorded." />;
+}
+
+function ExecutionTableHead({ table }: { table: TanStackTable<ExecutionRecord> }) {
+  return (
+    <TableHeader className="[&_tr]:bg-muted">
+      {table.getHeaderGroups().map((headerGroup) => (
+        <TableRow key={headerGroup.id}>
+          {headerGroup.headers.map((header) => (
+            <TableHead
+              key={header.id}
+              scope="col"
+              className={cn(HEAD_CLASS, header.column.columnDef.meta?.headerClassName)}
+            >
+              {flexRender(header.column.columnDef.header, header.getContext())}
+            </TableHead>
+          ))}
+        </TableRow>
+      ))}
+    </TableHeader>
+  );
+}
+
+// The "detail" column has no `cell` definition — it needs the row's resolved href, which
+// isn't available at column-definition time — so it is rendered here instead of via flexRender.
+function ExecutionCell({ cell, href }: { cell: Cell<ExecutionRecord, unknown>; href: string | null }) {
+  const className = cn(CELL_CLASS, cell.column.columnDef.meta?.cellClassName);
+
+  if (cell.column.id === "detail") {
+    return (
+      <TableCell className={className}>
+        {href && (
+          <span
+            className="inline-flex items-center justify-center align-middle"
+            data-testid="execution-detail-indicator"
+          >
+            <IconArrowRight />
+          </span>
+        )}
+      </TableCell>
+    );
+  }
+
+  const cellProps = cell.column.columnDef.meta?.cellProps?.(cell.row.original) ?? {};
+  return (
+    <TableCell className={className} {...cellProps}>
+      {flexRender(cell.column.columnDef.cell, cell.getContext())}
+    </TableCell>
+  );
+}
+
+interface ExecutionRowProps {
+  row: Row<ExecutionRecord>;
+  kind: ExecutionKind;
+  href: string | null;
+  tabIndex: number;
+  onSelect: () => void;
+  onOpenDetail: () => void;
+}
+
+function ExecutionRow({ row, kind, href, tabIndex, onSelect, onOpenDetail }: ExecutionRowProps) {
+  return (
+    <TableRow
+      className={cn("transition-colors", href && "cursor-pointer hover:bg-muted [&:hover_td:last-child]:text-primary")}
+      data-testid={kind === "handler" ? "invocation-row" : "execution-row"}
+      tabIndex={tabIndex}
+      role="row"
+      aria-label={href ? "View execution detail" : undefined}
+      data-roving-item
+      onClick={() => {
+        onSelect();
+        onOpenDetail();
+      }}
+      onKeyDown={href ? onActivateKeyDown(onOpenDetail) : undefined}
+    >
+      {row.getVisibleCells().map((cell) => (
+        <ExecutionCell key={cell.id} cell={cell} href={href} />
+      ))}
+    </TableRow>
+  );
+}
+
+interface ExecutionRowsProps extends DetailTarget {
+  table: TanStackTable<ExecutionRecord>;
+  kind: ExecutionKind;
+}
+
+// Owns the roving-tabindex wiring: the table body is the roving container, each row an item.
+function ExecutionRows({ table, kind, ...target }: ExecutionRowsProps) {
+  const rows = table.getRowModel().rows;
+  const { containerRef, onContainerKeyDown, getTabIndex, setActiveIndex } = useRovingTabIndex<HTMLTableSectionElement>(
+    rows.length,
+  );
+  const [, navigate] = useLocation();
+
+  return (
+    <TableBody ref={containerRef} onKeyDown={onContainerKeyDown}>
+      {rows.map((row, i) => {
+        const href = detailHref(row.original, target);
+        return (
+          <ExecutionRow
+            key={row.id}
+            row={row}
+            kind={kind}
+            href={href}
+            tabIndex={getTabIndex(i)}
+            onSelect={() => setActiveIndex(i)}
+            onOpenDetail={() => {
+              if (href) {
+                navigate(href);
+              }
+            }}
+          />
+        );
+      })}
+    </TableBody>
+  );
+}
 
 export function ExecutionTable({
   records,
@@ -155,10 +311,6 @@ export function ExecutionTable({
 }: ExecutionTableProps) {
   const [showAll, setShowAll] = useState(false);
   const visible = showAll ? records : records.slice(0, INITIAL_ROWS);
-  const { containerRef, onContainerKeyDown, getTabIndex, setActiveIndex } = useRovingTabIndex<HTMLTableSectionElement>(
-    visible.length,
-  );
-  const [, navigate] = useLocation();
 
   const table = useReactTable({
     data: visible,
@@ -168,18 +320,8 @@ export function ExecutionTable({
   });
 
   if (records.length === 0) {
-    return kind === "handler" ? (
-      <EmptyState
-        icon="◌"
-        title="no invocations recorded"
-        body="this handler hasn't been called yet in the current time window."
-      />
-    ) : (
-      <EmptyState title="no executions recorded." />
-    );
+    return <ExecutionEmptyState kind={kind} />;
   }
-
-  const hasMore = records.length > INITIAL_ROWS;
 
   return (
     <>
@@ -187,93 +329,17 @@ export function ExecutionTable({
         className="table-fixed bg-card max-mobile:table-auto [&_td]:overflow-hidden [&_td]:text-ellipsis"
         data-testid={tableId}
       >
-        <TableHeader className="[&_tr]:bg-muted">
-          {table.getHeaderGroups().map((headerGroup) => (
-            <TableRow key={headerGroup.id}>
-              {headerGroup.headers.map((header) => (
-                <TableHead
-                  key={header.id}
-                  scope="col"
-                  className={cn(
-                    "sticky top-0 z-[var(--z-table-head)] bg-muted px-2 py-1 font-mono text-xs font-medium uppercase tracking-[var(--text-label-tracking)] text-muted-foreground",
-                    header.column.columnDef.meta?.headerClassName,
-                  )}
-                >
-                  {flexRender(header.column.columnDef.header, header.getContext())}
-                </TableHead>
-              ))}
-            </TableRow>
-          ))}
-        </TableHeader>
-        <TableBody ref={containerRef} onKeyDown={onContainerKeyDown}>
-          {table.getRowModel().rows.map((row, i) => {
-            const record = row.original;
-            const canNavigate = appKey && handlerKind && handlerId !== undefined && record.execution_id;
-            const goToDetail = () => {
-              if (canNavigate) {
-                navigate(executionPath(appKey, handlerKind, handlerId, record.execution_id!) + (instanceQs ?? ""));
-              }
-            };
-
-            return (
-              <TableRow
-                key={row.id}
-                className={cn(
-                  "transition-colors",
-                  canNavigate && "cursor-pointer hover:bg-muted [&:hover_td:last-child]:text-primary",
-                )}
-                data-testid={kind === "handler" ? "invocation-row" : "execution-row"}
-                tabIndex={getTabIndex(i)}
-                role="row"
-                aria-label={canNavigate ? "View execution detail" : undefined}
-                data-roving-item
-                onClick={() => {
-                  setActiveIndex(i);
-                  goToDetail();
-                }}
-                onKeyDown={canNavigate ? onActivateKeyDown(goToDetail) : undefined}
-              >
-                {row.getVisibleCells().map((cell) => {
-                  if (cell.column.id === "detail") {
-                    return (
-                      <TableCell
-                        key={cell.id}
-                        className={cn(
-                          "px-2 py-1 max-mobile:px-1 max-mobile:text-xs",
-                          cell.column.columnDef.meta?.cellClassName,
-                        )}
-                      >
-                        {canNavigate && (
-                          <span
-                            className="inline-flex items-center justify-center align-middle"
-                            data-testid="execution-detail-indicator"
-                          >
-                            <IconArrowRight />
-                          </span>
-                        )}
-                      </TableCell>
-                    );
-                  }
-                  const cellProps = cell.column.columnDef.meta?.cellProps?.(record) ?? {};
-                  return (
-                    <TableCell
-                      key={cell.id}
-                      className={cn(
-                        "px-2 py-1 max-mobile:px-1 max-mobile:text-xs",
-                        cell.column.columnDef.meta?.cellClassName,
-                      )}
-                      {...cellProps}
-                    >
-                      {flexRender(cell.column.columnDef.cell, cell.getContext())}
-                    </TableCell>
-                  );
-                })}
-              </TableRow>
-            );
-          })}
-        </TableBody>
+        <ExecutionTableHead table={table} />
+        <ExecutionRows
+          table={table}
+          kind={kind}
+          appKey={appKey}
+          handlerKind={handlerKind}
+          handlerId={handlerId}
+          instanceQs={instanceQs}
+        />
       </Table>
-      {hasMore && (
+      {records.length > INITIAL_ROWS && (
         <ShowMoreButton showAll={showAll} onToggle={() => setShowAll((v) => !v)} totalCount={records.length} />
       )}
     </>

--- a/frontend/src/utils/status.ts
+++ b/frontend/src/utils/status.ts
@@ -43,8 +43,9 @@ export function isFailureStatus(status: ManifestStatus | ResourceStatus): boolea
   return IS_FAILURE_STATUS[status] ?? false;
 }
 
-/** Status key type for the per-app Start/Stop action-enablement maps below. */
-type ActionButtonStatusKey = ManifestStatus | ResourceStatus | UnknownStatus;
+/** Status key type for the per-app Start/Stop action-enablement maps below, and for
+ * `ActionButtons`' own `status` prop. */
+export type ActionButtonStatusKey = ManifestStatus | ResourceStatus | UnknownStatus;
 
 /**
  * True for statuses from which "Start" is a valid action. Record/satisfies instead of an ad hoc


### PR DESCRIPTION
## Summary

`ActionButtons()` (~121 lines) and `ExecutionTable()` (~135 lines) had each grown well past the
50-line function guideline in `coding-style.md`, bundling several unrelated concerns into a single
render function. This splits both along their real responsibility boundaries. No behavior changes —
this is a pure structural refactor.

## What changed

### `action-buttons.tsx`

- `performAction(appKey, name)` — the request/toast flow moves out of the component to a
  module-level async function. It no longer closes over component state, so the "what happens on
  click" logic is readable without tracing hook wiring.
- `buildButtonSpecs(status, onClick)` — the button-spec array becomes a pure function of status
  plus a handler map, separating "which buttons apply to this status" from "how a button renders".
- `ActionButton` and `StopConfirmDialog` — extracted components for the icon/text render branching
  and the confirmation dialog markup respectively.
- The `ManifestStatus | ResourceStatus | "unknown"` union is named `AppStatus` and hoisted, since
  three of the new signatures now reference it.

### `execution-table.tsx`

- `ExecutionEmptyState`, `ExecutionTableHead`, `ExecutionRow`, and `ExecutionCell` — extracted from
  the single render function.
- `ExecutionRows` owns the roving-tabindex wiring and `wouter` navigation, keeping that concern in
  one component instead of threaded through the row loop.
- `detailHref(record, target)` replaces the inline `canNavigate` check. It returns the resolved
  href or `null`, which drops a non-null assertion (`record.execution_id!`) and gives the row's
  hover/keyboard affordances a single source of truth instead of recomputing the condition in three
  places.
- The two long repeated `className` strings are hoisted to `HEAD_CLASS` / `CELL_CLASS`.

## Testing

`execution-table.tsx`'s roving-tabindex and keyboard-activation behavior moved between components
in this refactor and the existing suite did not cover it, so two characterization tests were added
first: arrow-key movement of the roving tabindex across rows, and Enter-key row activation
navigating to the execution detail page.

Verified locally:

- `uv run nox -s dev` — 7034 passed, 1 skipped, 2 xfailed
- `npm test` (frontend) — 1557 passed across 108 files
- `npm run build` (frontend) — clean
- `prek -a` — all hooks pass (ruff, eslint, stylelint, tsc, prettier, house-lint)
- `prek pyright -a --stage pre-push` — clean

## Visual evidence

None — this is a behavior-preserving decomposition with no rendered output change. The extracted
components emit the same markup, `data-testid`s, and class names as the inlined versions did.
Labeled `no-visual-change`.

Closes #1669
