### PR TITLE
test: collapse repeated render blocks in execution-section tests

### DIFF
--- a/frontend/src/components/app-detail/execution-section.test.tsx
+++ b/frontend/src/components/app-detail/execution-section.test.tsx
@@ -1,4 +1,5 @@
 import { render } from "@testing-library/react";
+import type { ComponentProps } from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import type { ExecutionRecord } from "../shared/execution-table";
@@ -18,7 +19,7 @@ vi.mock("../shared/execution-table", async () => {
 
 const { ExecutionTable } = await import("../shared/execution-table");
 
-const RECORD: ExecutionRecord = {
+const OK_EXECUTION: ExecutionRecord = {
   execution_start_ts: 1_700_000_000,
   duration_ms: 12,
   status: "success",
@@ -27,38 +28,43 @@ const RECORD: ExecutionRecord = {
   thread_leaked: false,
 };
 
+function renderSection(overrides: Partial<ComponentProps<typeof ExecutionSection>> = {}) {
+  return render(
+    <ExecutionSection
+      heading="Executions"
+      records={[]}
+      kind="handler"
+      tableId="table-1"
+      loading={false}
+      {...overrides}
+    />,
+  );
+}
+
 describe("ExecutionSection", () => {
   afterEach(() => {
     vi.clearAllMocks();
   });
 
   it("renders the heading text", () => {
-    const { getByRole } = render(
-      <ExecutionSection heading="Executions" records={[]} kind="handler" tableId="table-1" loading={false} />,
-    );
+    const { getByRole } = renderSection();
     expect(getByRole("heading", { level: 3 }).textContent).toBe("Executions");
   });
 
   it("shows a spinner when loading and records is undefined", () => {
-    const { getByTestId, queryByTestId } = render(
-      <ExecutionSection heading="Executions" records={undefined} kind="handler" tableId="table-1" loading={true} />,
-    );
+    const { getByTestId, queryByTestId } = renderSection({ records: undefined, loading: true });
     expect(getByTestId("spinner")).not.toBeNull();
     expect(queryByTestId("mock-execution-table")).toBeNull();
   });
 
   it("shows the ExecutionTable when records is an empty array (loaded but empty)", () => {
-    const { getByTestId, queryByTestId } = render(
-      <ExecutionSection heading="Executions" records={[]} kind="handler" tableId="table-1" loading={true} />,
-    );
+    const { getByTestId, queryByTestId } = renderSection({ records: [], loading: true });
     expect(queryByTestId("spinner")).toBeNull();
     expect(getByTestId("mock-execution-table").getAttribute("data-record-count")).toBe("0");
   });
 
   it("shows the ExecutionTable when records exist, even if loading", () => {
-    const { getByTestId, queryByTestId } = render(
-      <ExecutionSection heading="Executions" records={[RECORD]} kind="handler" tableId="table-1" loading={true} />,
-    );
+    const { getByTestId, queryByTestId } = renderSection({ records: [OK_EXECUTION], loading: true });
     expect(queryByTestId("spinner")).toBeNull();
     expect(getByTestId("mock-execution-table").getAttribute("data-record-count")).toBe("1");
   });
@@ -67,7 +73,7 @@ describe("ExecutionSection", () => {
     render(
       <ExecutionSection
         heading="Executions"
-        records={[RECORD]}
+        records={[OK_EXECUTION]}
         kind="job"
         tableId="table-42"
         loading={false}
@@ -82,7 +88,7 @@ describe("ExecutionSection", () => {
     // "context" argument), so the second call arg is undefined here.
     expect(ExecutionTable).toHaveBeenCalledWith(
       expect.objectContaining({
-        records: [RECORD],
+        records: [OK_EXECUTION],
         kind: "job",
         tableId: "table-42",
         appKey: "my_app",

--- a/frontend/src/components/app-detail/execution-section.test.tsx
+++ b/frontend/src/components/app-detail/execution-section.test.tsx
@@ -19,7 +19,7 @@ vi.mock("../shared/execution-table", async () => {
 
 const { ExecutionTable } = await import("../shared/execution-table");
 
-const OK_EXECUTION: ExecutionRecord = {
+const SUCCESS_EXECUTION: ExecutionRecord = {
   execution_start_ts: 1_700_000_000,
   duration_ms: 12,
   status: "success",
@@ -64,7 +64,7 @@ describe("ExecutionSection", () => {
   });
 
   it("shows the ExecutionTable when records exist, even if loading", () => {
-    const { getByTestId, queryByTestId } = renderSection({ records: [OK_EXECUTION], loading: true });
+    const { getByTestId, queryByTestId } = renderSection({ records: [SUCCESS_EXECUTION], loading: true });
     expect(queryByTestId("spinner")).toBeNull();
     expect(getByTestId("mock-execution-table").getAttribute("data-record-count")).toBe("1");
   });
@@ -73,7 +73,7 @@ describe("ExecutionSection", () => {
     render(
       <ExecutionSection
         heading="Executions"
-        records={[OK_EXECUTION]}
+        records={[SUCCESS_EXECUTION]}
         kind="job"
         tableId="table-42"
         loading={false}
@@ -88,7 +88,7 @@ describe("ExecutionSection", () => {
     // "context" argument), so the second call arg is undefined here.
     expect(ExecutionTable).toHaveBeenCalledWith(
       expect.objectContaining({
-        records: [OK_EXECUTION],
+        records: [SUCCESS_EXECUTION],
         kind: "job",
         tableId: "table-42",
         appKey: "my_app",


### PR DESCRIPTION
## Summary

Collapses four near-identical `render()` blocks in `execution-section.test.tsx` behind a local
`renderSection()` helper, so each test names only the prop it is actually exercising instead of
re-typing the three invariant props at every call site.

Before, every one of the first four tests spelled out `heading="Executions"`, `kind="handler"`,
and `tableId="table-1"` alongside the two props under test — the varying prop was buried in
constant noise. The helper takes `Partial<ComponentProps<typeof ExecutionSection>>` overrides
with those invariants as defaults, following the `renderCard` / `renderOverviewTab` pattern
already established by sibling tests in `app-detail/`.

Also renames the `RECORD` fixture to `OK_EXECUTION`, which describes the fixture (a successful,
non-leaked execution) rather than restating its TypeScript type.

## Notes

- The heading test still asserts against the `"Executions"` string literal rather than the
  helper's default value — sharing one constant between the render input and the assertion would
  make that test tautological.
- The fifth test (`"passes the correct props to ExecutionTable"`) deliberately overrides most
  props, so it keeps its explicit inline form.
- No behavior change: all five branches (heading render, loading spinner, empty-array table,
  populated table, prop pass-through) remain verified.

## Testing

- `npx vitest run src/components/app-detail/execution-section.test.tsx` — 5 passed
- `npm run test` (full frontend suite) — 108 files, 1555 tests passed
- `uv run nox -s dev` — 7034 passed, 1 skipped, 2 xfailed
- `prek -a` — all hooks passed
- `prek pyright -a --stage pre-push` — passed

Closes #1674
