### PR TITLE
test: compare enum-typed status fields against enum members instead of string literals

### DIFF
--- a/tests/unit/core/test_command_executor.py
+++ b/tests/unit/core/test_command_executor.py
@@ -10,6 +10,7 @@ from hassette.core.command_executor import CommandExecutor
 from hassette.core.execution_record import ExecutionRecord
 from hassette.exceptions import DependencyError, HassetteError
 from hassette.test_utils.factories import make_invoke_handler_cmd
+from hassette.types.types import ExecutionStatus
 from hassette.utils.execution import ExecutionResult
 
 from .conftest import make_executor
@@ -50,7 +51,7 @@ class TestCommandExecutorSourceTierBranching:
         """App-tier execution: DependencyError produces error_traceback=None."""
         result = await run_execute("app", DependencyError("missing dep"))
 
-        assert result.status == "error"
+        assert result.status is ExecutionStatus.ERROR
         assert result.error_type == "DependencyError"
         # App tier: DependencyError is a known_error → traceback suppressed
         assert result.error_traceback is None
@@ -59,14 +60,14 @@ class TestCommandExecutorSourceTierBranching:
         """App-tier execution: HassetteError produces error_traceback=None."""
         result = await run_execute("app", HassetteError("framework error"))
 
-        assert result.status == "error"
+        assert result.status is ExecutionStatus.ERROR
         assert result.error_traceback is None
 
     async def test_framework_tier_preserves_known_error_traceback(self) -> None:
         """Framework-tier execution: DependencyError preserves traceback."""
         result = await run_execute("framework", DependencyError("framework dep error"))
 
-        assert result.status == "error"
+        assert result.status is ExecutionStatus.ERROR
         assert result.error_type == "DependencyError"
         # Framework tier: no known_errors → traceback preserved
         assert result.error_traceback is not None
@@ -76,7 +77,7 @@ class TestCommandExecutorSourceTierBranching:
         """Framework-tier execution: HassetteError preserves traceback."""
         result = await run_execute("framework", HassetteError("internal framework error"))
 
-        assert result.status == "error"
+        assert result.status is ExecutionStatus.ERROR
         assert result.error_traceback is not None
 
     async def test_unexpected_source_tier_raises(self) -> None:
@@ -97,7 +98,7 @@ class TestCommandExecutorSourceTierBranching:
         """App-tier unknown exceptions (not DependencyError/HassetteError) still get tracebacks."""
         result = await run_execute("app", RuntimeError("unexpected app error"))
 
-        assert result.status == "error"
+        assert result.status is ExecutionStatus.ERROR
         assert result.error_type == "RuntimeError"
         assert result.error_traceback is not None
         assert "RuntimeError" in result.error_traceback

--- a/tests/unit/core/test_execution_timeout.py
+++ b/tests/unit/core/test_execution_timeout.py
@@ -5,6 +5,7 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 from hassette.commands import ExecuteJob, InvokeHandler
+from hassette.types.types import ExecutionStatus
 from hassette.utils.execution import ExecutionResult, track_execution
 
 
@@ -72,7 +73,7 @@ class TestTrackExecutionTimeout:
             async with track_execution() as result:
                 raise TimeoutError("timed out")
 
-        assert result.status == "timed_out"
+        assert result.status is ExecutionStatus.TIMED_OUT
 
 
 class TestExecutionResultIsTimedOut:

--- a/tests/unit/web/test_mappers.py
+++ b/tests/unit/web/test_mappers.py
@@ -59,7 +59,7 @@ def test_instance_response_from_copies_all_fields():
     assert result.index == 2
     assert result.instance_name == "app_a.2"
     assert result.class_name == "MyApp"
-    assert result.status == "running"
+    assert result.status is ResourceStatus.RUNNING
     assert result.error_message == "boom"
     assert result.error_traceback == "tb"
     assert result.owner_id == "owner-1"
@@ -73,7 +73,7 @@ def test_instance_response_from_ignores_source_error_attribute():
     result = instance_response_from(info)
 
     assert not hasattr(result, "error")
-    assert result.status == "failed"
+    assert result.status is ResourceStatus.FAILED
 
 
 def test_listener_summary_fields_are_subset_of_response():


### PR DESCRIPTION
## Summary

Finishes the migration started in #1671: bare string comparisons on **enum-typed** status
fields in the test suite are now identity checks against the enum member, so the suite has
one idiom for this comparison instead of two.

- `tests/unit/core/test_command_executor.py` — 5 assertions on `ExecutionResult.status`
  now use `is ExecutionStatus.ERROR`
- `tests/unit/core/test_execution_timeout.py` — 1 assertion now uses
  `is ExecutionStatus.TIMED_OUT`
- `tests/unit/web/test_mappers.py` — 2 assertions on `AppInstanceResponse.status` now use
  `is ResourceStatus.RUNNING` / `is ResourceStatus.FAILED`

Test-only change; no production code touched. `ExecutionStatus` and `ResourceStatus` are
`StrEnum`s, so runtime behavior is identical — this is purely about consistency, and the
`is` form additionally catches a plain string sneaking into an enum-typed field.

## Scope note: some listed lines were intentionally left alone

The issue listed nine `test_mappers.py` lines; only two were changed. The other seven
(`280`, `313`, `486`, `492`, `501`, `509`, `517`) assert on fields that are **not** enums:

- `SystemStatusResponse.status` and `ReadinessResponse.status` are
  `SystemHealthStatus = Literal["ok", "degraded", "starting"]` (`web/models.py:45`)
- `LivenessResponse.status` is `Literal["live"]` (`web/models.py:96`)

There is no enum member to compare against, so `== "ok"` is the correct idiom there.
Likewise, lines `146`, `181`, and `192` deliberately assert the *string* form to verify
enum→string conversion at the response boundary, and were left as-is.

## Testing

- `uv run nox -s dev` — 7034 passed, 1 skipped, 2 xfailed
- `prek -a` — all hooks pass
- `prek -a --hook-stage pre-push` — all hooks pass, including pyright and the
  schema-freshness check

Closes #1679
