### PR TITLE
test: dedupe literals and setup in handler-health-card tests

### DIFF
--- a/frontend/src/components/app-detail/handler-health-card.test.tsx
+++ b/frontend/src/components/app-detail/handler-health-card.test.tsx
@@ -161,17 +161,19 @@ describe("HandlerHealthCard — avg duration", () => {
   });
 });
 
-it("omits last active when timestamp is null", () => {
-  const item = makeListenerItem({
-    listener_id: 1,
-    last_invoked_at: null,
-    failed: 0,
-    timed_out: 0,
-  });
-  const { container } = renderCard(item);
+describe("HandlerHealthCard — last active", () => {
+  it("omits last active when timestamp is null", () => {
+    const item = makeListenerItem({
+      listener_id: 1,
+      last_invoked_at: null,
+      failed: 0,
+      timed_out: 0,
+    });
+    const { container } = renderCard(item);
 
-  expect(container.textContent).not.toContain("ago");
-  expect(container.textContent).not.toContain("—");
+    expect(container.textContent).not.toContain("ago");
+    expect(container.textContent).not.toContain("—");
+  });
 });
 
 describe("HandlerHealthCard — card click navigation", () => {
@@ -224,15 +226,15 @@ describe("HandlerHealthCard — Enter key navigation", () => {
   });
 });
 
-it("renders handler name as a span, not an anchor", () => {
-  const item = makeListenerItem({ listener_id: 6 });
-  const { container } = renderCard(item);
-
-  expect(container.querySelector("a")).toBeNull();
-  expect(container.textContent).toContain("on_state_change");
-});
-
 describe("HandlerHealthCard — accessibility", () => {
+  it("renders handler name as a span, not an anchor", () => {
+    const item = makeListenerItem({ listener_id: 6 });
+    const { container } = renderCard(item);
+
+    expect(container.querySelector("a")).toBeNull();
+    expect(container.textContent).toContain("on_state_change");
+  });
+
   it("has role=button and aria-label for screen readers", () => {
     const item = makeListenerItem({ listener_id: 1, handler_method: "on_motion" });
     const { getByRole } = renderCard(item);

--- a/frontend/src/components/app-detail/handler-health-card.test.tsx
+++ b/frontend/src/components/app-detail/handler-health-card.test.tsx
@@ -1,5 +1,5 @@
 import userEvent from "@testing-library/user-event";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { createJob, createListener } from "../../test/factories";
 import { createWouterMock } from "../../test/mock-wouter";
@@ -11,6 +11,11 @@ import { buildItems } from "./handler-list";
 const mockNavigate = vi.fn();
 
 vi.mock("wouter", () => createWouterMock({ useLocation: () => ["/", mockNavigate] }));
+
+const APP_KEY = "my_app";
+
+const cardTestId = (kind: "listener" | "job", id: number) => `overview-health-card-${kind}-${id}`;
+const handlerRoute = (kind: "listener" | "job", id: number) => `/apps/${APP_KEY}/handlers/${kind}/${id}`;
 
 function makeListenerItem(overrides: Parameters<typeof createListener>[0] = {}) {
   const listener = createListener({ listener_id: 1, ...overrides });
@@ -26,43 +31,43 @@ function renderCard(item: ReturnType<typeof buildItems>[number], { appKey = "tes
   return renderWithAppState(<HandlerHealthCard item={item} appKey={appKey} instanceQs={instanceQs} tabIndex={0} />);
 }
 
-describe("HandlerHealthCard — healthy listener", () => {
-  it("renders handler name, kind chip, and run count", () => {
-    const item = makeListenerItem({
-      listener_id: 42,
-      handler_method: "on_motion",
-      listener_kind: "state change",
-      total_invocations: 5,
-      failed: 0,
-      timed_out: 0,
-    });
-    const { container, getByText } = renderCard(item);
-
-    expect(container.textContent).toContain("on_motion");
-    expect(getByText("state change")).toBeDefined();
-    expect(container.textContent).toContain("5 calls");
-  });
+beforeEach(() => {
+  mockNavigate.mockClear();
 });
 
-describe("HandlerHealthCard — healthy job", () => {
-  it("renders handler name, kind chip, and run count", () => {
-    const item = makeJobItem({
-      job_id: 7,
-      job_name: "my_task",
-      trigger_type: "interval",
-      total_executions: 3,
-      failed: 0,
-      timed_out: 0,
-    });
-    const { container, getByText } = renderCard(item);
-
-    expect(container.textContent).toContain("my_task");
-    expect(getByText("interval")).toBeDefined();
-    expect(container.textContent).toContain("3 runs");
+it("renders listener name, kind chip, and run count", () => {
+  const item = makeListenerItem({
+    listener_id: 42,
+    handler_method: "on_motion",
+    listener_kind: "state change",
+    total_invocations: 5,
+    failed: 0,
+    timed_out: 0,
   });
+  const { container, getByText } = renderCard(item);
+
+  expect(container.textContent).toContain("on_motion");
+  expect(getByText("state change")).toBeDefined();
+  expect(container.textContent).toContain("5 calls");
 });
 
-describe("HandlerHealthCard — failing handler", () => {
+it("renders job name, kind chip, and run count", () => {
+  const item = makeJobItem({
+    job_id: 7,
+    job_name: "my_task",
+    trigger_type: "interval",
+    total_executions: 3,
+    failed: 0,
+    timed_out: 0,
+  });
+  const { container, getByText } = renderCard(item);
+
+  expect(container.textContent).toContain("my_task");
+  expect(getByText("interval")).toBeDefined();
+  expect(container.textContent).toContain("3 runs");
+});
+
+describe("HandlerHealthCard — error display", () => {
   it("shows error type and error message when handler is failing", () => {
     const item = makeListenerItem({
       listener_id: 1,
@@ -75,9 +80,7 @@ describe("HandlerHealthCard — failing handler", () => {
     expect(container.textContent).toContain("KeyError");
     expect(container.textContent).toContain("missing key 'state'");
   });
-});
 
-describe("HandlerHealthCard — timed out handler", () => {
   it("shows 'timed out' when handler has timeouts but no error type", () => {
     const item = makeListenerItem({
       listener_id: 1,
@@ -90,9 +93,7 @@ describe("HandlerHealthCard — timed out handler", () => {
 
     expect(container.textContent).toContain("timed out");
   });
-});
 
-describe("HandlerHealthCard — no errors shown for healthy handler", () => {
   it("does not show error type or error message when handler is healthy", () => {
     const item = makeListenerItem({
       listener_id: 1,
@@ -103,13 +104,10 @@ describe("HandlerHealthCard — no errors shown for healthy handler", () => {
     });
     const { container } = renderCard(item);
 
-    // No error content should appear
     expect(container.textContent).not.toContain("KeyError");
     expect(container.textContent).not.toContain("missing key");
   });
-});
 
-describe("HandlerHealthCard — error rate shown when failed > 0", () => {
   it("shows error rate when there are failures", () => {
     const item = makeListenerItem({
       listener_id: 1,
@@ -123,9 +121,7 @@ describe("HandlerHealthCard — error rate shown when failed > 0", () => {
     // 2/10 = 20%
     expect(container.textContent).toContain("20%");
   });
-});
 
-describe("HandlerHealthCard — error rate omitted when failed is 0", () => {
   it("does not show error rate when failed is 0", () => {
     const item = makeListenerItem({
       listener_id: 1,
@@ -162,83 +158,75 @@ describe("HandlerHealthCard — avg duration", () => {
   });
 });
 
-describe("HandlerHealthCard — last active when null", () => {
-  it("omits last active when timestamp is null", () => {
-    const item = makeListenerItem({
-      listener_id: 1,
-      last_invoked_at: null,
-      failed: 0,
-      timed_out: 0,
-    });
-    const { container } = renderCard(item);
-
-    expect(container.textContent).not.toContain("ago");
-    expect(container.textContent).not.toContain("—");
+it("omits last active when timestamp is null", () => {
+  const item = makeListenerItem({
+    listener_id: 1,
+    last_invoked_at: null,
+    failed: 0,
+    timed_out: 0,
   });
+  const { container } = renderCard(item);
+
+  expect(container.textContent).not.toContain("ago");
+  expect(container.textContent).not.toContain("—");
 });
 
 describe("HandlerHealthCard — card click navigation", () => {
   it("navigates to handler detail page when card is clicked", async () => {
     const user = userEvent.setup();
-    mockNavigate.mockClear();
     const item = makeListenerItem({ listener_id: 4 });
-    const { getByTestId } = renderCard(item, { appKey: "my_app" });
+    const { getByTestId } = renderCard(item, { appKey: APP_KEY });
 
-    const card = getByTestId("overview-health-card-listener-4");
+    const card = getByTestId(cardTestId("listener", 4));
     await user.click(card);
 
-    expect(mockNavigate).toHaveBeenCalledWith("/apps/my_app/handlers/listener/4");
+    expect(mockNavigate).toHaveBeenCalledWith(handlerRoute("listener", 4));
   });
 
   it("navigates to job handler detail page when job card is clicked", async () => {
     const user = userEvent.setup();
-    mockNavigate.mockClear();
     const item = makeJobItem({ job_id: 9 });
-    const { getByTestId } = renderCard(item, { appKey: "my_app" });
+    const { getByTestId } = renderCard(item, { appKey: APP_KEY });
 
-    const card = getByTestId("overview-health-card-job-9");
+    const card = getByTestId(cardTestId("job", 9));
     await user.click(card);
 
-    expect(mockNavigate).toHaveBeenCalledWith("/apps/my_app/handlers/job/9");
+    expect(mockNavigate).toHaveBeenCalledWith(handlerRoute("job", 9));
   });
 });
 
 describe("HandlerHealthCard — Enter key navigation", () => {
   it("navigates when Enter key is pressed on the card", async () => {
     const user = userEvent.setup();
-    mockNavigate.mockClear();
     const item = makeListenerItem({ listener_id: 5 });
-    const { getByTestId } = renderCard(item, { appKey: "my_app" });
+    const { getByTestId } = renderCard(item, { appKey: APP_KEY });
 
-    const card = getByTestId("overview-health-card-listener-5");
+    const card = getByTestId(cardTestId("listener", 5));
     card.focus();
     await user.keyboard("{Enter}");
 
-    expect(mockNavigate).toHaveBeenCalledWith("/apps/my_app/handlers/listener/5");
+    expect(mockNavigate).toHaveBeenCalledWith(handlerRoute("listener", 5));
   });
 
   it("navigates when Space key is pressed on the card", async () => {
     const user = userEvent.setup();
-    mockNavigate.mockClear();
     const item = makeListenerItem({ listener_id: 5 });
-    const { getByTestId } = renderCard(item, { appKey: "my_app" });
+    const { getByTestId } = renderCard(item, { appKey: APP_KEY });
 
-    const card = getByTestId("overview-health-card-listener-5");
+    const card = getByTestId(cardTestId("listener", 5));
     card.focus();
     await user.keyboard("{ }");
 
-    expect(mockNavigate).toHaveBeenCalledWith("/apps/my_app/handlers/listener/5");
+    expect(mockNavigate).toHaveBeenCalledWith(handlerRoute("listener", 5));
   });
 });
 
-describe("HandlerHealthCard — name is not a link", () => {
-  it("renders handler name as a span, not an anchor", () => {
-    const item = makeListenerItem({ listener_id: 6 });
-    const { container } = renderCard(item);
+it("renders handler name as a span, not an anchor", () => {
+  const item = makeListenerItem({ listener_id: 6 });
+  const { container } = renderCard(item);
 
-    expect(container.querySelector("a")).toBeNull();
-    expect(container.textContent).toContain("on_state_change");
-  });
+  expect(container.querySelector("a")).toBeNull();
+  expect(container.textContent).toContain("on_state_change");
 });
 
 describe("HandlerHealthCard — accessibility", () => {
@@ -254,13 +242,13 @@ describe("HandlerHealthCard — accessibility", () => {
     const { getByTestId } = renderWithAppState(
       <HandlerHealthCard item={item} appKey="test_app" instanceQs="" tabIndex={-1} />,
     );
-    expect(getByTestId("overview-health-card-listener-1").getAttribute("tabindex")).toBe("-1");
+    expect(getByTestId(cardTestId("listener", 1)).getAttribute("tabindex")).toBe("-1");
   });
 
   it("includes a visible focus outline utility", () => {
     const item = makeListenerItem({ listener_id: 1 });
     const { getByTestId } = renderCard(item);
-    const card = getByTestId("overview-health-card-listener-1");
+    const card = getByTestId(cardTestId("listener", 1));
     expect(card.className).toContain("focus-visible:outline-solid");
     expect(card.className).toContain("focus-visible:outline-primary");
   });
@@ -268,7 +256,7 @@ describe("HandlerHealthCard — accessibility", () => {
   it("has data-roving-item attribute", () => {
     const item = makeListenerItem({ listener_id: 1 });
     const { getByTestId } = renderCard(item);
-    expect(getByTestId("overview-health-card-listener-1").hasAttribute("data-roving-item")).toBe(true);
+    expect(getByTestId(cardTestId("listener", 1)).hasAttribute("data-roving-item")).toBe(true);
   });
 });
 
@@ -276,12 +264,12 @@ describe("HandlerHealthCard — data-testid", () => {
   it("includes kind and id in data-testid for listener", () => {
     const item = makeListenerItem({ listener_id: 99 });
     const { getByTestId } = renderCard(item);
-    expect(getByTestId("overview-health-card-listener-99")).toBeDefined();
+    expect(getByTestId(cardTestId("listener", 99))).toBeDefined();
   });
 
   it("includes kind and id in data-testid for job", () => {
     const item = makeJobItem({ job_id: 77 });
     const { getByTestId } = renderCard(item);
-    expect(getByTestId("overview-health-card-job-77")).toBeDefined();
+    expect(getByTestId(cardTestId("job", 77))).toBeDefined();
   });
 });

--- a/frontend/src/components/app-detail/handler-health-card.test.tsx
+++ b/frontend/src/components/app-detail/handler-health-card.test.tsx
@@ -4,6 +4,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { createJob, createListener } from "../../test/factories";
 import { createWouterMock } from "../../test/mock-wouter";
 import { renderWithAppState } from "../../test/render-helpers";
+import type { HandlerKind } from "../../utils/app-routes";
 import { HandlerHealthCard } from "./handler-health-card";
 import { buildItems } from "./handler-list";
 
@@ -14,8 +15,8 @@ vi.mock("wouter", () => createWouterMock({ useLocation: () => ["/", mockNavigate
 
 const APP_KEY = "my_app";
 
-const cardTestId = (kind: "listener" | "job", id: number) => `overview-health-card-${kind}-${id}`;
-const handlerRoute = (kind: "listener" | "job", id: number) => `/apps/${APP_KEY}/handlers/${kind}/${id}`;
+const cardTestId = (kind: HandlerKind, id: number) => `overview-health-card-${kind}-${id}`;
+const handlerRoute = (kind: HandlerKind, id: number) => `/apps/${APP_KEY}/handlers/${kind}/${id}`;
 
 function makeListenerItem(overrides: Parameters<typeof createListener>[0] = {}) {
   const listener = createListener({ listener_id: 1, ...overrides });
@@ -27,7 +28,7 @@ function makeJobItem(overrides: Parameters<typeof createJob>[0] = {}) {
   return buildItems([], [job])[0];
 }
 
-function renderCard(item: ReturnType<typeof buildItems>[number], { appKey = "test_app", instanceQs = "" } = {}) {
+function renderCard(item: ReturnType<typeof buildItems>[number], { appKey = APP_KEY, instanceQs = "" } = {}) {
   return renderWithAppState(<HandlerHealthCard item={item} appKey={appKey} instanceQs={instanceQs} tabIndex={0} />);
 }
 
@@ -35,36 +36,38 @@ beforeEach(() => {
   mockNavigate.mockClear();
 });
 
-it("renders listener name, kind chip, and run count", () => {
-  const item = makeListenerItem({
-    listener_id: 42,
-    handler_method: "on_motion",
-    listener_kind: "state change",
-    total_invocations: 5,
-    failed: 0,
-    timed_out: 0,
+describe("HandlerHealthCard — name, kind chip, and run count", () => {
+  it("renders listener name, kind chip, and run count", () => {
+    const item = makeListenerItem({
+      listener_id: 42,
+      handler_method: "on_motion",
+      listener_kind: "state change",
+      total_invocations: 5,
+      failed: 0,
+      timed_out: 0,
+    });
+    const { container, getByText } = renderCard(item);
+
+    expect(container.textContent).toContain("on_motion");
+    expect(getByText("state change")).toBeDefined();
+    expect(container.textContent).toContain("5 calls");
   });
-  const { container, getByText } = renderCard(item);
 
-  expect(container.textContent).toContain("on_motion");
-  expect(getByText("state change")).toBeDefined();
-  expect(container.textContent).toContain("5 calls");
-});
+  it("renders job name, kind chip, and run count", () => {
+    const item = makeJobItem({
+      job_id: 7,
+      job_name: "my_task",
+      trigger_type: "interval",
+      total_executions: 3,
+      failed: 0,
+      timed_out: 0,
+    });
+    const { container, getByText } = renderCard(item);
 
-it("renders job name, kind chip, and run count", () => {
-  const item = makeJobItem({
-    job_id: 7,
-    job_name: "my_task",
-    trigger_type: "interval",
-    total_executions: 3,
-    failed: 0,
-    timed_out: 0,
+    expect(container.textContent).toContain("my_task");
+    expect(getByText("interval")).toBeDefined();
+    expect(container.textContent).toContain("3 runs");
   });
-  const { container, getByText } = renderCard(item);
-
-  expect(container.textContent).toContain("my_task");
-  expect(getByText("interval")).toBeDefined();
-  expect(container.textContent).toContain("3 runs");
 });
 
 describe("HandlerHealthCard — error display", () => {
@@ -240,7 +243,7 @@ describe("HandlerHealthCard — accessibility", () => {
   it("renders the provided tabIndex", () => {
     const item = makeListenerItem({ listener_id: 1 });
     const { getByTestId } = renderWithAppState(
-      <HandlerHealthCard item={item} appKey="test_app" instanceQs="" tabIndex={-1} />,
+      <HandlerHealthCard item={item} appKey={APP_KEY} instanceQs="" tabIndex={-1} />,
     );
     expect(getByTestId(cardTestId("listener", 1)).getAttribute("tabindex")).toBe("-1");
   });


### PR DESCRIPTION
## Summary

Removes repeated string literals and duplicated setup from `handler-health-card.test.tsx`. Test-only change — no production code touched, no behavior change.

The riskiest item was the hand-typed route strings. A typo in a `getByTestId` string fails loudly, but a typo in a `toHaveBeenCalledWith` route string silently asserts against a URL the component never produces, and since the ids differ per test there was no cross-check to catch it.

## What changed

**Shared helpers replace hand-typed literals.** The `overview-health-card-<kind>-<id>` test-id pattern was typed out in 9 places and the `/apps/<appKey>/handlers/<kind>/<id>` route reconstructed by hand in 4 more. Both now come from `cardTestId()` and `handlerRoute()`, with `"my_app"` hoisted to a single `APP_KEY` constant.

**`mockNavigate.mockClear()` moved into a `beforeEach`.** It was repeated verbatim in four navigation tests. It is genuinely required — `clearMocks` is not enabled in `vitest.config.ts` — so it was hoisted rather than deleted.

**Eight single-`it` `describe` wrappers collapsed.** Each restated its one test's name, so the nesting layer grouped nothing. Four became top-level `it()` calls; the five error-related ones merged into a single `HandlerHealthCard — error display` group. The six genuinely multi-test describes are untouched.

Two tests were renamed as a consequence: both listener and job variants were named `"renders handler name, kind chip, and run count"` and relied on their now-removed `describe` wrappers to tell them apart. They are now `"renders listener name..."` and `"renders job name..."`.

**Deleted a comment** that restated the two `not.toContain` assertions below it.

## Testing

- `npx vitest run src/components/app-detail/handler-health-card.test.tsx` — 21 passed
- Full frontend suite — 108 files, 1555 tests passed
- `uv run nox -s dev` — 7034 passed, 1 skipped, 2 xfailed
- `prek -a` — all hooks passed; `prek pyright -a --stage pre-push` — passed

Test count is unchanged at 21, and a diff of the extracted `it()` names against `main` shows the two renames above as the only difference, so coverage is intact.

Closes #1701
