### PR TITLE
fix: keep non-active handler health cards out of the tab order

### DIFF
--- a/frontend/src/components/app-detail/handler-health-card.test.tsx
+++ b/frontend/src/components/app-detail/handler-health-card.test.tsx
@@ -257,6 +257,46 @@ describe("HandlerHealthCard — accessibility", () => {
     expect(getByTestId("overview-health-card-listener-1").getAttribute("tabindex")).toBe("-1");
   });
 
+  it("gives tooltip triggers the card's tabIndex so a non-active card adds no tab stops", () => {
+    const item = makeListenerItem({
+      listener_id: 1,
+      total_invocations: 10,
+      failed: 3,
+      avg_duration_ms: 12,
+      last_invoked_at: 1767225600,
+      last_error_message: "boom",
+      last_error_type: "ValueError",
+    });
+    const { getByTestId } = renderWithAppState(
+      <HandlerHealthCard item={item} appKey="test_app" instanceQs="" tabIndex={-1} />,
+    );
+    const card = getByTestId("overview-health-card-listener-1");
+    const inner = Array.from(card.querySelectorAll("[tabindex]"));
+
+    expect(inner.length).toBeGreaterThan(1);
+    for (const el of inner) {
+      expect(el.getAttribute("tabindex")).toBe("-1");
+    }
+  });
+
+  it("keeps tooltip triggers tab-reachable on the active card", () => {
+    const item = makeListenerItem({
+      listener_id: 1,
+      total_invocations: 10,
+      failed: 3,
+      avg_duration_ms: 12,
+      last_invoked_at: 1767225600,
+    });
+    const { getByTestId } = renderCard(item);
+    const card = getByTestId("overview-health-card-listener-1");
+    const inner = Array.from(card.querySelectorAll("[tabindex]"));
+
+    expect(inner.length).toBeGreaterThan(1);
+    for (const el of inner) {
+      expect(el.getAttribute("tabindex")).toBe("0");
+    }
+  });
+
   it("includes a visible focus outline utility", () => {
     const item = makeListenerItem({ listener_id: 1 });
     const { getByTestId } = renderCard(item);

--- a/frontend/src/components/app-detail/handler-health-card.tsx
+++ b/frontend/src/components/app-detail/handler-health-card.tsx
@@ -21,14 +21,14 @@ import {
 } from "./overview-tab-helpers";
 import type { UnifiedItem } from "./unified-handler-row";
 
+const STAT_ROW_CLASS = "flex gap-3 font-mono text-[length:var(--text-mono-sm)] text-muted-foreground";
+
 interface HandlerHealthCardProps {
   item: UnifiedItem;
   appKey: string;
   instanceQs: string;
   tabIndex: 0 | -1;
 }
-
-const STAT_ROW_CLASS = "flex gap-3 font-mono text-[length:var(--text-mono-sm)] text-muted-foreground";
 
 interface StatTooltipProps {
   label: string;

--- a/frontend/src/components/app-detail/handler-health-card.tsx
+++ b/frontend/src/components/app-detail/handler-health-card.tsx
@@ -28,11 +28,24 @@ interface HandlerHealthCardProps {
   tabIndex: 0 | -1;
 }
 
-function StatTooltip({ label, className, children }: { label: string; className?: string; children: ReactNode }) {
+const STAT_ROW_CLASS = "flex gap-3 font-mono text-[length:var(--text-mono-sm)] text-muted-foreground";
+
+interface StatTooltipProps {
+  label: string;
+  className?: string;
+  /**
+   * Mirrors the owning card's roving tabindex so a non-active card contributes no tab stops
+   * of its own, while the active card keeps its tooltips keyboard-reachable.
+   */
+  tabIndex: 0 | -1;
+  children: ReactNode;
+}
+
+function StatTooltip({ label, className, tabIndex, children }: StatTooltipProps) {
   return (
     <Tooltip>
       <TooltipTrigger asChild>
-        <span className={className} tabIndex={0}>
+        <span className={className} tabIndex={tabIndex}>
           {children}
         </span>
       </TooltipTrigger>
@@ -53,7 +66,7 @@ export function HandlerHealthCard({ item, appKey, instanceQs, tabIndex }: Handle
   const avgDuration = item.data.avg_duration_ms ?? null;
   const lastActiveAt = itemLastActiveAt(item);
   const lastActiveDisplay = useRelativeTime(lastActiveAt);
-  const failed = item.data.failed;
+  const failedCount = item.data.failed;
 
   const navigateToHandler = () => navigate(href);
 
@@ -98,31 +111,31 @@ export function HandlerHealthCard({ item, appKey, instanceQs, tabIndex }: Handle
         </div>
 
         {errorMessage && (
-          <StatTooltip label={errorMessage}>
+          <StatTooltip label={errorMessage} tabIndex={tabIndex}>
             <span className="block max-w-full truncate text-sm text-muted-foreground">{errorMessage}</span>
           </StatTooltip>
         )}
 
         <div className="flex flex-col gap-1">
-          <div className="flex gap-3 font-mono text-[length:var(--text-mono-sm)] text-muted-foreground">
-            <StatTooltip label={`total ${callLabel}s`}>
+          <div className={STAT_ROW_CLASS}>
+            <StatTooltip label={`total ${callLabel}s`} tabIndex={tabIndex}>
               <span>{pluralize(runCount, callLabel)}</span>
             </StatTooltip>
             {avgDuration !== null && avgDuration > 0 && (
-              <StatTooltip label="avg duration" className="ml-auto">
+              <StatTooltip label="avg duration" className="ml-auto" tabIndex={tabIndex}>
                 <span>{formatDuration(avgDuration)}</span>
               </StatTooltip>
             )}
           </div>
-          {(failed > 0 || lastActiveAt !== null) && (
-            <div className="flex gap-3 font-mono text-[length:var(--text-mono-sm)] text-muted-foreground">
-              {failed > 0 && (
-                <StatTooltip label="error rate">
-                  <span>{formatRate(failed, runCount)}</span>
+          {(failedCount > 0 || lastActiveAt !== null) && (
+            <div className={STAT_ROW_CLASS}>
+              {failedCount > 0 && (
+                <StatTooltip label="error rate" tabIndex={tabIndex}>
+                  <span>{formatRate(failedCount, runCount)}</span>
                 </StatTooltip>
               )}
               {lastActiveAt !== null && (
-                <StatTooltip label="last active" className="ml-auto">
+                <StatTooltip label="last active" className="ml-auto" tabIndex={tabIndex}>
                   <span>{lastActiveDisplay}</span>
                 </StatTooltip>
               )}


### PR DESCRIPTION
## Summary

`HandlerHealthCard` participates in a roving tabindex (via `useRovingTabIndex` and the `tabIndex: 0 | -1` prop), so exactly one card in the grid should be tab-reachable. But its inner `StatTooltip` triggers hardcoded `tabIndex={0}`, so every tooltip in every card was an unconditional tab stop. A grid of N cards produced roughly 4N tab stops instead of N, and a card explicitly marked `tabIndex={-1}` still contained focusable descendants.

This threads the card's `tabIndex` through to `StatTooltip` at all five call sites. A non-active card now contributes no tab stops of its own; the active card keeps its tooltip triggers keyboard-reachable so the tooltip content is still available without a mouse.

Also picks up the two hygiene findings filed alongside it in #1709:

- Hoisted the byte-identical stat-row class string (duplicated across the two stat rows) into a module-level `STAT_ROW_CLASS` constant, so a restyle can't drift the two rows apart.
- Renamed `failed` to `failedCount`. It holds a number but sat two lines below `failing`, an actual boolean — two near-identical names with different types invited a misread.

## Testing

- Two new tests in `handler-health-card.test.tsx`: one asserts every `[tabindex]` element inside a `tabIndex={-1}` card is `-1`, the other asserts they are all `0` on the active card. The existing coverage only checked the card element's own tabindex, which is why this gap went unnoticed.
- `uv run nox -s dev` — 7034 passed, 1 skipped, 2 xfailed.
- `npx vitest run src/components/app-detail/handler-health-card.test.tsx` — 23 passed.
- `prek -a` and `prek -a --hook-stage pre-push` (includes pyright, tsc, eslint) — all hooks pass.

No visual change: the diff only alters `tabindex` attribute values and refactors a class string into a constant with an identical value.

Closes #1709
