### PR TITLE
test: dedupe render props and card selectors in handler-health-grid tests

### DIFF
--- a/frontend/src/components/app-detail/handler-health-card.test.tsx
+++ b/frontend/src/components/app-detail/handler-health-card.test.tsx
@@ -5,6 +5,7 @@ import { createJob, createListener } from "../../test/factories";
 import { createWouterMock } from "../../test/mock-wouter";
 import { renderWithAppState } from "../../test/render-helpers";
 import type { HandlerKind } from "../../utils/app-routes";
+import { cardTestId } from "./handler-health.test-helpers";
 import { HandlerHealthCard } from "./handler-health-card";
 import { buildItems } from "./handler-list";
 
@@ -15,7 +16,6 @@ vi.mock("wouter", () => createWouterMock({ useLocation: () => ["/", mockNavigate
 
 const APP_KEY = "my_app";
 
-const cardTestId = (kind: HandlerKind, id: number) => `overview-health-card-${kind}-${id}`;
 const handlerRoute = (kind: HandlerKind, id: number) => `/apps/${APP_KEY}/handlers/${kind}/${id}`;
 
 function makeListenerItem(overrides: Parameters<typeof createListener>[0] = {}) {

--- a/frontend/src/components/app-detail/handler-health-grid.test.tsx
+++ b/frontend/src/components/app-detail/handler-health-grid.test.tsx
@@ -6,6 +6,7 @@ import { createWouterMock } from "../../test/mock-wouter";
 import { renderWithAppState } from "../../test/render-helpers";
 import { HandlerHealthGrid } from "./handler-health-grid";
 import { buildItems } from "./handler-list";
+import type { UnifiedItem } from "./unified-handler-row";
 
 vi.mock("wouter", () =>
   createWouterMock({
@@ -13,6 +14,22 @@ vi.mock("wouter", () =>
     useSearch: () => "",
   }),
 );
+
+const CARD_TESTID_PREFIX = "overview-health-card-";
+const CARD_SELECTOR = `[data-testid^='${CARD_TESTID_PREFIX}']`;
+const DEFAULT_GRID_PROPS = { appKey: "test_app", instanceQs: "" };
+
+function cardTestId(kind: UnifiedItem["kind"], id: number) {
+  return `${CARD_TESTID_PREFIX}${kind}-${id}`;
+}
+
+function renderGrid(items: UnifiedItem[], overrides: Partial<typeof DEFAULT_GRID_PROPS> = {}) {
+  return render(<HandlerHealthGrid items={items} {...DEFAULT_GRID_PROPS} {...overrides} />);
+}
+
+function renderGridWithAppState(items: UnifiedItem[], overrides: Partial<typeof DEFAULT_GRID_PROPS> = {}) {
+  return renderWithAppState(<HandlerHealthGrid items={items} {...DEFAULT_GRID_PROPS} {...overrides} />);
+}
 
 function makeListenerItem(overrides: Parameters<typeof createListener>[0] = {}) {
   const listener = createListener({ listener_id: 1, total_invocations: 1, ...overrides });
@@ -26,38 +43,38 @@ function makeJobItem(overrides: Parameters<typeof createJob>[0] = {}) {
 
 describe("HandlerHealthGrid — empty state", () => {
   it("renders the section wrapper with testid even when empty", () => {
-    const { getByTestId } = render(<HandlerHealthGrid items={[]} appKey="test_app" instanceQs="" />);
+    const { getByTestId } = renderGrid([]);
     expect(getByTestId("overview-health-grid")).toBeDefined();
   });
 
   it("renders EmptyState with testid when no items", () => {
-    const { getByTestId } = render(<HandlerHealthGrid items={[]} appKey="test_app" instanceQs="" />);
+    const { getByTestId } = renderGrid([]);
     expect(getByTestId("overview-health-empty")).toBeDefined();
   });
 
   it("does not render cards when items are empty", () => {
-    const { container } = render(<HandlerHealthGrid items={[]} appKey="test_app" instanceQs="" />);
-    expect(container.querySelectorAll("[data-testid^='overview-health-card-']")).toHaveLength(0);
+    const { container } = renderGrid([]);
+    expect(container.querySelectorAll(CARD_SELECTOR)).toHaveLength(0);
   });
 });
 
 describe("HandlerHealthGrid — with items", () => {
   it("renders a card per item", () => {
     const items = [makeListenerItem({ listener_id: 1 }), makeJobItem({ job_id: 2 })];
-    const { getByTestId } = renderWithAppState(<HandlerHealthGrid items={items} appKey="test_app" instanceQs="" />);
-    expect(getByTestId("overview-health-card-listener-1")).toBeDefined();
-    expect(getByTestId("overview-health-card-job-2")).toBeDefined();
+    const { getByTestId } = renderGridWithAppState(items);
+    expect(getByTestId(cardTestId("listener", 1))).toBeDefined();
+    expect(getByTestId(cardTestId("job", 2))).toBeDefined();
   });
 
   it("does not render EmptyState when items are present", () => {
     const items = [makeListenerItem({ listener_id: 1 })];
-    const { queryByTestId } = renderWithAppState(<HandlerHealthGrid items={items} appKey="test_app" instanceQs="" />);
+    const { queryByTestId } = renderGridWithAppState(items);
     expect(queryByTestId("overview-health-empty")).toBeNull();
   });
 
   it("renders the section heading", () => {
     const items = [makeListenerItem({ listener_id: 1 })];
-    const { container } = renderWithAppState(<HandlerHealthGrid items={items} appKey="test_app" instanceQs="" />);
+    const { container } = renderGridWithAppState(items);
     const heading = container.querySelector("h3");
     expect(heading?.textContent?.toLowerCase()).toContain("handler health");
   });
@@ -69,10 +86,10 @@ describe("HandlerHealthGrid — sorting (failing first)", () => {
       makeListenerItem({ listener_id: 1, failed: 0, timed_out: 0, handler_summary: "on_healthy()" }),
       makeListenerItem({ listener_id: 2, failed: 2, total_invocations: 5, handler_summary: "on_broken()" }),
     ];
-    const { container } = renderWithAppState(<HandlerHealthGrid items={items} appKey="test_app" instanceQs="" />);
-    const cards = container.querySelectorAll("[data-testid^='overview-health-card-']");
-    expect(cards[0].getAttribute("data-testid")).toBe("overview-health-card-listener-2");
-    expect(cards[1].getAttribute("data-testid")).toBe("overview-health-card-listener-1");
+    const { container } = renderGridWithAppState(items);
+    const cards = container.querySelectorAll(CARD_SELECTOR);
+    expect(cards[0].getAttribute("data-testid")).toBe(cardTestId("listener", 2));
+    expect(cards[1].getAttribute("data-testid")).toBe(cardTestId("listener", 1));
   });
 });
 
@@ -83,10 +100,8 @@ describe("HandlerHealthGrid — passes props to cards", () => {
       makeJobItem({ job_id: 7 }),
       makeListenerItem({ listener_id: 5 }),
     ];
-    const { container } = renderWithAppState(
-      <HandlerHealthGrid items={items} appKey="test_app" instanceQs="?instance=1" />,
-    );
-    const cards = container.querySelectorAll("[data-testid^='overview-health-card-']");
+    const { container } = renderGridWithAppState(items, { instanceQs: "?instance=1" });
+    const cards = container.querySelectorAll(CARD_SELECTOR);
     expect(cards).toHaveLength(3);
   });
 });

--- a/frontend/src/components/app-detail/handler-health-grid.test.tsx
+++ b/frontend/src/components/app-detail/handler-health-grid.test.tsx
@@ -4,6 +4,7 @@ import { describe, expect, it, vi } from "vitest";
 import { createJob, createListener } from "../../test/factories";
 import { createWouterMock } from "../../test/mock-wouter";
 import { renderWithAppState } from "../../test/render-helpers";
+import { CARD_SELECTOR, cardTestId } from "./handler-health.test-helpers";
 import { HandlerHealthGrid } from "./handler-health-grid";
 import { buildItems } from "./handler-list";
 import type { UnifiedItem } from "./unified-handler-row";
@@ -15,13 +16,7 @@ vi.mock("wouter", () =>
   }),
 );
 
-const CARD_TESTID_PREFIX = "overview-health-card-";
-const CARD_SELECTOR = `[data-testid^='${CARD_TESTID_PREFIX}']`;
 const DEFAULT_GRID_PROPS = { appKey: "test_app", instanceQs: "" };
-
-function cardTestId(kind: UnifiedItem["kind"], id: number) {
-  return `${CARD_TESTID_PREFIX}${kind}-${id}`;
-}
 
 function renderGrid(items: UnifiedItem[], overrides: Partial<typeof DEFAULT_GRID_PROPS> = {}) {
   return render(<HandlerHealthGrid items={items} {...DEFAULT_GRID_PROPS} {...overrides} />);

--- a/frontend/src/components/app-detail/handler-health.test-helpers.ts
+++ b/frontend/src/components/app-detail/handler-health.test-helpers.ts
@@ -1,0 +1,8 @@
+import type { HandlerKind } from "../../utils/app-routes";
+
+export const CARD_TESTID_PREFIX = "overview-health-card-";
+export const CARD_SELECTOR = `[data-testid^='${CARD_TESTID_PREFIX}']`;
+
+export function cardTestId(kind: HandlerKind, id: number) {
+  return `${CARD_TESTID_PREFIX}${kind}-${id}`;
+}


### PR DESCRIPTION
## Summary

Cleans up mechanical duplication in `handler-health-grid.test.tsx`:

- Adds a `renderGrid` / `renderGridWithAppState` helper pair that supplies the default
  `appKey`/`instanceQs` props (preserving the existing `render` vs `renderWithAppState`
  split), so each test only states what actually varies.
- Adds a `CARD_SELECTOR` constant and `cardTestId(kind, id)` helper to replace five
  inline spellings of the `overview-health-card-` test-id prefix.

Pure test-hygiene refactor — no assertions or test behavior changed.

## Testing

- `cd frontend && npx vitest run src/components/app-detail/handler-health-grid.test.tsx` — 8 passed
- `uv run nox -s dev` — 7034 passed, 1 skipped, 2 xfailed
- `prek -a` — all hooks passed
- `prek pyright -a --stage pre-push` — passed

Closes #1727
