### PR TITLE
test: cover exception toggle and unknown boot-issue severity in diagnostics UI

### DIFF
--- a/frontend/src/components/diagnostics/boot-issues-panel.test.tsx
+++ b/frontend/src/components/diagnostics/boot-issues-panel.test.tsx
@@ -8,13 +8,18 @@ describe("BootIssuesPanel", () => {
   it("sorts an unrecognized severity after the known err/warn/info order", () => {
     const issues: BootIssue[] = [
       { severity: "warn", label: "Config warning", detail: "check your config" },
-      { severity: "unrecognized" as BootIssue["severity"], label: "Mystery issue", detail: "no known severity" },
+      // @ts-expect-error intentionally invalid severity to exercise the unknown-severity sort fallback
+      { severity: "unrecognized", label: "Mystery issue", detail: "no known severity" },
       { severity: "err", label: "Critical error", detail: "failed to load something" },
+      // @ts-expect-error "info" is not part of the BootIssueResponse schema but the panel's
+      // SEVERITY_ORDER handles it defensively — exercise that fallback tier explicitly
+      { severity: "info", label: "Informational issue", detail: "additional information" },
     ];
     const { getByTestId } = render(<BootIssuesPanel bootIssues={issues} />);
 
     expect(getByTestId("diag-boot-label-0").textContent).toBe("Critical error");
     expect(getByTestId("diag-boot-label-1").textContent).toBe("Config warning");
-    expect(getByTestId("diag-boot-label-2").textContent).toBe("Mystery issue");
+    expect(getByTestId("diag-boot-label-2").textContent).toBe("Informational issue");
+    expect(getByTestId("diag-boot-label-3").textContent).toBe("Mystery issue");
   });
 });

--- a/frontend/src/components/diagnostics/boot-issues-panel.test.tsx
+++ b/frontend/src/components/diagnostics/boot-issues-panel.test.tsx
@@ -1,0 +1,20 @@
+import { render } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import type { BootIssue } from "../../api/endpoints";
+import { BootIssuesPanel } from "./boot-issues-panel";
+
+describe("BootIssuesPanel", () => {
+  it("sorts an unrecognized severity after the known err/warn/info order", () => {
+    const issues: BootIssue[] = [
+      { severity: "warn", label: "Config warning", detail: "check your config" },
+      { severity: "unrecognized" as BootIssue["severity"], label: "Mystery issue", detail: "no known severity" },
+      { severity: "err", label: "Critical error", detail: "failed to load something" },
+    ];
+    const { getByTestId } = render(<BootIssuesPanel bootIssues={issues} />);
+
+    expect(getByTestId("diag-boot-label-0").textContent).toBe("Critical error");
+    expect(getByTestId("diag-boot-label-1").textContent).toBe("Config warning");
+    expect(getByTestId("diag-boot-label-2").textContent).toBe("Mystery issue");
+  });
+});

--- a/frontend/src/components/diagnostics/service-row.test.tsx
+++ b/frontend/src/components/diagnostics/service-row.test.tsx
@@ -39,6 +39,6 @@ describe("ServiceRow", () => {
 
     await user.click(getByRole("button", { name: /hide exception/i }));
     expect(queryByText(exception)).toBeNull();
-    expect(getByRole("button", { name: /show exception/i })).toBeDefined();
+    expect(getByRole("button", { name: /show exception/i }).getAttribute("aria-expanded")).toBe("false");
   });
 });

--- a/frontend/src/components/diagnostics/service-row.test.tsx
+++ b/frontend/src/components/diagnostics/service-row.test.tsx
@@ -1,0 +1,44 @@
+import { render } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it } from "vitest";
+
+import type { MergedService } from "./merge-services";
+import { ServiceRow } from "./service-row";
+
+function makeService(overrides: Partial<MergedService> = {}): MergedService {
+  return {
+    resource_name: "bus",
+    status: "failed",
+    role: "core",
+    ready_phase: null,
+    retry_at: null,
+    exception: null,
+    ...overrides,
+  };
+}
+
+describe("ServiceRow", () => {
+  it("does not render the exception toggle when there is no exception", () => {
+    const { queryByRole } = render(<ServiceRow service={makeService({ exception: null })} />);
+    expect(queryByRole("button", { name: /show exception/i })).toBeNull();
+  });
+
+  it("toggles the exception text open and closed", async () => {
+    const user = userEvent.setup();
+    const exception = "RuntimeError: boom";
+    const { getByRole, queryByText } = render(<ServiceRow service={makeService({ exception })} />);
+
+    expect(queryByText(exception)).toBeNull();
+
+    const toggle = getByRole("button", { name: /show exception/i });
+    expect(toggle.getAttribute("aria-expanded")).toBe("false");
+
+    await user.click(toggle);
+    expect(queryByText(exception)).not.toBeNull();
+    expect(getByRole("button", { name: /hide exception/i }).getAttribute("aria-expanded")).toBe("true");
+
+    await user.click(getByRole("button", { name: /hide exception/i }));
+    expect(queryByText(exception)).toBeNull();
+    expect(getByRole("button", { name: /show exception/i })).toBeDefined();
+  });
+});


### PR DESCRIPTION
## Summary

Adds direct test coverage for two diagnostics UI branches that were never exercised, either before or after #1730's split of the monolithic `diagnostics.tsx` into `components/diagnostics/`:

- **`service-row.tsx`** — the exception show/hide toggle (`exceptionOpen` state, the toggle button, and the `<pre>` rendering `service.exception`). No existing test constructed a service with a non-null `exception`, so this branch — one of the failure paths the diagnostics page exists to render — was completely unexercised.
- **`boot-issues-panel.tsx`** — the `UNKNOWN_SEVERITY_SORT_ORDER` fallback, taken when a boot issue's severity falls outside `err`/`warn`/`info`.

The issue's third item, `merge-services.ts`, already has its own test file (`merge-services.test.ts`) from #1730 — confirmed no gap remains there, so no changes were needed for that file.

## Testing

- `npx vitest run` on the two new test files — both pass (3 tests total)
- `uv run nox -s dev` — full backend + frontend suite, 7034 passed, 1 skipped, 2 xfailed
- `prek -a && prek pyright -a --stage pre-push` — all lint/type/format hooks pass

Closes #1732
