### PR TITLE
fix: harden test-suite teardown and hang diagnostics

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,9 @@
 import asyncio
+import faulthandler
+import os
+import sys
+import threading
+import time
 import tracemalloc
 from collections.abc import AsyncIterator
 from pathlib import Path
@@ -28,6 +33,12 @@ if TYPE_CHECKING:
 
 tracemalloc.start()
 
+# Seconds to wait after the session reports its result before declaring the interpreter
+# wedged at shutdown. Normal teardown finishes well within this even under load; a leaked
+# non-daemon thread hangs it for minutes. Set above worst-case healthy teardown, well below
+# CI's job timeout.
+EXIT_WATCHDOG_TIMEOUT = 60  # seconds
+
 TEST_DATA_PATH = Path.cwd().joinpath("tests", "data")
 TEST_CONFIG_PATH = TEST_DATA_PATH / "config"
 TEST_EVENTS_PATH = TEST_DATA_PATH / "events"
@@ -53,6 +64,35 @@ pytest_plugins: list[str] = [
     # coverage was started by the nox sessions' .pth file. See tests/coverage_integrity.py.
     "tests.coverage_integrity",
 ]
+
+
+def pytest_sessionfinish(exitstatus: int) -> None:
+    """Diagnostic watchdog: dump thread state and force-exit if the interpreter hangs.
+
+    aiosqlite worker threads are set to daemon in DatabaseService.on_initialize(), so they
+    no longer block interpreter exit. This watchdog is retained as a diagnostic safety net
+    — if something else introduces a non-daemon thread leak, the watchdog catches it
+    instead of letting CI hang to the job timeout. Registered at the root conftest so it
+    protects every suite (unit, integration, e2e, system), not just tests/system/.
+    """
+
+    def force_exit_if_stalled() -> None:
+        time.sleep(EXIT_WATCHDOG_TIMEOUT)
+        non_daemon = [
+            t for t in threading.enumerate() if t.is_alive() and not t.daemon and t is not threading.main_thread()
+        ]
+        if not non_daemon:
+            return
+        sys.stderr.write(
+            f"\n[conftest] interpreter still alive {EXIT_WATCHDOG_TIMEOUT}s after session "
+            f"finish — {len(non_daemon)} non-daemon thread(s) blocking shutdown. "
+            "Thread tracebacks:\n"
+        )
+        sys.stderr.flush()
+        faulthandler.dump_traceback()
+        os._exit(exitstatus or 1)
+
+    threading.Thread(target=force_exit_if_stalled, name="exit-hang-watchdog", daemon=True).start()
 
 
 @pytest.fixture(autouse=True)

--- a/tests/system/conftest.py
+++ b/tests/system/conftest.py
@@ -197,9 +197,18 @@ async def startup_context(
     """
     hassette = Hassette(config)
     hassette.wire_services()
+    loop = asyncio.get_running_loop()
+    # Capture the factory before run_forever() installs its own (Hassette.run_forever() routes
+    # every new task through this instance's TaskBucket via loop.set_task_factory()). Restored
+    # unconditionally below — mirrors HassetteHarness._restore_context_and_loop() and
+    # tests/integration/conftest.py::hassette_instance, which close the same gap for the same
+    # reason: a shutdown that times out or gets force-cancelled can leave the loop routing
+    # create_task() through this instance's now-sealed TaskBucket, which crashes any later task
+    # creation on the shared session loop (e.g. pytest-asyncio's own async-generator teardown
+    # machinery) with "sealed and rejected new work".
+    previous_task_factory = loop.get_task_factory()
     task = asyncio.create_task(hassette.run_forever())
     try:
-        loop = asyncio.get_running_loop()
         deadline = loop.time() + timeout
         while not ready_check(hassette):
             if task.done():
@@ -211,17 +220,20 @@ async def startup_context(
             await asyncio.sleep(0.1)
         yield hassette
     finally:
-        hassette.shutdown_event.set()
         try:
-            await asyncio.wait_for(task, timeout=SHUTDOWN_TIMEOUT)
-        except asyncio.CancelledError:  # noqa: ASYNC103 — shutdown already triggered; cancellation is the expected path
-            pass  # noqa: ASYNC104
-        except TimeoutError:
-            logger.warning("Hassette shutdown timed out after 15s — forcing fallback")
-        if not hassette.shutdown_completed:
-            with contextlib.suppress(Exception):
-                await hassette.shutdown()
-        await asyncio.sleep(0)
+            hassette.shutdown_event.set()
+            try:
+                await asyncio.wait_for(task, timeout=SHUTDOWN_TIMEOUT)
+            except asyncio.CancelledError:  # noqa: ASYNC103 — shutdown already triggered; cancellation is the expected path
+                pass  # noqa: ASYNC104
+            except TimeoutError:
+                logger.warning("Hassette shutdown timed out after 15s — forcing fallback")
+            if not hassette.shutdown_completed:
+                with contextlib.suppress(Exception):
+                    await hassette.shutdown()
+            await asyncio.sleep(0)
+        finally:
+            loop.set_task_factory(previous_task_factory)
 
 
 def make_system_config(ha_url: str, tmp_path: Path) -> HassetteConfig:

--- a/tests/system/conftest.py
+++ b/tests/system/conftest.py
@@ -2,15 +2,12 @@
 
 import asyncio
 import contextlib
-import faulthandler
 import json
 import logging
 import os
 import shutil
 import socket
 import subprocess
-import sys
-import threading
 import time
 from collections.abc import AsyncIterator, Callable, Iterator
 from contextlib import asynccontextmanager
@@ -44,40 +41,6 @@ if not HA_TOKEN:
 HA_CONTAINER_NAME = "hassette-system-ha"
 STARTUP_TIMEOUT = 60  # seconds
 SHUTDOWN_TIMEOUT = 30  # seconds — matches Hassette's total_shutdown_timeout_seconds
-
-# Seconds to wait after the session reports its result before declaring the interpreter
-# wedged at shutdown. Normal teardown — Docker compose down plus coverage write — finishes
-# well within this even under load; a leaked non-daemon thread hangs it for minutes. Set
-# above worst-case healthy teardown, well below the 10-minute job timeout.
-EXIT_WATCHDOG_TIMEOUT = 60  # seconds
-
-
-def pytest_sessionfinish(exitstatus: int) -> None:
-    """Diagnostic watchdog: dump thread state and force-exit if the interpreter hangs.
-
-    aiosqlite worker threads are set to daemon in DatabaseService.on_initialize(), so they
-    no longer block interpreter exit. This watchdog is retained as a diagnostic safety net
-    — if something else introduces a non-daemon thread leak, the watchdog catches it
-    instead of letting CI hang to the job timeout.
-    """
-
-    def force_exit_if_stalled() -> None:
-        time.sleep(EXIT_WATCHDOG_TIMEOUT)
-        non_daemon = [
-            t for t in threading.enumerate() if t.is_alive() and not t.daemon and t is not threading.main_thread()
-        ]
-        if not non_daemon:
-            return
-        sys.stderr.write(
-            f"\n[system-conftest] interpreter still alive {EXIT_WATCHDOG_TIMEOUT}s after session "
-            f"finish — {len(non_daemon)} non-daemon thread(s) blocking shutdown. "
-            "Thread tracebacks:\n"
-        )
-        sys.stderr.flush()
-        faulthandler.dump_traceback()
-        os._exit(exitstatus or 1)
-
-    threading.Thread(target=force_exit_if_stalled, name="exit-hang-watchdog", daemon=True).start()
 
 
 class SystemTestConfig(HassetteConfig):

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -391,11 +391,21 @@ def sleeping_loop_worker(ready: threading.Event, interval: float = 0.01) -> Call
     return run
 
 
-def c_blocked_worker(ready: threading.Event, seconds: float = 60.0) -> Callable[[], None]:
+def c_blocked_worker(ready: threading.Event, seconds: float = 2.0) -> Callable[[], None]:
     """Build a worker that signals `ready`, then blocks in a C-level sleep.
 
     ``async_raise`` cannot interrupt this until the call returns to Python, so shutdown must
     abandon the thread at budget expiry instead of waiting for it.
+
+    The default is short (2s, well above the largest shutdown budget any caller tests — 1.0s
+    with up to 30% jitter margin) rather than a long duration: this thread is a stdlib
+    ``ThreadPoolExecutor`` worker, which CPython always creates non-daemon, so an abandoned one
+    keeps the interpreter alive at process exit until its sleep actually returns. A long default
+    (formerly 60s) turned a bare, non-xdist ``pytest`` run of a single test file into a minutes-
+    long hang after the tests themselves had already passed (see design/specs/105-teardown-
+    restart-safety/known-issues.md KI-001). Under the real xdist-parallel CI/dev invocation this
+    was never actually a hang — the worker process exits before the join would matter — so this
+    is a local-dev ergonomics fix, not a correctness fix.
     """
 
     def run() -> None:
@@ -432,7 +442,7 @@ def submit_busy_worker(
     await_worker_ready(ready)
 
 
-def submit_c_blocked_worker(executor: ThreadPoolExecutor, seconds: float = 60.0) -> None:
+def submit_c_blocked_worker(executor: ThreadPoolExecutor, seconds: float = 2.0) -> None:
     """Submit a C-blocked worker to `executor` and wait until it is blocked."""
     ready = threading.Event()
     executor.submit(c_blocked_worker(ready, seconds))

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -56,6 +56,10 @@ TZ = "America/Chicago"
 #: Upper bound on how long a submitted worker may take to signal that it is running.
 WORKER_READY_TIMEOUT = 2.0
 
+#: Default duration for a simulated C-blocked (``time.sleep``) worker — see
+#: ``c_blocked_worker``'s docstring for why this is short rather than long.
+C_BLOCKED_WORKER_DEFAULT_SECONDS = 2.0
+
 
 def make_sync_executor_config(
     max_workers: int = 4,
@@ -391,21 +395,23 @@ def sleeping_loop_worker(ready: threading.Event, interval: float = 0.01) -> Call
     return run
 
 
-def c_blocked_worker(ready: threading.Event, seconds: float = 2.0) -> Callable[[], None]:
+def c_blocked_worker(ready: threading.Event, seconds: float = C_BLOCKED_WORKER_DEFAULT_SECONDS) -> Callable[[], None]:
     """Build a worker that signals `ready`, then blocks in a C-level sleep.
 
     ``async_raise`` cannot interrupt this until the call returns to Python, so shutdown must
     abandon the thread at budget expiry instead of waiting for it.
 
-    The default is short (2s, well above the largest shutdown budget any caller tests — 1.0s
-    with up to 30% jitter margin) rather than a long duration: this thread is a stdlib
+    The default is short (2s) rather than a long duration: this thread is a stdlib
     ``ThreadPoolExecutor`` worker, which CPython always creates non-daemon, so an abandoned one
-    keeps the interpreter alive at process exit until its sleep actually returns. A long default
-    (formerly 60s) turned a bare, non-xdist ``pytest`` run of a single test file into a minutes-
-    long hang after the tests themselves had already passed (see design/specs/105-teardown-
-    restart-safety/known-issues.md KI-001). Under the real xdist-parallel CI/dev invocation this
-    was never actually a hang — the worker process exits before the join would matter — so this
-    is a local-dev ergonomics fix, not a correctness fix.
+    keeps the interpreter alive at process exit until its sleep actually returns. Every caller
+    across the test suite only needs the worker still blocked when its own shutdown budget is
+    checked — the largest of those budgets is 1.0s, with jitter margins up to 30% depending on
+    the caller — so 2s (2x the largest tested budget) is ample headroom. A long default (formerly
+    60s) turned a bare, non-xdist ``pytest`` run of a single test file into a minutes-long hang
+    after the tests themselves had already passed (see design/specs/105-teardown-restart-safety/
+    known-issues.md KI-001). Under the real xdist-parallel CI/dev invocation this was never
+    actually a hang — the worker process exits before the join would matter — so this is a
+    local-dev ergonomics fix, not a correctness fix.
     """
 
     def run() -> None:
@@ -442,7 +448,7 @@ def submit_busy_worker(
     await_worker_ready(ready)
 
 
-def submit_c_blocked_worker(executor: ThreadPoolExecutor, seconds: float = 2.0) -> None:
+def submit_c_blocked_worker(executor: ThreadPoolExecutor, seconds: float = C_BLOCKED_WORKER_DEFAULT_SECONDS) -> None:
     """Submit a C-blocked worker to `executor` and wait until it is blocked."""
     ready = threading.Event()
     executor.submit(c_blocked_worker(ready, seconds))

--- a/tests/unit/task_bucket/test_interruptible_executor.py
+++ b/tests/unit/task_bucket/test_interruptible_executor.py
@@ -303,7 +303,7 @@ class TestInterruptibleThreadPoolExecutorShutdown:
     def test_shutdown_without_join_skips_interrupt_loop(self) -> None:
         """shutdown(join_threads_or_timeout=False) must skip the join/interrupt loop."""
         executor = InterruptibleThreadPoolExecutor(max_workers=1)
-        submit_c_blocked_worker(executor, seconds=30)
+        submit_c_blocked_worker(executor)
 
         # Should return immediately (no join attempt)
         wall_start = time.monotonic()
@@ -376,6 +376,7 @@ class TestInterruptibleThreadPoolExecutorShutdown:
         """SystemError from async_raise (res>1 path) must be suppressed at shutdown."""
         executor = InterruptibleThreadPoolExecutor(max_workers=1)
         submit_busy_worker(executor, reraise=True)
+        worker_threads = set(executor._threads)  # pyright: ignore[reportAttributeAccessIssue]
 
         with patch(
             "hassette.task_bucket.interruptible_executor.async_raise",
@@ -383,3 +384,11 @@ class TestInterruptibleThreadPoolExecutorShutdown:
         ):
             # Must not raise
             executor.shutdown(join_threads_or_timeout=True, timeout=0.5)
+
+        # Clean up — async_raise was patched throughout shutdown, so the busy-loop worker was
+        # never actually interrupted and is still spinning. Unlike the raw threads used
+        # elsewhere in this file (daemon=True), this is a real ThreadPoolExecutor worker thread
+        # (non-daemon by stdlib design), so leaving it running blocks interpreter exit —
+        # interrupt it now that the real async_raise is back.
+        for t in worker_threads:
+            interrupt_and_join(t)


### PR DESCRIPTION
### Notable Changes

- Relocated the exit-hang watchdog (`force_exit_if_stalled` / `pytest_sessionfinish`) from `tests/system/conftest.py` to the root `tests/conftest.py` so it protects every suite, not just system tests. A leaked non-daemon thread in unit, integration, or e2e tests previously had zero diagnostic coverage — confirmed by observing `tests/integration/` finish in 255s while the pytest process never exited.

### System test teardown crash

- Fixed `startup_context()` in `tests/system/conftest.py` never restoring the loop's previous task factory after `hassette.run_forever()` installed its own (routing every new task through that instance's `TaskBucket`). A shutdown that timed out or got force-cancelled left the loop routing task creation through the now-sealed `TaskBucket`, crashing any later task creation on the shared session loop (e.g. pytest-asyncio's own async-generator teardown) with `"TaskBucket(...) is sealed and rejected new work"` — destroying the original test failure's traceback. Now captures the factory before `run_forever()`'s task is created and restores it unconditionally in a nested `finally`, mirroring the existing pattern in `tests/integration/conftest.py::hassette_instance` and `HassetteHarness._restore_context_and_loop()`.

### Non-daemon thread leaks in interruptible-executor tests

- `c_blocked_worker` / `submit_c_blocked_worker` (`tests/unit/conftest.py`) defaulted their simulated C-blocked (`time.sleep`) worker to 60s. `InterruptibleThreadPoolExecutor` deliberately abandons a C-blocked worker at shutdown-budget expiry — matching Home Assistant's accepted production behavior, not a bug — but the abandoned thread is a real stdlib `ThreadPoolExecutor` worker (always non-daemon by CPython design), so it kept the interpreter alive until its sleep actually returned. Every caller only needs the worker blocked for the shutdown budget under test (<=1.3s across every call site), so both defaults are shrunk to 2.0s (extracted as `C_BLOCKED_WORKER_DEFAULT_SECONDS`), with the redundant `seconds=30` override dropped.
- `test_res_greater_than_one_suppressed_during_shutdown` patched `async_raise` to always fail for the duration of a `shutdown()` call, so the submitted Python busy-loop worker was never actually interrupted and kept spinning (100% CPU) forever with no cleanup afterward — unlike two sibling tests in the same file that already restore the real `async_raise` and call `interrupt_and_join()`. Applied the same cleanup.
- Confirmed via the actual xdist-parallel CI/dev invocation (`pytest -n 4 --dist loadscope`, matching `noxfile.py` and `.github/workflows/tests.yml`) that this was never a CI hang — xdist's worker lifecycle doesn't wait on non-daemon threads the way a bare pytest process does. This is a local-dev ergonomics fix: the file now exits cleanly in ~7s standalone instead of hanging until the exit-hang watchdog force-exits it at 60s. No production code touched.

### Housekeeping

- Addressed clean-code findings from this PR's own diff: extracted `C_BLOCKED_WORKER_DEFAULT_SECONDS` as a shared constant instead of duplicating the 2.0 default, and clarified `c_blocked_worker`'s docstring so the 30% jitter margin is scoped to the one caller it actually applies to. Remaining out-of-scope clean-code findings filed as #1762.

Closes #1707
Closes #1724
Closes #1718
