### PR TITLE
refactor: extract shared shutdown-batch classification helper

### DIFF
--- a/src/hassette/core/core.py
+++ b/src/hassette/core/core.py
@@ -24,11 +24,10 @@ from hassette.resources.lifecycle import (
     mark_not_ready,
     start,
 )
-from hassette.resources.operations import shutdown_batch
+from hassette.resources.operations import finalize_shutdown_report, shutdown_batch
 from hassette.resources.teardown import (
     TeardownCause,
     TeardownReport,
-    add_teardown_evidence,
     merge_teardown_reports,
 )
 from hassette.scheduler import Scheduler
@@ -790,8 +789,7 @@ class Hassette(Resource):
             causes.extend(result.causes)
             affected.extend(result.affected)
 
-        merged = merge_teardown_reports(*child_reports) if child_reports else TeardownReport()
-        return add_teardown_evidence(merged, causes=tuple(causes), affected_resources=tuple(affected))
+        return finalize_shutdown_report(child_reports, causes, affected)
 
     async def _on_children_stopped(self) -> None:
         """Emit Hassette's own STOPPED event, then close event streams.

--- a/src/hassette/core/core.py
+++ b/src/hassette/core/core.py
@@ -20,11 +20,11 @@ from hassette.resources.base import Resource
 from hassette.resources.lifecycle import (
     COORDINATOR_MARGIN_FRACTION,
     children_budget_remaining,
-    create_lifecycle_task,
     handle_stop,
     mark_not_ready,
     start,
 )
+from hassette.resources.operations import shutdown_batch
 from hassette.resources.teardown import (
     TeardownCause,
     TeardownReport,
@@ -753,24 +753,19 @@ class Hassette(Resource):
     async def _shutdown_children(self) -> TeardownReport:
         """Wave-based shutdown: gather each dependency level sequentially.
 
-        Dependents (leaf services) shut down first, their dependencies last.
-        Within each wave, services shut down concurrently via gather.
+        Dependents (leaf services) shut down first, their dependencies last. Within each wave,
+        children shut down concurrently via a single ``shutdown_batch()`` call — see that
+        function for the per-child classification rules (failed/restart-unsafe/timed-out).
+        Evidence is accumulated across all waves and returned as one aggregated ``TeardownReport``.
 
-        Evidence is accumulated across all waves and returned as one aggregated
-        ``TeardownReport``, mirroring ``Resource._shutdown_children()``'s contract:
-
-        - A child whose ``shutdown()`` call itself raises unexpectedly adds
-          ``CHILD_SHUTDOWN_FAILED`` and the child's identity to ``affected_resources``.
-        - A child that returns without raising, but whose own report has
-          ``is_restart_safe`` ``False``, adds ``CHILD_RESTART_UNSAFE`` and the child's identity.
-        - A wave that exceeds the shutdown timeout adds ``CHILD_SHUTDOWN_TIMED_OUT``,
-          force-terminates only the children in that wave still unfinished, and proceeds to the
-          next (lower-dependency) wave rather than abandoning the rest of the shutdown — a wave
-          that owns real OS resources (DB connections, the sync-executor thread pool, the HTTP
-          session) must still get a chance to close them even when an earlier, more-dependent
-          wave ran over budget. Force-terminating the timed-out wave's children first makes this
-          safe: nothing in a later wave can still be depended on by anything left half-shut-down
-          above it.
+        A wave that exceeds the shutdown timeout adds ``CHILD_SHUTDOWN_TIMED_OUT``,
+        force-terminates only the children in that wave still unfinished, and proceeds to the
+        next (lower-dependency) wave rather than abandoning the rest of the shutdown — a wave
+        that owns real OS resources (DB connections, the sync-executor thread pool, the HTTP
+        session) must still get a chance to close them even when an earlier, more-dependent
+        wave ran over budget. Force-terminating the timed-out wave's children first makes this
+        safe: nothing in a later wave can still be depended on by anything left half-shut-down
+        above it.
 
         Each wave's own timeout is capped at ``children_budget_remaining()`` — the time
         left until ``body_deadline``, floored at ``children_floor_seconds``. Multiple waves
@@ -789,51 +784,11 @@ class Hassette(Resource):
                 continue
             timeout = min(self.config.lifecycle.resource_shutdown_timeout_seconds, children_budget_remaining(self))
             self.logger.debug("Shutting down wave: [%s]", ", ".join(c.class_name for c in wave))
-            try:
-                async with asyncio.timeout(timeout):
-                    # create_lifecycle_task(), not asyncio.gather()'s own implicit task creation --
-                    # self.task_bucket is already sealed here, and for this root resource it also
-                    # doubles as the loop's global factory bucket (see run_forever()); see
-                    # create_lifecycle_task()'s docstring for why that matters.
-                    wave_tasks = [
-                        create_lifecycle_task(child.shutdown(), name=f"resource:shutdown_propagate:{child.unique_name}")
-                        for child in wave
-                    ]
-                    results = await asyncio.gather(*wave_tasks, return_exceptions=True)
-            except TimeoutError:
-                self.logger.error(
-                    "Shutdown wave [%s] timed out after %ss — forcing remaining children",
-                    ", ".join(c.class_name for c in wave),
-                    timeout,
-                )
-                causes.append(TeardownCause.CHILD_SHUTDOWN_TIMED_OUT)
-                for child in wave:
-                    if not child.shutdown_completed:
-                        child._force_terminal()
-                        affected.append(child.unique_name)
-                    child_report = child.teardown_report
-                    if child_report is not None:
-                        child_reports.append(child_report)
-                continue
 
-            for child, result in zip(wave, results, strict=True):
-                if isinstance(result, BaseException):
-                    self.logger.error("Child %s shutdown failed: %s", child.unique_name, result)
-                    causes.append(TeardownCause.CHILD_SHUTDOWN_FAILED)
-                    affected.append(child.unique_name)
-                    # The coordinator stores evidence (e.g. COORDINATOR_FAILED) on the child's own
-                    # report before re-raising -- see coordinate_shutdown()'s except Exception
-                    # branch in lifecycle.py. Merge it in so the child's concrete cause and
-                    # failed_operations survive in the parent's aggregated report instead of being
-                    # replaced by only the generic CHILD_SHUTDOWN_FAILED cause.
-                    child_report = child.teardown_report
-                    if child_report is not None:
-                        child_reports.append(child_report)
-                    continue
-                child_reports.append(result)
-                if not result.is_restart_safe:
-                    causes.append(TeardownCause.CHILD_RESTART_UNSAFE)
-                    affected.append(child.unique_name)
+            result = await shutdown_batch(self, wave, timeout)
+            child_reports.extend(result.reports)
+            causes.extend(result.causes)
+            affected.extend(result.affected)
 
         merged = merge_teardown_reports(*child_reports) if child_reports else TeardownReport()
         return add_teardown_evidence(merged, causes=tuple(causes), affected_resources=tuple(affected))

--- a/src/hassette/resources/base.py
+++ b/src/hassette/resources/base.py
@@ -13,7 +13,6 @@ from hassette.resources.lifecycle import (
     children_budget_remaining,
     coordinate_initialize,
     coordinate_shutdown,
-    create_lifecycle_task,
     create_service_status_event,
     handle_failed,
     handle_running,
@@ -21,7 +20,7 @@ from hassette.resources.lifecycle import (
     handle_stop,
     mark_not_ready,
 )
-from hassette.resources.operations import ordered_children_for_shutdown, run_hooks
+from hassette.resources.operations import ordered_children_for_shutdown, run_hooks, shutdown_batch
 from hassette.resources.teardown import (
     TeardownCause,
     TeardownReport,
@@ -393,17 +392,8 @@ class Resource(LifecycleMixin, metaclass=FinalMeta):
         """Propagate shutdown to children and aggregate their teardown reports.
 
         Children shut down concurrently, in reverse insertion order
-        (``ordered_children_for_shutdown()``), via ``asyncio.gather(return_exceptions=True)``
-        so one child's failure does not stop its siblings from completing:
-
-        - A child whose ``shutdown()`` call itself raises unexpectedly adds
-          ``CHILD_SHUTDOWN_FAILED`` and the child's identity to ``affected_resources``.
-        - A child that returns without raising, but whose own report has
-          ``is_restart_safe`` ``False``, adds ``CHILD_RESTART_UNSAFE`` and the child's identity —
-          the child's own causes and details are merged in first.
-        - A wave that exceeds the shutdown timeout adds ``CHILD_SHUTDOWN_TIMED_OUT`` and
-          force-terminates only the children still unfinished at that point; a child that
-          already completed keeps its own (possibly restart-safe) report unchanged.
+        (``ordered_children_for_shutdown()``), as a single ``shutdown_batch()`` call — see that
+        function for the per-child classification rules (failed/restart-unsafe/timed-out).
 
         Children benefit from any slack the hooks pool didn't use — their budget is
         ``max(children_floor_seconds, body_deadline - now)``, so early-finishing hooks pass
@@ -419,54 +409,9 @@ class Resource(LifecycleMixin, metaclass=FinalMeta):
         if not children:
             return TeardownReport()
 
-        child_reports: list[TeardownReport] = []
-        causes: list[TeardownCause] = []
-        affected: list[str] = []
-
-        try:
-            async with asyncio.timeout(timeout):
-                # create_lifecycle_task(), not asyncio.gather()'s own implicit task creation --
-                # this resource's own TaskBucket is already sealed here; see
-                # create_lifecycle_task()'s docstring for why that matters.
-                child_tasks = [
-                    create_lifecycle_task(child.shutdown(), name=f"resource:shutdown_propagate:{child.unique_name}")
-                    for child in children
-                ]
-                results = await asyncio.gather(*child_tasks, return_exceptions=True)
-        except TimeoutError:
-            self.logger.error("Timed out waiting for children to shut down after %ss", timeout)
-            causes.append(TeardownCause.CHILD_SHUTDOWN_TIMED_OUT)
-            for child in children:
-                if not child.shutdown_completed:
-                    child._force_terminal()
-                    affected.append(child.unique_name)
-                child_report = child.teardown_report
-                if child_report is not None:
-                    child_reports.append(child_report)
-            merged = merge_teardown_reports(*child_reports) if child_reports else TeardownReport()
-            return add_teardown_evidence(merged, causes=tuple(causes), affected_resources=tuple(affected))
-
-        for child, result in zip(children, results, strict=True):
-            if isinstance(result, BaseException):
-                self.logger.error("Child %s shutdown failed: %s", child.unique_name, result)
-                causes.append(TeardownCause.CHILD_SHUTDOWN_FAILED)
-                affected.append(child.unique_name)
-                # The coordinator stores evidence (e.g. COORDINATOR_FAILED) on the child's own
-                # report before re-raising -- see coordinate_shutdown()'s except Exception branch
-                # in lifecycle.py. Merge it in so the child's concrete cause and
-                # failed_operations survive in the parent's aggregated report instead of being
-                # replaced by only the generic CHILD_SHUTDOWN_FAILED cause.
-                child_report = child.teardown_report
-                if child_report is not None:
-                    child_reports.append(child_report)
-                continue
-            child_reports.append(result)
-            if not result.is_restart_safe:
-                causes.append(TeardownCause.CHILD_RESTART_UNSAFE)
-                affected.append(child.unique_name)
-
-        merged = merge_teardown_reports(*child_reports) if child_reports else TeardownReport()
-        return add_teardown_evidence(merged, causes=tuple(causes), affected_resources=tuple(affected))
+        result = await shutdown_batch(self, children, timeout)
+        merged = merge_teardown_reports(*result.reports) if result.reports else TeardownReport()
+        return add_teardown_evidence(merged, causes=tuple(result.causes), affected_resources=tuple(result.affected))
 
     async def _run_task_bucket_shutdown_stage(self) -> TeardownReport:
         """Seal the TaskBucket, cancel tracked work, and record final pending-task evidence.

--- a/src/hassette/resources/base.py
+++ b/src/hassette/resources/base.py
@@ -20,11 +20,15 @@ from hassette.resources.lifecycle import (
     handle_stop,
     mark_not_ready,
 )
-from hassette.resources.operations import ordered_children_for_shutdown, run_hooks, shutdown_batch
+from hassette.resources.operations import (
+    finalize_shutdown_report,
+    ordered_children_for_shutdown,
+    run_hooks,
+    shutdown_batch,
+)
 from hassette.resources.teardown import (
     TeardownCause,
     TeardownReport,
-    add_teardown_evidence,
     merge_teardown_reports,
 )
 from hassette.types.enums import ResourceRole, ResourceStatus
@@ -410,8 +414,7 @@ class Resource(LifecycleMixin, metaclass=FinalMeta):
             return TeardownReport()
 
         result = await shutdown_batch(self, children, timeout)
-        merged = merge_teardown_reports(*result.reports) if result.reports else TeardownReport()
-        return add_teardown_evidence(merged, causes=tuple(result.causes), affected_resources=tuple(result.affected))
+        return finalize_shutdown_report(result.reports, result.causes, result.affected)
 
     async def _run_task_bucket_shutdown_stage(self) -> TeardownReport:
         """Seal the TaskBucket, cancel tracked work, and record final pending-task evidence.

--- a/src/hassette/resources/operations.py
+++ b/src/hassette/resources/operations.py
@@ -17,7 +17,7 @@ from hassette.resources.lifecycle import (
     reject_lifecycle_reentry,
     start,
 )
-from hassette.resources.teardown import TeardownCause, TeardownReport
+from hassette.resources.teardown import TeardownCause, TeardownReport, add_teardown_evidence, merge_teardown_reports
 from hassette.utils.service_utils import wait_for_ready
 
 if typing.TYPE_CHECKING:
@@ -184,7 +184,7 @@ class ShutdownBatchResult(typing.NamedTuple):
     affected: list[str]
 
 
-async def shutdown_batch(parent: "Resource", batch: "list[Resource]", timeout: float) -> ShutdownBatchResult:
+async def shutdown_batch(resource: "Resource", batch: "list[Resource]", timeout: float) -> ShutdownBatchResult:
     """Shut down one batch of children concurrently and classify the results.
 
     Shared by ``Resource._shutdown_children()`` (one batch: all children) and
@@ -211,7 +211,7 @@ async def shutdown_batch(parent: "Resource", batch: "list[Resource]", timeout: f
     try:
         async with asyncio.timeout(timeout):
             # create_lifecycle_task(), not asyncio.gather()'s own implicit task creation --
-            # parent's own TaskBucket is already sealed here; see create_lifecycle_task()'s
+            # resource's own TaskBucket is already sealed here; see create_lifecycle_task()'s
             # docstring for why that matters.
             child_tasks = [
                 create_lifecycle_task(child.shutdown(), name=f"resource:shutdown_propagate:{child.unique_name}")
@@ -219,7 +219,7 @@ async def shutdown_batch(parent: "Resource", batch: "list[Resource]", timeout: f
             ]
             results = await asyncio.gather(*child_tasks, return_exceptions=True)
     except TimeoutError:
-        parent.logger.error(
+        resource.logger.error(
             "Timed out waiting for children to shut down after %ss: [%s]",
             timeout,
             ", ".join(child.class_name for child in batch),
@@ -236,7 +236,7 @@ async def shutdown_batch(parent: "Resource", batch: "list[Resource]", timeout: f
 
     for child, result in zip(batch, results, strict=True):
         if isinstance(result, BaseException):
-            parent.logger.error("Child %s shutdown failed: %s", child.unique_name, result)
+            resource.logger.error("Child %s shutdown failed: %s", child.unique_name, result)
             causes.append(TeardownCause.CHILD_SHUTDOWN_FAILED)
             affected.append(child.unique_name)
             child_report = child.teardown_report
@@ -249,3 +249,16 @@ async def shutdown_batch(parent: "Resource", batch: "list[Resource]", timeout: f
             affected.append(child.unique_name)
 
     return ShutdownBatchResult(child_reports, causes, affected)
+
+
+def finalize_shutdown_report(
+    reports: list[TeardownReport], causes: list[TeardownCause], affected: list[str]
+) -> TeardownReport:
+    """Merge accumulated batch reports and stamp on the accumulated causes/affected evidence.
+
+    Shared tail of ``Resource._shutdown_children()`` and ``Hassette._shutdown_children()``: both
+    accumulate ``ShutdownBatchResult`` fields across one or more ``shutdown_batch()`` calls, then
+    call this once to produce the single aggregated ``TeardownReport`` they return.
+    """
+    merged = merge_teardown_reports(*reports) if reports else TeardownReport()
+    return add_teardown_evidence(merged, causes=tuple(causes), affected_resources=tuple(affected))

--- a/src/hassette/resources/operations.py
+++ b/src/hassette/resources/operations.py
@@ -10,7 +10,14 @@ import typing
 from contextlib import suppress
 
 from hassette.exceptions import RestartRefusedError
-from hassette.resources.lifecycle import handle_failed, hooks_pool_remaining, reject_lifecycle_reentry, start
+from hassette.resources.lifecycle import (
+    create_lifecycle_task,
+    handle_failed,
+    hooks_pool_remaining,
+    reject_lifecycle_reentry,
+    start,
+)
+from hassette.resources.teardown import TeardownCause, TeardownReport
 from hassette.utils.service_utils import wait_for_ready
 
 if typing.TYPE_CHECKING:
@@ -162,3 +169,83 @@ async def run_hooks(
 def ordered_children_for_shutdown(resource: "Resource") -> "list[Resource]":
     """Return children in shutdown order (reverse insertion)."""
     return list(reversed(resource.children))
+
+
+class ShutdownBatchResult(typing.NamedTuple):
+    """One batch's contribution to a caller's aggregated ``TeardownReport``.
+
+    Returned by ``shutdown_batch()``; the caller extends its own running lists with these
+    three fields across every batch it runs, then merges once at the end (see
+    ``Resource._shutdown_children()`` and ``Hassette._shutdown_children()``).
+    """
+
+    reports: list[TeardownReport]
+    causes: list[TeardownCause]
+    affected: list[str]
+
+
+async def shutdown_batch(parent: "Resource", batch: "list[Resource]", timeout: float) -> ShutdownBatchResult:
+    """Shut down one batch of children concurrently and classify the results.
+
+    Shared by ``Resource._shutdown_children()`` (one batch: all children) and
+    ``Hassette._shutdown_children()`` (one batch per dependency wave, called once per wave).
+    Each caller owns its own aggregation across batches -- this function only classifies a
+    single batch and returns the pieces:
+
+    - A child whose ``shutdown()`` call itself raises unexpectedly adds ``CHILD_SHUTDOWN_FAILED``
+      and the child's identity to the affected list. The coordinator stores evidence (e.g.
+      ``COORDINATOR_FAILED``) on the child's own report before re-raising -- see
+      ``coordinate_shutdown()``'s ``except Exception`` branch in ``lifecycle.py`` -- so that
+      report is merged in when present, instead of being replaced by only the generic cause.
+    - A child that returns without raising, but whose own report has ``is_restart_safe`` ``False``,
+      adds ``CHILD_RESTART_UNSAFE`` and the child's identity -- the child's own causes and
+      details are merged in first.
+    - A batch that exceeds ``timeout`` adds ``CHILD_SHUTDOWN_TIMED_OUT`` and force-terminates only
+      the children still unfinished at that point; a child that already completed keeps its own
+      (possibly restart-safe) report unchanged.
+    """
+    child_reports: list[TeardownReport] = []
+    causes: list[TeardownCause] = []
+    affected: list[str] = []
+
+    try:
+        async with asyncio.timeout(timeout):
+            # create_lifecycle_task(), not asyncio.gather()'s own implicit task creation --
+            # parent's own TaskBucket is already sealed here; see create_lifecycle_task()'s
+            # docstring for why that matters.
+            child_tasks = [
+                create_lifecycle_task(child.shutdown(), name=f"resource:shutdown_propagate:{child.unique_name}")
+                for child in batch
+            ]
+            results = await asyncio.gather(*child_tasks, return_exceptions=True)
+    except TimeoutError:
+        parent.logger.error(
+            "Timed out waiting for children to shut down after %ss: [%s]",
+            timeout,
+            ", ".join(child.class_name for child in batch),
+        )
+        causes.append(TeardownCause.CHILD_SHUTDOWN_TIMED_OUT)
+        for child in batch:
+            if not child.shutdown_completed:
+                child._force_terminal()
+                affected.append(child.unique_name)
+            child_report = child.teardown_report
+            if child_report is not None:
+                child_reports.append(child_report)
+        return ShutdownBatchResult(child_reports, causes, affected)
+
+    for child, result in zip(batch, results, strict=True):
+        if isinstance(result, BaseException):
+            parent.logger.error("Child %s shutdown failed: %s", child.unique_name, result)
+            causes.append(TeardownCause.CHILD_SHUTDOWN_FAILED)
+            affected.append(child.unique_name)
+            child_report = child.teardown_report
+            if child_report is not None:
+                child_reports.append(child_report)
+            continue
+        child_reports.append(result)
+        if not result.is_restart_safe:
+            causes.append(TeardownCause.CHILD_RESTART_UNSAFE)
+            affected.append(child.unique_name)
+
+    return ShutdownBatchResult(child_reports, causes, affected)


### PR DESCRIPTION
### Shared shutdown-batch classification helper

- Extracted the near-identical per-child shutdown classification loop that `Resource._shutdown_children()` and `Hassette._shutdown_children()` each carried into a single `shutdown_batch()` function in `src/hassette/resources/operations.py`. Both callers now delegate to it instead of duplicating the failed/restart-unsafe/timed-out classification logic.
- `shutdown_batch()` returns a `ShutdownBatchResult` (reports, causes, affected) so each caller keeps accumulating results across its own batches (one batch for `Resource`, one per dependency wave for `Hassette`) before merging once at the end.
- Added `finalize_shutdown_report()` to also share the trailing merge-and-stamp step (`merge_teardown_reports()` + `add_teardown_evidence()`), removing the last bit of duplicated tail logic between the two callers.
- Pure structural extraction — no behavior change. Existing regression coverage in `tests/unit/resources/lifecycle/test_shutdown.py` and `tests/unit/resources/lifecycle/test_total_timeout.py` passes unchanged, and each caller's distinct child-set iteration order (reverse insertion for `Resource`, reverse dependency-wave for `Hassette`) is preserved.

### Housekeeping

- Renamed `shutdown_batch()`'s first parameter from `parent` to `resource` for consistency with every other module-level function in `operations.py` (clean-code follow-up).

Closes #1719
