### PR TITLE
feat: log elapsed time per shutdown phase for diagnostics

### DIFF
--- a/src/hassette/core/core.py
+++ b/src/hassette/core/core.py
@@ -21,6 +21,7 @@ from hassette.resources.lifecycle import (
     COORDINATOR_MARGIN_FRACTION,
     children_budget_remaining,
     create_lifecycle_task,
+    elapsed_since,
     handle_stop,
     mark_not_ready,
     start,
@@ -806,7 +807,7 @@ class Hassette(Resource):
                 self.logger.error(
                     "Shutdown wave [%s] timed out after %.2fs (budget %.2fs) — forcing remaining children",
                     ", ".join(c.class_name for c in wave),
-                    asyncio.get_running_loop().time() - wave_start,
+                    elapsed_since(wave_start),
                     timeout,
                 )
                 causes.append(TeardownCause.CHILD_SHUTDOWN_TIMED_OUT)
@@ -822,7 +823,7 @@ class Hassette(Resource):
             self.logger.debug(
                 "Shutdown wave [%s] completed in %.2fs",
                 ", ".join(c.class_name for c in wave),
-                asyncio.get_running_loop().time() - wave_start,
+                elapsed_since(wave_start),
             )
             for child, result in zip(wave, results, strict=True):
                 if isinstance(result, BaseException):
@@ -843,7 +844,7 @@ class Hassette(Resource):
                     causes.append(TeardownCause.CHILD_RESTART_UNSAFE)
                     affected.append(child.unique_name)
 
-        self.logger.debug("All shutdown waves completed in %.2fs", asyncio.get_running_loop().time() - waves_start)
+        self.logger.debug("All shutdown waves completed in %.2fs", elapsed_since(waves_start))
         merged = merge_teardown_reports(*child_reports) if child_reports else TeardownReport()
         return add_teardown_evidence(merged, causes=tuple(causes), affected_resources=tuple(affected))
 

--- a/src/hassette/core/core.py
+++ b/src/hassette/core/core.py
@@ -783,12 +783,14 @@ class Hassette(Resource):
         causes: list[TeardownCause] = []
         affected: list[str] = []
 
+        waves_start = asyncio.get_running_loop().time()
         for wave_types in reversed(self._init_waves):
             wave = [type_to_instance[t] for t in wave_types if t in type_to_instance]
             if not wave:
                 continue
             timeout = min(self.config.lifecycle.resource_shutdown_timeout_seconds, children_budget_remaining(self))
             self.logger.debug("Shutting down wave: [%s]", ", ".join(c.class_name for c in wave))
+            wave_start = asyncio.get_running_loop().time()
             try:
                 async with asyncio.timeout(timeout):
                     # create_lifecycle_task(), not asyncio.gather()'s own implicit task creation --
@@ -802,8 +804,9 @@ class Hassette(Resource):
                     results = await asyncio.gather(*wave_tasks, return_exceptions=True)
             except TimeoutError:
                 self.logger.error(
-                    "Shutdown wave [%s] timed out after %ss — forcing remaining children",
+                    "Shutdown wave [%s] timed out after %.2fs (budget %.2fs) — forcing remaining children",
                     ", ".join(c.class_name for c in wave),
+                    asyncio.get_running_loop().time() - wave_start,
                     timeout,
                 )
                 causes.append(TeardownCause.CHILD_SHUTDOWN_TIMED_OUT)
@@ -816,6 +819,11 @@ class Hassette(Resource):
                         child_reports.append(child_report)
                 continue
 
+            self.logger.debug(
+                "Shutdown wave [%s] completed in %.2fs",
+                ", ".join(c.class_name for c in wave),
+                asyncio.get_running_loop().time() - wave_start,
+            )
             for child, result in zip(wave, results, strict=True):
                 if isinstance(result, BaseException):
                     self.logger.error("Child %s shutdown failed: %s", child.unique_name, result)
@@ -835,6 +843,7 @@ class Hassette(Resource):
                     causes.append(TeardownCause.CHILD_RESTART_UNSAFE)
                     affected.append(child.unique_name)
 
+        self.logger.debug("All shutdown waves completed in %.2fs", asyncio.get_running_loop().time() - waves_start)
         merged = merge_teardown_reports(*child_reports) if child_reports else TeardownReport()
         return add_teardown_evidence(merged, causes=tuple(causes), affected_resources=tuple(affected))
 

--- a/src/hassette/resources/base.py
+++ b/src/hassette/resources/base.py
@@ -15,6 +15,7 @@ from hassette.resources.lifecycle import (
     coordinate_shutdown,
     create_lifecycle_task,
     create_service_status_event,
+    elapsed_since,
     handle_failed,
     handle_running,
     handle_starting,
@@ -494,7 +495,7 @@ class Resource(LifecycleMixin, metaclass=FinalMeta):
         self.logger.debug(
             "%s: task-bucket cancel stage completed in %.2fs",
             self.unique_name,
-            asyncio.get_running_loop().time() - cancel_start,
+            elapsed_since(cancel_start),
         )
         pending = self.task_bucket.pending_task_names()
         if pending:
@@ -532,7 +533,7 @@ class Resource(LifecycleMixin, metaclass=FinalMeta):
         self.logger.debug(
             "%s: cleanup() stage completed in %.2fs",
             self.unique_name,
-            asyncio.get_running_loop().time() - cleanup_start,
+            elapsed_since(cleanup_start),
         )
 
         children_start = asyncio.get_running_loop().time()
@@ -540,7 +541,7 @@ class Resource(LifecycleMixin, metaclass=FinalMeta):
         self.logger.debug(
             "%s: child shutdown propagation completed in %.2fs",
             self.unique_name,
-            asyncio.get_running_loop().time() - children_start,
+            elapsed_since(children_start),
         )
         reports.append(children_report)
 

--- a/src/hassette/resources/base.py
+++ b/src/hassette/resources/base.py
@@ -489,7 +489,13 @@ class Resource(LifecycleMixin, metaclass=FinalMeta):
             self.unique_name,
             cancel_budget,
         )
+        cancel_start = asyncio.get_running_loop().time()
         await self.task_bucket.cancel_all(timeout=cancel_budget)
+        self.logger.debug(
+            "%s: task-bucket cancel stage completed in %.2fs",
+            self.unique_name,
+            asyncio.get_running_loop().time() - cancel_start,
+        )
         pending = self.task_bucket.pending_task_names()
         if pending:
             return TeardownReport(causes=(TeardownCause.TASKS_PENDING,), pending_tasks=pending)
@@ -513,6 +519,7 @@ class Resource(LifecycleMixin, metaclass=FinalMeta):
             self.unique_name,
             cleanup_timeout,
         )
+        cleanup_start = asyncio.get_running_loop().time()
         try:
             async with asyncio.timeout(cleanup_timeout):
                 await self.cleanup()
@@ -522,8 +529,19 @@ class Resource(LifecycleMixin, metaclass=FinalMeta):
         except Exception as exc:
             self.logger.exception("Error during cleanup: %s %s", type(exc).__name__, exc)
             reports.append(TeardownReport(causes=(TeardownCause.CLEANUP_FAILED,), failed_operations=("cleanup",)))
+        self.logger.debug(
+            "%s: cleanup() stage completed in %.2fs",
+            self.unique_name,
+            asyncio.get_running_loop().time() - cleanup_start,
+        )
 
+        children_start = asyncio.get_running_loop().time()
         children_report = await self._shutdown_children()
+        self.logger.debug(
+            "%s: child shutdown propagation completed in %.2fs",
+            self.unique_name,
+            asyncio.get_running_loop().time() - children_start,
+        )
         reports.append(children_report)
 
         if children_report.is_restart_safe:

--- a/src/hassette/resources/lifecycle.py
+++ b/src/hassette/resources/lifecycle.py
@@ -583,6 +583,17 @@ def total_deadline_remaining(resource: _LifecycleHostP) -> float:
     return max(0.0, budget.total_deadline - asyncio.get_running_loop().time())
 
 
+def elapsed_since(start: float) -> float:
+    """Seconds elapsed since ``start``, an ``asyncio.get_running_loop().time()`` snapshot.
+
+    Shared by every shutdown-stage timing log (waves, task-bucket cancel, cleanup,
+    child propagation, initializer observation, shutdown-body wait, and the coordinator
+    itself) so each stage measures its own span with one line instead of repeating the
+    subtraction.
+    """
+    return asyncio.get_running_loop().time() - start
+
+
 def _install_exception_observer(resource: _LifecycleHostP, task: asyncio.Task, label: str) -> None:
     """Attach a done callback that retrieves and logs any exception the task raised.
 
@@ -697,7 +708,7 @@ async def _observe_active_initializer(resource: "LifecycleMixin") -> bool:
     resource.logger.debug(
         "%s: initializer observation completed in %.2fs (budget %.2fs)",
         resource.unique_name,
-        asyncio.get_running_loop().time() - observe_start,
+        elapsed_since(observe_start),
         timeout,
     )
     if pending:
@@ -764,7 +775,7 @@ async def _run_shutdown_coordinator(resource: "LifecycleMixin") -> TeardownRepor
         wait_timeout = total_deadline_remaining(resource)
         body_wait_start = asyncio.get_running_loop().time()
         done, _pending = await asyncio.wait([body_task], timeout=wait_timeout)
-        body_wait_elapsed = asyncio.get_running_loop().time() - body_wait_start
+        body_wait_elapsed = elapsed_since(body_wait_start)
 
         if body_task in done:
             try:
@@ -837,7 +848,7 @@ async def _run_shutdown_coordinator(resource: "LifecycleMixin") -> TeardownRepor
     resource.logger.debug(
         "%s: shutdown coordinator completed in %.2fs",
         resource.unique_name,
-        asyncio.get_running_loop().time() - coordinator_start,
+        elapsed_since(coordinator_start),
     )
     resource._teardown_report = report
     return report

--- a/src/hassette/resources/lifecycle.py
+++ b/src/hassette/resources/lifecycle.py
@@ -692,7 +692,14 @@ async def _observe_active_initializer(resource: "LifecycleMixin") -> bool:
 
     init_task.cancel()
     timeout = hooks_pool_remaining(resource)
+    observe_start = asyncio.get_running_loop().time()
     _done, pending = await asyncio.wait([init_task], timeout=timeout)
+    resource.logger.debug(
+        "%s: initializer observation completed in %.2fs (budget %.2fs)",
+        resource.unique_name,
+        asyncio.get_running_loop().time() - observe_start,
+        timeout,
+    )
     if pending:
         return True
 
@@ -725,9 +732,9 @@ async def _run_shutdown_coordinator(resource: "LifecycleMixin") -> TeardownRepor
         else:
             timeout = resource.hassette.config.lifecycle.resource_shutdown_timeout_seconds
 
-        now = asyncio.get_running_loop().time()
+        coordinator_start = asyncio.get_running_loop().time()
         task_cancel_ceiling = resource.hassette.config.lifecycle.task_cancellation_timeout_seconds
-        resource._shutdown_budget = compute_shutdown_budget(timeout, now, task_cancel_ceiling)
+        resource._shutdown_budget = compute_shutdown_budget(timeout, coordinator_start, task_cancel_ceiling)
 
         initialization_pending = await _observe_active_initializer(resource)
         if initialization_pending:
@@ -755,7 +762,9 @@ async def _run_shutdown_coordinator(resource: "LifecycleMixin") -> TeardownRepor
         # internal logic (e.g. Hassette._shutdown_body()'s TOTAL_TIMEOUT fallback) bounds itself
         # with, so it gets a chance to finish gracefully before this cruder outer backstop fires.
         wait_timeout = total_deadline_remaining(resource)
+        body_wait_start = asyncio.get_running_loop().time()
         done, _pending = await asyncio.wait([body_task], timeout=wait_timeout)
+        body_wait_elapsed = asyncio.get_running_loop().time() - body_wait_start
 
         if body_task in done:
             try:
@@ -770,12 +779,14 @@ async def _run_shutdown_coordinator(resource: "LifecycleMixin") -> TeardownRepor
                 report = TeardownReport(
                     causes=(TeardownCause.SHUTDOWN_BODY_FAILED,), failed_operations=("_shutdown_body",)
                 )
+            resource.logger.debug("%s: shutdown body completed in %.2fs", resource.unique_name, body_wait_elapsed)
         else:
             resource.logger.warning(
-                "%s shutdown body did not complete within its %ss deadline (%ss configured timeout)",
+                "%s shutdown body did not complete within its %.2fs deadline (%.2fs configured timeout, %.2fs elapsed)",
                 resource.unique_name,
                 wait_timeout,
                 timeout,
+                body_wait_elapsed,
             )
             report = TeardownReport(causes=(TeardownCause.SHUTDOWN_BODY_TIMED_OUT,))
             resource._force_terminal()
@@ -823,6 +834,11 @@ async def _run_shutdown_coordinator(resource: "LifecycleMixin") -> TeardownRepor
     if existing is not None:
         report = merge_teardown_reports(existing, report)
 
+    resource.logger.debug(
+        "%s: shutdown coordinator completed in %.2fs",
+        resource.unique_name,
+        asyncio.get_running_loop().time() - coordinator_start,
+    )
     resource._teardown_report = report
     return report
 

--- a/src/hassette/task_bucket/task_bucket.py
+++ b/src/hassette/task_bucket/task_bucket.py
@@ -427,11 +427,18 @@ class TaskBucket(Resource):
 
         effective_timeout = timeout if timeout is not None else self.config_cancel_timeout
         self.logger.debug("Cancelling %d tasks in bucket %s", len(tasks), self.unique_name)
+        cancel_start = asyncio.get_running_loop().time()
         for t in tasks:
             t.cancel()
 
         done, pending = await asyncio.wait(tasks, timeout=effective_timeout)
-        self.logger.debug("%d tasks done, %d still pending in bucket %s", len(done), len(pending), self.unique_name)
+        self.logger.debug(
+            "%d tasks done, %d still pending in bucket %s — completed in %.2fs",
+            len(done),
+            len(pending),
+            self.unique_name,
+            asyncio.get_running_loop().time() - cancel_start,
+        )
 
         for t in done:
             if t.cancelled():

--- a/src/hassette/task_bucket/task_bucket.py
+++ b/src/hassette/task_bucket/task_bucket.py
@@ -10,7 +10,7 @@ from typing import Any, ParamSpec, TypeVar, cast, overload
 
 from hassette import context as ctx
 from hassette.resources.base import Resource
-from hassette.resources.lifecycle import mark_ready
+from hassette.resources.lifecycle import elapsed_since, mark_ready
 from hassette.resources.operations import register_task_bucket_factory
 from hassette.types.types import LOG_LEVEL_TYPE, CoroLikeT
 from hassette.utils.func_utils import is_async_callable
@@ -437,7 +437,7 @@ class TaskBucket(Resource):
             len(done),
             len(pending),
             self.unique_name,
-            asyncio.get_running_loop().time() - cancel_start,
+            elapsed_since(cancel_start),
         )
 
         for t in done:


### PR DESCRIPTION
### Shutdown timing diagnostics

- Add debug/warning logging around each shutdown phase — wave-based child shutdown, task-bucket cancellation, `cleanup()`, child-shutdown propagation, initializer observation, and shutdown-body waiting — so a timeout log shows a per-phase elapsed breakdown instead of just "shutdown timed out." Makes diagnosing budget consumption during shutdown timeouts (e.g. #1723's wave timeout) tractable.
- Extract a shared `elapsed_since()` helper in `resources/lifecycle.py` after clean-code review flagged the same start/elapsed timing idiom hand-copied 7 times across `core.py`, `base.py`, `lifecycle.py`, and `task_bucket.py`. No behavior or log-message change from the refactor itself.

Closes #1736
