### PR TITLE
refactor: rename single-letter parameters in handler-list health helpers

### DIFF
--- a/frontend/src/components/app-detail/handler-list.tsx
+++ b/frontend/src/components/app-detail/handler-list.tsx
@@ -22,12 +22,12 @@ function healthKindFromCounts(failed: number, timedOut: number, total: number) {
   return statusToKind("stopped");
 }
 
-export function listenerHealthKind(l: ListenerData) {
-  return healthKindFromCounts(l.failed, l.timed_out, l.total_invocations);
+export function listenerHealthKind(listener: ListenerData) {
+  return healthKindFromCounts(listener.failed, listener.timed_out, listener.total_invocations);
 }
 
-export function jobHealthKind(j: JobData) {
-  return healthKindFromCounts(j.failed, j.timed_out, j.total_executions);
+export function jobHealthKind(job: JobData) {
+  return healthKindFromCounts(job.failed, job.timed_out, job.total_executions);
 }
 
 export function buildItems(listeners: ListenerData[], jobs: JobData[]): UnifiedItem[] {


### PR DESCRIPTION
## Summary

Renames the single-letter parameters in the two exported health-kind helpers in
`frontend/src/components/app-detail/handler-list.tsx`:

- `listenerHealthKind(l: ListenerData)` → `listenerHealthKind(listener: ListenerData)`
- `jobHealthKind(j: JobData)` → `jobHealthKind(job: JobData)`

Both helpers are exported and consumed by sibling modules (`overview-tab.tsx`, `job-detail.tsx`,
`listener-detail.tsx`, `handlers-tab.tsx`), so their signatures are part of the module's readable
surface. The same file already spells these concepts out as `listener` and `job` inside
`buildItems`, so this just makes the naming consistent within one file.

The parameters are positional, so no call sites changed. No behavior change.

## Testing

All green on this branch:

- `uv run nox -s dev` — 7188 passed, 1 skipped, 2 xfailed
- `prek -a` — all 28 hooks passed (ruff, eslint, prettier, stylelint, tsc, house-lint, typos, and the repo's custom checks)
- `prek pyright -a --stage pre-push` — passed
- `cd frontend && npm run test -- --run` — 110 files, 1562 tests passed
- `cd frontend && npm run build` — built cleanly

## Notes for review

Opened as a draft because the change arrived as an uncommitted working-tree edit with no prior
commit on the branch, so it has not had a human review pass — not because anything is failing.
Verification above is fully green and the change satisfies every acceptance criterion on the issue.
Ready to mark non-draft once reviewed.

No screenshots: this is a parameter rename with no rendered output change.

Partial progress on #1761 — needs human review
