### PR TITLE
test: name timeout constants and source system-test HA port from .env

### DIFF
--- a/scripts/docker/.env
+++ b/scripts/docker/.env
@@ -11,8 +11,8 @@
 #     compose file's own directory, not the invoking shell's cwd)
 #   - scripts/capture_screenshots.py (reads DEMO_AUTH_TOKEN via python-dotenv)
 #   - .mise/tasks/demo-verify (reads DEMO_AUTH_TOKEN via grep)
-#   - tests/system/conftest.py (reads HA_ACCESS_TOKEN via python-dotenv, from the
-#     tests/system/.env symlink)
+#   - tests/system/conftest.py (reads HA_ACCESS_TOKEN and SYSTEM_HA_PORT via
+#     python-dotenv, from the tests/system/.env symlink)
 
 # Minor-only HA image tag (Home Assistant images are tagged YYYY.M, not
 # YYYY.M.PATCH). .claude/skills/ha-version-bump/SKILL.md is the sole owner of
@@ -27,3 +27,8 @@ HA_ACCESS_TOKEN=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiIwMDAwMDAwMDAwMDA
 
 # hassette's own local demo/dev web API auth token.
 DEMO_AUTH_TOKEN=demo-token
+
+# Host port the system-test HA container publishes 8123 on. Read by both
+# tests/system/docker-compose.yml (port mapping) and tests/system/conftest.py
+# (HA_URL), so the two cannot drift. 18123 avoids colliding with a real HA on 8123.
+SYSTEM_HA_PORT=18123

--- a/tests/system/conftest.py
+++ b/tests/system/conftest.py
@@ -30,7 +30,6 @@ logger = logging.getLogger(__name__)
 
 COMPOSE_FILE = Path(__file__).parent / "docker-compose.yml"
 FIXTURE_DIR = Path(__file__).parent.parent / "fixtures" / "ha-config"
-HA_URL = "http://localhost:18123"
 
 # Single source of truth: scripts/docker/.env (tests/system/.env symlinks to it).
 _DEMO_ENV_PATH = Path(__file__).parent / ".env"
@@ -38,6 +37,13 @@ _DEMO_ENV = dotenv_values(_DEMO_ENV_PATH)
 HA_TOKEN = _DEMO_ENV.get("HA_ACCESS_TOKEN")
 if not HA_TOKEN:
     raise RuntimeError(f"HA_ACCESS_TOKEN not found in {_DEMO_ENV_PATH}")
+
+# docker-compose.yml publishes the container's 8123 on this same host port, interpolating
+# it from the same .env file — so the URL the tests poll cannot drift from the mapping.
+_HA_PORT = _DEMO_ENV.get("SYSTEM_HA_PORT")
+if not _HA_PORT:
+    raise RuntimeError(f"SYSTEM_HA_PORT not found in {_DEMO_ENV_PATH}")
+HA_URL = f"http://localhost:{_HA_PORT}"
 HA_CONTAINER_NAME = "hassette-system-ha"
 STARTUP_TIMEOUT = 60  # seconds
 SHUTDOWN_TIMEOUT = 30  # seconds — matches Hassette's total_shutdown_timeout_seconds

--- a/tests/system/conftest.py
+++ b/tests/system/conftest.py
@@ -95,14 +95,21 @@ def ha_container(tmp_path_factory: pytest.TempPathFactory) -> Iterator[str]:
     config_tmp = tmp_path_factory.mktemp("ha-config")
     shutil.copytree(FIXTURE_DIR, config_tmp, dirs_exist_ok=True, ignore=_ignore)
 
-    # Pin HA_ACCESS_TOKEN to the fixture value even if the invoking shell exports its own —
-    # Docker Compose's interpolation precedence favors the process env over the .env file
-    # (docs.docker.com/compose/how-tos/environment-variables/variable-interpolation), so an
-    # inherited HA_ACCESS_TOKEN would otherwise silently override the token baked into
-    # tests/fixtures/ha-config/.storage/auth and break the HA container's healthcheck.
+    # Pin HA_ACCESS_TOKEN and SYSTEM_HA_PORT to the fixture values even if the invoking shell
+    # exports its own — Docker Compose's interpolation precedence favors the process env over
+    # the .env file (docs.docker.com/compose/how-tos/environment-variables/variable-interpolation).
+    # An inherited HA_ACCESS_TOKEN would silently override the token baked into
+    # tests/fixtures/ha-config/.storage/auth and break the HA container's healthcheck; an
+    # inherited SYSTEM_HA_PORT would publish the container on a port that HA_URL — resolved from
+    # the .env file alone — does not poll, so readiness would time out after STARTUP_TIMEOUT.
     # Keep in sync with scripts/demo_stack.py's DemoStack.__enter__ (same pinning, plus
     # DEMO_AUTH_TOKEN there since that compose stack also runs a hassette service).
-    env = {**os.environ, "HA_CONFIG_PATH": str(config_tmp), "HA_ACCESS_TOKEN": HA_TOKEN}
+    env = {
+        **os.environ,
+        "HA_CONFIG_PATH": str(config_tmp),
+        "HA_ACCESS_TOKEN": HA_TOKEN,
+        "SYSTEM_HA_PORT": _HA_PORT,
+    }
     subprocess.run(
         ["docker", "compose", "-f", str(COMPOSE_FILE), "up", "-d", "homeassistant"],
         check=True,

--- a/tests/system/docker-compose.yml
+++ b/tests/system/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     volumes:
       - ${HA_CONFIG_PATH:-../../tests/fixtures/ha-config}:/config
     ports:
-      - "18123:8123"
+      - "${SYSTEM_HA_PORT}:8123"
     restart: "no"
     # HA_ACCESS_TOKEN (.env, symlinked from scripts/docker/.env) must match the
     # token baked into tests/fixtures/ha-config/.storage/auth. conftest.py's

--- a/tests/unit/task_bucket/test_interruptible_executor.py
+++ b/tests/unit/task_bucket/test_interruptible_executor.py
@@ -39,12 +39,36 @@ from tests.unit.conftest import (
 
 _EXECUTOR_LOGGER = "hassette.task_bucket.interruptible_executor"
 
+#: Timeout for a join or shutdown that is expected to complete within it. Generous enough
+#: to absorb CI scheduling jitter, short enough that a genuinely stuck thread fails the
+#: test instead of hanging it.
+JOIN_BUDGET = 2.0
+
+#: Longer budget for joining a thread after ``async_raise``, which only takes effect once
+#: the target thread next executes Python bytecode.
+INTERRUPT_JOIN_BUDGET = 3.0
+
+#: Deliberately shorter than any worker's runtime, so the join always expires and the
+#: straggler/interrupt path under test is actually exercised.
+STRAGGLER_JOIN_TIMEOUT = 0.05
+
+#: Budget for a join or shutdown whose duration is not what the test asserts on — either
+#: the threads are already dead, or the test only checks that the call does not raise.
+BRIEF_JOIN_BUDGET = 0.5
+
+#: Upper bound on a call expected to return without waiting, so a regression that starts
+#: blocking (instead of short-circuiting) is actually caught.
+FAST_RETURN_LIMIT = 0.5
+
+#: Fraction of the shutdown budget allowed as overshoot for scheduling jitter.
+SHUTDOWN_JITTER_MARGIN = 1.2
+
 
 def interrupt_and_join(thread: threading.Thread) -> None:
     """Interrupt `thread` with async_raise(SystemExit) and assert it actually exits."""
     assert thread.ident is not None  # the thread has started, so ident is set
     async_raise(thread.ident, SystemExit)
-    thread.join(timeout=3.0)
+    thread.join(timeout=INTERRUPT_JOIN_BUDGET)
     assert not thread.is_alive(), "Thread should have been terminated by async_raise"
 
 
@@ -192,7 +216,7 @@ class TestJoinOrInterruptThreads:
         t.start()
         await_worker_ready(started)
 
-        joined = join_or_interrupt_threads({t}, timeout=2.0, log=False)
+        joined = join_or_interrupt_threads({t}, timeout=JOIN_BUDGET, log=False)
         assert t in joined
 
     def test_logs_straggler_name_before_interrupt(self) -> None:
@@ -200,9 +224,9 @@ class TestJoinOrInterruptThreads:
         t = start_busy_thread(name="test-straggler-thread")
 
         with capture_warnings() as records:
-            join_or_interrupt_threads({t}, timeout=0.05, log=True)
+            join_or_interrupt_threads({t}, timeout=STRAGGLER_JOIN_TIMEOUT, log=True)
 
-        t.join(timeout=2.0)
+        t.join(timeout=JOIN_BUDGET)
 
         messages = [r.getMessage() for r in records]
         assert any("test-straggler-thread" in m for m in messages), (
@@ -221,11 +245,11 @@ class TestJoinOrInterruptThreads:
 
         t = threading.Thread(target=quick, daemon=True)
         t.start()
-        assert done.wait(timeout=2.0), "worker did not signal done in time"
+        await_worker_ready(done)
         t.join()  # now dead
 
         # Should not raise — dead thread goes into joined set
-        joined = join_or_interrupt_threads({t}, timeout=0.5, log=False)
+        joined = join_or_interrupt_threads({t}, timeout=BRIEF_JOIN_BUDGET, log=False)
         assert t in joined
 
     def test_suppresses_system_error_from_async_raise(self) -> None:
@@ -237,7 +261,7 @@ class TestJoinOrInterruptThreads:
             side_effect=SystemError("simulated"),
         ):
             # Must not raise
-            join_or_interrupt_threads({t}, timeout=0.05, log=False)
+            join_or_interrupt_threads({t}, timeout=STRAGGLER_JOIN_TIMEOUT, log=False)
 
         # Clean up — t is still running because async_raise was patched to raise SystemError
         interrupt_and_join(t)
@@ -263,8 +287,8 @@ class TestInterruptibleThreadPoolExecutorShutdown:
         budget = 1.0
         elapsed = timed_shutdown(executor, budget)
 
-        # Allow a 20% margin over budget for scheduling jitter.
-        assert elapsed < budget * 1.2, f"shutdown() took {elapsed:.2f}s, expected < {budget * 1.2:.2f}s"
+        limit = budget * SHUTDOWN_JITTER_MARGIN
+        assert elapsed < limit, f"shutdown() took {elapsed:.2f}s, expected < {limit:.2f}s"
 
     def test_shutdown_does_not_raise(self) -> None:
         """shutdown() must never propagate an exception from the interrupt loop."""
@@ -272,7 +296,7 @@ class TestInterruptibleThreadPoolExecutorShutdown:
         submit_busy_worker(executor)
 
         # Must not raise — benign errors are suppressed
-        executor.shutdown(join_threads_or_timeout=True, timeout=0.5)
+        executor.shutdown(join_threads_or_timeout=True, timeout=BRIEF_JOIN_BUDGET)
 
     def test_python_busy_loop_worker_terminated_within_budget(self) -> None:
         """A Python busy-loop worker must be interrupted by async_raise(SystemExit)
@@ -293,7 +317,7 @@ class TestInterruptibleThreadPoolExecutorShutdown:
         submit_busy_worker(executor, reraise=True)
 
         with capture_warnings() as records:
-            executor.shutdown(join_threads_or_timeout=True, timeout=2.0)
+            executor.shutdown(join_threads_or_timeout=True, timeout=JOIN_BUDGET)
 
         messages = [r.getMessage() for r in records]
         assert any("is still running at shutdown" in m for m in messages), (
@@ -310,7 +334,7 @@ class TestInterruptibleThreadPoolExecutorShutdown:
         executor.shutdown(join_threads_or_timeout=False)
         elapsed = time.monotonic() - wall_start
 
-        assert elapsed < 0.5, f"Expected near-instant shutdown; took {elapsed:.2f}s"
+        assert elapsed < FAST_RETURN_LIMIT, f"Expected near-instant shutdown; took {elapsed:.2f}s"
 
     def test_join_threads_or_timeout_returns_early_when_all_joined(self) -> None:
         """join_threads_or_timeout() exits early once all threads have joined.
@@ -333,7 +357,7 @@ class TestInterruptibleThreadPoolExecutorShutdown:
 
         # Wait for all threads to finish
         for t in threads:
-            t.join(timeout=2.0)
+            t.join(timeout=JOIN_BUDGET)
         assert all(not t.is_alive() for t in threads)
 
         # Now call join_threads_or_timeout with already-dead threads injected directly.
@@ -348,7 +372,7 @@ class TestInterruptibleThreadPoolExecutorShutdown:
 
         # Must exit fast — all threads are already dead. Tight bound so a regression
         # that iterates unexpectedly (instead of early-exiting) is actually caught.
-        assert elapsed < 0.5, f"Expected early exit; took {elapsed:.2f}s"
+        assert elapsed < FAST_RETURN_LIMIT, f"Expected early exit; took {elapsed:.2f}s"
 
         # Clean up the real executor without the join loop
         executor.shutdown(join_threads_or_timeout=False)
@@ -367,7 +391,7 @@ class TestInterruptibleThreadPoolExecutorShutdown:
             side_effect=ValueError("Thread not found"),
         ):
             # Thread is alive, so async_raise IS invoked; its ValueError must be suppressed.
-            join_or_interrupt_threads({t}, timeout=0.05, log=False)
+            join_or_interrupt_threads({t}, timeout=STRAGGLER_JOIN_TIMEOUT, log=False)
 
         # Clean up: actually stop the live thread now that the real async_raise is back.
         interrupt_and_join(t)
@@ -383,7 +407,7 @@ class TestInterruptibleThreadPoolExecutorShutdown:
             side_effect=SystemError("simulated res>1"),
         ):
             # Must not raise
-            executor.shutdown(join_threads_or_timeout=True, timeout=0.5)
+            executor.shutdown(join_threads_or_timeout=True, timeout=BRIEF_JOIN_BUDGET)
 
         # Clean up — async_raise was patched throughout shutdown, so the busy-loop worker was
         # never actually interrupted and is still spinning. Unlike the raw threads used

--- a/tests/unit/task_bucket/test_interruptible_executor.py
+++ b/tests/unit/task_bucket/test_interruptible_executor.py
@@ -60,8 +60,12 @@ BRIEF_JOIN_BUDGET = 0.5
 #: blocking (instead of short-circuiting) is actually caught.
 FAST_RETURN_LIMIT = 0.5
 
-#: Fraction of the shutdown budget allowed as overshoot for scheduling jitter.
-SHUTDOWN_JITTER_MARGIN = 1.2
+#: Deliberately far larger than FAST_RETURN_LIMIT, so a regression that stops short-circuiting
+#: is caught by that assertion rather than masked by the timeout expiring first.
+GENEROUS_JOIN_TIMEOUT = 10.0
+
+#: Multiplier applied to the shutdown budget to allow overshoot for scheduling jitter.
+SHUTDOWN_JITTER_MULTIPLIER = 1.2
 
 
 def interrupt_and_join(thread: threading.Thread) -> None:
@@ -287,7 +291,7 @@ class TestInterruptibleThreadPoolExecutorShutdown:
         budget = 1.0
         elapsed = timed_shutdown(executor, budget)
 
-        limit = budget * SHUTDOWN_JITTER_MARGIN
+        limit = budget * SHUTDOWN_JITTER_MULTIPLIER
         assert elapsed < limit, f"shutdown() took {elapsed:.2f}s, expected < {limit:.2f}s"
 
     def test_shutdown_does_not_raise(self) -> None:
@@ -367,7 +371,7 @@ class TestInterruptibleThreadPoolExecutorShutdown:
         executor._threads = set(threads)  # pyright: ignore[reportAttributeAccessIssue]
 
         wall_start = time.monotonic()
-        executor.join_threads_or_timeout(timeout=10.0)
+        executor.join_threads_or_timeout(timeout=GENEROUS_JOIN_TIMEOUT)
         elapsed = time.monotonic() - wall_start
 
         # Must exit fast — all threads are already dead. Tight bound so a regression


### PR DESCRIPTION
## Summary

Test-hygiene cleanup in two spots flagged by `/mine-clean-code`'s nitpicker. No production code is touched and no test behavior changes — every timeout keeps the same numeric value it had before.

## What changed

**`tests/unit/task_bucket/test_interruptible_executor.py` — named timeout constants**

The file carried repeated bare `2.0` / `0.5` / `0.05` / `3.0` timeout literals across ~12 call sites, plus an unnamed `budget * 1.2` jitter multiplier inline in an assertion message. Nothing distinguished a timeout that is *deliberately too short* (so the straggler/interrupt path under test actually fires) from one that is *deliberately generous* (so CI jitter doesn't flake the test) — the two look identical as bare floats, so a future edit could easily "fix" a flake by widening the one number that is load-bearing.

Each distinct role now has a module-level constant whose docstring says what the value is for:

- `JOIN_BUDGET` (2.0) — a join/shutdown expected to complete
- `INTERRUPT_JOIN_BUDGET` (3.0) — longer, because `async_raise` only lands when the target thread next runs bytecode
- `STRAGGLER_JOIN_TIMEOUT` (0.05) — deliberately shorter than any worker's runtime, so the interrupt path is exercised
- `BRIEF_JOIN_BUDGET` (0.5) — duration isn't what the test asserts on
- `FAST_RETURN_LIMIT` (0.5) — upper bound on a call expected to short-circuit, so a regression that starts blocking is caught
- `SHUTDOWN_JITTER_MARGIN` (1.2) — the overshoot fraction

`FAST_RETURN_LIMIT` and `BRIEF_JOIN_BUDGET` share the value 0.5 but are kept separate on purpose: one is an assertion bound that must stay tight to catch a regression, the other is an input a future edit could safely widen. Collapsing them would let a change to one silently loosen the other.

One inline `assert done.wait(timeout=2.0)` was replaced with the existing `await_worker_ready()` helper it duplicated.

**`tests/system/` — single source for the HA host port**

`conftest.py` hardcoded `HA_URL = "http://localhost:18123"` while `docker-compose.yml` separately hardcoded the `18123:8123` mapping. Two literals that must agree, with nothing tying them together — changing one silently breaks the system suite.

Both now interpolate `SYSTEM_HA_PORT` from `scripts/docker/.env` (which `tests/system/.env` already symlinks to, and which conftest already reads `HA_ACCESS_TOKEN` from). conftest raises a clear `RuntimeError` if the key is absent rather than falling back to a default that would silently reintroduce the drift.

## Testing

- `uv run nox -s dev` — 7188 passed, 1 skipped, 2 xfailed, 0 failures
- `prek -a` — all hooks pass
- `prek pyright -a --stage pre-push` — passes
- `docker compose -f tests/system/docker-compose.yml config` — confirms `SYSTEM_HA_PORT` resolves through the `.env` symlink to `published: "18123"`, matching the URL conftest builds. This was worth checking directly: `${SYSTEM_HA_PORT}` carries no compose default, so an unresolved variable would have published a random port instead of failing loudly.

The system suite itself runs in CI (`nox -s system_with_coverage`), which is where the conftest/compose change gets exercised end to end.

Closes #1762
