### PR TITLE
fix: align duration log precision in shutdown path

### DIFF
--- a/src/hassette/resources/base.py
+++ b/src/hassette/resources/base.py
@@ -473,7 +473,7 @@ class Resource(LifecycleMixin, metaclass=FinalMeta):
             async with asyncio.timeout(cleanup_timeout):
                 await self.cleanup()
         except TimeoutError:
-            self.logger.warning("cleanup() timed out after %ss for %s", cleanup_timeout, self.unique_name)
+            self.logger.warning("cleanup() timed out after %.2fs for %s", cleanup_timeout, self.unique_name)
             reports.append(TeardownReport(causes=(TeardownCause.CLEANUP_TIMED_OUT,), failed_operations=("cleanup",)))
         except Exception as exc:
             self.logger.exception("Error during cleanup: %s %s", type(exc).__name__, exc)

--- a/src/hassette/task_bucket/task_bucket.py
+++ b/src/hassette/task_bucket/task_bucket.py
@@ -449,7 +449,7 @@ class TaskBucket(Resource):
 
         for t in pending:
             self.logger.warning(
-                "[%s] task %s refused to die within %.1fs", self.unique_name, t.get_name(), effective_timeout
+                "[%s] task %s refused to die within %.2fs", self.unique_name, t.get_name(), effective_timeout
             )
 
         return tuple(sorted(t.get_name() for t in pending))


### PR DESCRIPTION
## Summary

Two log lines in the shutdown path formatted their duration values at a precision
inconsistent with the sibling duration logs in the same method. This aligns both to
`%.2f`, matching the surrounding elapsed-time logging.

- `src/hassette/resources/base.py` — the cleanup-timeout warning rendered
  `cleanup_timeout` as a raw float via `%ss`. Now `%.2fs`.
- `src/hassette/task_bucket/task_bucket.py` — the "task refused to die" warning used
  `%.1fs`, while the elapsed-time log a few lines above it uses `%.2f` for the same
  kind of duration. Now `%.2fs`.

Both were surfaced by `/mine-clean-code` while shipping #1736 and predate that PR's
changes. No behavior change — these are format specifiers on `logger.warning` calls in
paths that only fire on cleanup timeout or a task that outlives its shutdown deadline.

## Testing

- `uv run nox -s dev` — 7188 passed, 1 skipped, 2 xfailed.
  (An initial run hit an unrelated flake in
  `tests/integration/bus/test_bus_duration.py::test_duration_once_removal_on_exception`
  — a timer-wait timeout under full-suite parallel load. It passed on a clean re-run of
  the full suite, and 45/45 on repeated isolated runs of that file.)
- `prek -a` — all hooks pass.
- `prek pyright -a --stage pre-push` — passes.

Closes #1765
