### PR TITLE
fix: salvage standalone hardening fixes from closed PR #1782

### DIFF
--- a/src/hassette/core/service_watcher.py
+++ b/src/hassette/core/service_watcher.py
@@ -25,6 +25,13 @@ if typing.TYPE_CHECKING:
 
 SERVICE_STATUS_PATH = "payload.data.status"
 
+_STATUS_EVENT_DISPATCH_TIMEOUT_SECONDS = 5.0
+"""Upper bound on how long dispatch_status_event_best_effort() waits for send_event() to accept
+a status event. send_event() awaits a bounded channel that can stay full indefinitely if nothing
+is draining it; every caller here has already committed to its state transition or shutdown
+before this runs, so a stalled channel must degrade to a logged, swallowed timeout rather than
+hang the caller the way an unguarded await would."""
+
 
 class RestartBudget:
     """Sliding-window restart budget tracker.
@@ -228,6 +235,35 @@ class ServiceWatcher(Resource):
             self.logger.debug("Restart admission blocked (fatal reason or shutdown requested), skipping %s", action)
         return True
 
+    async def dispatch_status_event_best_effort(
+        self, name: str, role: ResourceRole, event: HassetteServiceEvent
+    ) -> None:
+        """Send a service-status event without letting delivery failure -- or a stalled channel --
+        block the caller's already-decided state transition or shutdown call.
+
+        Event dispatch is telemetry, not the control path: every caller here has already recorded
+        the fatal reason, requested shutdown, or otherwise committed to its outcome before this is
+        called, so a ``send_event`` failure or hang must be logged and swallowed rather than left
+        to propagate (or block indefinitely) and abort whatever the caller does next. ``send_event``
+        awaits a bounded channel with no timeout of its own, so it is bounded here -- this timeout
+        is local to this method; other ``send_event`` call sites elsewhere in the codebase are not
+        bounded by it and remain a plain, unguarded await.
+        """
+        try:
+            await asyncio.wait_for(self.hassette.send_event(event), timeout=_STATUS_EVENT_DISPATCH_TIMEOUT_SECONDS)
+        except TimeoutError:
+            self.logger.error(
+                "%s '%s' timed out dispatching %s event after %.1fs",
+                role,
+                name,
+                event.payload.data.status.name,
+                _STATUS_EVENT_DISPATCH_TIMEOUT_SECONDS,
+            )
+        except Exception as exc:
+            self.logger.error(
+                "%s '%s' failed to dispatch %s event: %s", role, name, event.payload.data.status.name, exc
+            )
+
     async def handle_restart_refused(self, name: str, role: ResourceRole, error: RestartRefusedError) -> None:
         """Escalate a typed restart refusal to one fatal outcome.
 
@@ -255,10 +291,7 @@ class ServiceWatcher(Resource):
             exception=error,
             ready=False,
         )
-        try:
-            await self.hassette.send_event(crashed_event)
-        except Exception as exc:
-            self.logger.error("%s '%s' failed to dispatch CRASHED event after restart refusal: %s", role, name, exc)
+        await self.dispatch_status_event_best_effort(name, role, crashed_event)
 
     async def handle_exhaustion(
         self,
@@ -286,7 +319,7 @@ class ServiceWatcher(Resource):
                 previous_status=ResourceStatus.FAILED,
                 source_payload=status_payload,
             )
-            await self.hassette.send_event(crashed_event)
+            await self.dispatch_status_event_best_effort(name, role, crashed_event)
             await self.hassette.shutdown()
 
         elif spec.restart_type == RestartType.TRANSIENT:
@@ -306,7 +339,7 @@ class ServiceWatcher(Resource):
                 source_payload=status_payload,
                 retry_at=retry_at,
             )
-            await self.hassette.send_event(cooling_event)
+            await self.dispatch_status_event_best_effort(name, role, cooling_event)
             self.set_service_status(name, role, ResourceStatus.EXHAUSTED_COOLING)
             # Cancel existing cooldown for this service if any
             existing = self._cooldown_tasks.get(key)
@@ -331,7 +364,7 @@ class ServiceWatcher(Resource):
                 previous_status=ResourceStatus.FAILED,
                 source_payload=status_payload,
             )
-            await self.hassette.send_event(dead_event)
+            await self.dispatch_status_event_best_effort(name, role, dead_event)
             self.set_service_status(name, role, ResourceStatus.EXHAUSTED_DEAD)
 
     async def cooldown_and_retry(self, name: str, role: ResourceRole, key: str, spec: RestartSpec) -> None:
@@ -359,7 +392,7 @@ class ServiceWatcher(Resource):
                 status=ResourceStatus.EXHAUSTED_DEAD,
                 previous_status=ResourceStatus.EXHAUSTED_COOLING,
             )
-            await self.hassette.send_event(dead_event)
+            await self.dispatch_status_event_best_effort(name, role, dead_event)
             self.set_service_status(name, role, ResourceStatus.EXHAUSTED_DEAD, "cooldown cycle limit")
             return
 
@@ -438,7 +471,7 @@ class ServiceWatcher(Resource):
                 previous_status=ResourceStatus.FAILED,
                 source_payload=status_payload,
             )
-            await self.hassette.send_event(crashed_event)
+            await self.dispatch_status_event_best_effort(name, role, crashed_event)
             await self.hassette.shutdown()
             return
 

--- a/src/hassette/resources/base.py
+++ b/src/hassette/resources/base.py
@@ -1,7 +1,6 @@
 import asyncio
 import typing
 import uuid
-from contextlib import suppress
 from logging import INFO, Filter, Logger, LogRecord, getLogger
 from typing import Any, ClassVar, TypeVar, final
 
@@ -32,7 +31,7 @@ from hassette.resources.teardown import (
     TeardownReport,
     merge_teardown_reports,
 )
-from hassette.types.enums import ResourceRole, ResourceStatus
+from hassette.types.enums import TERMINAL_STATUSES, ResourceRole, ResourceStatus
 from hassette.types.types import FRAMEWORK_APP_KEY_PREFIX, LOG_LEVEL_TYPE, SourceTier
 
 from .mixins import LifecycleMixin
@@ -388,7 +387,17 @@ class Resource(LifecycleMixin, metaclass=FinalMeta):
         ):
             self._shutdown_task.cancel()
         self.task_bucket.cancel_all_sync()
-        self._status = ResourceStatus.STOPPED  # bypass setter to skip validation
+        if self._status in TERMINAL_STATUSES:
+            # Don't silently clobber a status this resource already reached on its own (e.g.
+            # EXHAUSTED_DEAD from the confirmed-quiescent restart-refusal path) -- overwriting it
+            # to STOPPED here would erase that evidence with no trace for post-incident triage.
+            self.logger.debug(
+                "%s: force-terminal called but status is already terminal (%s) -- leaving unchanged",
+                self.unique_name,
+                self._status.value,
+            )
+        else:
+            self._status = ResourceStatus.STOPPED  # bypass setter to skip validation
         mark_not_ready(self, "shutdown timed out")
         for child in self.children:
             child._force_terminal()
@@ -657,7 +666,22 @@ class Resource(LifecycleMixin, metaclass=FinalMeta):
 
         cancel(self)
         if self._init_task and not self._init_task.done():
-            with suppress(asyncio.CancelledError):
+            try:
                 await asyncio.wait_for(self._init_task, timeout=timeout)
+            except asyncio.CancelledError:  # noqa: ASYNC103 — re-raised below when this task's own cancellation is detected
+                # cancel(self) above cancels _init_task -- a different task object than the one
+                # running this coroutine -- so its CancelledError propagating here is expected
+                # and safe to swallow. But an external cancellation of *this* coroutine (e.g. the
+                # enclosing asyncio.timeout(cleanup_timeout) in _run_post_hook_shutdown_stage
+                # expiring while this await is suspended) raises CancelledError at this same
+                # point and is indistinguishable by exception type alone. current_task.cancelling()
+                # disambiguates: it is only nonzero when something called .cancel() on *this*
+                # task, which happens only in the latter case. Swallowing that case would prevent
+                # the enclosing asyncio.timeout() from ever observing its own expiration, silently
+                # losing the CLEANUP_TIMED_OUT evidence it depends on to convert the cancellation
+                # into a TimeoutError.
+                current_task = asyncio.current_task()
+                if current_task is not None and current_task.cancelling():
+                    raise
 
         self.logger.debug("Cleaned up resources")

--- a/tests/unit/core/test_service_watcher_coverage.py
+++ b/tests/unit/core/test_service_watcher_coverage.py
@@ -7,6 +7,7 @@ listener registration, the BusService-recovery gate, on_service_running's early-
 guards, cooldown abort/failure paths, and service lookup.
 """
 
+import asyncio
 from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
 import pytest
@@ -485,6 +486,35 @@ class TestHandleRestartRefused:
 
         hassette.record_fatal_reason.assert_called_once()
         mock_request_shutdown.assert_called_once()
+
+
+class TestDispatchStatusEventBestEffort:
+    async def test_bounds_a_hanging_send_event(self) -> None:
+        """A stalled event channel must not hang the caller's already-decided status transition --
+        the dispatch is bounded by a timeout and swallowed rather than blocking indefinitely.
+        """
+        hassette = make_watcher_hassette()
+        entered = asyncio.Event()
+
+        async def hang_forever(_event: HassetteServiceEvent) -> None:
+            entered.set()
+            await asyncio.Event().wait()  # never resolves on its own
+
+        hassette.send_event = AsyncMock(side_effect=hang_forever)
+        watcher = make_watcher(hassette)
+        event = watcher.emit_service_status_event(
+            PLACEHOLDER_SERVICE_NAME, ResourceRole.SERVICE, ResourceStatus.CRASHED, ResourceStatus.RUNNING
+        )
+
+        with patch("hassette.core.service_watcher._STATUS_EVENT_DISPATCH_TIMEOUT_SECONDS", 0.05):
+            # Deterministic bound on the test itself: if the fix regresses and the dispatch hangs
+            # again, this fails fast instead of stalling the suite.
+            await asyncio.wait_for(
+                watcher.dispatch_status_event_best_effort(PLACEHOLDER_SERVICE_NAME, ResourceRole.SERVICE, event),
+                timeout=2,
+            )
+
+        assert entered.is_set()
 
 
 class TestExecuteRestartCatchesRefusal:

--- a/tests/unit/resources/lifecycle/test_force_terminal.py
+++ b/tests/unit/resources/lifecycle/test_force_terminal.py
@@ -276,6 +276,37 @@ async def test_force_terminal_reaches_grandchild_under_already_reported_child():
     assert grandchild.status == ResourceStatus.STOPPED
 
 
+async def test_force_terminal_does_not_clobber_already_terminal_status():
+    """`_force_terminal()` must not silently overwrite a status the resource already reached on
+    its own (e.g. EXHAUSTED_DEAD from a restart-refusal path) with STOPPED. Before this fix, the
+    unconditional `self._status = ResourceStatus.STOPPED` bypassed the setter's transition
+    validation and would erase that evidence with no trace -- EXHAUSTED_DEAD's only modeled
+    outbound transition is to STOPPING, never back to STOPPED, so this reversion could only
+    happen via this bypass.
+    """
+    hassette = make_mock_hassette(sealed=False)
+    resource = SimpleParent(hassette)
+    resource._status = ResourceStatus.EXHAUSTED_DEAD
+
+    resource._force_terminal()
+
+    assert resource.status == ResourceStatus.EXHAUSTED_DEAD
+
+
+async def test_force_terminal_still_sets_stopped_from_a_non_terminal_status():
+    """Companion to the guard test above: a resource NOT already in a terminal status is still
+    forced to STOPPED as before -- the guard only protects an existing terminal status, it does
+    not disable force-terminal's normal behavior.
+    """
+    hassette = make_mock_hassette(sealed=False)
+    resource = SimpleParent(hassette)
+    assert resource.status == ResourceStatus.NOT_STARTED
+
+    resource._force_terminal()
+
+    assert resource.status == ResourceStatus.STOPPED
+
+
 async def test_service_force_terminal_cancels_serve_task():
     """Service._force_terminal() cancels the _serve_task before calling super()."""
     svc = await make_running_simple_service()

--- a/tests/unit/resources/test_shutdown_edge_cases.py
+++ b/tests/unit/resources/test_shutdown_edge_cases.py
@@ -6,10 +6,15 @@ Verifies:
 - shutdown() skips the STOPPING transition when status is already terminal
 - _shutdown_body() swallows an exception raised by handle_stop()
 - _emit_readiness_event() swallows an exception raised while building/sending the event
+- cleanup() propagates an external cancellation of its own coroutine instead of mistaking it
+  for _init_task's own requested cancellation
 """
 
 import asyncio
+from contextlib import suppress
 from unittest.mock import AsyncMock, patch
+
+import pytest
 
 from hassette.resources.lifecycle import mark_ready
 from hassette.resources.teardown import TeardownCause
@@ -143,3 +148,53 @@ class TestEmitReadinessEventSwallowsException:
 
         # Must not raise despite send_event() blowing up.
         await resource._emit_readiness_event()
+
+
+class TestCleanupPropagatesExternalCancellation:
+    async def test_external_cancellation_is_not_swallowed_as_init_task_cancellation(self) -> None:
+        """cleanup() must not swallow a CancelledError caused by an external cancellation of its
+        own coroutine (e.g. an enclosing asyncio.timeout() expiring) as if it were _init_task's
+        own requested cancellation completing. Doing so would silently defeat the caller's
+        timeout: the CancelledError never propagates far enough for asyncio.timeout() to detect
+        its own expiration and convert it into a TimeoutError, and _run_post_hook_shutdown_stage()
+        would never record CLEANUP_TIMED_OUT.
+        """
+        # Sequence this test drives, mapped to the two CancelledErrors involved:
+        #   1. cleanup() calls cancel(self), which cancels _init_task -- this is the FIRST
+        #      cancellation the fake task below sees, and it deliberately ignores it (like a
+        #      real init task that doesn't unwind instantly), so _init_task stays "not done".
+        #   2. cleanup() is still suspended in `await asyncio.wait_for(self._init_task, ...)`
+        #      when the outer `asyncio.timeout(0.05)` below expires -- this is the SECOND,
+        #      "external" cancellation, delivered at that same await point. This is the one
+        #      the fix must let propagate rather than swallow as if it were _init_task's own.
+        hassette = make_mock_hassette(sealed=False)
+        resource = ConcreteResource(hassette=hassette)
+
+        entered = asyncio.Event()
+        never_resolves = asyncio.Event()  # deliberately never .set() — keeps the task suspended
+        has_ignored_one_cancel = False
+
+        async def stubborn_init_task() -> None:
+            nonlocal has_ignored_one_cancel
+            while True:
+                try:
+                    entered.set()
+                    await never_resolves.wait()
+                except asyncio.CancelledError:  # noqa: ASYNC103 — re-raised once one cancel has been ignored
+                    if has_ignored_one_cancel:
+                        raise
+                    # Ignore exactly cancel(self)'s cancellation (see step 1 above).
+                    has_ignored_one_cancel = True
+                    continue  # noqa: ASYNC104 — deliberate one-time swallow, see comment above
+
+        resource._init_task = asyncio.create_task(stubborn_init_task())
+        await asyncio.wait_for(entered.wait(), timeout=1)
+
+        try:
+            with pytest.raises(TimeoutError):
+                async with asyncio.timeout(0.05):
+                    await resource.cleanup(timeout=10)
+        finally:
+            resource._init_task.cancel()
+            with suppress(asyncio.CancelledError):
+                await resource._init_task


### PR DESCRIPTION
### Restart/shutdown hardening

Cherry-picks three independent bugfixes from the closed scoped-degradation PR's branch (`1716`, head `231ebc7`). None of that PR's scoped-degradation policy code came along — these are standalone fixes.

- `ServiceWatcher`'s fatal/exhaustion-path `send_event` calls are now bounded by a 5s timeout via the new `dispatch_status_event_best_effort()`. `send_event` awaits a bounded channel that can stay full indefinitely if nothing is draining it; every caller here has already committed to its state transition or shutdown before this runs, so a stalled channel now degrades to a logged, swallowed timeout instead of hanging the caller.
- `Resource.cleanup()` now disambiguates an external cancellation of its own coroutine (e.g. the enclosing `asyncio.timeout(cleanup_timeout)` expiring) from `_init_task`'s own expected cancellation, using `asyncio.current_task().cancelling()`. Previously both cases were swallowed identically via `contextlib.suppress(asyncio.CancelledError)`, which silently discarded the `CLEANUP_TIMED_OUT` evidence the enclosing timeout depends on.
- `Resource._force_terminal()` no longer clobbers an already-terminal status (e.g. `EXHAUSTED_DEAD`) with `STOPPED`, preserving that evidence for post-incident triage instead of overwriting it with no trace.

Closes #1795
