### PR TITLE
chore: add 2026-09-02 Fable audit series (4 reports)

### DIFF
--- a/design/audits/2026-09-02-backend-core-correctness-audit.md
+++ b/design/audits/2026-09-02-backend-core-correctness-audit.md
@@ -1,0 +1,268 @@
+# Backend Core Correctness & Coherence Audit — 2026-09-02
+
+**Scope:** Backend core, deep pass — lifecycle/teardown machinery (`resources/`), root coordinator
+(`core/core.py`), the readiness lattice (WebsocketService / StateProxy / AppBootstrapCoordinator),
+bus stack (`bus/`, `core/bus_service.py`), scheduler stack, app lifecycle
+(`app_lifecycle_service.py`, `app_handler.py`, `app_registry.py`), ServiceWatcher, CommandExecutor,
+DatabaseService, SessionManager, EventStreamService, SyncExecutor, LoggingService, Api layer, App base.
+**Not covered:** web layer, frontend, CLI, docs, deep `triggers.py` pass, sync facades beyond spot checks.
+
+**Lenses:** correctness/races first, design coherence second. Decomposition/file-size debt was
+deliberately excluded — the issue backlog already tracks it (#1759, #1576, #1575, #1574, #1721, #1686).
+
+**Method:** direct line-by-line read of ~10k lines of the intricate core (task bucket, resources,
+core, websocket, state proxy, bootstrap coordinator, bus, service watcher, app lifecycle, command
+executor, database service), plus two full-context delegate passes over the scheduler stack and the
+api/support-services slice whose findings were then spot-verified. The headline finding (F1) was
+confirmed with a runtime probe, not just reading.
+
+**Overall assessment:** this core is in unusually good shape. The lifecycle coordinator, teardown
+report/budget machinery, StateProxy generation fencing + journal replay, bus dispatch/backpressure
+bookkeeping, duration-timer state machine, and the telemetry write pipeline all survived detailed
+adversarial reading — including deliberate interleaving analysis — with no correctness findings.
+The findings below cluster at the *seams between subsystems* (timeout wrappers around coordinator
+front doors, retry policies around side-effectful sends, event handlers blind to a dimension of the
+events they receive), not inside the machines themselves.
+
+---
+
+## Findings
+
+### F1 — HIGH · App init timeout leaves a ghost initializer running (runtime-confirmed)
+
+`app_lifecycle_service.py:193` wraps `await inst.initialize()` in `anyio.fail_after(startup_timeout)`.
+But `initialize()` is the coordinator front door: `coordinate_initialize()`
+(`resources/lifecycle.py:658`) runs the real work as `_init_task` and joins it via
+`await asyncio.shield(init_task)`. The timeout cancels only the outer await — **the shield keeps the
+initializer running**. The timeout branch (`app_lifecycle_service.py:202-212`) then sets
+`inst.status = STOPPED`, runs `cleanup_failed_instance()` (listeners/jobs/cache — but never cancels
+`_init_task`, never calls `inst.shutdown()` or `cancel(inst)`), and pops the instance from the
+registry via `record_failure()`.
+
+**Runtime probe** (real `Resource` through `initialize_instances()`, `on_initialize` sleeping past
+the timeout): after the timeout path finished — status STOPPED, failure recorded — `_init_task` was
+still pending. When the hung hook completed, the discarded instance registered its listener
+*post-cleanup* and transitioned STOPPED→RUNNING (invalid transition, applied with a warning in
+non-strict mode; raises inside the orphan task under `strict_lifecycle`).
+
+**Consequences:** a ghost instance with live listeners/jobs, unreachable by stop/reload (registry
+already dropped it), emitting RUNNING status events for an instance the dashboard shows as FAILED.
+If the user reloads the app meanwhile, ghost and replacement share `instance_name`/owner_id, so a
+later teardown rips out both sets of registrations. Trigger condition is mundane: any app
+`on_initialize` that outlives `app_startup_timeout_seconds` (default 20s) and later completes —
+a slow HTTP call, a stuck device, a long first sync.
+
+**Fix direction:** on timeout, drive the machinery that already exists for exactly this — cancel
+and bound-observe the initializer (`_observe_active_initializer` semantics) or run a bounded
+`inst.shutdown()` — instead of the ad-hoc cleanup. Cross-references: #1367 covers the *exception*
+path of the same seam (hook raises → allocated resources leak); #1689 Gap 2 covers the *shutdown*
+twin (`shutdown_instance`'s swallowed `fail_after`), where the background continuation is at least
+budget-bounded by design. The init side has no bound and no observer at all.
+
+Probe: `scratchpad/probe_f1_ghost_init.py` (session scratchpad; reproduce with any Resource whose
+`on_initialize` sleeps past a shrunk timeout).
+
+### F2 — MED-HIGH · WS retry re-sends non-idempotent commands on response timeout (double execution)
+
+`WebsocketService.send_and_wait` (`websocket_service.py:669-691`) retries on
+`FailedMessageError` with `code is None` — which is exactly what a *response timeout* raises
+(`:686-689`) after the payload was already **sent successfully**. `Api._call_service` with
+`return_response=True` (`api/api.py:601`) and `_fire_event` (`:505`) route through it. When HA is
+merely slow (integration reload, recorder purge), a `call_service` response exceeding
+`resp_timeout_seconds` re-sends the command under a new msg_id: a toggle flickers, a script/scene/
+notify runs twice. The codebase already recognizes this exact hazard for `subscribe_events`
+(`:563-605` proactively unsubscribes the abandoned attempt before retrying) — service calls get no
+equivalent treatment. **Fix direction:** retry only reads on response timeout; for side-effectful
+commands surface a distinct "sent but unconfirmed" error (or make retry opt-in per call).
+
+### F3 — MED · StateProxy read-path retry blocks the event loop with `time.sleep`
+
+`state_proxy.py:36-43`: `_retry_on_not_ready` is a **sync** tenacity retry
+(`wait_exponential_jitter(0.01..0.1)`, 5 attempts) decorating sync methods (`get_state`,
+`yield_domain_states`) called from async handlers via StateManager. Sync tenacity waits are
+`time.sleep()` — on the loop thread. During the UNAVAILABLE window every read can stall the loop up
+to ~0.3-0.4s, and since the Tier-2 block-IO guard patches `time.sleep`
+(`block_io_guard.py:59`), the framework's own read path would trip its own blocking-IO detector.
+**Fix direction:** drop the retry (raise `ResourceNotReadyError` immediately — callers already
+handle it) or move retrying to an async read path.
+
+### F4 — MED · ServiceWatcher handlers are role-blind; APP-role service-status events cause noise now, process-kill later
+
+`service_watcher.py` filters `restart_service` and `shutdown_if_crashed` on *status only*. App
+resources emit `HASSETTE_EVENT_SERVICE_STATUS` too (Resource-level `handle_failed`/`handle_crash`).
+Today: every app init failure fires `restart_service`, which resolves no Service and logs
+`"No App found for 'X', skipping restart"` — recurring warning noise. The hazard: `shutdown_if_crashed`
+has no role filter, so any future path that drives an APP-role resource through `handle_crash`
+(the machinery exists and `bootstrap_apps` already calls it on the lifecycle service itself) takes
+down the whole process. Related but distinct from #1666 (filtering app-role events from the *web
+UI* WS stream); the watcher-side blindness is unfiled. **Fix:** role-filter the watcher's
+subscriptions (`role == SERVICE`) or the predicates.
+
+### F5 — MED · `remove_jobs_by_owner` is an orphaned trap with a Protocol advertising it
+
+`scheduler_service.py:797-803` / `:178-188`: zero production callers, but exported on the service
+protocol (`types/types.py:267`) and cited as the mirror pattern by BusService docstrings. Unlike the
+unified removal op it skips `_dequeued`, `_jobs_by_id`, and `removed_at`, and scans only the heap —
+a future caller gets zombie jobs that survive owner removal and refire forever (a job popped
+mid-dispatch is invisible to the heap scan and re-enqueues itself). **Fix:** delete it (and the
+protocol entry), or reimplement over `_remove_from_live_state()`.
+
+### F6 — MED · Queued-mode spawn failure at drain time parks a dispatch task forever and leaks a bus semaphore slot
+
+`execution_mode.py:165-171` (`drain_next`): a queued factory whose `run_and_track()` raises is
+dropped and the drain continues — but its completion future (bridge in `run_through_guard`) is never
+resolved, so the outer dispatch task stays parked on `await done`. For bus listeners that task holds
+one `_dispatch_semaphore` slot (`bus_service.py:463-478`), permanently shrinking
+`max_concurrent_dispatches` by one per occurrence. The realistic raiser is `TaskBucket.spawn` on a
+sealed bucket (teardown-adjacent — same family as F9, and F9 also eats the `release_guard()` call
+that would otherwise unwind it). Distinct from the tracked drain/release detach edge (#1099).
+**Fix:** resolve the dropped factory's future in `drain_next`'s except branch (wrap factory to
+resolve-on-spawn-failure).
+
+### F7 — LOW · Crashed-then-killed sessions are immortal to once-listener cleanup
+
+`session_manager.py:167-187` sets `status='failure'` on crash but leaves `stopped_at` NULL;
+orphan-marking (`:143-152`) only matches `status='running'`. A session that recorded a crash and
+died before `finalize_session` keeps `stopped_at IS NULL` forever, and the once=True cleanup's
+NOT EXISTS join (`:222-227`) treats its executions as belonging to a live session — those rows are
+never reaped. **Fix:** orphan-mark on `stopped_at IS NULL` regardless of status, or set
+`stopped_at` in the crash UPDATE.
+
+### F8 — LOW · once=True cleanup only reaps listeners that *fired*; comment drift in core.py
+
+`session_manager.py:215-229`: the first EXISTS requires ≥1 execution, so a once listener from a
+prior session that never fired is never deleted, contradicting the "prevents unbounded row growth"
+docstring. App-owned rows get caught by per-restart reconciliation; framework-owned once listeners
+have no such path. Also `core.py:704-706` describes a `session_id = ?` guard that no longer matches
+the actual SQL. **Fix:** add a never-fired branch to the cleanup query; refresh the comment.
+
+### F9 — LOW · Sync cancel/removal paths spawn onto possibly-sealed TaskBuckets
+
+`listeners.py:496` (`Listener.cancel()` → spawn `release_guard`) raises `RuntimeError` if the owning
+bucket is sealed. Normal teardown ordering avoids it (listener removal happens in `Bus.on_shutdown`,
+before that bucket's seal), but force-terminal windows hit it: a force-terminated app's stale
+listeners (hooks skipped — documented accepted gap in `_force_terminal`) removed later via
+`remove_listeners_by_owner` raise mid-loop, leaving remaining listeners uncancelled and callbacks
+unfired (routes are already cleared). Compounds F6. **Fix:** make `spawn`-for-cleanup tolerate
+sealed buckets (fall back to inline sync release or drop with debug log).
+
+### F10 — LOW · Resource logger filters accumulate across reload cycles
+
+`resources/base.py:198-212`: `_setup_logger` does `addFilter(_ResourceContextFilter(...))` on a
+process-global logger every construction; `_ResourceContextFilter` has no `__eq__`, so stdlib dedupe
+never fires. App instances recreated on hot-reload reuse the same logger name → one filter per
+reload, unbounded, O(n) filter chain on hot log paths. **Fix:** dedupe by filter type before adding.
+
+### F11 — LOW · Per-wave shutdown floor can structurally overrun the coordinator margin
+
+`Hassette._shutdown_children` gives *every* wave `max(1s floor, body_deadline − now)`
+(`children_budget_remaining`), so N hung waves overrun `body_deadline` by up to N×1s while the
+coordinator margin is only 10% of total (3s at the 30s default). With 4+ hung waves the "graceful"
+path is guaranteed to bust `total_deadline`, making the crude force-terminal backstop the *normal*
+outcome exactly in the pathological cases the wave logic was built for. **Fix direction:** budget
+per-wave as `remaining/waves_left`, or validate config so `margin ≥ waves × floor`.
+
+### F12 — LOW · Assorted small verified items
+
+- **DB worker cancellation mid-write leaves an in-flight `submit()` future unresolved**
+  (`database_service.py:426-450` — `except Exception` doesn't cover `CancelledError`; force-terminal
+  path only; add `except CancelledError: future.cancel(); raise`).
+- **`Resource.cleanup(timeout=0)` falsy-`or`** (`resources/base.py:656`, same pattern in
+  `app/app.py:250`).
+- **TaskBucket cross-thread spawn timeout can still create the task later** — caller saw
+  `RuntimeError`, work runs anyway (`task_bucket.py:249-261`); tracked-in-bucket so bounded.
+- **`submit()` after shutdown reports "called before on_initialize()"** — misleading error text
+  (`database_service.py:467-469`).
+- **`_serve_wrapper` STOPPING→CRASHED**: a `FatalError` from `serve()` during the shutdown window
+  drives an invalid transition (`VALID_TRANSITIONS[STOPPING]` lacks CRASHED) — warning-level noise,
+  raises under `strict_lifecycle`.
+
+### F13 — INFO · Coherence notes (no action required, worth knowing)
+
+- **`allow_pre_ready` is a no-op** — `send_json()` (`websocket_service.py:744`) is a pure
+  pass-through to `_send_json_when_socket_live()`; both branches of `send_and_await_response` gate
+  only on the private `_send_ready_event`. The documented public/private send-capability split
+  doesn't exist at the send layer. Mitigated in practice: `Api` checks `is_connected` before
+  delegating (`api/api.py:331,337`). Either move the external-readiness gate into `send_json` or
+  delete the parameter and the doc claim.
+- **StateProxy awaits raw sync tasks** (`await task` in `_request_*_synchronization`) — a
+  disconnect-cancel propagates `CancelledError` into the poll job, producing spurious
+  `status='cancelled'` execution rows on every mid-poll disconnect. Harmless (next occurrence is
+  enqueued before the handler runs). `lifecycle.py` deliberately uses `asyncio.wait()` for exactly
+  this decoupling; StateProxy could match.
+- **`App.unique_name` `startswith` heuristic** (`app/app.py:171-176`) can collide across classes
+  (class `Light` + instance `LightsOut` vs class `LightsOut`) — same owner-registry consequence as
+  #1689 Gap 3, distinct mechanism; fold into that issue's scope.
+- **Removed-job current-fire semantics**: `Job.remove()` landing after `dispatch_and_log`'s entry
+  check doesn't stop the popped fire; the guard has no terminal state. Documented as
+  trigger-outcome-independence, not removal-independence — clarify if "remove = no further user
+  code" ever becomes the contract.
+- **Cron catch-up loop** (`classes.py:102-147`) can do up to 10k synchronous `croniter` steps on
+  the loop — bounded, acknowledged, may trip the loop watchdog at pathological settings.
+- **`Job.__eq__`/`__lt__` raise for never-scheduled jobs** (`sort_index` unset) — latent trap,
+  carefully routed around today.
+- **`set_state` double-GET** (`api.py:971-972`) — `entity_exists()` + `get_state_raw()`; one
+  404-tolerant GET would do.
+- **ServiceWatcher-synthesized restart flow after app FAILED events** produces the F4 warning noise
+  today; the same fix covers it.
+
+---
+
+## Clean areas (checked hard, no findings)
+
+- **Lifecycle coordinator** (`coordinate_initialize`/`coordinate_shutdown`/`_run_shutdown_coordinator`):
+  admission atomicity, re-entry rejection, pending-start race closure, cancellation-with-evidence
+  conversion, budget allocation — all interleavings traced held up.
+- **TeardownReport** monotonic-evidence model; **`shutdown_batch`** classification and force-terminal
+  propagation.
+- **StateProxy synchronization**: baseline/journal/commit protocol under the two-lock discipline
+  (never held simultaneously), generation fencing on events, commits, and retries.
+- **Bus dispatch**: semaphore/pending bookkeeping including the no-await windows the comments claim;
+  DROP_NEWEST accounting; once-guard; debounce/throttle atomicity; duration-timer cycle events and
+  active-counter balance across restart/cancel/fire interleavings.
+- **Scheduler heap integrity** (off-heap-only mutation invariant, `_dequeued` in-lock re-check,
+  KI-006 cleanup), pending EntityTime transitions, restart-mode guard, removal identity checks,
+  `_add_job` rollback.
+- **CommandExecutor** batch/retry/FK-fallback pipeline, execution-marker publication discipline.
+- **DatabaseService** single-writer drain/close ordering (modulo F12 nit); **SessionManager** happy
+  paths; **EventStreamService** close/send races all handled at call sites; **SyncExecutor**
+  handle/ContextVar discipline; **LoggingService** handler swap; **App/AppSync** surface minimalism
+  and teardown overrides.
+
+## Issue tracking
+
+Filed 2026-09-02 during the findings walkthrough:
+
+| Finding | Issue |
+|---|---|
+| F1 ghost initializer | #1797 (priority:high) |
+| F2 WS double-send | #1798 (priority:high) |
+| F3 loop-blocking retry | #1803; companion `wait_fresh()` enhancement #1804 |
+| F4 role-blind watcher | #1799 |
+| F5 `remove_jobs_by_owner` trap | #1800 (Code Quality) |
+| F6 dispatch-slot leak | #1805 |
+| F7 immortal crashed sessions | #1806 |
+| F8 once-cleanup gaps | #1807 |
+| F9 sealed-bucket spawns | #1810 |
+| F10 logger filter accumulation | #1808 |
+| F11 wave floor vs margin | #1809 (priority:low) |
+| F12 grouped small edges | #1811 |
+| F13 `allow_pre_ready` vestige | #1812 (Architecture) |
+| F13 spurious cancelled telemetry | #1813 |
+| F13 `unique_name` prefix collision | comment on #1689 |
+
+Report-only (deliberate skips): removed-job current-fire semantics (documented behavior),
+cron catch-up stall (bounded + acknowledged), `set_state` double-GET (micro),
+cross-thread spawn timeout (accepted-risk, documented inside #1811).
+
+## Suggested sequencing
+
+1. **F1** — file + fix soon; it undermines the teardown-safety story the last three months of work
+   built, and the fix is mostly wiring existing machinery into the timeout branch. Coordinate with
+   #1367 (exception path) and #1689 (shutdown path) — three seams, one theme: *every* exit from
+   `initialize_instances`/`shutdown_instance` should leave the instance either fully alive or fully
+   torn down, using the coordinator, not ad-hoc cleanup.
+2. **F2** — small, contained, user-visible correctness (double service execution).
+3. **F4 + F5** — both are "delete/guard a trap before someone steps on it."
+4. **F3, F6-F11** — batch as normal backlog items.
+5. F12/F13 — optional hygiene batch or fold into adjacent issues.

--- a/design/audits/2026-09-02-cli-docker-triggers-helpers-audit.md
+++ b/design/audits/2026-09-02-cli-docker-triggers-helpers-audit.md
@@ -1,0 +1,317 @@
+# CLI, Docker Onboarding, Triggers & Helpers Audit — 2026-09-02 (run 4, mop-up)
+
+**Scope:** The remaining territory from the run 1–3 coverage map: the `hassette` CLI end to end
+(`src/hassette/cli/` + `docs/pages/cli/`), the Docker onboarding path (Dockerfile, entrypoint,
+compose snippets, `docs/pages/getting-started/docker/`), project scaffolding, the scheduler
+trigger layer (`scheduler/triggers.py`, `scheduler/classes.py`), and the helpers API
+(`api/helpers.py`).
+
+**Not covered this run:** `scheduler/scheduler.py`/`scheduler_service.py` dispatch internals
+(run 1 territory; only the trigger-facing seams were re-read), the AppDaemon migration docs
+journey, `sync.py` facades.
+
+**Method:** Same as runs 1–3 — Fable deep read as the engine, two Sonnet reader agents for
+breadth (CLI systematic pass; Docker/scaffolding docs-vs-code), every reader claim re-verified
+against the actual code before making this report, and live verification for everything
+probeable:
+
+- Full CLI command + error-path matrix against the live demo stack (auth, happy paths, bad app
+  keys, bad flags, server down, bad token, `--json` variants; captured in session scratchpad).
+- A 200-with-non-JSON probe server to reproduce the CLI's malformed-response path.
+- A raw WebSocket probe against the demo HA container (2026.8) replaying the exact payloads
+  `HelperClient` sends — counter create / increment / reset with and without
+  `return_response`.
+- **The published Docker image (`ghcr.io/nodejsmith/hassette:latest-py3.13`) run twice against
+  the demo HA, following the getting-started Docker journey file-for-file** — once exactly as
+  documented (fails) and once with `HASSETTE__APPS__DIRECTORY=/apps` added (works) — proving
+  both the bug and the root cause end to end.
+- `whenever` DST probes for trigger construction edges (spring-forward gap, fall-back
+  ambiguity).
+
+---
+
+## Verdict up front
+
+Three of the four surfaces are in better shape than their age would predict: the CLI's docs
+have essentially **zero drift** (every endpoint, flag, exit code, and error string checked out),
+the trigger layer's DST handling is unusually careful, and the Docker image itself is solidly
+built. The debt concentrates in two places, both continuations of the audit series' running
+theme of **silent absence**:
+
+1. **The documented Docker quick start does not work.** The published image never looks at the
+   `/apps` mount the docs (and the Dockerfile's own `VOLUME`) advertise — a newcomer's first
+   app loads zero apps with no error, no log line naming the scanned directory, and a
+   troubleshooting page that actively misdiagnoses it (F1, live-confirmed on the published
+   image).
+2. **The counter helper shortcuts have never worked against real Home Assistant** — every
+   `helpers.increment()/decrement()/reset()` call is rejected by HA with
+   `service_validation_error`, invisible to the test suite because every helper test mocks
+   `ws_send_and_wait` (F2, live-confirmed against HA 2026.8).
+
+Both flagship findings share a meta-cause worth keeping: **the project's internal configs and
+tests already do the right thing** (demo compose and Docker integration tests set
+`HASSETTE__APPS__DIRECTORY`; helper CRUD works fine over the same WS plumbing) — the drift is
+specifically between what the maintainers' own tooling knows and what ships to users.
+
+---
+
+## Findings
+
+Severity reflects user impact. Every finding marked **live-confirmed** was reproduced this run.
+
+### HIGH
+
+#### F1. The documented Docker quick start loads zero apps — live-confirmed on the published image
+
+Followed `docs/pages/getting-started/docker/index.md` exactly: `mkdir` project with
+`config/` + `apps/`, the documented `docker-compose.yml` snippet (mounting `./apps:/apps`),
+`config/.env` with token + base_url, the documented `apps/my_app.py`. Result on
+`ghcr.io/nodejsmith/hassette:latest-py3.13` (0.52.0):
+
+```
+"Found 0 active apps"
+"Found 0 inactive apps"
+"Hassette is running."
+```
+
+No error, no warning, no log line naming the directory that was scanned. The docs' promised
+`Hello from Docker!` never appears. Re-running the identical setup with one env var added —
+`HASSETTE__APPS__DIRECTORY=/apps` — auto-detects and runs the app immediately.
+
+Root cause chain (each link verified):
+
+- `AppsConfig.directory` defaults to `Path.cwd() / "apps"` (`config/models.py:471`); the final
+  image stage sets `WORKDIR /app` (`Dockerfile:79`) and nothing ever changes cwd — so the real
+  default inside the container is **`/app/apps`**.
+- The Dockerfile sets `ENV HASSETTE__APP_DIR=/apps` (`Dockerfile:99`) — **not a real settings
+  field**. With `extra="allow"` on `HassetteConfig` (`config/config.py:55`) it is silently
+  absorbed as an unused extra. Its only consumer is `docker_start.sh:29`, which uses it for the
+  `requirements.txt` scan — and that subsystem's `/apps` default *works*, which is exactly what
+  makes the app-loading half easy to miss.
+- `docs/pages/getting-started/docker/troubleshooting.md:35` states "Hassette looks for apps at
+  `/apps` inside the container" (false) and tells the user to verify the mount with
+  `ls /apps` — which succeeds, actively steering the user away from the real cause.
+- The project's own internal configs prove the correct spelling:
+  `tests/test_docker_integration.py:36` and `scripts/docker/ha-demo.yml:32` both set
+  `HASSETTE__APPS__DIRECTORY` explicitly.
+
+**Fix shape (layered):** (a) `HASSETTE__APPS__DIRECTORY=/apps` in the Dockerfile — one line,
+the published image then matches its own `VOLUME` declaration; (b) a startup INFO line
+"resolved apps directory: X (N apps found)" so this class of misconfiguration is diagnosable
+from logs (this also covers the scaffolding gap in F6); (c) fix troubleshooting.md's claim and
+add the real failure mode to it; (d) related open question from the reader pass, worth a note
+in the same issue: fixed uid-1000 container user vs. host bind-mount ownership on non-1000
+hosts (unverified, NAS-style deployments).
+`type:bug, area:config, size:medium, priority:high` (+ docs half).
+
+#### F2. Counter helper shortcuts (`increment`/`decrement`/`reset`) never work against real HA — live-confirmed
+
+`HelperClient.increment()` (`api/helpers.py:296-308`, same for `decrement`/`reset`) calls
+`call_service(..., return_response=True)` — the comment says "surfaces HA errors instead of
+fire-and-forget." But `_call_service` forwards `return_response` verbatim into the WS
+`call_service` command (`api/api.py:590`), and `counter.increment`/`decrement`/`reset` are
+`SupportsResponse.NONE` services. Real HA (2026.8, demo container) rejects the exact payload
+hassette sends:
+
+```
+{"success": false, "error": {"code": "service_validation_error", "message":
+"Validation error: An action which does not return responses can't be called with
+return_response=True", ...}}
+```
+
+So every call to any of the three shortcuts raises `FailedMessageError`. The same probe
+confirmed the control case: the identical call with `return_response=False` succeeds — and the
+WS `call_service` **still returns a result envelope** (success/error + context), which is the
+mechanism the fix wants.
+
+The test suite cannot see this: every test in `tests/integration/test_api_helpers.py` mocks
+`ws_send_and_wait`, so the HA-side contract (`supports_response`) is exactly at the mocked
+boundary — the same blind spot run 1 flagged for core services. Helper CRUD
+(`list`/`create`/`update`/`delete`) was probed too and works correctly against real HA.
+
+**Fix shape:** send the service call through `ws_send_and_wait` *without*
+`return_response` — the result envelope still surfaces HA errors (proven by the probe), which
+is what the shortcuts wanted from `return_response=True` in the first place. That capability
+("awaited call_service that doesn't request a service response") arguably belongs on
+`call_service` itself rather than being special-cased in the shortcuts. Follow-up worth
+bundling: one thin system test that exercises `HelperClient` against the system-test HA
+container so this contract class stays covered.
+`type:bug, area:api, size:small, priority:high`.
+
+### MEDIUM
+
+#### F3. `app health` reports "excellent" for apps that don't exist — live-confirmed; extends #1825
+
+`hassette app health nonexistent_app` (and `--instance 99` on a real app) prints a full healthy
+card — `health_status excellent`, exit 0, same in `--json`. Server-side:
+`GET /api/telemetry/app/{app_key}/health` (`web/routes/telemetry.py:115-132`) never validates
+the key against the manifest registry — it aggregates over zero rows and the zero-invocation
+path classifies as "excellent" (documented at `telemetry.py:106-110` for the *known-app*
+zero-invocation case, but the unknown-key case is a different problem). An operator
+health-checking a typo'd key gets a green light.
+
+Existing issue **#1825** already covers CLI-side `--app` validation for listing commands and
+empty-result disambiguation. This finding extends it server-side: the health endpoint should
+404 for a key the manifest registry doesn't know (the registry is queryable without telemetry),
+which fixes every consumer at once. The CLI reader's related LOW — `resolve_instance()`
+skips app-key validation only on the numeric-instance path (`cli/client.py:196-212`) — is the
+same validation work and should ride along. Proposed disposition: scope-extending comment on
+#1825 rather than a new issue (mirrors the F2/#1610 pattern from run 3).
+
+#### F4. CLI prints a raw 25-line traceback on a 2xx response with a non-JSON or model-incompatible body — live-confirmed
+
+Pointed the CLI at a server returning `200` with a non-JSON body: `json.decoder.JSONDecodeError`
+traceback straight to the terminal, bypassing the CLI's entire designed error surface. Cause
+(reader claim, verified in code and live): `client.py:135-148` only catches `ValueError` for the
+`tolerate_503` path; cyclopts' `exit_on_error` guards token parsing only, and nothing in
+`launcher()`/`entrypoint()` catches command-body exceptions. Realistic triggers: `-s` pointed at
+the wrong service, a reverse proxy serving an HTML error page with 200, version skew between CLI
+and server (`model_validate` failure takes the same unguarded path).
+
+**Fix shape:** catch `JSONDecodeError`/`ValidationError` in `client.get()` and emit the standard
+error framing ("response from {url} is not a hassette API response — check --server-url /
+version skew"), non-zero exit, JSON envelope in `--json` mode.
+`type:bug, area:cli, size:small`.
+
+#### F5. The documented compose snippet sets `HASSETTE__LOG_LEVEL`, a silent no-op — and any typo'd `HASSETTE__*` var is swallowed
+
+`docs/pages/getting-started/docker/snippets/docker-compose.yml:15` sets
+`HASSETTE__LOG_LEVEL=info`. The real field is `logging.log_level`
+(`config/models.py`, nested), so the correct var is `HASSETTE__LOGGING__LOG_LEVEL`; there is no
+top-level `log_level` field. With `extra="allow"` the wrong var is silently absorbed — a user
+bumping to `debug` for troubleshooting gets no error and no effect.
+
+Two layers: (a) docs fix, one line (`type:documentation, size:small`); (b) the structural
+version — F1 and F5 are the *same* failure mechanism (`extra="allow"` eating misspelled env
+vars without a sound). An enhancement worth filing separately: at startup, WARN listing
+unconsumed `HASSETTE__*` environment keys (and extra top-level TOML keys) that matched no known
+field — one log line that would have caught both the Dockerfile's own dead var and every future
+user typo. `type:enhancement, area:config, size:small`.
+
+#### F6. No scaffolding story: `hassette init` doesn't exist, layout errors are silent — DISCUSS
+
+Confirmed against the full CLI command tree: no `init`/scaffold command; both quickstarts are
+manual `mkdir` + copy-paste, `hassette.toml` is never introduced in getting-started (the Docker
+flow is entirely env-var-driven), and the failure modes of a mis-built layout are silent (F1's
+zero-apps case; a `[hassette.apps.<name>]` entry missing `filename`/`class_name` is a WARNING
+that skips the app, `config/config.py:409`).
+
+The sharp edge (no startup echo of the resolved apps directory) is folded into F1's fix. The
+open design question for Jessica: is a minimal `hassette init` wanted (write
+`hassette.toml` + `apps/` + `.env` skeleton + example app — it would also give the Docker docs
+a place to introduce the toml), or is the manual flow + F1's logging fix enough for a framework
+this size? Not filing without that call.
+
+### LOW
+
+#### F7. Piped/non-TTY CLI output truncates every table at 80 columns
+
+`stdout_console = Console(file=sys.stdout)` (`cli/output.py:31`) → Rich's 80-col non-TTY
+default. Live: `hassette app | grep motion_lights` cannot match — the cell renders as
+`motion…`. The log table is the worst case (multi-line tracebacks ellipsized per-line inside
+table cells, plus three zero-width columns at 80 cols). `--json` is the designed escape hatch,
+so LOW — but grep-ability of the human output is cheap to restore (wide fallback width or
+respect `COLUMNS` when piped). `type:enhancement, area:cli, size:small`.
+
+#### F8. `hassette log --instance` is a phantom flag
+
+Declared as a normal parameter (`cli/commands/log.py:32-44`) so it appears in `--help` and
+shell completions, but its only behavior is `error_usage("--instance is not supported on the
+log command")` (live-verified: clean error, exit 1). Hide it or say "(not supported)" in its
+help string. `type:enhancement, area:cli, size:small` — can ride with F7 or F13.
+
+#### F9. Trigger API nits: `After` has no `hours=`; `timedelta=` silently wins over `seconds`/`minutes`
+
+`After(seconds, minutes, timedelta)` (`scheduler/triggers.py:134-145`) — no `hours=` while
+`Every` has it, and passing both `timedelta=` and `seconds=` silently ignores the latter
+(docstring says "mutually exclusive" but nothing raises). Add `hours=` and raise on the
+conflicting combination. `type:enhancement, area:scheduler, size:small, topic:dx`.
+
+#### F10. Helper `helper_id` vs `entity_id` is a documented-nowhere distinction
+
+`update()`/`delete()` take the storage-collection id (`record.id` — a slug for YAML-imported
+helpers, opaque for UI-created ones), not the entity_id every HA user actually knows. Passing
+`"input_boolean.vacation_mode"` fails with HA's generic not-found. Docstrings just say "The ID
+of the helper." Cheap fixes: name the distinction in the docstrings + helpers docs page;
+optionally accept an entity_id and resolve/strip. Also noted: `create()` logs INFO while
+`update()`/`delete()` log DEBUG (`helpers.py:216,254,285`) — equally-mutating operations,
+asymmetric levels. `type:documentation/enhancement, area:api, size:small, topic:dx`.
+
+#### F13. CLI dead code / latent inconsistencies (pre-existing, mechanical)
+
+From the CLI reader pass, each verified: `JsonArg` in `cli/types.py:100` defined and never
+used; `run.py:62` raises bare `SystemExit` instead of routing through `error_usage` (latent —
+`run` has no `--json` today, but the shape breaks the envelope convention the moment a flag is
+added); `client.py:228-229` unreachable `AssertionError` after a `NoReturn` call. One
+code-quality issue per `clean-code-findings.md` (`topic:code-quality`, Code Quality milestone,
+`area:cli, size:small`).
+
+### Notes (no action proposed)
+
+- **DST disambiguation is inconsistent between `Once` and the cron-backed triggers** — `Once`
+  construction resolves an ambiguous fall-back time via `whenever`'s compatible mode (earlier
+  fold), while `CronTrigger._dst_safe_from_dt` deliberately picks fold=1 (later). Probed both;
+  neither crashes, gaps shift +1h cleanly. A once-a-year one-hour divergence between two trigger
+  types; not worth machinery.
+- **`Every`/`After`/`Cron` `trigger_id()` collisions** (two `Every(hours=1)` jobs share
+  `every:3600`) initially looked like heap-identity trouble given `Once`'s shadowing comment —
+  verified harmless: `trigger_id` participates only in `Job.matches()` dedup, which also
+  compares callable/args/group, so the collision is exactly the intended dedup semantics.
+- **`parse_entity_time` + `daily=False` on a time-only entity** parks the job (`WAITING`) once
+  today's occurrence passes until the entity changes — correct per the docstrings, but the
+  docs page for `EntityTime` should keep steering `input_datetime`-style time-only sources to
+  `daily=True` (it currently does; no drift found).
+
+---
+
+## Strengths (genuine, keep doing these)
+
+- **CLI docs have zero drift.** Every documented endpoint, flag, response field, exit code, and
+  error-message string was cross-checked against routes/models/implementation and matched —
+  unusual, and worth calling out given how fast this surface moves.
+- **The CLI's plumbing conventions are right:** exit 1 vs 2 (HTTP/usage vs network) verified
+  live; `--json` mode's "stdout is exactly one JSON document" discipline holds everywhere
+  probed; the `--since` error message (formats listed, compound-duration exclusion named) is a
+  model error string; the credential-resolution chain's scoped `CredentialSource` design makes
+  the loopback-only gate structurally hard to break.
+- **The trigger layer's hard parts are handled with care:** croniter fall-back ambiguity is
+  UTC-normalized and fold-disambiguated with a single summary log; catch-up is bounded
+  (`MAX_CRON_ITERATIONS`) with a timezone-preserving skip-ahead; the `WAITING` sentinel design
+  (typed, off-heap, three documented legs in `scheduler_service`) is exactly the "model the
+  domain" shape.
+- **The Docker image itself is well built** — multi-stage, non-root, tini, correct healthcheck
+  guidance (`/api/health/live` vs `ready`, restart-loop warning), and the dependency-install
+  entrypoint flow is accurate and documented honestly.
+- **The native (non-Docker) quickstart is accurate end to end** — the cwd-relative apps default
+  genuinely works there; only the Docker translation broke.
+
+---
+
+## Slate
+
+| # | Severity | Finding | Proposed disposition |
+|---|---|---|---|
+| F1 | HIGH | Docker quick start loads zero apps (published image, live) | New issue, `priority:high` (Dockerfile + startup log + troubleshooting + compose snippet; uid-1000 note) |
+| F2 | HIGH | Counter shortcuts always rejected by real HA (live) | New issue, `priority:high` (+ system-test note) |
+| F3 | MEDIUM | Health endpoint 200-excellent for unknown app/instance (live) | Scope-extending comment on #1825 (server-side 404 + resolve_instance validation) |
+| F4 | MEDIUM | Raw traceback on malformed 2xx response (live) | New issue |
+| F5 | MEDIUM | `HASSETTE__LOG_LEVEL` no-op in docs; typo'd env vars swallowed | Two: docs one-liner + unconsumed-env-var warning enhancement |
+| F6 | MEDIUM | No `hassette init` / silent layout errors | **Discuss with Jessica** (init command yes/no; logging half folds into F1) |
+| F7 | LOW | 80-col truncation when piped | New issue (can bundle F8) |
+| F8 | LOW | `log --instance` phantom flag | Bundle with F7 |
+| F9 | LOW | `After` missing `hours=`, silent arg precedence | New issue |
+| F10 | LOW | helper_id vs entity_id undocumented; log-level asymmetry | New issue |
+| F13 | LOW | CLI dead code / SystemExit bypass | Code Quality issue |
+
+Also absorbed by existing issues (no action): bare-401 wording → #1823; CLI app-table health
+visibility → #1825; log-table traceback framework-frame noise → #1832.
+
+## Meta-findings for the series
+
+1. **Internal-vs-shipped drift** (F1, F5): the demo stack, integration tests, and maintainer
+   muscle memory all carry correct configuration that the shipped Dockerfile and public docs
+   lack. Anything the demo/test configs set explicitly is worth auditing for "does the public
+   path get this too?"
+2. **Mock-boundary contract blindness** (F2, continuing run 1's theme): both flagship bugs live
+   exactly at a mocked seam. The system-test suite is the designed home for these; F2's issue
+   proposes the first helper-surface system test.

--- a/design/audits/2026-09-02-cli-docker-triggers-helpers-audit.md
+++ b/design/audits/2026-09-02-cli-docker-triggers-helpers-audit.md
@@ -289,19 +289,19 @@ code-quality issue per `clean-code-findings.md` (`topic:code-quality`, Code Qual
 
 ## Slate
 
-| # | Severity | Finding | Proposed disposition |
+| # | Severity | Finding | Filed as (2026-09-02) |
 |---|---|---|---|
-| F1 | HIGH | Docker quick start loads zero apps (published image, live) | New issue, `priority:high` (Dockerfile + startup log + troubleshooting + compose snippet; uid-1000 note) |
-| F2 | HIGH | Counter shortcuts always rejected by real HA (live) | New issue, `priority:high` (+ system-test note) |
-| F3 | MEDIUM | Health endpoint 200-excellent for unknown app/instance (live) | Scope-extending comment on #1825 (server-side 404 + resolve_instance validation) |
-| F4 | MEDIUM | Raw traceback on malformed 2xx response (live) | New issue |
-| F5 | MEDIUM | `HASSETTE__LOG_LEVEL` no-op in docs; typo'd env vars swallowed | Two: docs one-liner + unconsumed-env-var warning enhancement |
-| F6 | MEDIUM | No `hassette init` / silent layout errors | **Discuss with Jessica** (init command yes/no; logging half folds into F1) |
-| F7 | LOW | 80-col truncation when piped | New issue (can bundle F8) |
-| F8 | LOW | `log --instance` phantom flag | Bundle with F7 |
-| F9 | LOW | `After` missing `hours=`, silent arg precedence | New issue |
-| F10 | LOW | helper_id vs entity_id undocumented; log-level asymmetry | New issue |
-| F13 | LOW | CLI dead code / SystemExit bypass | Code Quality issue |
+| F1 | HIGH | Docker quick start loads zero apps (published image, live) | **#1850** (`priority:high`; Dockerfile + startup log + troubleshooting + compose snippet; uid-1000 note) |
+| F2 | HIGH | Counter shortcuts always rejected by real HA (live) | **#1851** (`priority:high`; + system-test note) |
+| F3 | MEDIUM | Health endpoint 200-excellent for unknown app/instance (live) | Scope-extending comment on **#1825** (server-side 404 + resolve_instance validation) |
+| F4 | MEDIUM | Raw traceback on malformed 2xx response (live) | **#1852** |
+| F5 | MEDIUM | `HASSETTE__LOG_LEVEL` no-op in docs; typo'd env vars swallowed | **#1853** (docs fix) + **#1854** (unconsumed-env-var warning) |
+| F6 | MEDIUM | No `hassette init` / silent layout errors | Context comment on existing **#541** (Jessica's call: init command wanted; logging half folds into #1850) |
+| F7 | LOW | 80-col truncation when piped | **#1855** (bundled with F8) |
+| F8 | LOW | `log --instance` phantom flag | **#1855** (with F7) |
+| F9 | LOW | `After` missing `hours=`, silent arg precedence | **#1856** |
+| F10 | LOW | helper_id vs entity_id undocumented; log-level asymmetry | **#1857** |
+| F13 | LOW | CLI dead code / SystemExit bypass | **#1858** (Code Quality milestone) |
 
 Also absorbed by existing issues (no action): bare-401 wording → #1823; CLI app-table health
 visibility → #1825; log-table traceback framework-frame noise → #1832.

--- a/design/audits/2026-09-02-dx-onboarding-audit.md
+++ b/design/audits/2026-09-02-dx-onboarding-audit.md
@@ -1,0 +1,182 @@
+# DX & Onboarding Audit — 2026-09-02
+
+**Run 2 of the Fable audit series** (run 1: [backend core correctness](2026-09-02-backend-core-correctness-audit.md), issues #1797–#1813; run 3, committed next: frontend deep-dive).
+
+**Scope:** app-author DX — API ergonomics, error-path quality, docs onboarding, the testing story — plus operational surfaces (CLI, telemetry API) where the DX journeys touch them. Deliberately narrowed so each facet gets depth; frontend gets its own full run.
+
+**Method — live evidence, not code reading:**
+
+- Executed the quickstart literally: `uv tool install hassette` (PyPI 0.52.0) in a clean directory against the live demo stack, TTY and piped.
+- Three blind personas (fresh Sonnet agents, no audit context, docs-only rules, think-aloud journals): P1 newcomer first-automation, P2 testing-story, P3 debugging three seeded silent failures. Journals under the session scratchpad (`persona1..3/journal.md`).
+- Caller-corpus sweep: `~/homelab/hautomate` (~9k lines of real hassette apps + tests, the one known power-user corpus) cataloged for friction patterns (`corpus-sweep.md` in scratchpad).
+- Error lab: seven failure scenarios executed against 0.52.0 (missing/invalid token, SIGINT/SIGTERM timing, app-init crash, syntax error, missing config), isolated data dir.
+- CLI + telemetry REST driven against the live demo instance (9 apps, seeded activity).
+
+**Not covered this run:** Docker onboarding path, AppDaemon migration docs journey, the web dashboard beyond what P3's debugging needed (run 3), `hassette init`/scaffolding, helpers API DX.
+
+**Corpus caveat:** hautomate is one power-user corpus, largely Claude-written; where it predates recent framework fixes I say so rather than counting stale pain as current debt.
+
+---
+
+## Thesis
+
+The documentation is good — the troubleshooting page names the real traps, the testing docs carried a blind persona to a 3/3 pass in two runs, and the reference is thorough. The telemetry backend is rich. The exception messages (the newer ones) are exemplary. **The debt concentrates in four places:** (1) silent-by-design behaviors with no runtime signal — filtered events, entity typos, forgotten awaits at the API layer; (2) the async/sync three-surface split, which confused even the power user into shipping a never-working automation and documenting a falsehood in their own CLAUDE.md; (3) the error contract — mixed typed/stdlib raises, nothing exported, no guidance page, so callers guess catch-tuples (30 occurrences in the corpus); and (4) the first five minutes — a phantom log line the docs promise, a 30-second silent hang on Ctrl+C, and a flagship dashboard the quickstart never mentions.
+
+A cross-cutting meta-finding: the framework has been fixing this user's pains (per-instance cache keys, forgotten-await detection, the test harness) faster than any channel tells existing users their workarounds are obsolete.
+
+---
+
+## Findings
+
+Severity reflects app-author impact. Every finding is verified live unless marked otherwise.
+
+### HIGH
+
+#### F1. Ctrl+C shutdown: 30 seconds of silence (no SIGINT handler)
+
+`server.py:27` registers a handler for SIGTERM only. Measured on a healthy, idle, single-app 0.52.0 instance:
+
+- **SIGTERM → 1.0s**, acknowledged ("shutdown requested"), full orderly teardown log, "Hassette stopped."
+- **SIGINT → 30.1s**, zero hassette output (no acknowledgment; logging is torn down by cancellation), then exit. The 30s is `total_shutdown_timeout_seconds`' default being burned on the disorderly path.
+
+The quickstart flow itself sends users here — uvicorn prints "Press CTRL+C to quit." Blind persona P1 hit it twice, concluded the process was hung, and used `kill -9`. Docker/production (SIGTERM) is unaffected; the broken path is exactly the dev-terminal one newcomers live on.
+
+**Fix shape:** register SIGINT alongside SIGTERM; conventional second-Ctrl+C-forces-immediate-exit; log the acknowledgment before teardown. `type:bug, area:core, size:small, priority:high`.
+
+#### F2. Filtered events are invisible — silent listener failures are structurally undiagnosable
+
+Listener telemetry counts `total_invocations/successful/failed/di_failures/cancelled` — there is **no counter for events that matched the entity but were dropped by `changed=`/predicates**. A listener whose filter drops everything shows 0 invocations, indistinguishable from "no events ever arrived." This is the exact shape of the corpus's real incident (a meeting-light handler that never fired because `changed=True` drops attribute-only changes — the user's CLAUDE.md carries a warning block about it).
+
+The scheduler side proves the model works: job telemetry *does* track `skipped` (predicate_demo: 73 skips in the JSON) — **but the CLI job table omits the column**, rendering `Total 68 / OK 0 / Fail 0`, arithmetic that visibly doesn't add up while hiding the one thing the operator needs.
+
+**Fix shape:** (a) bus-side evaluated-but-filtered counter per listener (consider distinguishing `changed=`-drops from predicate-drops), surfaced in `/api/telemetry/.../listeners`, CLI, and dashboard; (b) add the Skipped column to `hassette job`. (a) is `type:enhancement, area:bus, area:database, topic:telemetry, size:medium`; (b) is `type:bug, area:cli, size:small`.
+
+#### F11. `logging.captureWarnings(True)` black-holes every Python warning — including the forgotten-await guard
+
+(Numbered out of order — found last, belongs in HIGH.)
+
+The forgotten-await detection (`utils/await_guard.py`) is well built: `RegistrationHandle.__del__` emits `HassetteForgottenAwaitWarning` with app, call site, and "Did you forget 'await'?", verified working in isolation (immediate GC → warning caught). **In a running hassette process it is never seen.** `logging_.py:452` calls `logging.captureWarnings(True)`, routing all Python warnings to the `py.warnings` logger — which the logging configuration gives no route to console, JSON, or telemetry. Verified with a control: a bare `warnings.warn("PROBE-DIRECT-WARNING", RuntimeWarning)` in `on_initialize` produces zero output anywhere (even with `PYTHONWARNINGS=always`, which `captureWarnings` overrides).
+
+Compounding it: the guard closes the inner coroutine specifically to suppress CPython's native "coroutine was never awaited" warning — so when its own warning is swallowed, the app author gets *strictly less* signal than plain Python would have given them. Blind persona P3, handed a forgotten-await bug, exhausted CLI, dashboard, and logs, found "no exception, no warning, no boot issue — total silence," and could only fall back to reading the code.
+
+Every other warning in the process (user-dependency deprecations included) is swallowed by the same mechanism.
+
+**Fix shape:** wire `py.warnings` into the logging pipeline (console + capture + a listener-telemetry/boot-issue surface for `HassetteForgottenAwaitWarning` specifically — it names the owning app, so it can land on that app's dashboard card). Add a regression test that a warning emitted in app code reaches the console. `type:bug, area:core, topic:errors, priority:high, size:small`.
+
+### MEDIUM
+
+#### F3. The async/sync three-surface split ships real silent bugs
+
+Three surfaces coexist: async `self.api.*`, sync `self.states.*`, and `.sync.*` facades for `AppSync` apps. Corpus evidence of the cost:
+
+- `front_door_camera_app.py:52` calls async `Api.get_state_value` **un-awaited in a sync method** — the busy-check compares a coroutine object and is silently always-false. Shipped, in production.
+- hautomate's own CLAUDE.md canonizes the confusion: "State reads — synchronous, no await" — flatly wrong for `self.api` (right for `self.states`).
+- Forgotten-await guarding covers bus/scheduler registration and Api's write trio (`fire_event`/`call_service`/`set_state`) but **not Api read methods** — `get_state_value`, the exact method in the shipped bug, is unguarded. (And what is guarded is currently inaudible — see F11.)
+
+**Fix shape:** extend `guard_await` to Api read coroutines; fix F11 so any of it is heard; add a docs matrix page: what may be sync where (apps × handlers × registration × api/states), including that `HandlerType` officially accepts sync handlers (`handlers.md` currently opens "A handler is an async method," under-telling the contract). `type:enhancement, area:api, topic:dx, size:medium` + docs follow-up.
+
+#### F4. No error contract: callers guess catch-tuples (30 occurrences)
+
+The API surface raises a mix of typed hassette exceptions and bare stdlib ones (`api/methods.md` documents `ValueError` and `RuntimeError` raises); almost nothing is exported from the top-level package (only the two warning classes); there is no error-handling concept page (what happens when a handler raises, what `api.*` can raise, what's retryable). Corpus result: a guessed `(OSError, TimeoutError, ValueError, RuntimeError)` tuple repeated ~30 times, growing per-app to 7 exception types, plus a comment documenting the discovery that some `HassetteError` subclasses escape the stdlib catch.
+
+**Fix shape:** decide and document the raise-contract per API method; export the exception hierarchy (or bless `hassette.exceptions` in docs); consider a curated `RECOVERABLE_HA_ERRORS` tuple; add an error-handling concept page (handler exceptions are already isolated + telemetered — say so). `type:enhancement, area:api, topic:errors, topic:dx, size:medium`.
+
+#### F5. Every shutdown ends with spurious ERRORs (extends #1810)
+
+Every orderly SIGTERM shutdown — healthy runs included — logs two ERROR-level `RuntimeError: TaskBucket(Hassette.SchedulerService.TaskBucket) is sealed and rejected new work: scheduler:remove_jobs`, plus a stray "WebSocket connection reset by peer" ERROR. The last thing an operator ever sees is a scary error. #1810 (run 1) covers the sealed-bucket family but claims "normal teardown ordering avoids this — the reachable window today is force-terminal"; this evidence shows the ordinary path hits it on every out-of-box run. **Action: comment on #1810 extending scope + raising priority, not a new issue.** Repro: quickstart config, `kill -TERM`, read the tail.
+
+#### F6. Quickstart promises output that cannot happen; connection success is never logged
+
+`docs/pages/getting-started/snippets/run_output.txt` shows `INFO hassette ... ─ Connected to Home Assistant`. That string exists nowhere in `src/` — the only connect log is `logger.debug("Connected to WebSocket at %s")` (`websocket_service.py:416`), invisible at defaults. The newcomer's #1 question — "did my token work?" — is answered by silence; blind persona P1 independently flagged the mismatch. Related first-run noise: ~25 lines of framework internals on the console (dependency-graph dump, 11× "Waiting for dependencies", manifest JSON, interleaved bare-uvicorn lines) burying the "Hello from Hassette!" payoff, and a WARNING that fires on the *default* config (0.0.0.0 bind + no trusted_proxies — if the default warns, the default or the warning is wrong; a token-login UI on 0.0.0.0 by default also deserves a deliberate decision).
+
+**Fix shape:** promote connection-established (and lost/re-established) to INFO — it's a state transition per the project's own logging rules; quiet the startup internals to DEBUG in console mode; reconcile `run_output.txt` with reality; decide loopback-vs-0.0.0.0 default. `type:bug, area:websocket, size:small` + `type:enhancement, area:core, topic:dx`.
+
+#### F7. Quickstart never mentions the dashboard; web-API auth is undiscoverable from where it bites
+
+The web UI — the flagship differentiator — appears in the quickstart only as a buried log line ("Open http://127.0.0.1:8126 to log in"). P1's single biggest time sink: `hassette status` returning `Error 401: Not authenticated` with no pointer to the separate web-API-token concept; the 401 text doesn't match the docs' own documented message, and `cli/configuration.md` isn't linked from the quickstart. Also verified: against a *wrong*-credential loopback target the CLI silently attaches the local instance's `.web_api_token` (multi-instance trap) and the 401 names neither the credential source used nor a remedy — the docs explicitly promise "a 401 naming the remedy."
+
+**Fix shape:** quickstart section for the dashboard; 401 message that names the credential source tried + the fix; link the auth page from the error. `type:bug, area:cli, topic:dx, size:small` + docs.
+
+#### F8. CLI under-selects from its own excellent telemetry
+
+- `hassette app` shows `Invoc/1h` (listener invocations only) and **no health/error column**, while the same backend reports `health_status: "critical"`, `error_rate: 78.7`, `total_job_errors: 122` for a demo app. An app failing 109×/hour renders as "running, 1 invocation."
+- The data *is* reachable via `hassette app health <key>` — but nothing in the listing hints that drill-down exists, and it prints `error_rate 78.83597883597884` (unformatted).
+- `--app <nonexistent-key>` returns the same bare `No results.` as a real-but-quiet app — no existence validation, no "known apps" hint, no cross-hint ("0 listeners; this app has 1 scheduled job — try `hassette job`").
+
+**Fix shape:** Health + Err columns in `hassette app`; validate `--app` keys; disambiguate empty results; format percentages. `type:enhancement, area:cli, size:small` (bundle).
+
+#### F9. App-init failures are logged three times
+
+One `ValueError` in `on_initialize` produces three stacked ERROR tracebacks (hook runner, init coordinator, `AppLifecycleService`). The behavior is otherwise right — framework stays up, user file:line named. Log once at the layer that owns the decision; DEBUG elsewhere. `type:bug, area:core, topic:errors, size:small`.
+
+#### F10. Registration accepts entity IDs that cannot match
+
+"Hassette does not error on a non-existent entity ID. The handler simply never fires" — a documented checklist item (troubleshooting.md #1) that could be a runtime signal instead: the state proxy holds the full entity list at registration time. Warn (log + listener telemetry flag + dashboard badge) when a literal, non-pattern entity ID matches nothing, tolerant of entities created later. Same family as F2 — silent-by-design, observable-in-principle. `type:enhancement, area:bus, topic:dx, size:medium`.
+
+### LOW / DISCUSS
+
+- **D1. `name=` ceremony on every registration.** PR #922 made `name=` mandatory for DB-upsert identity; no recorded consideration of auto-deriving (`ClassName.handler` + topic — equally stable), requiring explicit names only on `DuplicateListenerError` collision. Would erase the most-typed parameter in the API for the majority case. Worth a design discussion, not a defect.
+- **D2. P/C/D/A conceptual load vs observed usage.** The corpus uses P×1, C×2, and none of the richer D variants; filtering is done imperatively in handler bodies. The layered design is principled, but docs could bless the built-in kwargs (`changed_to`/`changed_from`/`debounce`) as the 90% path and position P/C as advanced composition. Docs-emphasis change, not API change.
+- **D3. Typed-state distrust (contracts mostly verified, distrust is behavioral).** 10+ redundant `if not new_state:` guards under `D.StateNew`, 12× defensive `(KeyError, AttributeError)` around `states[...]`, `getattr()` on typed `ClimateState` attributes 4×, isinstance + type-ignore for light-group member lists. Verified: the `D.StateNew` raises-contract holds (`ensure_present`, dependencies.py:85 — the guards are dead code), and group membership is typed (`AttributesBase.entity_id: list[str] | None`, base.py:47) with an `is_group` property (base.py:122) the corpus never found — though the base model's own pyright-ignores there suggest the typing is awkward even internally. Remaining unknown: the ClimateState `getattr` pattern. Fix shape: a docs statement strong enough to let authors delete these guards + a look at the group-entity ergonomics; investigate the climate attrs case.
+- **D4. Stale event-entity replays.** The corpus hand-rolls an `event_age_seconds` guard (~18 lines per button app) against HA-restart replays. Note: a generic `max_event_age=` would NOT fix this — replays carry a fresh `time_fired`; the staleness signal is the event entity's ISO state value. Fix shape is an `EventState`-aware freshness predicate (e.g. `P.EventEntityFresh(max_age=10)`). Small enhancement.
+- **D5. `call_service` swallows the most natural wrong call.** `**data` means a bare `entity_id=` kwarg lands in service data, where HA happens to tolerate it — the wrong form works, so the `target=` contract is unlearnable (the corpus uses both, and its CLAUDE.md declares `target=` a MUST without knowing why). Consider detecting `entity_id` in `**data` and either promoting it to `target` or warning.
+- **D6. No restart/backoff primitive for app background loops.** `task_bucket.spawn()` exists, is documented, and logs crashes (ERROR) — but a crashed loop stays dead, so the corpus hand-rolled ~50 lines of supervision (bedtime) and ~60 lines of init retry (laundry) while the framework keeps `restart_spec` internal-only. Discuss exposing a minimal supervised-loop helper. (The corpus's "asyncio swallows exceptions" complaint is a discoverability miss — spawn already observes them.)
+- **D7. Raw repr leak:** job telemetry's `predicate_description` renders `<bound method PredicateDemo.is_motion_detected of <PredicateDemo ...>>` beside a polished `human_description`. Cosmetic.
+- **D8. Log-table tracebacks are framework-heavy** — user code is 2 of 10 frames in a typical handler error; consider folding framework frames in CLI/dashboard rendering.
+- **D9. Docs nits from personas:** first-automation's `light.porch` not flagged as substitute-me (P1); seed-vs-simulate ordering rule split across two testing pages; `freeze_time`'s xdist warning lives on a different page from `freeze_time` itself (P2).
+
+### META — fixes outrun the channel that announces them
+
+Per-instance cache keys (the corpus still namespaces manually, 8×), forgotten-await detection (corpus CLAUDE.md still calls it a silent footgun), and the mature test harness (corpus tests still hand-roll `App.__new__` + AsyncMocks + 55 sleeps, with its own comment admitting "AsyncMock silently accepts any call shape") all solved pains the one known power user still works around — and one corpus doc claim is now factually wrong ("state reads are synchronous"). Consider an "for app authors: you can now delete X" section per release in `operating/upgrading.md`, fed from changelog entries. `type:documentation, topic:dx, size:small` (process, mostly).
+
+---
+
+## Strengths (genuine, keep doing these)
+
+- **The testing story is excellent now.** A blind persona reached 3/3 passing tests — including the hard cancel-pending-job-on-retrigger shape — in 2 runs, with `freeze_time`/`advance_time`/`trigger_due_jobs` working first try, named `DrainTimeout`/`DrainError`, `assert_call_count`, and the `hassette[test]` extra.
+- **The newer exception classes are exemplary** — `ListenerNameRequiredError`/`DuplicateListenerError` print the fix with a code sample; structured attributes throughout; `FailedMessageError.code` for programmatic handling.
+- **The troubleshooting page names the real traps** (entity typo, `changed_to=True`, attribute-only changes, forgotten await) — it matches what actually bites users.
+- **CLI tables are good operator surfaces** — per-listener OK/Fail/Avg/Last, `registration_source` carrying the actual registration code in telemetry, `boot_issues` in status.
+- **Failure isolation behaves right:** app crashes don't take the framework down; syntax errors leave it serving for fix-and-reload; missing-token and invalid-token messages are clear (redacted token, exact env vars named).
+- **DI works as advertised** for the newcomer path — P1: "zero friction, exactly as documented."
+
+## P3 — debugging persona (results, verified)
+
+Setup: a blind persona was handed a running app with three seeded bugs matching the audit's silent-failure classes, instructed to debug from the observability surfaces first (CLI → dashboard → logs → docs), reading code only as a last resort.
+
+| Seeded bug | Localized by | Attempts | Verdict on the surfaces |
+|---|---|---|---|
+| Entity-ID typo (`movment_backyard`) | CLI — `hassette listener --json` showed the wrong target string immediately | 1 | Excellent; called it "the single most useful command all session" |
+| Forgotten `await` on registration | **Nothing.** CLI + dashboard showed only the *absence* of a listener; no warning, error, or boot issue anywhere. Fell back to reading code | 3 (exhausted) | Worst gap — see F11; independently corroborates it end-to-end |
+| `.upper()` on a `bool` state value (DI type confusion) | CLI — `hassette log --app` full traceback, exact file:line; the dashboard's failing-handlers card surfaced it proactively too | 1 | Excellent |
+
+All three fixed and verified live (0% error rate after). Verification notes on P3's claims: the forgotten-await silence is independently reproduced (F11 lab); the typo-diagnosis and traceback claims match its journal and screenshots. Two P3 claims carry caveats: its "loopback `.web_api_token` auto-fallback never worked" experience is consistent with the multi-instance token trap in F7 but may involve shared-data-dir contamination between audit instances, so it is folded into F7 rather than counted separately; and its "dashboard Reload served stale code" hit is at least partially a known limitation (CLAUDE.md documents stale-module reuse when reloading *failed* apps) — worth checking whether the running-app path has the same hole before filing.
+
+P3's dashboard-specific findings, banked for run 3 (frontend): handler cards don't show the subscribed entity/target (would have solved the typo bug from the dashboard alone); the failing-handlers summary card is genuinely good (beat the CLI to bug 3); Reload-vs-restart semantics need surfacing in the UI.
+
+## Issue slate — walked through with Jessica 2026-09-02, filed as #1815–#1834
+
+| Finding | Disposition |
+|---|---|
+| F1 SIGINT silent hang | **#1815** (bug, high) |
+| F11 warnings black hole | **#1816** (bug, high) |
+| F2a listener filtered counter | **#1817** (enhancement) |
+| F2b job-table Skipped column | **#1818** (bug) |
+| F3 guard Api reads + sync/async docs matrix | **#1819** (enhancement; depends on #1816 for audibility) |
+| F4 error contract | **#1820** (enhancement) |
+| F5 sealed-bucket ERRORs every shutdown | **comment on #1810** (scope extension: reachable on the ordinary path, not just force-terminal) |
+| F6 connect INFO log + quickstart output | **#1821** (bug) + **#1822** (startup noise + default-bind decision) |
+| F7 401 message/docs + auth-resolution rethink | **#1823** (immediate fix) + **#1824** (design discussion, per Jessica's call to split) |
+| F8 CLI display bundle | **#1825** (enhancement) |
+| F9 triple-logged init failure | **#1826** (bug) |
+| F10 unknown-entity registration warning | **#1827** (enhancement) |
+| D4 event-entity freshness predicate | **#1828** (enhancement) |
+| D5 call_service targeting contract | **#1829** (filed non-prescriptive per Jessica — surfaces the tension, doesn't pick promote-vs-warn) |
+| D6 supervised background loops | **#1830** (design discussion) |
+| D7 predicate_description repr | **#1831** (bug) |
+| D8 traceback frame folding | **#1832** (enhancement; linked to #749) |
+| D9 docs followability nits | **#1833** (documentation) |
+| META upgrade-notes discipline | **#1834** (documentation) |
+| D1 `name=` auto-derivation | **Dropped** — Jessica: keep explicit identity required |
+| D2 P/C docs re-emphasis | **Dropped** — single Claude-written corpus too weak a signal |
+| D3 typed-state distrust bundle | **Dropped** — legacy corpus behavior, not tracked |

--- a/design/audits/2026-09-02-frontend-web-layer-audit.md
+++ b/design/audits/2026-09-02-frontend-web-layer-audit.md
@@ -1,0 +1,234 @@
+# Frontend + Web Layer Audit — 2026-09-02 (run 3)
+
+**Scope:** The web dashboard end to end — `frontend/src/` (state, WS handling, query layer, pages,
+components, utils) plus `src/hassette/web/` (routes, models, mappers, auth, middleware) as the
+frontend's data-contract boundary. Both dimensions: data correctness (staleness, contract drift,
+wrong/missing values) and visual/UX quality (live demo stack, screenshot matrix at 1440px and
+390px).
+
+**Not covered this run:** deep a11y audit (screen-reader walkthrough), the seeded-scenario DBs
+(`large-volume`/`adversarial` states — demo-stack live data only), frontend test quality
+(tracked separately, #1282), bundle/performance profiling (#1477 tracks code-splitting).
+
+**Lenses:** correctness first, UX/polish second. Same method as runs 1-2: Fable reasoning as the
+engine, two Sonnet reader agents for breadth (frontend long-tail, web layer) whose findings were
+each re-verified against the actual code before making this report, and live verification on the
+demo stack for anything probeable.
+
+**Method — live evidence:**
+
+- Demo stack (HA + hassette 0.52.0 + Vite), authenticated session, Playwright-driven browsing.
+- Live probes: WS reconnect repro via `docker restart` of the hassette container with a
+  half-failed app; `GET /api/scheduler/jobs` field inspection; 65-second uptime-label watch.
+- Screenshot matrix: apps, app-detail (degraded multi-instance), handlers, logs, diagnostics,
+  config at 1440×900; apps + logs at 390×844.
+
+---
+
+## Verdict up front
+
+This is a **well-built frontend**. The store's reconnect atomicity, the WS message validation,
+the exhaustively-`satisfies`-typed status maps, the staleness reasoning documented inline in
+`appLiveStatus`, and the auth layer (timing-safe comparisons, no header-spoofable trust, WS/HTTP
+sharing one auth decision function) are all better than typical production dashboards. The
+findings below are real, but they are cracks in a good structure, not signs of rot. The dominant
+theme: **the time-window/uptime model has a broken core assumption** (F1), and **WS-overlay state
+has one missing invalidation** (F2, already tracked as #1610 — this run adds a live repro and a
+scope extension).
+
+---
+
+## Findings
+
+### F1. The since-restart window drifts forward with page-open time; uptime label frozen; runs/hr inflates — HIGH, live-confirmed
+
+`ConnectedPayload.uptime_seconds` is stored once per WS connect (`store.ts:236`) and never
+updated. Every consumer then treats it as if it were live:
+
+- `resolveSince("since-restart")` (`time-window.ts:21`) computes `Date.now()/1000 −
+  uptimeSeconds` **at each fetch** — the "restart boundary" moves forward one second per
+  wall-clock second the tab is open. A dashboard open 2 hours silently excludes the first 2
+  hours of post-restart telemetry from every since-restart query (listeners, jobs, activity,
+  logs, dashboard grid). Since-restart is the **default preset**, so this is the out-of-box
+  behavior.
+- The status-bar uptime label renders `formatUptime(uptimeSeconds)` — frozen at its
+  connect-time value. Live-confirmed: 65 s after a reconnect the label still read "up 1s".
+- `apps.tsx:240-242` uses the static uptime as the runs/hr denominator: numerator (runs) grows,
+  denominator stays frozen → the rate inflates the longer the tab is open.
+
+**Fix shape:** store `restartEpochSeconds = Date.now()/1000 − data.uptime_seconds` in
+`handleWsConnected`; `resolveSince` returns it directly; uptime label and runs/hr derive live
+uptime as `now − restartEpochSeconds` (the existing 30 s `tick` already re-renders on schedule).
+One store field change fixes all three symptoms.
+
+### F2. Stale appStatus overlay survives reconnect and outranks fresh REST data — HIGH, live-confirmed → extends #1610
+
+`handleWsConnected`'s `isReconnect` branch clears `serviceStatus` and the log buffer but not
+`appStatus` (`store.ts:234-245`), and `appLiveStatus`/`instanceLiveStatus` give the WS entry
+precedence over refetched grid/manifest data. The backend deliberately emits STOPPED correction
+events so the WS cache can't stick on FAILED (`app_lifecycle_service.py:505-568`) — but only a
+*connected* client sees them. Any status transition that happens while the client is
+disconnected is lost forever.
+
+**Live repro (this run):** started `degraded_demo` (instance 0 running, instance 1 failed → UI
+"degraded"); `docker restart hassette-demo-hassette`; after the WS reconnected (fresh connected
+payload, uptime reset) REST truth was `stopped, 0 instances` while the apps table still rendered
+`degraded` — indefinitely, until a hard page reload.
+
+**Already tracked as #1610**, which frames it as the multi-instance shrink + forward-probe case
+and names the destructive consumer ("Stop all failing" palette action can stop a healthy app).
+This run's contribution: a concrete every-restart repro, plus scope extension — the plain
+single-key overlay path (`appStatuses[key]?.status ?? row.status`) is equally affected, no
+forward probe or instance shrink required. Any app whose state changed across a disconnect
+renders wrong. #1610's "simplest" option (clear `appStatus` in the reconnect branch, symmetric
+with `serviceStatus`) fixes both shapes.
+
+### F3. Stale `?window=` URL param silently overrides the time window after navigation — MEDIUM-HIGH, code-confirmed
+
+`TimePresetSelector` (mounted once in `StatusBar` above the router `Switch`, never remounts)
+parses `?window=` into `urlWindowParam` in a **mount-only** effect
+(`time-preset-selector.tsx:26-34`). Every scoped query computes its window as
+`urlWindowParam ?? timePreset`. Every preset click writes `?window=` into the URL, so bookmarks
+and shared links routinely carry it. Land on such a URL with a different stored preset, then
+navigate anywhere in-app: the selector shows the stored preset as active while every query
+silently keeps using the URL's window. Only a manual preset click resyncs. The UI and the data
+disagree with no visible signal.
+
+**Fix shape:** re-parse `?window=` on every location/search change, or demote it to a one-shot
+initializer of `timePreset` and delete `urlWindowParam` entirely (simpler model, one less store
+field).
+
+### F4. `fire_at` is nulled for every non-jittered job in the jobs APIs — MEDIUM, live-confirmed
+
+`enrich_jobs_with_live` (`web/utils.py`) gates `fire_at` on `live_job.jitter is not None`, but
+`Job.set_next_run()` (`scheduler/classes.py:508-515`) sets `fire_at` unconditionally — jitter
+only offsets it afterwards. Since jitter defaults to `None`, essentially every scheduled job
+returns `fire_at: null` from `GET /api/scheduler/jobs` and `GET /api/telemetry/app/{key}/jobs`
+despite holding a valid value. Live-confirmed on the demo stack: all non-jittered scheduled jobs
+show `next_run=<ts>, fire_at=None`. UI impact is muted (job-detail prefers `next_run`), but the
+field is documented API surface and any other consumer receives a silently wrong value. The one
+test covering this path only exercises the jitter case and treats the bug as intended. Fix:
+drop the jitter clause.
+
+### F5. `app_activity` violates the telemetry module's documented `since` contract — LOW-MEDIUM
+
+`routes/telemetry.py` documents "omit `since` for all-time aggregates"; every endpoint honors it
+except `app_activity`, which substitutes `now − 24h` when `since` is omitted. The shipped UI
+always sends an explicit `since`, so this only bites direct API consumers — who get silently
+wrong "all-time" data. Either honor the contract or document the 24 h default in the endpoint.
+
+### F6. Framework-tier handlers have no UI surface — MEDIUM, enhancement
+
+`handlers.tsx:106` hard-filters `source_tier === "app"` — framework listeners/jobs are fetched,
+then discarded, with no toggle; no other page shows them. The logs page *does* have an
+app/framework tier toggle, and the CLI exposes `--source-tier`. An operator investigating
+framework behavior (RQS listeners, StateProxy polling jobs) has telemetry in the DB and no way
+to see it in the dashboard.
+
+### F7. Sidebar groups degraded apps under the label "SLOW" — MEDIUM, UX terminology
+
+`sidebar-groups.ts`: the `warn` group renders as "SLOW" but contains `degraded`,
+`exhausted_cooling`, `stopping`, `shutting_down` — none of which mean slow. A half-crashed app
+filed under "SLOW" actively misleads (screenshot evidence: `degraded_demo` with a failed
+instance sat under "SLOW ⚠ 1"). Nothing in the product measures slowness. Rename to match the
+tone key it already has ("WARNING" / "DEGRADED" / "ATTENTION").
+
+### F8. Time and count columns truncate at ordinary viewports — MEDIUM, polish bundle
+
+Screenshot-confirmed at 1440×900 (a common desktop size) and 390px:
+
+- Apps table RUNS column: sparkline + count renders as "1…", "3…" — the count is unreadable.
+- Logs table TIMESTAMP column clips its own seconds digit ("09/02 12:28:5…").
+- Mobile logs WHEN column renders every row as "just …" (32px column, "just now" doesn't fit).
+- Handlers table APP column truncates most app keys while TYPE/TRIGGER columns hold slack;
+  NEXT RUN clips "completed" to "comple…".
+- Related cosmetic: the failed-apps banner renders the app key twice ("degraded_demo —
+  degraded_demo: …") because the error message already begins with the key.
+
+Individually trivial; together they read as one issue: fixed column-percentage/px allocations
+were tuned for one width and never re-checked at common sizes. Time and count cells should never
+be the ones that give way.
+
+### F9. `get_app_source` does blocking file I/O on the event loop — LOW
+
+`routes/apps.py:415` calls `Path.read_text()` inside the async handler, stalling the loop
+(including the HA WebSocket receive loop) for the read's duration. Small files today; trivial to
+route through the sync executor or `anyio.to_thread`.
+
+### F10. Execution rows without an execution_id are keyboard-focusable but inert — LOW-MEDIUM, a11y
+
+`execution-table.tsx:244-263`: rows with `execution_id` absent get no `onKeyDown`, but still
+receive a roving-tabindex stop. Mouse users see "not clickable" styling; keyboard users land on
+a focusable row where Enter/Space silently do nothing. Skip such rows in the roving sequence (or
+mark them `aria-disabled` and communicate it).
+
+### F11. Log `rowKey()` treats a real `seq: 0` as absent — LOW
+
+`log-table/types.ts:44-46`: `entry.seq ? … : …` — records that bypass `CorrelationFilter`
+(early-startup, third-party loggers) carry the backend's explicit `seq: 0` fallback
+(`logging_.py:91`) and fall back to a weaker `timestamp-logger-lineno` key that can collide
+(React key collision → wrong row selected/highlighted). Use `entry.seq > 0` or key on
+seq-presence explicitly.
+
+### F12. `/logs/recent` defaults `source_tier=None` while every telemetry endpoint defaults `"app"` — LOW, discuss
+
+Possibly deliberate (a raw log viewer arguably should default to everything), but it's the only
+asymmetry of its kind in the layer and nothing documents it. Decide and write it down, or align
+it.
+
+### F13. `useQueryParams` parses `?foo` and `?foo=` inconsistently — LOW, discuss/drop
+
+`use-query-params.ts:48-63`: bare key → `""` present; explicit-empty → dropped, contradicting
+the hook's own "empty string = absent" doc. Only reachable via hand-edited URLs.
+
+---
+
+## Minor notes (not slated)
+
+- The log stream's WS subscription level is set by whichever log table mounted last and is never
+  reset on unmount — picking "All levels" on /logs leaves the stream at DEBUG until another
+  table mounts or the socket reconnects. Waste, not incorrectness.
+- App-detail for a failed app shows the same error string three times on one screen (banner,
+  Last Error box, instance card). Acceptable for a monitoring tool; worth a squint in any
+  future information-density pass.
+- `useTelemetryHealth`'s docstring says fetch failure sets `telemetryDegraded = true`; the code
+  deliberately only does that on HTTP 503 (the code is right, the comment is stale).
+- WS broadcast drops for slow clients are logged server-side but invisible to the client — the
+  frontend has no "you may have missed events" signal. Related to the #1610 family; the fix
+  there (clear + refetch on reconnect) is the same medicine.
+
+## Strengths (verified, keep doing this)
+
+- **Store discipline:** `handleWsConnected`'s single-`set()` atomicity with its reasoning
+  documented inline; selector-based subscriptions that keep pages off the fleet-wide render path
+  (`use-scoped-execution.ts` is exemplary, including its documented one-extra-render bound).
+- **Contract typing:** status maps typed as `Record` + `satisfies` so a new enum variant is a
+  compile error at every consumer; generated REST + WS types with CI freshness enforcement.
+- **WS hygiene:** validated messages with an exhaustiveness check, handshake timeout, backoff
+  reset only on completed handshake, auth-rejection confirmed via REST before redirecting.
+- **Auth layer:** timing-safe comparisons with the reachable `TypeError` path guarded, no
+  header-spoofable proxy trust, stateless HMAC session cookies with sliding renewal, one shared
+  auth-decision function for HTTP and WS. Reviewed adversarially; nothing found.
+- **Degradation architecture:** the `db_degrades_to` category system matches its documented
+  classification table at every spot-checked site; 503 vs legit-empty is distinguishable
+  everywhere it matters.
+
+## Issue tracking
+
+Filed 2026-09-02 (F6/F12 held for discussion; F2 went as a comment, not a new issue):
+
+| # | Finding | Disposition |
+|---|---------|-------------|
+| F1 | since-restart drift + frozen uptime + inflated runs/hr | **#1837** (bug, priority:high) |
+| F2 | stale appStatus overlay after reconnect | **comment on #1610** — live repro + single-key scope extension |
+| F3 | stale `?window=` override after navigation | **#1838** (bug) |
+| F4 | `fire_at` nulled for non-jittered jobs | **#1839** (bug) |
+| F5 | `app_activity` breaks documented since contract | **#1840** (bug) |
+| F6 | framework-tier handlers invisible in UI | **#1847** (enhancement — tier toggle on handlers page, per discussion) |
+| F7 | "SLOW" sidebar label for degraded apps | **#1841** (enhancement) |
+| F8 | truncation family (time/count columns, banner dup) | **#1842** (enhancement, polish bundle) |
+| F9 | blocking `read_text` in `get_app_source` | **#1843** (bug) |
+| F10 | inert keyboard-focusable execution rows | **#1844** (enhancement, a11y) |
+| F11 | `rowKey()` vs `seq: 0` | **#1845** (bug) |
+| F12 | `/logs/recent` tier default asymmetry | **#1848** (docs — asymmetry confirmed deliberate, document it) |
+| F13 | `?foo` vs `?foo=` parse inconsistency | **#1846** (bug) |


### PR DESCRIPTION
### Fable audit series (2026-09-02)

Four focused audit reports covering the full framework surface, added under `design/audits/`:

- **Run 1 — Backend core correctness & coherence** (`2026-09-02-backend-core-correctness-audit.md`): lifecycle/teardown machinery, the readiness lattice, bus/scheduler stacks, app lifecycle, ServiceWatcher, CommandExecutor, and the Api layer.
- **Run 2 — DX & onboarding** (`2026-09-02-dx-onboarding-audit.md`): app-author ergonomics, error-path quality, docs onboarding, and the testing story, driven by live quickstart execution and blind personas rather than code reading alone.
- **Run 3 — Frontend + web layer** (`2026-09-02-frontend-web-layer-audit.md`): the web dashboard end to end, data correctness and visual/UX quality, verified against the live demo stack and a screenshot matrix.
- **Run 4 — CLI, Docker onboarding, triggers & helpers (mop-up)** (`2026-09-02-cli-docker-triggers-helpers-audit.md`): the remaining coverage gaps from runs 1-3 — the CLI end to end, the Docker onboarding path, the scheduler trigger layer, and the helpers API.

Every finding across the series is already tracked:

- Run 1: #1797-#1813
- Run 2: #1815-#1834
- Run 3: #1837-#1848, plus a scope-extending comment on #1610
- Run 4: #1850-#1858, plus scope comments on #1825 and #541

See each report for full method, live-verification evidence, and per-finding disposition.
