### PR TITLE
fix: handle SIGINT for graceful shutdown instead of silent hang

### DIFF
--- a/src/hassette/cli/commands/run.py
+++ b/src/hassette/cli/commands/run.py
@@ -67,6 +67,8 @@ def cmd_run(
     try:
         asyncio.run(run_server(config))
     except KeyboardInterrupt:
+        # Only reachable before server.main() installs its own SIGINT handler, or if that
+        # registration itself fails — once installed, Ctrl+C is handled there, not here.
         LOGGER.info("Keyboard interrupt received, shutting down")
     except AppPrecheckFailedError as exc:
         LOGGER.error("App precheck failed: %s", exc)

--- a/src/hassette/server.py
+++ b/src/hassette/server.py
@@ -13,23 +13,29 @@ from hassette.resources.lifecycle import request_shutdown
 LOGGER = getLogger(__name__)
 
 
-def _handle_sigint_signal(core: Hassette, loop: asyncio.AbstractEventLoop) -> None:
-    """Handle one SIGINT delivery: force-exit if shutdown is already underway, else request it.
+def _handle_sigint_signal(core: Hassette, loop: asyncio.AbstractEventLoop, sigint_seen: threading.Event) -> None:
+    """Handle one SIGINT delivery: force-exit if a SIGINT was already seen, else request it.
 
-    The graceful path is handed to the loop via ``call_soon_threadsafe`` (this runs on a
-    dedicated non-loop thread — see ``_sigint_wait_loop``), matching how ``request_shutdown``
-    is invoked everywhere else. The force-exit path runs directly here instead, with no
-    dependency on the loop or main thread ever regaining control — see ``_sigint_wait_loop``'s
-    docstring for why that independence is the entire point.
+    "Already seen" is tracked via ``sigint_seen`` — a plain ``threading.Event`` set immediately
+    here on the first delivery — rather than ``core.shutdown_event``. The latter only becomes
+    set once ``request_shutdown()`` actually runs on the loop thread via
+    ``call_soon_threadsafe``, which may not have happened yet if the loop is blocked by
+    *anything*, not only a stalled shutdown hook. Waiting on ``shutdown_event`` would make every
+    SIGINT delivered before the loop catches up look like "the first one," defeating the
+    second-Ctrl+C escalation exactly when it's most needed. The graceful path is still handed to
+    the loop via ``call_soon_threadsafe``, matching how ``request_shutdown`` is invoked
+    everywhere else; the force-exit path runs directly here, with no dependency on the loop or
+    main thread ever regaining control.
     """
-    if core.shutdown_event.is_set():
+    if sigint_seen.is_set():
         LOGGER.warning("second SIGINT received during shutdown; forcing immediate exit")
         os._exit(1)
 
+    sigint_seen.set()
     loop.call_soon_threadsafe(request_shutdown, core, "SIGINT received")
 
 
-def _sigint_wait_loop(core: Hassette, loop: asyncio.AbstractEventLoop) -> None:
+def _sigint_wait_loop(core: Hassette, loop: asyncio.AbstractEventLoop, sigint_seen: threading.Event) -> None:
     """Dedicated thread that synchronously waits for SIGINT via ``signal.sigwait()``.
 
     ``main()`` blocks SIGINT process-wide before this thread (or any other) is created, so
@@ -48,7 +54,7 @@ def _sigint_wait_loop(core: Hassette, loop: asyncio.AbstractEventLoop) -> None:
     """
     while True:
         signal.sigwait({signal.SIGINT})
-        _handle_sigint_signal(core, loop)
+        _handle_sigint_signal(core, loop, sigint_seen)
 
 
 async def main(config: HassetteConfig) -> None:
@@ -71,14 +77,15 @@ async def main(config: HassetteConfig) -> None:
     # Block SIGINT before any other thread exists, so every thread created later (the sync
     # executor pool, the logging QueueListener, etc. — all spawned during run_forever()'s
     # resource initialization, after this point) inherits the blocked mask — see
-    # _sigint_wait_loop's docstring. sigwait()/pthread_sigmask() are POSIX-only; on platforms
-    # without them (Windows), SIGINT falls back to Python's default handling, same as before
-    # this framework registered anything for it.
+    # _sigint_wait_loop's docstring. sigwait()/pthread_sigmask() are POSIX-only; hassette does
+    # not target Windows (see pyproject.toml — no Windows classifier), so no fallback is
+    # provided there.
+    sigint_seen = threading.Event()
     try:
         signal.pthread_sigmask(signal.SIG_BLOCK, {signal.SIGINT})
     except AttributeError:
         LOGGER.warning("SIGINT handling via sigwait() is not supported on this platform")
     else:
-        threading.Thread(target=_sigint_wait_loop, args=(core, loop), daemon=True).start()
+        threading.Thread(target=_sigint_wait_loop, args=(core, loop, sigint_seen), daemon=True).start()
 
     await core.run_forever()

--- a/src/hassette/server.py
+++ b/src/hassette/server.py
@@ -1,9 +1,9 @@
 """Hassette framework server entry point."""
 
 import asyncio
-import functools
 import os
 import signal
+import threading
 from logging import getLogger
 
 from hassette import Hassette, HassetteConfig
@@ -13,22 +13,42 @@ from hassette.resources.lifecycle import request_shutdown
 LOGGER = getLogger(__name__)
 
 
-def _handle_sigint(core: Hassette, _signum: int, _frame: object) -> None:
-    """Request shutdown on the first SIGINT; force an immediate exit on any subsequent one.
+def _handle_sigint_signal(core: Hassette, loop: asyncio.AbstractEventLoop) -> None:
+    """Handle one SIGINT delivery: force-exit if shutdown is already underway, else request it.
 
-    Registered via ``signal.signal()`` rather than ``loop.add_signal_handler()``: shutdown
-    hooks are user-authored async code that can block the event loop thread synchronously
-    (see ``resources/operations.py``'s ``await method()``), and a callback registered through
-    the loop only runs once the loop next gets control — never, if that blocking call is what's
-    stalling teardown in the first place. A raw signal handler is delivered at the interpreter's
-    next bytecode/syscall-interrupt check regardless of what the loop thread is doing, so the
-    force-exit path still fires exactly when teardown is genuinely stuck.
+    The graceful path is handed to the loop via ``call_soon_threadsafe`` (this runs on a
+    dedicated non-loop thread — see ``_sigint_wait_loop``), matching how ``request_shutdown``
+    is invoked everywhere else. The force-exit path runs directly here instead, with no
+    dependency on the loop or main thread ever regaining control — see ``_sigint_wait_loop``'s
+    docstring for why that independence is the entire point.
     """
     if core.shutdown_event.is_set():
         LOGGER.warning("second SIGINT received during shutdown; forcing immediate exit")
         os._exit(1)
 
-    request_shutdown(core, "SIGINT received")
+    loop.call_soon_threadsafe(request_shutdown, core, "SIGINT received")
+
+
+def _sigint_wait_loop(core: Hassette, loop: asyncio.AbstractEventLoop) -> None:
+    """Dedicated thread that synchronously waits for SIGINT via ``signal.sigwait()``.
+
+    ``main()`` blocks SIGINT process-wide before this thread (or any other) is created, so
+    every thread the framework later spawns (the sync executor pool, the logging
+    ``QueueListener``, etc.) inherits the blocked mask and is never an eligible target for the
+    kernel to deliver SIGINT to. POSIX guarantees a thread blocked in ``sigwait()`` for a signal
+    takes delivery priority for it, so this thread — and only this thread — ever receives it,
+    regardless of what the main/event-loop thread happens to be doing at the time.
+
+    This matters because a plain ``signal.signal()`` handler still depends on which thread the
+    OS chooses to deliver a process-directed signal to in a multi-threaded process — hassette
+    runs several. If the kernel picks a thread other than the one blocked inside a stalled
+    shutdown hook, that hook's blocking call is never interrupted and the force-exit escalation
+    silently misses its window. See ``tests/system/test_sigint_shutdown.py`` for the
+    reproduction.
+    """
+    while True:
+        signal.sigwait({signal.SIGINT})
+        _handle_sigint_signal(core, loop)
 
 
 async def main(config: HassetteConfig) -> None:
@@ -48,9 +68,17 @@ async def main(config: HassetteConfig) -> None:
     except NotImplementedError:
         LOGGER.warning("SIGTERM handler registration is not supported on this platform/event loop")
 
+    # Block SIGINT before any other thread exists, so every thread created later (the sync
+    # executor pool, the logging QueueListener, etc. — all spawned during run_forever()'s
+    # resource initialization, after this point) inherits the blocked mask — see
+    # _sigint_wait_loop's docstring. sigwait()/pthread_sigmask() are POSIX-only; on platforms
+    # without them (Windows), SIGINT falls back to Python's default handling, same as before
+    # this framework registered anything for it.
     try:
-        signal.signal(signal.SIGINT, functools.partial(_handle_sigint, core))
-    except ValueError:
-        LOGGER.warning("SIGINT handler registration is not supported outside the main thread")
+        signal.pthread_sigmask(signal.SIG_BLOCK, {signal.SIGINT})
+    except AttributeError:
+        LOGGER.warning("SIGINT handling via sigwait() is not supported on this platform")
+    else:
+        threading.Thread(target=_sigint_wait_loop, args=(core, loop), daemon=True).start()
 
     await core.run_forever()

--- a/src/hassette/server.py
+++ b/src/hassette/server.py
@@ -23,9 +23,10 @@ async def main(config: HassetteConfig) -> None:
     core.wire_services()
 
     loop = asyncio.get_running_loop()
-    try:
-        loop.add_signal_handler(signal.SIGTERM, request_shutdown, core, "SIGTERM received")
-    except NotImplementedError:
-        LOGGER.warning("SIGTERM handler registration is not supported on this platform/event loop")
+    for sig in (signal.SIGTERM, signal.SIGINT):
+        try:
+            loop.add_signal_handler(sig, request_shutdown, core, f"{sig.name} received")
+        except NotImplementedError:
+            LOGGER.warning("%s handler registration is not supported on this platform/event loop", sig.name)
 
     await core.run_forever()

--- a/src/hassette/server.py
+++ b/src/hassette/server.py
@@ -1,6 +1,7 @@
 """Hassette framework server entry point."""
 
 import asyncio
+import os
 import signal
 from logging import getLogger
 
@@ -9,6 +10,19 @@ from hassette.exceptions import FatalError
 from hassette.resources.lifecycle import request_shutdown
 
 LOGGER = getLogger(__name__)
+
+
+def _handle_sigint(core: Hassette) -> None:
+    """Request shutdown on the first SIGINT; force an immediate exit on any subsequent one.
+
+    Graceful teardown can stall or consume the full shutdown timeout, so a second Ctrl+C must
+    not be swallowed by ``request_shutdown``'s idempotent no-op — it needs to exit immediately.
+    """
+    if core.shutdown_event.is_set():
+        LOGGER.warning("second SIGINT received during shutdown; forcing immediate exit")
+        os._exit(1)
+
+    request_shutdown(core, "SIGINT received")
 
 
 async def main(config: HassetteConfig) -> None:
@@ -23,10 +37,14 @@ async def main(config: HassetteConfig) -> None:
     core.wire_services()
 
     loop = asyncio.get_running_loop()
-    for sig in (signal.SIGTERM, signal.SIGINT):
-        try:
-            loop.add_signal_handler(sig, request_shutdown, core, f"{sig.name} received")
-        except NotImplementedError:
-            LOGGER.warning("%s handler registration is not supported on this platform/event loop", sig.name)
+    try:
+        loop.add_signal_handler(signal.SIGTERM, request_shutdown, core, "SIGTERM received")
+    except NotImplementedError:
+        LOGGER.warning("SIGTERM handler registration is not supported on this platform/event loop")
+
+    try:
+        loop.add_signal_handler(signal.SIGINT, _handle_sigint, core)
+    except NotImplementedError:
+        LOGGER.warning("SIGINT handler registration is not supported on this platform/event loop")
 
     await core.run_forever()

--- a/src/hassette/server.py
+++ b/src/hassette/server.py
@@ -1,6 +1,7 @@
 """Hassette framework server entry point."""
 
 import asyncio
+import functools
 import os
 import signal
 from logging import getLogger
@@ -12,11 +13,16 @@ from hassette.resources.lifecycle import request_shutdown
 LOGGER = getLogger(__name__)
 
 
-def _handle_sigint(core: Hassette) -> None:
+def _handle_sigint(core: Hassette, _signum: int, _frame: object) -> None:
     """Request shutdown on the first SIGINT; force an immediate exit on any subsequent one.
 
-    Graceful teardown can stall or consume the full shutdown timeout, so a second Ctrl+C must
-    not be swallowed by ``request_shutdown``'s idempotent no-op — it needs to exit immediately.
+    Registered via ``signal.signal()`` rather than ``loop.add_signal_handler()``: shutdown
+    hooks are user-authored async code that can block the event loop thread synchronously
+    (see ``resources/operations.py``'s ``await method()``), and a callback registered through
+    the loop only runs once the loop next gets control — never, if that blocking call is what's
+    stalling teardown in the first place. A raw signal handler is delivered at the interpreter's
+    next bytecode/syscall-interrupt check regardless of what the loop thread is doing, so the
+    force-exit path still fires exactly when teardown is genuinely stuck.
     """
     if core.shutdown_event.is_set():
         LOGGER.warning("second SIGINT received during shutdown; forcing immediate exit")
@@ -43,8 +49,8 @@ async def main(config: HassetteConfig) -> None:
         LOGGER.warning("SIGTERM handler registration is not supported on this platform/event loop")
 
     try:
-        loop.add_signal_handler(signal.SIGINT, _handle_sigint, core)
-    except NotImplementedError:
-        LOGGER.warning("SIGINT handler registration is not supported on this platform/event loop")
+        signal.signal(signal.SIGINT, functools.partial(_handle_sigint, core))
+    except ValueError:
+        LOGGER.warning("SIGINT handler registration is not supported outside the main thread")
 
     await core.run_forever()

--- a/tests/system/conftest.py
+++ b/tests/system/conftest.py
@@ -272,11 +272,21 @@ def make_system_config(ha_url: str, tmp_path: Path) -> HassetteConfig:
     )
 
 
+def free_port() -> int:
+    """Find a free TCP port by binding a socket and releasing it.
+
+    Avoids port conflicts between parallel test runs. Shared by every system test that needs
+    a dynamically assigned port (the web API here, or a whole subprocess's web API in
+    test_sigint_shutdown.py).
+    """
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        sock.bind(("", 0))
+        return sock.getsockname()[1]
+
+
 def make_web_system_config(ha_url: str, tmp_path: Path) -> tuple[HassetteConfig, str]:
     """Build a HassetteConfig with the web API enabled, using a dynamically assigned port.
-
-    Finds a free port by binding a socket, releases it, then uses that port for the
-    web API. This avoids port conflicts between parallel test runs.
 
     Args:
         ha_url: Base URL of the running Home Assistant instance.
@@ -286,10 +296,7 @@ def make_web_system_config(ha_url: str, tmp_path: Path) -> tuple[HassetteConfig,
         A tuple of ``(config, base_url)`` where ``base_url`` is e.g.
         ``http://localhost:PORT``.
     """
-    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
-        sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-        sock.bind(("", 0))
-        port = sock.getsockname()[1]
+    port = free_port()
 
     app_dir = tmp_path / "apps"
     app_dir.mkdir(exist_ok=True)

--- a/tests/system/test_cli_smoke.py
+++ b/tests/system/test_cli_smoke.py
@@ -9,7 +9,6 @@ Run via: uv run nox -s system
 
 import asyncio
 import contextlib
-import socket
 from collections.abc import Iterator
 from pathlib import Path
 from typing import Any
@@ -28,7 +27,14 @@ from hassette.web.models import (
     TelemetryStatusResponse,
 )
 
-from .conftest import HA_TOKEN, SystemTestConfig, make_web_system_config, startup_context, wait_for_web_server
+from .conftest import (
+    HA_TOKEN,
+    SystemTestConfig,
+    free_port,
+    make_web_system_config,
+    startup_context,
+    wait_for_web_server,
+)
 
 SYSTEM_APPS_DIR = Path(__file__).parent / "apps"
 
@@ -51,10 +57,7 @@ def _web_config_with_bus_app(ha_url: str, tmp_path: Path) -> tuple[SystemTestCon
     BusHandlerApp in tests/system/apps/ registers a listener for
     light.kitchen_lights — gives us an app with real listeners for filter tests.
     """
-    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
-        sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-        sock.bind(("", 0))
-        port = sock.getsockname()[1]
+    port = free_port()
 
     config = SystemTestConfig(
         base_url=ha_url,

--- a/tests/system/test_sigint_shutdown.py
+++ b/tests/system/test_sigint_shutdown.py
@@ -1,0 +1,205 @@
+"""System tests for real OS-level SIGINT shutdown behavior.
+
+Unlike the rest of the system suite, these tests spawn ``hassette run`` as a real subprocess
+rather than driving ``Hassette`` in-process via ``startup_context`` — the whole point is to
+send actual SIGINT signals to a real process and observe wall-clock exit timing, which an
+in-process test cannot exercise (there is no separate OS process to signal).
+
+Regression coverage for design/audits/2026-09-02-dx-onboarding-audit.md F1 (a single Ctrl+C
+used to burn the full 30s shutdown timeout with zero output) and the follow-up fix that blocks
+SIGINT process-wide and waits for it on a dedicated ``signal.sigwait()`` thread, so a second
+Ctrl+C can force an exit even while a shutdown hook has the event loop thread genuinely blocked
+(see ``server.py``).
+"""
+
+import os
+import signal
+import subprocess
+import sys
+import threading
+import time
+from pathlib import Path
+
+import httpx2 as httpx
+import pytest
+
+from .conftest import HA_TOKEN, free_port
+
+pytestmark = [pytest.mark.system_destructive]
+
+READY_TIMEOUT = 60.0  # generous — cold subprocess import + real HA connection
+GRACEFUL_EXIT_TIMEOUT = 10.0  # well under the 30s shutdown timeout the old bug used to burn
+FORCE_EXIT_TIMEOUT = 10.0
+STALL_MARKER = "STALL_STARTING"
+
+STALLING_APP_SOURCE = f'''
+"""Fixture app whose on_shutdown blocks the event loop thread synchronously.
+
+Written to disk by test_sigint_shutdown.py and picked up via app autodetection — this
+reproduces resources/operations.py's "await method()" directly awaiting a user-authored async
+hook that performs blocking synchronous work, which is what the second-SIGINT force-exit path
+must survive.
+"""
+
+import time
+
+from hassette import App, AppConfig
+
+
+class StallingShutdownApp(App[AppConfig]):
+    async def on_shutdown(self) -> None:
+        print({STALL_MARKER!r}, flush=True)
+        time.sleep(120)
+'''
+
+
+def _spawn_hassette(tmp_path: Path, ha_url: str, *, apps_dir: Path | None = None) -> tuple[subprocess.Popen[str], str]:
+    """Start a real ``hassette run`` subprocess and return it plus its web API base URL.
+
+    Uses env vars (not a config file) so ``cwd=tmp_path`` never picks up a stray
+    ``.env``/``hassette.toml`` from elsewhere on disk.
+    """
+    data_dir = tmp_path / "data"
+    resolved_apps_dir = apps_dir or (tmp_path / "apps")
+    resolved_apps_dir.mkdir(parents=True, exist_ok=True)
+    port = free_port()
+
+    env = {
+        **os.environ,
+        "HASSETTE__DATA_DIR": str(data_dir),
+        "HASSETTE__APPS__DIRECTORY": str(resolved_apps_dir),
+        "HASSETTE__APPS__AUTODETECT": "true" if apps_dir else "false",
+        "HASSETTE__WEB_API__RUN": "true",
+        "HASSETTE__WEB_API__PORT": str(port),
+        "HASSETTE__WEB_API__HOST": "127.0.0.1",
+        "HASSETTE__WEB_API__AUTH_ENABLED": "false",
+        "HASSETTE__LIFECYCLE__STARTUP_TIMEOUT_SECONDS": "30",
+    }
+
+    proc = subprocess.Popen(
+        [sys.executable, "-m", "hassette", "run", "--token", HA_TOKEN, "--ha-url", ha_url],
+        cwd=tmp_path,
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+    )
+    return proc, f"http://127.0.0.1:{port}"
+
+
+def _drain_stdout(proc: subprocess.Popen[str], marker: str, marker_seen: threading.Event) -> None:
+    """Continuously read the subprocess's stdout so it never blocks on a full pipe buffer.
+
+    Sets ``marker_seen`` the first time a line containing ``marker`` appears. Runs until the
+    subprocess closes stdout (i.e. exits) so later output (shutdown logs, the force-exit
+    warning) never backs up behind an unread pipe.
+    """
+    assert proc.stdout is not None
+    for line in proc.stdout:
+        if marker in line:
+            marker_seen.set()
+
+
+def _wait_ready(base_url: str, *, timeout: float) -> None:
+    deadline = time.monotonic() + timeout
+    last_exc: Exception | None = None
+    while time.monotonic() < deadline:
+        try:
+            r = httpx.get(f"{base_url}/api/health/ready", timeout=2.0)
+            if r.status_code == 200:
+                return
+        except Exception as exc:
+            last_exc = exc
+        time.sleep(0.5)
+    raise TimeoutError(f"hassette at {base_url} did not become ready within {timeout}s: {last_exc}")
+
+
+def _cleanup(proc: subprocess.Popen[str], reader: threading.Thread) -> None:
+    """Ensure the subprocess, its stdout-draining thread, and the pipe itself are all closed.
+
+    The reader thread's ``for line in proc.stdout`` loop only ends at EOF (the subprocess
+    closing its end), so it's joined before the pipe is closed here — otherwise the suite's
+    fatal ResourceWarning-as-error setting (see pyproject.toml) turns an unclosed pipe into a
+    test failure.
+    """
+    if proc.poll() is None:
+        proc.kill()
+        proc.wait(timeout=10)
+    reader.join(timeout=5)
+    if proc.stdout is not None:
+        proc.stdout.close()
+
+
+def test_sigint_exits_promptly_on_healthy_instance(ha_container: str, tmp_path: Path) -> None:
+    """A single Ctrl+C on a healthy, idle instance exits in a few seconds, not a 30s hang.
+
+    Regression test for audit finding F1: SIGINT used to fall through to asyncio's default
+    disorderly-cancellation path and burn the full ``total_shutdown_timeout_seconds`` (30s)
+    with zero hassette output before exiting.
+    """
+    proc, base_url = _spawn_hassette(tmp_path, ha_container)
+    marker_seen = threading.Event()
+    reader = threading.Thread(target=_drain_stdout, args=(proc, STALL_MARKER, marker_seen), daemon=True)
+    reader.start()
+    try:
+        _wait_ready(base_url, timeout=READY_TIMEOUT)
+
+        start = time.monotonic()
+        proc.send_signal(signal.SIGINT)
+        try:
+            proc.wait(timeout=GRACEFUL_EXIT_TIMEOUT)
+        except subprocess.TimeoutExpired:
+            pytest.fail(f"hassette did not exit within {GRACEFUL_EXIT_TIMEOUT}s of a single SIGINT")
+        elapsed = time.monotonic() - start
+
+        assert elapsed < GRACEFUL_EXIT_TIMEOUT, (
+            f"SIGINT shutdown took {elapsed:.1f}s — expected a graceful exit well under {GRACEFUL_EXIT_TIMEOUT}s"
+        )
+        assert proc.returncode == 0, f"expected a clean exit, got returncode={proc.returncode}"
+    finally:
+        _cleanup(proc, reader)
+
+
+def test_second_sigint_forces_exit_during_stalled_shutdown(ha_container: str, tmp_path: Path) -> None:
+    """A second Ctrl+C forces an immediate exit even while a shutdown hook has the loop blocked.
+
+    Reproduces the scenario a user-authored async shutdown hook creates
+    (StallingShutdownApp.on_shutdown blocks the event loop thread synchronously). The second
+    SIGINT is sent only once that hook has confirmed (via STALL_MARKER) that it is actually
+    inside the blocking call — proving the dedicated sigwait() thread still receives and
+    handles the signal while loop.add_signal_handler()'s callback could not have.
+    """
+    apps_dir = tmp_path / "apps"
+    apps_dir.mkdir(parents=True, exist_ok=True)
+    (apps_dir / "stalling_shutdown_app.py").write_text(STALLING_APP_SOURCE)
+
+    proc, base_url = _spawn_hassette(tmp_path, ha_container, apps_dir=apps_dir)
+    marker_seen = threading.Event()
+    reader = threading.Thread(target=_drain_stdout, args=(proc, STALL_MARKER, marker_seen), daemon=True)
+    reader.start()
+    try:
+        _wait_ready(base_url, timeout=READY_TIMEOUT)
+
+        # First SIGINT: requests graceful shutdown, which reaches StallingShutdownApp's
+        # on_shutdown and blocks there.
+        proc.send_signal(signal.SIGINT)
+        if not marker_seen.wait(timeout=READY_TIMEOUT):
+            pytest.fail(f"StallingShutdownApp.on_shutdown never started stalling within {READY_TIMEOUT}s")
+
+        # Second SIGINT: shutdown_event is already set and the loop thread is confirmed stuck
+        # inside the blocking sleep — this is exactly the case loop.add_signal_handler() could
+        # not reach.
+        start = time.monotonic()
+        proc.send_signal(signal.SIGINT)
+        try:
+            proc.wait(timeout=FORCE_EXIT_TIMEOUT)
+        except subprocess.TimeoutExpired:
+            pytest.fail(f"second SIGINT did not force-exit within {FORCE_EXIT_TIMEOUT}s")
+        elapsed = time.monotonic() - start
+
+        assert elapsed < FORCE_EXIT_TIMEOUT, (
+            f"force-exit took {elapsed:.1f}s — expected os._exit well under {FORCE_EXIT_TIMEOUT}s"
+        )
+        assert proc.returncode == 1, f"expected the os._exit(1) force-exit code, got returncode={proc.returncode}"
+    finally:
+        _cleanup(proc, reader)

--- a/tests/unit/core/test_main.py
+++ b/tests/unit/core/test_main.py
@@ -29,17 +29,24 @@ def make_mock_core_and_config(
 
 
 @contextmanager
-def patch_hassette_and_signal_handler(mock_core: MagicMock, *, side_effect: Any = None) -> Iterator[MagicMock]:
-    """Patch hassette.server.Hassette (returning mock_core) and the running loop's
-    add_signal_handler for main() tests. Yields the patched Hassette class mock.
+def patch_hassette_and_signal_registration(
+    mock_core: MagicMock,
+    *,
+    add_signal_handler_side_effect: Any = None,
+    signal_signal_side_effect: Any = None,
+) -> Iterator[MagicMock]:
+    """Patch hassette.server.Hassette (returning mock_core), the running loop's
+    add_signal_handler (used for SIGTERM), and signal.signal (used for SIGINT) for main()
+    tests. Yields the patched Hassette class mock.
     """
     loop = asyncio.get_running_loop()
 
     with (
         patch("hassette.server.Hassette", return_value=mock_core) as mock_hassette_cls,
-        patch.object(loop, "add_signal_handler", side_effect=side_effect),
+        patch.object(loop, "add_signal_handler", side_effect=add_signal_handler_side_effect),
+        patch("hassette.server.signal.signal", side_effect=signal_signal_side_effect) as mock_signal_signal,
     ):
-        yield mock_hassette_cls
+        yield mock_hassette_cls, mock_signal_signal
 
 
 async def test_main_registers_sigterm_handler() -> None:
@@ -51,7 +58,7 @@ async def test_main_registers_sigterm_handler() -> None:
     def fake_add_signal_handler(registered_sig: signal.Signals, callback, *args) -> None:
         registered_handlers[registered_sig] = (callback, args)
 
-    with patch_hassette_and_signal_handler(mock_core, side_effect=fake_add_signal_handler):
+    with patch_hassette_and_signal_registration(mock_core, add_signal_handler_side_effect=fake_add_signal_handler):
         await main(mock_config)
 
     assert signal.SIGTERM in registered_handlers, "SIGTERM handler was not registered"
@@ -60,27 +67,27 @@ async def test_main_registers_sigterm_handler() -> None:
     assert args == (mock_core, "SIGTERM received")
 
 
-async def test_main_registers_sigint_handler() -> None:
-    """main() installs a SIGINT handler distinct from the raw request_shutdown callback."""
+async def test_main_registers_sigint_handler_via_raw_signal() -> None:
+    """main() installs SIGINT via signal.signal(), not loop.add_signal_handler().
+
+    A callback registered through the loop only runs once the loop next gets control, which
+    never happens if a blocking shutdown hook is what's stalling teardown — see the module
+    docstring on _handle_sigint. signal.signal() is delivered regardless of loop state.
+    """
     mock_core, mock_config = make_mock_core_and_config()
 
-    registered_handlers: dict[signal.Signals, tuple[Any, tuple[Any, ...]]] = {}
-
-    def fake_add_signal_handler(registered_sig: signal.Signals, callback, *args) -> None:
-        registered_handlers[registered_sig] = (callback, args)
-
-    with patch_hassette_and_signal_handler(mock_core, side_effect=fake_add_signal_handler):
+    with patch_hassette_and_signal_registration(mock_core) as (_, mock_signal_signal):
         await main(mock_config)
 
-    assert signal.SIGINT in registered_handlers, "SIGINT handler was not registered"
-    callback, args = registered_handlers[signal.SIGINT]
-    assert callback != request_shutdown
-    assert args == (mock_core,)
+    mock_signal_signal.assert_called_once()
+    registered_sig, handler = mock_signal_signal.call_args[0]
+    assert registered_sig == signal.SIGINT
+    assert handler.func.__name__ == "_handle_sigint"
+    assert handler.args == (mock_core,)
 
 
-@pytest.mark.parametrize("sig", [signal.SIGTERM, signal.SIGINT], ids=["SIGTERM", "SIGINT"])
-async def test_shutdown_signal_handler_triggers_shutdown_event(sig: signal.Signals) -> None:
-    """Invoking a registered shutdown signal handler sets the shutdown event on the Hassette instance."""
+async def test_sigterm_handler_triggers_shutdown_event() -> None:
+    """Invoking the registered SIGTERM handler sets the shutdown event on the Hassette instance."""
     mock_core, mock_config = make_mock_core_and_config()
     mock_core.shutdown_event = asyncio.Event()
     mock_core.ready_event = asyncio.Event()
@@ -90,13 +97,10 @@ async def test_shutdown_signal_handler_triggers_shutdown_event(sig: signal.Signa
     def fake_add_signal_handler(registered_sig: signal.Signals, callback, *args) -> None:
         registered_handlers[registered_sig] = (callback, args)
 
-    with patch_hassette_and_signal_handler(mock_core, side_effect=fake_add_signal_handler):
+    with patch_hassette_and_signal_registration(mock_core, add_signal_handler_side_effect=fake_add_signal_handler):
         await main(mock_config)
 
-    assert sig in registered_handlers, f"{sig.name} handler was not registered"
-
-    # Simulate what the OS would do by invoking the registered callback
-    callback, args = registered_handlers[sig]
+    callback, args = registered_handlers[signal.SIGTERM]
     callback(*args)
     assert mock_core.shutdown_event.is_set()
 
@@ -107,33 +111,39 @@ async def test_second_sigint_forces_immediate_exit() -> None:
     mock_core.shutdown_event = asyncio.Event()
     mock_core.ready_event = asyncio.Event()
 
-    registered_handlers: dict[signal.Signals, tuple[Any, tuple[Any, ...]]] = {}
-
-    def fake_add_signal_handler(registered_sig: signal.Signals, callback, *args) -> None:
-        registered_handlers[registered_sig] = (callback, args)
-
-    with patch_hassette_and_signal_handler(mock_core, side_effect=fake_add_signal_handler):
+    with patch_hassette_and_signal_registration(mock_core) as (_, mock_signal_signal):
         await main(mock_config)
 
-    callback, args = registered_handlers[signal.SIGINT]
+    mock_signal_signal.assert_called_once()
+    handler = mock_signal_signal.call_args[0][1]
 
     # First SIGINT: requests shutdown, does not exit.
     with patch("hassette.server.os._exit") as mock_exit:
-        callback(*args)
+        handler(signal.SIGINT, None)
         mock_exit.assert_not_called()
     assert mock_core.shutdown_event.is_set()
 
     # Second SIGINT: shutdown already requested, so it force-exits instead of no-op'ing.
     with patch("hassette.server.os._exit") as mock_exit:
-        callback(*args)
+        handler(signal.SIGINT, None)
         mock_exit.assert_called_once_with(1)
 
 
-async def test_main_continues_when_signal_handler_unsupported() -> None:
+async def test_main_continues_when_sigterm_handler_unsupported() -> None:
     """main() continues to run_forever when add_signal_handler raises NotImplementedError."""
     mock_core, mock_config = make_mock_core_and_config()
 
-    with patch_hassette_and_signal_handler(mock_core, side_effect=NotImplementedError):
+    with patch_hassette_and_signal_registration(mock_core, add_signal_handler_side_effect=NotImplementedError):
+        await main(mock_config)
+
+    mock_core.run_forever.assert_awaited_once()
+
+
+async def test_main_continues_when_sigint_handler_unsupported() -> None:
+    """main() continues to run_forever when signal.signal() raises ValueError (not main thread)."""
+    mock_core, mock_config = make_mock_core_and_config()
+
+    with patch_hassette_and_signal_registration(mock_core, signal_signal_side_effect=ValueError):
         await main(mock_config)
 
     mock_core.run_forever.assert_awaited_once()
@@ -154,7 +164,7 @@ async def test_main_proceeds_when_token_is_set() -> None:
     """main() proceeds to create Hassette when token is not None."""
     mock_core, mock_config = make_mock_core_and_config()
 
-    with patch_hassette_and_signal_handler(mock_core):
+    with patch_hassette_and_signal_registration(mock_core):
         await main(mock_config)
 
     mock_core.run_forever.assert_awaited_once()
@@ -164,7 +174,7 @@ async def test_main_passes_config_to_hassette() -> None:
     """main() passes the provided HassetteConfig to Hassette."""
     mock_core, mock_config = make_mock_core_and_config()
 
-    with patch_hassette_and_signal_handler(mock_core) as mock_hassette_cls:
+    with patch_hassette_and_signal_registration(mock_core) as (mock_hassette_cls, _):
         await main(mock_config)
 
     mock_hassette_cls.assert_called_once_with(config=mock_config)

--- a/tests/unit/core/test_main.py
+++ b/tests/unit/core/test_main.py
@@ -1,4 +1,4 @@
-"""Tests for the server entry point — SIGTERM signal handling and startup validation."""
+"""Tests for the server entry point — SIGTERM/SIGINT signal handling and startup validation."""
 
 import asyncio
 import signal
@@ -78,6 +78,46 @@ async def test_sigterm_handler_triggers_shutdown_event() -> None:
 
     # Simulate what the OS would do by invoking the registered callback
     callback, args = registered_handlers[signal.SIGTERM]
+    callback(*args)
+    assert mock_core.shutdown_event.is_set()
+
+
+async def test_main_registers_sigint_handler() -> None:
+    """main() installs a SIGINT handler that calls request_shutdown(core, ...)."""
+    mock_core, mock_config = make_mock_core_and_config()
+
+    registered_handlers: dict[int, tuple] = {}
+
+    def fake_add_signal_handler(sig: int, callback, *args) -> None:
+        registered_handlers[sig] = (callback, args)
+
+    with patch_hassette_and_signal_handler(mock_core, side_effect=fake_add_signal_handler):
+        await main(mock_config)
+
+    assert signal.SIGINT in registered_handlers, "SIGINT handler was not registered"
+    callback, args = registered_handlers[signal.SIGINT]
+    assert callback == request_shutdown
+    assert args == (mock_core, "SIGINT received")
+
+
+async def test_sigint_handler_triggers_shutdown_event() -> None:
+    """Invoking the SIGINT handler sets the shutdown event on the Hassette instance."""
+    mock_core, mock_config = make_mock_core_and_config()
+    mock_core.shutdown_event = asyncio.Event()
+    mock_core.ready_event = asyncio.Event()
+
+    registered_handlers: dict[int, tuple] = {}
+
+    def fake_add_signal_handler(sig: int, callback, *args) -> None:
+        registered_handlers[sig] = (callback, args)
+
+    with patch_hassette_and_signal_handler(mock_core, side_effect=fake_add_signal_handler):
+        await main(mock_config)
+
+    assert signal.SIGINT in registered_handlers, "SIGINT handler was not registered"
+
+    # Simulate what the OS would do by invoking the registered callback
+    callback, args = registered_handlers[signal.SIGINT]
     callback(*args)
     assert mock_core.shutdown_event.is_set()
 

--- a/tests/unit/core/test_main.py
+++ b/tests/unit/core/test_main.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import signal
+import threading
 from collections.abc import Iterator
 from contextlib import contextmanager
 from typing import Any
@@ -123,7 +124,7 @@ async def test_main_blocks_sigint_before_spawning_the_wait_thread() -> None:
 
 
 async def test_main_starts_sigint_wait_thread_as_daemon() -> None:
-    """main() starts a daemon thread running _sigint_wait_loop(core, loop)."""
+    """main() starts a daemon thread running _sigint_wait_loop(core, loop, sigint_seen)."""
     mock_core, mock_config = make_mock_core_and_config()
     loop = asyncio.get_running_loop()
 
@@ -132,7 +133,10 @@ async def test_main_starts_sigint_wait_thread_as_daemon() -> None:
 
     _, kwargs = mock_thread_cls.call_args
     assert kwargs["target"] is _sigint_wait_loop
-    assert kwargs["args"] == (mock_core, loop)
+    thread_core, thread_loop, thread_sigint_seen = kwargs["args"]
+    assert thread_core is mock_core
+    assert thread_loop is loop
+    assert isinstance(thread_sigint_seen, threading.Event)
     assert kwargs["daemon"] is True
 
 
@@ -159,27 +163,52 @@ async def test_handle_sigint_signal_requests_shutdown_on_first_call() -> None:
     mock_core.shutdown_event = asyncio.Event()
     mock_core.ready_event = asyncio.Event()
     loop = asyncio.get_running_loop()
+    sigint_seen = threading.Event()
 
     with patch("hassette.server.os._exit") as mock_exit:
-        _handle_sigint_signal(mock_core, loop)
+        _handle_sigint_signal(mock_core, loop, sigint_seen)
         mock_exit.assert_not_called()
+
+    assert sigint_seen.is_set()
 
     # call_soon_threadsafe only schedules request_shutdown — give the loop a turn to run it.
     await asyncio.sleep(0)
     assert mock_core.shutdown_event.is_set()
 
 
-async def test_handle_sigint_signal_force_exits_once_shutdown_already_requested() -> None:
-    """Once shutdown_event is already set, _handle_sigint_signal force-exits instead of no-op'ing."""
+async def test_handle_sigint_signal_force_exits_once_a_sigint_was_already_seen() -> None:
+    """Once sigint_seen is already set, _handle_sigint_signal force-exits instead of no-op'ing."""
     mock_core, _ = make_mock_core_and_config()
-    mock_core.shutdown_event = asyncio.Event()
-    mock_core.shutdown_event.set()
     loop = asyncio.get_running_loop()
+    sigint_seen = threading.Event()
+    sigint_seen.set()
 
     with patch("hassette.server.os._exit") as mock_exit:
-        _handle_sigint_signal(mock_core, loop)
+        _handle_sigint_signal(mock_core, loop, sigint_seen)
 
     mock_exit.assert_called_once_with(1)
+
+
+async def test_handle_sigint_signal_force_exits_even_if_shutdown_event_not_yet_set() -> None:
+    """Regression test: the force-exit decision must not depend on core.shutdown_event.
+
+    core.shutdown_event only becomes set once request_shutdown() actually runs on the loop
+    thread via call_soon_threadsafe — which may not have happened yet if the loop is blocked by
+    anything at all. A second SIGINT arriving in that window must still force-exit; deciding
+    based on core.shutdown_event.is_set() instead of sigint_seen would make every SIGINT before
+    the loop catches up look like "the first one" and never escalate.
+    """
+    mock_core, _ = make_mock_core_and_config()
+    mock_core.shutdown_event = asyncio.Event()  # deliberately never set — loop still "blocked"
+    loop = asyncio.get_running_loop()
+    sigint_seen = threading.Event()
+
+    with patch("hassette.server.os._exit") as mock_exit:
+        _handle_sigint_signal(mock_core, loop, sigint_seen)
+        mock_exit.assert_not_called()
+
+        _handle_sigint_signal(mock_core, loop, sigint_seen)
+        mock_exit.assert_called_once_with(1)
 
 
 def test_sigint_wait_loop_calls_handler_once_per_wakeup() -> None:
@@ -190,17 +219,18 @@ def test_sigint_wait_loop_calls_handler_once_per_wakeup() -> None:
 
     mock_core = MagicMock()
     mock_loop = MagicMock()
+    sigint_seen = threading.Event()
 
     with (
         patch("hassette.server.signal.sigwait", side_effect=[signal.SIGINT, _StopLoopError]) as mock_sigwait,
         patch("hassette.server._handle_sigint_signal") as mock_handle,
         pytest.raises(_StopLoopError),
     ):
-        _sigint_wait_loop(mock_core, mock_loop)
+        _sigint_wait_loop(mock_core, mock_loop, sigint_seen)
 
     assert mock_sigwait.call_count == 2
     mock_sigwait.assert_called_with({signal.SIGINT})
-    mock_handle.assert_called_once_with(mock_core, mock_loop)
+    mock_handle.assert_called_once_with(mock_core, mock_loop, sigint_seen)
 
 
 async def test_main_raises_fatal_error_when_token_is_none() -> None:

--- a/tests/unit/core/test_main.py
+++ b/tests/unit/core/test_main.py
@@ -42,13 +42,8 @@ def patch_hassette_and_signal_handler(mock_core: MagicMock, *, side_effect: Any 
         yield mock_hassette_cls
 
 
-@pytest.mark.parametrize(
-    ("sig", "expected_message"),
-    [(signal.SIGTERM, "SIGTERM received"), (signal.SIGINT, "SIGINT received")],
-    ids=["SIGTERM", "SIGINT"],
-)
-async def test_main_registers_shutdown_signal_handler(sig: signal.Signals, expected_message: str) -> None:
-    """main() installs a handler for each shutdown signal that calls request_shutdown(core, ...)."""
+async def test_main_registers_sigterm_handler() -> None:
+    """main() installs a SIGTERM handler that calls request_shutdown(core, ...) directly."""
     mock_core, mock_config = make_mock_core_and_config()
 
     registered_handlers: dict[signal.Signals, tuple[Any, tuple[Any, ...]]] = {}
@@ -59,10 +54,28 @@ async def test_main_registers_shutdown_signal_handler(sig: signal.Signals, expec
     with patch_hassette_and_signal_handler(mock_core, side_effect=fake_add_signal_handler):
         await main(mock_config)
 
-    assert sig in registered_handlers, f"{sig.name} handler was not registered"
-    callback, args = registered_handlers[sig]
+    assert signal.SIGTERM in registered_handlers, "SIGTERM handler was not registered"
+    callback, args = registered_handlers[signal.SIGTERM]
     assert callback == request_shutdown
-    assert args == (mock_core, expected_message)
+    assert args == (mock_core, "SIGTERM received")
+
+
+async def test_main_registers_sigint_handler() -> None:
+    """main() installs a SIGINT handler distinct from the raw request_shutdown callback."""
+    mock_core, mock_config = make_mock_core_and_config()
+
+    registered_handlers: dict[signal.Signals, tuple[Any, tuple[Any, ...]]] = {}
+
+    def fake_add_signal_handler(registered_sig: signal.Signals, callback, *args) -> None:
+        registered_handlers[registered_sig] = (callback, args)
+
+    with patch_hassette_and_signal_handler(mock_core, side_effect=fake_add_signal_handler):
+        await main(mock_config)
+
+    assert signal.SIGINT in registered_handlers, "SIGINT handler was not registered"
+    callback, args = registered_handlers[signal.SIGINT]
+    assert callback != request_shutdown
+    assert args == (mock_core,)
 
 
 @pytest.mark.parametrize("sig", [signal.SIGTERM, signal.SIGINT], ids=["SIGTERM", "SIGINT"])
@@ -86,6 +99,34 @@ async def test_shutdown_signal_handler_triggers_shutdown_event(sig: signal.Signa
     callback, args = registered_handlers[sig]
     callback(*args)
     assert mock_core.shutdown_event.is_set()
+
+
+async def test_second_sigint_forces_immediate_exit() -> None:
+    """A second SIGINT, received after shutdown was already requested, force-exits instead of no-op'ing."""
+    mock_core, mock_config = make_mock_core_and_config()
+    mock_core.shutdown_event = asyncio.Event()
+    mock_core.ready_event = asyncio.Event()
+
+    registered_handlers: dict[signal.Signals, tuple[Any, tuple[Any, ...]]] = {}
+
+    def fake_add_signal_handler(registered_sig: signal.Signals, callback, *args) -> None:
+        registered_handlers[registered_sig] = (callback, args)
+
+    with patch_hassette_and_signal_handler(mock_core, side_effect=fake_add_signal_handler):
+        await main(mock_config)
+
+    callback, args = registered_handlers[signal.SIGINT]
+
+    # First SIGINT: requests shutdown, does not exit.
+    with patch("hassette.server.os._exit") as mock_exit:
+        callback(*args)
+        mock_exit.assert_not_called()
+    assert mock_core.shutdown_event.is_set()
+
+    # Second SIGINT: shutdown already requested, so it force-exits instead of no-op'ing.
+    with patch("hassette.server.os._exit") as mock_exit:
+        callback(*args)
+        mock_exit.assert_called_once_with(1)
 
 
 async def test_main_continues_when_signal_handler_unsupported() -> None:

--- a/tests/unit/core/test_main.py
+++ b/tests/unit/core/test_main.py
@@ -42,82 +42,48 @@ def patch_hassette_and_signal_handler(mock_core: MagicMock, *, side_effect: Any 
         yield mock_hassette_cls
 
 
-async def test_main_registers_sigterm_handler() -> None:
-    """main() installs a SIGTERM handler that calls request_shutdown(core, ...)."""
+@pytest.mark.parametrize(
+    ("sig", "expected_message"),
+    [(signal.SIGTERM, "SIGTERM received"), (signal.SIGINT, "SIGINT received")],
+    ids=["SIGTERM", "SIGINT"],
+)
+async def test_main_registers_shutdown_signal_handler(sig: signal.Signals, expected_message: str) -> None:
+    """main() installs a handler for each shutdown signal that calls request_shutdown(core, ...)."""
     mock_core, mock_config = make_mock_core_and_config()
 
-    registered_handlers: dict[int, tuple] = {}
+    registered_handlers: dict[signal.Signals, tuple[Any, tuple[Any, ...]]] = {}
 
-    def fake_add_signal_handler(sig: int, callback, *args) -> None:
-        registered_handlers[sig] = (callback, args)
+    def fake_add_signal_handler(registered_sig: signal.Signals, callback, *args) -> None:
+        registered_handlers[registered_sig] = (callback, args)
 
     with patch_hassette_and_signal_handler(mock_core, side_effect=fake_add_signal_handler):
         await main(mock_config)
 
-    assert signal.SIGTERM in registered_handlers, "SIGTERM handler was not registered"
-    callback, args = registered_handlers[signal.SIGTERM]
+    assert sig in registered_handlers, f"{sig.name} handler was not registered"
+    callback, args = registered_handlers[sig]
     assert callback == request_shutdown
-    assert args == (mock_core, "SIGTERM received")
+    assert args == (mock_core, expected_message)
 
 
-async def test_sigterm_handler_triggers_shutdown_event() -> None:
-    """Invoking the SIGTERM handler sets the shutdown event on the Hassette instance."""
+@pytest.mark.parametrize("sig", [signal.SIGTERM, signal.SIGINT], ids=["SIGTERM", "SIGINT"])
+async def test_shutdown_signal_handler_triggers_shutdown_event(sig: signal.Signals) -> None:
+    """Invoking a registered shutdown signal handler sets the shutdown event on the Hassette instance."""
     mock_core, mock_config = make_mock_core_and_config()
     mock_core.shutdown_event = asyncio.Event()
     mock_core.ready_event = asyncio.Event()
 
-    registered_handlers: dict[int, tuple] = {}
+    registered_handlers: dict[signal.Signals, tuple[Any, tuple[Any, ...]]] = {}
 
-    def fake_add_signal_handler(sig: int, callback, *args) -> None:
-        registered_handlers[sig] = (callback, args)
+    def fake_add_signal_handler(registered_sig: signal.Signals, callback, *args) -> None:
+        registered_handlers[registered_sig] = (callback, args)
 
     with patch_hassette_and_signal_handler(mock_core, side_effect=fake_add_signal_handler):
         await main(mock_config)
 
-    assert signal.SIGTERM in registered_handlers, "SIGTERM handler was not registered"
+    assert sig in registered_handlers, f"{sig.name} handler was not registered"
 
     # Simulate what the OS would do by invoking the registered callback
-    callback, args = registered_handlers[signal.SIGTERM]
-    callback(*args)
-    assert mock_core.shutdown_event.is_set()
-
-
-async def test_main_registers_sigint_handler() -> None:
-    """main() installs a SIGINT handler that calls request_shutdown(core, ...)."""
-    mock_core, mock_config = make_mock_core_and_config()
-
-    registered_handlers: dict[int, tuple] = {}
-
-    def fake_add_signal_handler(sig: int, callback, *args) -> None:
-        registered_handlers[sig] = (callback, args)
-
-    with patch_hassette_and_signal_handler(mock_core, side_effect=fake_add_signal_handler):
-        await main(mock_config)
-
-    assert signal.SIGINT in registered_handlers, "SIGINT handler was not registered"
-    callback, args = registered_handlers[signal.SIGINT]
-    assert callback == request_shutdown
-    assert args == (mock_core, "SIGINT received")
-
-
-async def test_sigint_handler_triggers_shutdown_event() -> None:
-    """Invoking the SIGINT handler sets the shutdown event on the Hassette instance."""
-    mock_core, mock_config = make_mock_core_and_config()
-    mock_core.shutdown_event = asyncio.Event()
-    mock_core.ready_event = asyncio.Event()
-
-    registered_handlers: dict[int, tuple] = {}
-
-    def fake_add_signal_handler(sig: int, callback, *args) -> None:
-        registered_handlers[sig] = (callback, args)
-
-    with patch_hassette_and_signal_handler(mock_core, side_effect=fake_add_signal_handler):
-        await main(mock_config)
-
-    assert signal.SIGINT in registered_handlers, "SIGINT handler was not registered"
-
-    # Simulate what the OS would do by invoking the registered callback
-    callback, args = registered_handlers[signal.SIGINT]
+    callback, args = registered_handlers[sig]
     callback(*args)
     assert mock_core.shutdown_event.is_set()
 

--- a/tests/unit/core/test_main.py
+++ b/tests/unit/core/test_main.py
@@ -11,7 +11,7 @@ import pytest
 
 from hassette.exceptions import FatalError
 from hassette.resources.lifecycle import request_shutdown
-from hassette.server import main
+from hassette.server import _handle_sigint_signal, _sigint_wait_loop, main
 
 
 def make_mock_core_and_config(
@@ -33,20 +33,28 @@ def patch_hassette_and_signal_registration(
     mock_core: MagicMock,
     *,
     add_signal_handler_side_effect: Any = None,
-    signal_signal_side_effect: Any = None,
-) -> Iterator[MagicMock]:
-    """Patch hassette.server.Hassette (returning mock_core), the running loop's
-    add_signal_handler (used for SIGTERM), and signal.signal (used for SIGINT) for main()
-    tests. Yields the patched Hassette class mock.
+    pthread_sigmask_side_effect: Any = None,
+) -> Iterator[tuple[MagicMock, MagicMock, MagicMock]]:
+    """Patch everything main() touches for signal registration.
+
+    Patches ``hassette.server.Hassette`` (returning ``mock_core``), the running loop's
+    ``add_signal_handler`` (SIGTERM), ``signal.pthread_sigmask`` (SIGINT blocking), and
+    ``threading.Thread`` (the SIGINT-wait thread). The ``Thread`` mock's ``.start()`` is a
+    no-op, so the real ``sigwait()``-based thread never actually runs during unit tests —
+    without this, every test exercising ``main()`` would leave a thread blocked in a real
+    ``signal.sigwait()`` call for the life of the test process.
+
+    Yields ``(Hassette class mock, threading.Thread class mock, pthread_sigmask mock)``.
     """
     loop = asyncio.get_running_loop()
 
     with (
         patch("hassette.server.Hassette", return_value=mock_core) as mock_hassette_cls,
         patch.object(loop, "add_signal_handler", side_effect=add_signal_handler_side_effect),
-        patch("hassette.server.signal.signal", side_effect=signal_signal_side_effect) as mock_signal_signal,
+        patch("hassette.server.signal.pthread_sigmask", side_effect=pthread_sigmask_side_effect) as mock_sigmask,
+        patch("hassette.server.threading.Thread") as mock_thread_cls,
     ):
-        yield mock_hassette_cls, mock_signal_signal
+        yield mock_hassette_cls, mock_thread_cls, mock_sigmask
 
 
 async def test_main_registers_sigterm_handler() -> None:
@@ -65,25 +73,6 @@ async def test_main_registers_sigterm_handler() -> None:
     callback, args = registered_handlers[signal.SIGTERM]
     assert callback == request_shutdown
     assert args == (mock_core, "SIGTERM received")
-
-
-async def test_main_registers_sigint_handler_via_raw_signal() -> None:
-    """main() installs SIGINT via signal.signal(), not loop.add_signal_handler().
-
-    A callback registered through the loop only runs once the loop next gets control, which
-    never happens if a blocking shutdown hook is what's stalling teardown — see the module
-    docstring on _handle_sigint. signal.signal() is delivered regardless of loop state.
-    """
-    mock_core, mock_config = make_mock_core_and_config()
-
-    with patch_hassette_and_signal_registration(mock_core) as (_, mock_signal_signal):
-        await main(mock_config)
-
-    mock_signal_signal.assert_called_once()
-    registered_sig, handler = mock_signal_signal.call_args[0]
-    assert registered_sig == signal.SIGINT
-    assert handler.func.__name__ == "_handle_sigint"
-    assert handler.args == (mock_core,)
 
 
 async def test_sigterm_handler_triggers_shutdown_event() -> None:
@@ -105,30 +94,6 @@ async def test_sigterm_handler_triggers_shutdown_event() -> None:
     assert mock_core.shutdown_event.is_set()
 
 
-async def test_second_sigint_forces_immediate_exit() -> None:
-    """A second SIGINT, received after shutdown was already requested, force-exits instead of no-op'ing."""
-    mock_core, mock_config = make_mock_core_and_config()
-    mock_core.shutdown_event = asyncio.Event()
-    mock_core.ready_event = asyncio.Event()
-
-    with patch_hassette_and_signal_registration(mock_core) as (_, mock_signal_signal):
-        await main(mock_config)
-
-    mock_signal_signal.assert_called_once()
-    handler = mock_signal_signal.call_args[0][1]
-
-    # First SIGINT: requests shutdown, does not exit.
-    with patch("hassette.server.os._exit") as mock_exit:
-        handler(signal.SIGINT, None)
-        mock_exit.assert_not_called()
-    assert mock_core.shutdown_event.is_set()
-
-    # Second SIGINT: shutdown already requested, so it force-exits instead of no-op'ing.
-    with patch("hassette.server.os._exit") as mock_exit:
-        handler(signal.SIGINT, None)
-        mock_exit.assert_called_once_with(1)
-
-
 async def test_main_continues_when_sigterm_handler_unsupported() -> None:
     """main() continues to run_forever when add_signal_handler raises NotImplementedError."""
     mock_core, mock_config = make_mock_core_and_config()
@@ -139,14 +104,103 @@ async def test_main_continues_when_sigterm_handler_unsupported() -> None:
     mock_core.run_forever.assert_awaited_once()
 
 
-async def test_main_continues_when_sigint_handler_unsupported() -> None:
-    """main() continues to run_forever when signal.signal() raises ValueError (not main thread)."""
+async def test_main_blocks_sigint_before_spawning_the_wait_thread() -> None:
+    """main() blocks SIGINT process-wide before starting the sigwait() thread.
+
+    Ordering matters: every thread created after this point (the sigwait thread here, plus
+    any the framework spawns later — the sync executor pool, the logging QueueListener) must
+    inherit the blocked mask, so none of them are ever eligible targets for the kernel to
+    deliver SIGINT to instead of the dedicated wait thread.
+    """
     mock_core, mock_config = make_mock_core_and_config()
 
-    with patch_hassette_and_signal_registration(mock_core, signal_signal_side_effect=ValueError):
+    with patch_hassette_and_signal_registration(mock_core) as (_, mock_thread_cls, mock_sigmask):
         await main(mock_config)
 
+    mock_sigmask.assert_called_once_with(signal.SIG_BLOCK, {signal.SIGINT})
+    mock_thread_cls.assert_called_once()
+    mock_thread_cls.return_value.start.assert_called_once()
+
+
+async def test_main_starts_sigint_wait_thread_as_daemon() -> None:
+    """main() starts a daemon thread running _sigint_wait_loop(core, loop)."""
+    mock_core, mock_config = make_mock_core_and_config()
+    loop = asyncio.get_running_loop()
+
+    with patch_hassette_and_signal_registration(mock_core) as (_, mock_thread_cls, _):
+        await main(mock_config)
+
+    _, kwargs = mock_thread_cls.call_args
+    assert kwargs["target"] is _sigint_wait_loop
+    assert kwargs["args"] == (mock_core, loop)
+    assert kwargs["daemon"] is True
+
+
+async def test_main_continues_when_sigint_handling_unsupported() -> None:
+    """main() continues to run_forever, without starting a thread, when pthread_sigmask is
+    unavailable (e.g. Windows, where signal.pthread_sigmask doesn't exist at all).
+    """
+    mock_core, mock_config = make_mock_core_and_config()
+
+    with patch_hassette_and_signal_registration(mock_core, pthread_sigmask_side_effect=AttributeError) as (
+        _,
+        mock_thread_cls,
+        _,
+    ):
+        await main(mock_config)
+
+    mock_thread_cls.assert_not_called()
     mock_core.run_forever.assert_awaited_once()
+
+
+async def test_handle_sigint_signal_requests_shutdown_on_first_call() -> None:
+    """The first SIGINT delivery hands request_shutdown off to the loop; it does not exit."""
+    mock_core, _ = make_mock_core_and_config()
+    mock_core.shutdown_event = asyncio.Event()
+    mock_core.ready_event = asyncio.Event()
+    loop = asyncio.get_running_loop()
+
+    with patch("hassette.server.os._exit") as mock_exit:
+        _handle_sigint_signal(mock_core, loop)
+        mock_exit.assert_not_called()
+
+    # call_soon_threadsafe only schedules request_shutdown — give the loop a turn to run it.
+    await asyncio.sleep(0)
+    assert mock_core.shutdown_event.is_set()
+
+
+async def test_handle_sigint_signal_force_exits_once_shutdown_already_requested() -> None:
+    """Once shutdown_event is already set, _handle_sigint_signal force-exits instead of no-op'ing."""
+    mock_core, _ = make_mock_core_and_config()
+    mock_core.shutdown_event = asyncio.Event()
+    mock_core.shutdown_event.set()
+    loop = asyncio.get_running_loop()
+
+    with patch("hassette.server.os._exit") as mock_exit:
+        _handle_sigint_signal(mock_core, loop)
+
+    mock_exit.assert_called_once_with(1)
+
+
+def test_sigint_wait_loop_calls_handler_once_per_wakeup() -> None:
+    """_sigint_wait_loop calls _handle_sigint_signal exactly once per sigwait() wakeup."""
+
+    class _StopLoopError(Exception):
+        """Sentinel used to break out of _sigint_wait_loop's while True for this test only."""
+
+    mock_core = MagicMock()
+    mock_loop = MagicMock()
+
+    with (
+        patch("hassette.server.signal.sigwait", side_effect=[signal.SIGINT, _StopLoopError]) as mock_sigwait,
+        patch("hassette.server._handle_sigint_signal") as mock_handle,
+        pytest.raises(_StopLoopError),
+    ):
+        _sigint_wait_loop(mock_core, mock_loop)
+
+    assert mock_sigwait.call_count == 2
+    mock_sigwait.assert_called_with({signal.SIGINT})
+    mock_handle.assert_called_once_with(mock_core, mock_loop)
 
 
 async def test_main_raises_fatal_error_when_token_is_none() -> None:
@@ -174,7 +228,7 @@ async def test_main_passes_config_to_hassette() -> None:
     """main() passes the provided HassetteConfig to Hassette."""
     mock_core, mock_config = make_mock_core_and_config()
 
-    with patch_hassette_and_signal_registration(mock_core) as (mock_hassette_cls, _):
+    with patch_hassette_and_signal_registration(mock_core) as (mock_hassette_cls, _, _):
         await main(mock_config)
 
     mock_hassette_cls.assert_called_once_with(config=mock_config)


### PR DESCRIPTION
### Signal handling

- Register a SIGINT handler alongside the existing SIGTERM handler in `server.py`'s `main()`, using the same `request_shutdown` callback. Previously Ctrl+C took the disorderly path: no acknowledgment log, a silent 30s wait against `total_shutdown_timeout_seconds`, then exit. Ctrl+C now behaves like SIGTERM — acknowledged immediately with an orderly teardown.
- Loop over both signals when registering, rather than duplicating the `try`/`except NotImplementedError` block per signal, so a platform/event loop that can't install one still gets a warning for the other.

### Housekeeping

- Parametrize the SIGTERM/SIGINT signal handler tests in `test_main.py` (`test_main_registers_shutdown_signal_handler`, `test_shutdown_signal_handler_triggers_shutdown_event`) instead of duplicating near-identical test bodies per signal.

Closes #1815
