### PR TITLE
fix: route captured warnings through the logging pipeline

### DIFF
--- a/src/hassette/core/logging_service.py
+++ b/src/hassette/core/logging_service.py
@@ -8,6 +8,7 @@ from typing import ClassVar
 
 from hassette.core.database_service import DatabaseService
 from hassette.logging_ import (
+    LOGGER_NAMES,
     CorrelationFilter,
     HassetteQueueHandler,
     HassetteQueueListener,
@@ -22,11 +23,28 @@ if typing.TYPE_CHECKING:
 
 _QUEUE_LISTENER_STOP_TIMEOUT_SECONDS = 5.0
 
-# "py.warnings" mirrors "hassette" throughout this file's handler swaps so that captured
-# warnings.warn(...) calls (e.g. HassetteForgottenAwaitWarning) reach the same console/
-# capture/persistence pipeline as regular hassette logs, instead of a handler-less logger.
-# See enable_basic_logging() in logging_.py, which sets up the identical wiring for Phase 1.
-_MIRRORED_LOGGER_NAMES = ("hassette", "py.warnings")
+
+def _get_loggers() -> list[logging.Logger]:
+    """The loggers this file keeps in sync — see LOGGER_NAMES in logging_.py."""
+    return [logging.getLogger(name) for name in LOGGER_NAMES]
+
+
+def _remove_stale_queue_handlers(loggers: list[logging.Logger]) -> None:
+    """Defensive cleanup: drop any leftover QueueHandler from a previous init."""
+    for logger in loggers:
+        for h in list(logger.handlers):
+            if isinstance(h, logging.handlers.QueueHandler):
+                logger.removeHandler(h)
+
+
+def _add_handler(loggers: list[logging.Logger], handler: logging.Handler) -> None:
+    for logger in loggers:
+        logger.addHandler(handler)
+
+
+def _remove_handler(loggers: list[logging.Logger], handler: logging.Handler) -> None:
+    for logger in loggers:
+        logger.removeHandler(handler)
 
 
 class LoggingService(Resource):
@@ -63,12 +81,9 @@ class LoggingService(Resource):
 
     async def on_initialize(self) -> None:
         """Upgrade logging from sync to async pipeline."""
-        mirrored_loggers = [logging.getLogger(name) for name in _MIRRORED_LOGGER_NAMES]
+        loggers = _get_loggers()
 
-        for logger in mirrored_loggers:
-            for h in list(logger.handlers):
-                if isinstance(h, logging.handlers.QueueHandler):
-                    logger.removeHandler(h)
+        _remove_stale_queue_handlers(loggers)
         if self._queue_listener is not None:
             with contextlib.suppress(Exception):
                 await asyncio.to_thread(self._queue_listener.stop)
@@ -102,11 +117,9 @@ class LoggingService(Resource):
         listener = HassetteQueueListener(q, *handlers)
 
         # Atomic swap: add QueueHandler FIRST, then remove StreamHandler
-        for logger in mirrored_loggers:
-            logger.addHandler(queue_handler)
+        _add_handler(loggers, queue_handler)
         if self._stream_handler is not None:
-            for logger in mirrored_loggers:
-                logger.removeHandler(self._stream_handler)
+            _remove_handler(loggers, self._stream_handler)
 
         listener.start()
 
@@ -118,14 +131,12 @@ class LoggingService(Resource):
     async def on_shutdown(self) -> None:
         """Stop the async logging pipeline and restore synchronous console logging."""
         self.capture_handler.shutting_down = True
-        mirrored_loggers = [logging.getLogger(name) for name in _MIRRORED_LOGGER_NAMES]
+        loggers = _get_loggers()
 
         if self._queue_handler is not None:
-            for logger in mirrored_loggers:
-                logger.removeHandler(self._queue_handler)
+            _remove_handler(loggers, self._queue_handler)
         if self._stream_handler is not None:
-            for logger in mirrored_loggers:
-                logger.addHandler(self._stream_handler)
+            _add_handler(loggers, self._stream_handler)
 
         self.logger.warning("LoggingService shutting down — subsequent log records will be console-only")
 

--- a/src/hassette/core/logging_service.py
+++ b/src/hassette/core/logging_service.py
@@ -22,6 +22,12 @@ if typing.TYPE_CHECKING:
 
 _QUEUE_LISTENER_STOP_TIMEOUT_SECONDS = 5.0
 
+# "py.warnings" mirrors "hassette" throughout this file's handler swaps so that captured
+# warnings.warn(...) calls (e.g. HassetteForgottenAwaitWarning) reach the same console/
+# capture/persistence pipeline as regular hassette logs, instead of a handler-less logger.
+# See enable_basic_logging() in logging_.py, which sets up the identical wiring for Phase 1.
+_MIRRORED_LOGGER_NAMES = ("hassette", "py.warnings")
+
 
 class LoggingService(Resource):
     """Owns the full async logging pipeline.
@@ -57,11 +63,12 @@ class LoggingService(Resource):
 
     async def on_initialize(self) -> None:
         """Upgrade logging from sync to async pipeline."""
-        hassette_logger = logging.getLogger("hassette")
+        mirrored_loggers = [logging.getLogger(name) for name in _MIRRORED_LOGGER_NAMES]
 
-        for h in list(hassette_logger.handlers):
-            if isinstance(h, logging.handlers.QueueHandler):
-                hassette_logger.removeHandler(h)
+        for logger in mirrored_loggers:
+            for h in list(logger.handlers):
+                if isinstance(h, logging.handlers.QueueHandler):
+                    logger.removeHandler(h)
         if self._queue_listener is not None:
             with contextlib.suppress(Exception):
                 await asyncio.to_thread(self._queue_listener.stop)
@@ -95,9 +102,11 @@ class LoggingService(Resource):
         listener = HassetteQueueListener(q, *handlers)
 
         # Atomic swap: add QueueHandler FIRST, then remove StreamHandler
-        hassette_logger.addHandler(queue_handler)
+        for logger in mirrored_loggers:
+            logger.addHandler(queue_handler)
         if self._stream_handler is not None:
-            hassette_logger.removeHandler(self._stream_handler)
+            for logger in mirrored_loggers:
+                logger.removeHandler(self._stream_handler)
 
         listener.start()
 
@@ -109,12 +118,14 @@ class LoggingService(Resource):
     async def on_shutdown(self) -> None:
         """Stop the async logging pipeline and restore synchronous console logging."""
         self.capture_handler.shutting_down = True
-        hassette_logger = logging.getLogger("hassette")
+        mirrored_loggers = [logging.getLogger(name) for name in _MIRRORED_LOGGER_NAMES]
 
         if self._queue_handler is not None:
-            hassette_logger.removeHandler(self._queue_handler)
+            for logger in mirrored_loggers:
+                logger.removeHandler(self._queue_handler)
         if self._stream_handler is not None:
-            hassette_logger.addHandler(self._stream_handler)
+            for logger in mirrored_loggers:
+                logger.addHandler(self._stream_handler)
 
         self.logger.warning("LoggingService shutting down — subsequent log records will be console-only")
 

--- a/src/hassette/logging_.py
+++ b/src/hassette/logging_.py
@@ -448,8 +448,19 @@ def enable_basic_logging(
     stream_handler.setFormatter(formatter)
     logger.addHandler(stream_handler)
 
-    # Capture warnings.warn(...) and friends messages in logs.
+    # Capture warnings.warn(...) and friends messages in logs. Route "py.warnings" through
+    # the same handler as "hassette" — otherwise captured warnings (e.g.
+    # HassetteForgottenAwaitWarning) reach a logger with no handlers of its own and, via
+    # propagation to root's unformatted lastResort handler, bypass the console formatter
+    # and never reach the capture/persistence pipeline. LoggingService.on_initialize()/
+    # on_shutdown() (Phase 2) mirror this same wiring for the async pipeline.
     logging.captureWarnings(True)
+    warnings_logger = logging.getLogger("py.warnings")
+    warnings_logger.setLevel(logging.WARNING)
+    warnings_logger.propagate = False
+    warnings_logger.handlers.clear()
+    warnings_logger.filters.clear()
+    warnings_logger.addHandler(stream_handler)
 
     # Suppress overly verbose logs from libraries that aren't helpful
     logging.getLogger("requests").setLevel(logging.WARNING)

--- a/src/hassette/logging_.py
+++ b/src/hassette/logging_.py
@@ -22,6 +22,14 @@ from hassette.context import CURRENT_EXECUTION_ID
 
 DEQUEUE_TIMEOUT_SECONDS = 0.2
 
+HASSETTE_LOGGER_NAME = "hassette"
+# logging.captureWarnings(True) routes warnings.warn(...) calls (e.g.
+# HassetteForgottenAwaitWarning) to this logger. It must stay wired to the same handlers
+# as HASSETTE_LOGGER_NAME — see enable_basic_logging() below and LoggingService in
+# logging_service.py, which keep both loggers in sync through both phases of the logging model.
+PY_WARNINGS_LOGGER_NAME = "py.warnings"
+LOGGER_NAMES = (HASSETTE_LOGGER_NAME, PY_WARNINGS_LOGGER_NAME)
+
 if TYPE_CHECKING:
     from hassette.core.database_service import DatabaseService
 
@@ -372,6 +380,16 @@ def _extract_record_fields(
     return event_dict
 
 
+def _reset_logger(name: str, level: int | str) -> logging.Logger:
+    """Return the named logger cleared of handlers/filters, non-propagating, at ``level``."""
+    logger = logging.getLogger(name)
+    logger.setLevel(level)
+    logger.propagate = False
+    logger.handlers.clear()
+    logger.filters.clear()
+    return logger
+
+
 def enable_basic_logging(
     log_level: Literal["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"],
     *,
@@ -437,11 +455,7 @@ def enable_basic_logging(
         ],
     )
 
-    logger = logging.getLogger("hassette")
-    logger.setLevel(log_level)
-    logger.propagate = False
-    logger.handlers.clear()
-    logger.filters.clear()
+    logger = _reset_logger(HASSETTE_LOGGER_NAME, log_level)
 
     stream_handler = logging.StreamHandler(out)
     stream_handler.setLevel(logging.NOTSET)
@@ -452,14 +466,15 @@ def enable_basic_logging(
     # the same handler as "hassette" — otherwise captured warnings (e.g.
     # HassetteForgottenAwaitWarning) reach a logger with no handlers of its own and, via
     # propagation to root's unformatted lastResort handler, bypass the console formatter
-    # and never reach the capture/persistence pipeline. LoggingService.on_initialize()/
-    # on_shutdown() (Phase 2) mirror this same wiring for the async pipeline.
+    # and never reach the capture/persistence pipeline. Fixed at WARNING rather than
+    # log_level: captureWarnings always emits at WARNING, so that's the only threshold
+    # that has any effect, and this must stay independent of log_level so raising
+    # log_level to reduce noise can't silently suppress HassetteForgottenAwaitWarning too —
+    # ForgottenAwaitBehavior.IGNORE is the intended lever for that.
+    # LoggingService.on_initialize()/on_shutdown() (Phase 2) mirror this same wiring for
+    # the async pipeline.
     logging.captureWarnings(True)
-    warnings_logger = logging.getLogger("py.warnings")
-    warnings_logger.setLevel(logging.WARNING)
-    warnings_logger.propagate = False
-    warnings_logger.handlers.clear()
-    warnings_logger.filters.clear()
+    warnings_logger = _reset_logger(PY_WARNINGS_LOGGER_NAME, logging.WARNING)
     warnings_logger.addHandler(stream_handler)
 
     # Suppress overly verbose logs from libraries that aren't helpful

--- a/tests/unit/core/test_logging_service.py
+++ b/tests/unit/core/test_logging_service.py
@@ -6,8 +6,9 @@ import logging.handlers
 import queue
 from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
-from hassette.core.logging_service import _MIRRORED_LOGGER_NAMES, LoggingService
+from hassette.core.logging_service import LoggingService
 from hassette.logging_ import (
+    LOGGER_NAMES,
     HassetteQueueHandler,
     HassetteQueueListener,
     LogCaptureHandler,
@@ -18,7 +19,7 @@ from hassette.test_utils.mock_hassette import make_mock_hassette
 
 def remove_queue_handlers() -> None:
     """Remove all QueueHandlers from the hassette and py.warnings loggers."""
-    for logger_name in _MIRRORED_LOGGER_NAMES:
+    for logger_name in LOGGER_NAMES:
         logger = logging.getLogger(logger_name)
         for h in list(logger.handlers):
             if isinstance(h, logging.handlers.QueueHandler):

--- a/tests/unit/core/test_logging_service.py
+++ b/tests/unit/core/test_logging_service.py
@@ -6,7 +6,7 @@ import logging.handlers
 import queue
 from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
-from hassette.core.logging_service import LoggingService
+from hassette.core.logging_service import _MIRRORED_LOGGER_NAMES, LoggingService
 from hassette.logging_ import (
     HassetteQueueHandler,
     HassetteQueueListener,
@@ -17,11 +17,12 @@ from hassette.test_utils.mock_hassette import make_mock_hassette
 
 
 def remove_queue_handlers() -> None:
-    """Remove all QueueHandlers from the hassette logger."""
-    hassette_logger = logging.getLogger("hassette")
-    for h in list(hassette_logger.handlers):
-        if isinstance(h, logging.handlers.QueueHandler):
-            hassette_logger.removeHandler(h)
+    """Remove all QueueHandlers from the hassette and py.warnings loggers."""
+    for logger_name in _MIRRORED_LOGGER_NAMES:
+        logger = logging.getLogger(logger_name)
+        for h in list(logger.handlers):
+            if isinstance(h, logging.handlers.QueueHandler):
+                logger.removeHandler(h)
 
 
 def make_db_service() -> MagicMock:
@@ -304,6 +305,44 @@ class TestLoggingServiceOnShutdown:
         svc.persistence_handler.flush_if_pending.assert_called_once()
 
         remove_queue_handlers()
+
+
+class TestPyWarningsLoggerWiring:
+    """py.warnings gets the same QueueHandler as hassette, so captured warnings (e.g.
+    HassetteForgottenAwaitWarning) reach the full async pipeline — not just Phase 1's
+    StreamHandler (issue #1816).
+    """
+
+    async def test_on_initialize_attaches_queue_handler_to_py_warnings_logger(self) -> None:
+        """After init, py.warnings carries the same QueueHandler instance as hassette."""
+        svc = await make_initialized_logging_service()
+
+        try:
+            warnings_logger = logging.getLogger("py.warnings")
+            assert svc._queue_handler is not None
+            assert svc._queue_handler in warnings_logger.handlers
+        finally:
+            if svc._queue_listener is not None:
+                svc._queue_listener.stop()
+            remove_queue_handlers()
+
+    async def test_on_shutdown_restores_stream_handler_on_py_warnings_logger(self) -> None:
+        """Shutdown removes the QueueHandler and restores the StreamHandler on py.warnings too."""
+        warnings_logger = logging.getLogger("py.warnings")
+        stream_handler = logging.StreamHandler()
+        warnings_logger.addHandler(stream_handler)
+
+        svc = await make_initialized_logging_service(stream_handler=stream_handler)
+        queue_handler = svc._queue_handler
+
+        await svc.on_shutdown()
+
+        try:
+            assert stream_handler in warnings_logger.handlers
+            assert queue_handler not in warnings_logger.handlers
+        finally:
+            warnings_logger.removeHandler(stream_handler)
+            remove_queue_handlers()
 
 
 class TestPersistenceActive:

--- a/tests/unit/test_logging_setup.py
+++ b/tests/unit/test_logging_setup.py
@@ -129,6 +129,41 @@ class TestNoisyLibrarySuppression:
         assert logging.getLogger("httpx2").getEffectiveLevel() == logging.WARNING
 
 
+class TestCapturedWarningsRoutedToPipeline:
+    """logging.captureWarnings(True) sends records to a 'py.warnings' logger — enable_basic_logging
+    must wire that logger to the same handler as 'hassette', or captured warnings (e.g.
+    HassetteForgottenAwaitWarning) reach a handler-less logger and are silently dropped (issue #1816).
+    """
+
+    def test_py_warnings_logger_configured_like_hassette_logger(self) -> None:
+        """py.warnings gets the same stream handler, non-propagating, as the hassette logger."""
+        stream = StringIO()
+        handler = enable_basic_logging("WARNING", log_format="console", stream=stream)
+        warnings_logger = logging.getLogger("py.warnings")
+        assert warnings_logger.propagate is False
+        assert handler in warnings_logger.handlers
+
+    def test_captured_warning_reaches_console_stream(self) -> None:
+        """A record on the 'py.warnings' logger — what logging.captureWarnings' internal
+        _showwarning() emits — surfaces in the console stream, not just the message text.
+
+        Exercises the 'py.warnings' logger directly rather than warnings.warn() itself:
+        stdlib's captureWarnings() only rewires warnings.showwarning the first time it's
+        toggled on per-process, and pytest's own per-test catch_warnings(record=True)
+        wrapper installs a fresh recorder before every test body runs — so by the time
+        this suite reaches this test, warnings.warn() no longer routes through hassette's
+        _showwarning at all. That's a pytest/stdlib interaction, not something this fix
+        touches; the handler wiring below is what issue #1816 actually changed.
+        """
+        stream = StringIO()
+        enable_basic_logging("WARNING", log_format="console", stream=stream)
+
+        logging.getLogger("py.warnings").warning("forgotten await test warning")
+
+        output = stream.getvalue()
+        assert "forgotten await test warning" in output
+
+
 class TestColoredlogsRemoved:
     """coloredlogs is not imported anywhere in the codebase."""
 


### PR DESCRIPTION
### Route captured warnings through the logging pipeline

- `logging.captureWarnings(True)` sends `warnings.warn()` calls — including `HassetteForgottenAwaitWarning`, used to catch a forgotten `await` on Bus/Scheduler/Api registration calls — to a `py.warnings` logger. That logger had no handlers wired to the console/capture/persistence pipeline, so captured warnings bypassed the formatter and never reached the web UI's log viewer or persisted telemetry.
- Wire `py.warnings` to the same handlers as `hassette` at both phases of the logging model: the synchronous `StreamHandler` installed by `enable_basic_logging()`, and the async `QueueHandler` installed by `LoggingService.on_initialize()`/`on_shutdown()`.
- The `py.warnings` threshold is pinned at `WARNING` independent of `log_level` — `captureWarnings` always emits at `WARNING`, and keeping it independent means raising `log_level` to reduce noise can't silently suppress `HassetteForgottenAwaitWarning` too. `ForgottenAwaitBehavior.IGNORE` remains the intended lever for that.

### Housekeeping

- Moved the shared logger-name pair into a single `LOGGER_NAMES` constant in `logging_.py` instead of duplicating string literals across `logging_.py` and `logging_service.py`.
- Added a `_reset_logger()` helper for the repeated logger setup sequence and collapsed the repeated add/remove-handler loops in `LoggingService` into small module-level functions, addressing clean-code review feedback on the warnings wiring.

Closes #1816
