### PR TITLE
chore: add lint rule to catch blind **kwargs forwarding into typed constructors

### DIFF
--- a/prek.toml
+++ b/prek.toml
@@ -286,3 +286,11 @@ entry = "./tools/check_coordinator_internal.py"
 pass_filenames = false
 files = '^tests/.*\.py$'
 stages = ["pre-commit", "pre-push"]
+
+[[repos.hooks]]
+id = "check-kwargs-forwarding"
+name = "Check for blind **kwargs forwarding typed object/Any"
+language = "system"
+entry = "./tools/check_kwargs_forwarding.py"
+files = '^src/hassette/.*\.py$'
+stages = ["pre-commit", "pre-push"]

--- a/src/hassette/task_bucket/task_bucket.py
+++ b/src/hassette/task_bucket/task_bucket.py
@@ -473,7 +473,9 @@ def make_task_factory(
         # note: ignore any comments by AI tools about loop being deprecated/removed, because it's not
         # i'm honestly not sure where they get that idea from
         explicit_name = kwargs.pop("name", None)
-        t: asyncio.Task[Any] = asyncio.Task(coro, loop=loop, **kwargs)
+        # kwargs is whatever asyncio's event loop decides to pass a task factory -- a stdlib
+        # calling convention this code doesn't control (see docstring above).
+        t: asyncio.Task[Any] = asyncio.Task(coro, loop=loop, **kwargs)  # kwargs-forward-ok: see comment above
         if explicit_name is not None:
             t.set_name(explicit_name)
         elif not t.get_name() or t.get_name().startswith("Task-"):

--- a/tests/unit/tools/test_check_kwargs_forwarding.py
+++ b/tests/unit/tools/test_check_kwargs_forwarding.py
@@ -1,0 +1,159 @@
+"""Characterization tests for tools/check_kwargs_forwarding.py.
+
+These pin the guard's observable behavior — which blind '**kwargs: object/Any' forwards into
+a constructor call are flagged — so the detection internals can be reworked without changing
+what the guard reports.
+"""
+
+from collections.abc import Callable
+from pathlib import Path
+
+import pytest
+from check_kwargs_forwarding import check_file, iter_paths
+
+# Each case: (id, source, expected violations as [(lineno, message), ...]).
+CASES: list[tuple[str, str, list[tuple[int, str]]]] = [
+    (
+        "object_forwarded_into_constructor_flagged",
+        """\
+        def make_spec(**overrides: object) -> RestartSpec:
+            return RestartSpec(**overrides)
+        """,
+        [(2, "make_spec: '**overrides: object' forwarded blindly via '**overrides' into RestartSpec(...)")],
+    ),
+    (
+        "any_forwarded_into_constructor_flagged",
+        """\
+        def make_spec(**overrides: Any) -> RestartSpec:
+            return RestartSpec(**overrides)
+        """,
+        [(2, "make_spec: '**overrides: Any' forwarded blindly via '**overrides' into RestartSpec(...)")],
+    ),
+    (
+        "typing_any_qualified_flagged",
+        """\
+        import typing
+
+        def make_spec(**overrides: typing.Any) -> RestartSpec:
+            return RestartSpec(**overrides)
+        """,
+        [(4, "make_spec: '**overrides: Any' forwarded blindly via '**overrides' into RestartSpec(...)")],
+    ),
+    (
+        "method_flagged_with_qualname",
+        """\
+        class SpecFactory:
+            def build(self, **overrides: object) -> RestartSpec:
+                return RestartSpec(**overrides)
+        """,
+        [(3, "SpecFactory.build: '**overrides: object' forwarded blindly via '**overrides' into RestartSpec(...)")],
+    ),
+    (
+        "nested_closure_flagged_with_qualname",
+        """\
+        def make_factory():
+            def factory(**overrides: object) -> RestartSpec:
+                return RestartSpec(**overrides)
+            return factory
+        """,
+        [(3, "make_factory.factory: '**overrides: object' forwarded blindly via '**overrides' into RestartSpec(...)")],
+    ),
+    (
+        "lowercase_target_not_flagged",
+        """\
+        def wrapper(*args: object, **kwargs: Any) -> Any:
+            return original(*args, **kwargs)
+        """,
+        [],
+    ),
+    (
+        "shadowed_kwarg_in_nested_function_not_misattributed_to_outer",
+        """\
+        def outer(**kwargs: object) -> RestartSpec:
+            def inner(**kwargs: int) -> Foo:
+                return Foo(**kwargs)
+            return RestartSpec(a=1)
+        """,
+        [],
+    ),
+    (
+        "nested_function_own_violation_attributed_to_itself_not_outer",
+        """\
+        def outer(**kwargs: object) -> RestartSpec:
+            def inner(**kwargs: object) -> Foo:
+                return Foo(**kwargs)
+            return RestartSpec(a=1)
+        """,
+        [(3, "outer.inner: '**kwargs: object' forwarded blindly via '**kwargs' into Foo(...)")],
+    ),
+    (
+        "self_recursive_super_call_not_flagged",
+        """\
+        class Base:
+            def __init_subclass__(cls, **kwargs: Any) -> None:
+                super().__init_subclass__(**kwargs)
+        """,
+        [],
+    ),
+    (
+        "dynamically_referenced_class_in_lowercase_var_not_flagged",
+        """\
+        def add_child(self, child_class, **kwargs: Any):
+            return child_class(**kwargs)
+        """,
+        [],
+    ),
+    (
+        "typed_kwarg_not_flagged",
+        """\
+        def make_spec(**overrides: int) -> RestartSpec:
+            return RestartSpec(**overrides)
+        """,
+        [],
+    ),
+    (
+        "no_forwarding_not_flagged",
+        """\
+        def make_spec(**overrides: object) -> RestartSpec:
+            defaults = {"backoff_base_seconds": 0}
+            defaults.update(overrides)
+            return RestartSpec(**defaults)
+        """,
+        [],
+    ),
+    (
+        "no_kwargs_param_not_flagged",
+        """\
+        def make_spec(overrides: dict[str, object]) -> RestartSpec:
+            return RestartSpec(**overrides)
+        """,
+        [],
+    ),
+    (
+        "escape_hatch_annotation_suppresses",
+        """\
+        def factory(**kwargs: Any) -> Task:
+            return Task(**kwargs)  # kwargs-forward-ok: asyncio calling convention
+        """,
+        [],
+    ),
+    (
+        "escape_hatch_requires_reason",
+        """\
+        def factory(**kwargs: Any) -> Task:
+            return Task(**kwargs)  # kwargs-forward-ok:
+        """,
+        [(2, "factory: '**kwargs: Any' forwarded blindly via '**kwargs' into Task(...)")],
+    ),
+]
+
+
+@pytest.mark.parametrize(("source", "expected"), [(c[1], c[2]) for c in CASES], ids=[c[0] for c in CASES])
+def test_guard_behavior(write_sample: Callable[[str], Path], source: str, expected: list[tuple[int, str]]) -> None:
+    assert check_file(write_sample(source)) == expected
+
+
+@pytest.mark.parametrize("path", iter_paths(), ids=lambda p: str(p))
+def test_real_repo_files_pass(path: Path) -> None:
+    """The guard must stay green on the actual src/hassette source it polices."""
+    assert check_file(path) == []

--- a/tests/unit/tools/test_check_kwargs_forwarding.py
+++ b/tests/unit/tools/test_check_kwargs_forwarding.py
@@ -101,6 +101,29 @@ CASES: list[tuple[str, str, list[tuple[int, str]]]] = [
         [(3, "outer: '**kwargs: object' forwarded blindly via '**kwargs' into Foo(...)")],
     ),
     (
+        "local_reassignment_in_closure_not_misattributed_to_outer",
+        """\
+        def outer(**kwargs: object) -> RestartSpec:
+            def inner() -> Foo:
+                kwargs = {"a": 1}
+                return Foo(**kwargs)
+            return RestartSpec(**kwargs)
+        """,
+        [(5, "outer: '**kwargs: object' forwarded blindly via '**kwargs' into RestartSpec(...)")],
+    ),
+    (
+        "nonlocal_reassignment_in_closure_still_flagged",
+        """\
+        def outer(**kwargs: object) -> Foo:
+            def inner() -> Foo:
+                nonlocal kwargs
+                kwargs = {"a": 1}
+                return Foo(**kwargs)
+            return inner()
+        """,
+        [(5, "outer: '**kwargs: object' forwarded blindly via '**kwargs' into Foo(...)")],
+    ),
+    (
         "self_recursive_super_call_not_flagged",
         """\
         class Base:

--- a/tests/unit/tools/test_check_kwargs_forwarding.py
+++ b/tests/unit/tools/test_check_kwargs_forwarding.py
@@ -11,6 +11,10 @@ from pathlib import Path
 import pytest
 from check_kwargs_forwarding import check_file, iter_paths
 
+#: Every .py file under src/hassette, captured once so the not-empty guard and the
+#: parametrization below see the same collection.
+REPO_FILES = iter_paths()
+
 # Each case: (id, source, expected violations as [(lineno, message), ...]).
 CASES: list[tuple[str, str, list[tuple[int, str]]]] = [
     (
@@ -87,6 +91,16 @@ CASES: list[tuple[str, str, list[tuple[int, str]]]] = [
         [(3, "outer.inner: '**kwargs: object' forwarded blindly via '**kwargs' into Foo(...)")],
     ),
     (
+        "closure_over_outer_kwargs_flagged_not_missed",
+        """\
+        def outer(**kwargs: object) -> Callable[[], Foo]:
+            def inner() -> Foo:
+                return Foo(**kwargs)
+            return inner
+        """,
+        [(3, "outer: '**kwargs: object' forwarded blindly via '**kwargs' into Foo(...)")],
+    ),
+    (
         "self_recursive_super_call_not_flagged",
         """\
         class Base:
@@ -153,7 +167,12 @@ def test_guard_behavior(write_sample: Callable[[str], Path], source: str, expect
     assert check_file(write_sample(source)) == expected
 
 
-@pytest.mark.parametrize("path", iter_paths(), ids=lambda p: str(p))
+def test_repo_files_found() -> None:
+    """Guard against a misconfigured SCAN_DIRS silently yielding zero files to check."""
+    assert REPO_FILES
+
+
+@pytest.mark.parametrize("path", REPO_FILES, ids=lambda p: str(p))
 def test_real_repo_files_pass(path: Path) -> None:
     """The guard must stay green on the actual src/hassette source it polices."""
     assert check_file(path) == []

--- a/tools/check_kwargs_forwarding.py
+++ b/tools/check_kwargs_forwarding.py
@@ -105,25 +105,39 @@ def _is_forwarding_keyword(kw: ast.keyword, kwarg_name: str) -> bool:
     return kw.arg is None and isinstance(kw.value, ast.Name) and kw.value.id == kwarg_name
 
 
-def _own_scope_nodes(node: ast.AST) -> Iterator[ast.AST]:
-    """Yield every descendant of ``node`` in its own execution scope.
+def _binds_name(func: ast.FunctionDef | ast.AsyncFunctionDef | ast.Lambda, name: str) -> bool:
+    """True if ``func``'s own parameter list rebinds ``name`` as one of its own parameters."""
+    args = func.args
+    names = [a.arg for a in (*args.posonlyargs, *args.args, *args.kwonlyargs)]
+    if args.vararg:
+        names.append(args.vararg.arg)
+    if args.kwarg:
+        names.append(args.kwarg.arg)
+    return name in names
 
-    Recurses through control flow (``if``/``for``/``with``/``try``/...) but stops at nested
-    function/class/lambda boundaries — those introduce their own scope, with their own
-    parameters, so a same-named ``**kwargs`` inside one is a different variable, not the
-    outer function's. Without this boundary, a nested function's own (possibly safely-typed)
-    ``**kwargs`` forwarding gets misattributed to the outer function's ``object``/``Any``
-    parameter just because the names happen to match.
+
+def _own_scope_nodes(node: ast.AST, kwarg_name: str) -> Iterator[ast.AST]:
+    """Yield every descendant of ``node`` that still runs against ``kwarg_name``'s binding.
+
+    Recurses through control flow (``if``/``for``/``with``/``try``/...) and through nested
+    functions/lambdas that don't rebind ``kwarg_name`` — those close over the outer binding, so
+    a forwarding call inside one is still forwarding the same variable. Stops at a nested
+    function/lambda whose own parameter list rebinds ``kwarg_name`` (a different variable that
+    merely shares the name) and always stops at class boundaries, which get their own pass via
+    ``_iter_functions``.
     """
     for child in ast.iter_child_nodes(node):
         yield child
-        if not isinstance(child, ast.FunctionDef | ast.AsyncFunctionDef | ast.ClassDef | ast.Lambda):
-            yield from _own_scope_nodes(child)
+        if isinstance(child, ast.ClassDef):
+            continue
+        if isinstance(child, ast.FunctionDef | ast.AsyncFunctionDef | ast.Lambda) and _binds_name(child, kwarg_name):
+            continue
+        yield from _own_scope_nodes(child, kwarg_name)
 
 
 def _forwarding_calls(node: ast.FunctionDef | ast.AsyncFunctionDef, kwarg_name: str) -> Iterator[ast.Call]:
     """Yield every call in ``node``'s own scope that forwards ``**kwarg_name`` onward."""
-    for inner in _own_scope_nodes(node):
+    for inner in _own_scope_nodes(node, kwarg_name):
         if not isinstance(inner, ast.Call):
             continue
         if any(_is_forwarding_keyword(kw, kwarg_name) for kw in inner.keywords):

--- a/tools/check_kwargs_forwarding.py
+++ b/tools/check_kwargs_forwarding.py
@@ -1,0 +1,203 @@
+#!/usr/bin/env python3
+"""CI guard: ban blind **kwargs forwarding typed object/Any into a constructor call.
+
+A ``**kwargs``-shaped parameter typed ``object`` or ``Any`` erases pyright's field-level
+checking for everything the caller passes through it. That is usually fine — most
+``**kwargs: Any`` parameters forward into another opaque or already-dynamic callable (a
+decorator's wrapped function, a cooperative ``super().__init_subclass__(**kwargs)``, a thin
+delegate calling its own same-named method) where there was never anything for pyright to
+check in the first place. It stops being fine the moment the forwarding target is a locally
+meaningful, field-typed constructor: a typo'd field name or a wrong-typed value then only
+surfaces at runtime, not from pyright. This happened for real —
+``single_point_of_failure_restart(**overrides: object) -> RestartSpec`` forwarded straight
+into ``RestartSpec(**overrides)`` behind a ``# pyright: ignore[reportArgumentType]``, and a
+throwaway repro confirmed pyright missed a typo'd field name before the fix (see #1780).
+
+Detection is AST-based. For every function/method whose ``**kwargs``-style parameter
+(``ast.arguments.kwarg``) is annotated ``object`` or ``Any`` (bare or ``typing.Any``), the
+body is scanned for a call that forwards it onward via ``**<same name>``. Only calls whose
+target name starts with an uppercase letter are flagged — the PEP 8 convention for a class,
+and the shape of the real incident above (``RestartSpec(...)``, not ``some_helper(...)``).
+This is a deliberate, narrower net than "any forwarding call": without it, this guard would
+also flag every legitimate transparent-proxy pattern already in this codebase (decorator
+wrappers forwarding into an ``Any``-typed wrapped callable, ``model_dump`` overrides calling
+``super().model_dump(**kwargs)``, sync-facade methods delegating to their async twin,
+cooperative ``__init_subclass__``) — none of which lose anything to pyright, since their
+forwarding target was never field-typed to begin with. The narrower net does mean a
+dynamically-referenced class held in a lowercase variable (``child_class(**kwargs)``) is not
+caught — a known, accepted false negative, not a bug in the heuristic.
+
+Fix guidance for a real hit: narrow the outer parameter list to explicit, named parameters
+(most callers only need to override a handful of fields), or — if the callee's full field set
+genuinely must stay overridable — type the parameter ``**kwargs: Unpack[SomeTypedDict]``
+instead of ``object``/``Any`` so pyright can still check it field-by-field.
+
+Escape hatch: a call that is a deliberate, unavoidable passthrough (e.g. a stdlib calling
+convention this code doesn't control, like a task factory receiving whatever kwargs a future
+Python version's event loop decides to forward) can be annotated on the *call's own line*
+with ``# kwargs-forward-ok: <reason>`` to suppress — mirroring the ``# factory-local:``
+escape hatch in ``check_test_factories.py``. The reason must be non-empty.
+
+Usage:
+    python tools/check_kwargs_forwarding.py [FILE ...]
+
+With no arguments, scans every file under src/hassette. Given file paths (as pre-commit
+passes the staged files), scans only those — paths outside src/hassette or non-Python paths
+are ignored. Scoped to src/hassette only: this is a framework-API type-safety guard, and
+test helpers (which have their own, separate hygiene conventions) are out of scope.
+"""
+
+import ast
+import re
+import sys
+from collections.abc import Iterator
+from pathlib import Path
+
+from lint_helpers import REPO_ROOT, extract_comments, iter_python_files, run_check
+
+SCAN_DIRS = ["src/hassette"]
+
+ANNOTATION = "# kwargs-forward-ok:"
+
+#: Matches the escape-hatch annotation followed by a non-empty reason.
+ANNOTATION_RE = re.compile(r"#\s*kwargs-forward-ok:\s*\S")
+
+FOOTER = (
+    "A '**kwargs'/'**overrides' parameter typed 'object'/'Any' that is forwarded via\n"
+    "'**<name>' straight into a constructor call erases pyright's field-level checking for\n"
+    "every value the caller passes — a typo'd field name or a wrong-typed value only\n"
+    "surfaces at runtime. Prefer explicit, named parameters on the outer function, or\n"
+    "'**kwargs: Unpack[SomeTypedDict]' if the callee's full field set must stay overridable.\n"
+    f"Deliberate, unavoidable passthroughs may be annotated on the call's own line with\n"
+    f"'{ANNOTATION} <reason>' to suppress."
+)
+
+
+def _object_or_any(annotation: ast.expr) -> str | None:
+    """Return "object"/"Any" if annotation is a bare object/Any type, else None."""
+    if isinstance(annotation, ast.Name) and annotation.id in {"object", "Any"}:
+        return annotation.id
+    if isinstance(annotation, ast.Attribute) and annotation.attr == "Any":
+        return "Any"
+    return None
+
+
+def _call_target_name(func_expr: ast.expr) -> str | None:
+    """Return the bare name a call targets, for ``Name`` and ``Attribute`` call forms."""
+    if isinstance(func_expr, ast.Name):
+        return func_expr.id
+    if isinstance(func_expr, ast.Attribute):
+        return func_expr.attr
+    return None
+
+
+def _looks_like_constructor(name: str) -> bool:
+    """True for a PEP 8 class-shaped name (leading uppercase letter)."""
+    return name[:1].isupper()
+
+
+def _is_forwarding_keyword(kw: ast.keyword, kwarg_name: str) -> bool:
+    """True for the ``**kwarg_name`` unpacking keyword in a call's argument list.
+
+    ``kw.arg is None`` is what marks a ``**`` unpacking keyword (as opposed to a plain
+    ``name=value`` keyword, which always has ``kw.arg`` set).
+    """
+    return kw.arg is None and isinstance(kw.value, ast.Name) and kw.value.id == kwarg_name
+
+
+def _own_scope_nodes(node: ast.AST) -> Iterator[ast.AST]:
+    """Yield every descendant of ``node`` in its own execution scope.
+
+    Recurses through control flow (``if``/``for``/``with``/``try``/...) but stops at nested
+    function/class/lambda boundaries — those introduce their own scope, with their own
+    parameters, so a same-named ``**kwargs`` inside one is a different variable, not the
+    outer function's. Without this boundary, a nested function's own (possibly safely-typed)
+    ``**kwargs`` forwarding gets misattributed to the outer function's ``object``/``Any``
+    parameter just because the names happen to match.
+    """
+    for child in ast.iter_child_nodes(node):
+        yield child
+        if not isinstance(child, ast.FunctionDef | ast.AsyncFunctionDef | ast.ClassDef | ast.Lambda):
+            yield from _own_scope_nodes(child)
+
+
+def _forwarding_calls(node: ast.FunctionDef | ast.AsyncFunctionDef, kwarg_name: str) -> Iterator[ast.Call]:
+    """Yield every call in ``node``'s own scope that forwards ``**kwarg_name`` onward."""
+    for inner in _own_scope_nodes(node):
+        if not isinstance(inner, ast.Call):
+            continue
+        if any(_is_forwarding_keyword(kw, kwarg_name) for kw in inner.keywords):
+            yield inner
+
+
+def _iter_functions(node: ast.AST, qualname: str = "") -> Iterator[tuple[ast.FunctionDef | ast.AsyncFunctionDef, str]]:
+    """Yield (function node, dotted qualname) for every def reachable from ``node``.
+
+    Descends into classes (prefixing ``Class.``) and into nested functions (prefixing
+    ``outer.``), so a decorator's inner ``wrapper`` or a factory's inner closure gets a
+    readable qualname in violation messages, not just its bare local name.
+    """
+    for child in ast.iter_child_nodes(node):
+        if isinstance(child, ast.ClassDef):
+            yield from _iter_functions(child, f"{qualname}{child.name}.")
+        elif isinstance(child, ast.FunctionDef | ast.AsyncFunctionDef):
+            full = f"{qualname}{child.name}"
+            yield child, full
+            yield from _iter_functions(child, f"{full}.")
+        else:
+            yield from _iter_functions(child, qualname)
+
+
+def check_source(source: str) -> list[tuple[int, str]]:
+    """Return sorted (1-based line number, message) for every blind-kwargs-forward violation."""
+    tree = ast.parse(source)
+    comments = extract_comments(source)
+    violations: list[tuple[int, str]] = []
+
+    for func, qualname in _iter_functions(tree):
+        kwarg = func.args.kwarg
+        if kwarg is None or kwarg.annotation is None:
+            continue
+        ann_name = _object_or_any(kwarg.annotation)
+        if ann_name is None:
+            continue
+
+        for call in _forwarding_calls(func, kwarg.arg):
+            target = _call_target_name(call.func)
+            if target is None or not _looks_like_constructor(target):
+                continue
+            if ANNOTATION_RE.search(comments.get(call.lineno, "")):
+                continue
+            violations.append(
+                (
+                    call.lineno,
+                    f"{qualname}: '**{kwarg.arg}: {ann_name}' forwarded blindly via '**{kwarg.arg}' into {target}(...)",
+                )
+            )
+
+    return sorted(violations)
+
+
+def check_file(path: Path) -> list[tuple[int, str]]:
+    """Return sorted (1-based line number, message) violations in ``path``."""
+    return check_source(path.read_text())
+
+
+def iter_paths() -> list[Path]:
+    """Return every .py file under src/hassette, sorted for stable output."""
+    return iter_python_files([], SCAN_DIRS)
+
+
+def main() -> int:
+    return run_check(
+        iter_python_files(sys.argv[1:], SCAN_DIRS),
+        REPO_ROOT,
+        check_file,
+        summary="blind **kwargs (typed object/Any) forwarded into a constructor call",
+        ok="no blind **kwargs forwarding into a constructor call.",
+        footer=FOOTER,
+    )
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/check_kwargs_forwarding.py
+++ b/tools/check_kwargs_forwarding.py
@@ -8,24 +8,23 @@ decorator's wrapped function, a cooperative ``super().__init_subclass__(**kwargs
 delegate calling its own same-named method) where there was never anything for pyright to
 check in the first place. It stops being fine the moment the forwarding target is a locally
 meaningful, field-typed constructor: a typo'd field name or a wrong-typed value then only
-surfaces at runtime, not from pyright. This happened for real —
-``single_point_of_failure_restart(**overrides: object) -> RestartSpec`` forwarded straight
-into ``RestartSpec(**overrides)`` behind a ``# pyright: ignore[reportArgumentType]``, and a
-throwaway repro confirmed pyright missed a typo'd field name before the fix (see #1780).
+surfaces at runtime, not from pyright (see #1780).
 
 Detection is AST-based. For every function/method whose ``**kwargs``-style parameter
 (``ast.arguments.kwarg``) is annotated ``object`` or ``Any`` (bare or ``typing.Any``), the
 body is scanned for a call that forwards it onward via ``**<same name>``. Only calls whose
-target name starts with an uppercase letter are flagged — the PEP 8 convention for a class,
-and the shape of the real incident above (``RestartSpec(...)``, not ``some_helper(...)``).
+target name starts with an uppercase letter are flagged — the PEP 8 convention for a class.
 This is a deliberate, narrower net than "any forwarding call": without it, this guard would
 also flag every legitimate transparent-proxy pattern already in this codebase (decorator
 wrappers forwarding into an ``Any``-typed wrapped callable, ``model_dump`` overrides calling
 ``super().model_dump(**kwargs)``, sync-facade methods delegating to their async twin,
 cooperative ``__init_subclass__``) — none of which lose anything to pyright, since their
-forwarding target was never field-typed to begin with. The narrower net does mean a
-dynamically-referenced class held in a lowercase variable (``child_class(**kwargs)``) is not
-caught — a known, accepted false negative, not a bug in the heuristic.
+forwarding target was never field-typed to begin with. The narrower net accepts two known
+false negatives, not bugs in the heuristic: a dynamically-referenced class held in a
+lowercase variable (``child_class(**kwargs)``), and forwarding mediated through an
+intermediate dict (``defaults.update(overrides); Ctor(**defaults)``) rather than a direct
+``**kwargs`` unpack — both require broader data-flow tracking than this guard's local,
+per-call AST check does.
 
 Fix guidance for a real hit: narrow the outer parameter list to explicit, named parameters
 (most callers only need to override a handful of fields), or — if the callee's full field set
@@ -59,8 +58,9 @@ SCAN_DIRS = ["src/hassette"]
 
 ANNOTATION = "# kwargs-forward-ok:"
 
-#: Matches the escape-hatch annotation followed by a non-empty reason.
-ANNOTATION_RE = re.compile(r"#\s*kwargs-forward-ok:\s*\S")
+#: Matches the escape-hatch annotation followed by a non-empty reason. Derived from ``ANNOTATION``
+#: so the two can't drift apart if the escape-hatch keyword is ever renamed.
+ANNOTATION_RE = re.compile(rf"{re.escape(ANNOTATION.lstrip('# ').rstrip(':'))}:\s*\S")
 
 FOOTER = (
     "A '**kwargs'/'**overrides' parameter typed 'object'/'Any' that is forwarded via\n"
@@ -68,8 +68,22 @@ FOOTER = (
     "every value the caller passes — a typo'd field name or a wrong-typed value only\n"
     "surfaces at runtime. Prefer explicit, named parameters on the outer function, or\n"
     "'**kwargs: Unpack[SomeTypedDict]' if the callee's full field set must stay overridable.\n"
-    f"Deliberate, unavoidable passthroughs may be annotated on the call's own line with\n"
+    "Deliberate, unavoidable passthroughs may be annotated on the call's own line with\n"
     f"'{ANNOTATION} <reason>' to suppress."
+)
+
+#: Node types that introduce their own scope for the names assigned inside them: a comprehension's
+#: loop variable never leaks into the enclosing function (walrus-in-comprehension's PEP 572
+#: exception to this is not modeled — a known, narrow gap).
+_OWN_SCOPE_TYPES = (
+    ast.FunctionDef,
+    ast.AsyncFunctionDef,
+    ast.ClassDef,
+    ast.Lambda,
+    ast.ListComp,
+    ast.SetComp,
+    ast.DictComp,
+    ast.GeneratorExp,
 )
 
 
@@ -116,13 +130,60 @@ def _binds_name(func: ast.FunctionDef | ast.AsyncFunctionDef | ast.Lambda, name:
     return name in names
 
 
-def _own_scope_nodes(node: ast.AST, kwarg_name: str) -> Iterator[ast.AST]:
+def _iter_own_scope_body(node: ast.AST) -> Iterator[ast.AST]:
+    """Yield every descendant of ``node`` still running in ``node``'s own scope.
+
+    Recurses through control flow (``if``/``for``/``with``/``try``/...) but stops unconditionally
+    at any nested scope boundary (see ``_OWN_SCOPE_TYPES``) — used to check whether ``node``
+    itself rebinds a name anywhere in its body, not to search for forwarding calls (see
+    ``_reachable_under_binding`` for that).
+    """
+    for child in ast.iter_child_nodes(node):
+        yield child
+        if not isinstance(child, _OWN_SCOPE_TYPES):
+            yield from _iter_own_scope_body(child)
+
+
+def _rebinds_name(func: ast.FunctionDef | ast.AsyncFunctionDef | ast.Lambda, name: str) -> bool:
+    """True if ``func``'s own scope creates a new local binding for ``name``.
+
+    Its parameter list obviously rebinds. So does a plain assignment target anywhere in its body
+    — Python scopes bind at function level, not block level, so ``name = ...`` three ``if``s deep
+    still shadows an enclosing function's same-named parameter for the rest of ``func``'s body —
+    unless ``func`` declares ``name`` ``nonlocal``/``global``, in which case the assignment
+    modifies the outer binding instead of creating a new local one. A lambda body is a single
+    expression, so it can only rebind via its own parameters.
+    """
+    if _binds_name(func, name):
+        return True
+    if isinstance(func, ast.Lambda):
+        return False
+
+    body = list(_iter_own_scope_body(func))
+    if any(isinstance(n, ast.Nonlocal | ast.Global) and name in n.names for n in body):
+        return False
+
+    for n in body:
+        targets: list[ast.expr] = []
+        if isinstance(n, ast.Assign):
+            targets = n.targets
+        elif isinstance(n, ast.AugAssign | ast.AnnAssign | ast.NamedExpr | ast.For | ast.AsyncFor):
+            targets = [n.target]
+        elif isinstance(n, ast.withitem) and n.optional_vars is not None:
+            targets = [n.optional_vars]
+        for target in targets:
+            if any(isinstance(leaf, ast.Name) and leaf.id == name for leaf in ast.walk(target)):
+                return True
+    return False
+
+
+def _reachable_under_binding(node: ast.AST, kwarg_name: str) -> Iterator[ast.AST]:
     """Yield every descendant of ``node`` that still runs against ``kwarg_name``'s binding.
 
     Recurses through control flow (``if``/``for``/``with``/``try``/...) and through nested
-    functions/lambdas that don't rebind ``kwarg_name`` — those close over the outer binding, so
-    a forwarding call inside one is still forwarding the same variable. Stops at a nested
-    function/lambda whose own parameter list rebinds ``kwarg_name`` (a different variable that
+    functions/lambdas that don't rebind ``kwarg_name`` (see ``_rebinds_name``) — those close over
+    the outer binding, so a forwarding call inside one is still forwarding the same variable.
+    Stops at a nested function/lambda that does rebind ``kwarg_name`` (a different variable that
     merely shares the name) and always stops at class boundaries, which get their own pass via
     ``_iter_functions``.
     """
@@ -130,14 +191,14 @@ def _own_scope_nodes(node: ast.AST, kwarg_name: str) -> Iterator[ast.AST]:
         yield child
         if isinstance(child, ast.ClassDef):
             continue
-        if isinstance(child, ast.FunctionDef | ast.AsyncFunctionDef | ast.Lambda) and _binds_name(child, kwarg_name):
+        if isinstance(child, ast.FunctionDef | ast.AsyncFunctionDef | ast.Lambda) and _rebinds_name(child, kwarg_name):
             continue
-        yield from _own_scope_nodes(child, kwarg_name)
+        yield from _reachable_under_binding(child, kwarg_name)
 
 
 def _forwarding_calls(node: ast.FunctionDef | ast.AsyncFunctionDef, kwarg_name: str) -> Iterator[ast.Call]:
     """Yield every call in ``node``'s own scope that forwards ``**kwarg_name`` onward."""
-    for inner in _own_scope_nodes(node, kwarg_name):
+    for inner in _reachable_under_binding(node, kwarg_name):
         if not isinstance(inner, ast.Call):
             continue
         if any(_is_forwarding_keyword(kw, kwarg_name) for kw in inner.keywords):
@@ -149,7 +210,11 @@ def _iter_functions(node: ast.AST, qualname: str = "") -> Iterator[tuple[ast.Fun
 
     Descends into classes (prefixing ``Class.``) and into nested functions (prefixing
     ``outer.``), so a decorator's inner ``wrapper`` or a factory's inner closure gets a
-    readable qualname in violation messages, not just its bare local name.
+    readable qualname in violation messages, not just its bare local name. A nested function with
+    its own ``**kwargs`` of the same name is checked twice — once as part of the outer function's
+    own scan (and skipped there via ``_rebinds_name``), once here as its own top-level entry — an
+    accepted, bounded re-walk rather than a bug, since ``check_source`` runs once per file, not
+    per line of source.
     """
     for child in ast.iter_child_nodes(node):
         if isinstance(child, ast.ClassDef):


### PR DESCRIPTION
## Summary

Adds a new prek/pre-commit hook, `tools/check_kwargs_forwarding.py`, that flags a `**kwargs`-shaped parameter typed `object`/`Any` whose body forwards it via `**<name>` straight into what looks like a constructor call (a call target starting with an uppercase letter, per PEP 8 class-naming convention).

This closes the gap that let `single_point_of_failure_restart(**overrides: object) -> RestartSpec` forward untyped kwargs into `RestartSpec(**overrides)` behind a `# pyright: ignore[reportArgumentType]` — a typo'd field name or wrong-typed value would only surface at runtime, not from pyright.

The check is deliberately narrow so it doesn't false-positive on legitimate transparent-proxy patterns already in the codebase: decorator wrappers forwarding into an `Any`-typed wrapped callable, `super().__init_subclass__(**kwargs)`, `model_dump` overrides, sync-facade methods delegating to their async twin. Only calls whose target name is PEP-8-class-shaped (leading uppercase) are flagged, and a call can be explicitly exempted with a `# kwargs-forward-ok: <reason>` comment on its own line for genuinely unavoidable passthroughs (e.g. `asyncio`'s task-factory calling convention).

## Changes

- `tools/check_kwargs_forwarding.py` — AST-based detector: walks every function/method, finds `**kwargs`-style parameters annotated `object`/`Any` (bare or `typing.Any`), and scans the body (stopping at nested function/class/lambda scope boundaries) for a call that forwards the same name via `**` into a class-shaped call target.
- `prek.toml` — registers the new hook (`check-kwargs-forwarding`), scoped to `src/hassette/**/*.py`, running on `pre-commit` and `pre-push`.
- `src/hassette/task_bucket/task_bucket.py` — the one real hit the new check found in this repo: `asyncio.Task(coro, loop=loop, **kwargs)` inside `make_task_factory`, where `kwargs` is whatever `asyncio`'s event loop forwards to a task factory. This is a real, unavoidable stdlib passthrough, so it's annotated with `# kwargs-forward-ok: <reason>` plus a comment explaining why.
- `tests/unit/tools/test_check_kwargs_forwarding.py` — characterization tests pinning what the guard flags and what it doesn't (constructors vs. lowercase targets, `object` vs `Any`/`typing.Any`, nested-scope shadowing, the escape-hatch annotation, etc.).

## Testing

- `uv run nox -s dev` — 7544 passed, 1 skipped, 2 xfailed
- `prek -a` — all hooks pass, including the new `check-kwargs-forwarding` hook against the full `src/hassette` tree
- `prek pyright -a --stage pre-push` — passes

Closes #1780
