### PR TITLE
test: dedupe fixture values in handlers-tab rendering test

### DIFF
--- a/frontend/src/components/app-detail/handlers-tab.rendering.test.tsx
+++ b/frontend/src/components/app-detail/handlers-tab.rendering.test.tsx
@@ -1,8 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { createWouterMock } from "../../test/mock-wouter";
-import { renderWithAppState } from "../../test/render-helpers";
-import { HandlersTab } from "./handlers-tab";
 import { renderHandlersTab } from "./handlers-tab.test-helpers";
 
 // Mock child components that make API calls
@@ -40,10 +38,7 @@ describe("HandlersTab rendering", () => {
   });
 
   it("renders empty state when no listeners or jobs", () => {
-    const { getByTestId } = renderWithAppState(
-      <HandlersTab listeners={[]} jobs={[]} selectedHandler={null} selectedExecId={null} appKey="test_app" />,
-      { storeOverrides: { uptimeSeconds: 120 } },
-    );
+    const { getByTestId } = renderHandlersTab([], []);
     expect(getByTestId("handlers-empty")).toBeDefined();
   });
 


### PR DESCRIPTION
## Summary

Replaces the hand-built `renderWithAppState(...)` call in the "renders empty state when no listeners or jobs" test with `renderHandlersTab([], [])`, removing the inline duplication of `appKey`, `selectedHandler`, `selectedExecId`, and `uptimeSeconds` that already live in the shared `handlers-tab.test-helpers.ts` helper. Also drops the now-unused `HandlersTab` and `renderWithAppState` imports.

This is a pre-existing code-quality finding surfaced by an automated scan (see #1783) — mechanical, test-only, no behavior change.

## Testing

- `cd frontend && npx vitest run src/components/app-detail/handlers-tab.rendering.test.tsx` — 4 passed
- `uv run nox -s dev` — 7661 passed, 1 skipped, 2 xfailed
- `prek -a` — all hooks passed
- `prek pyright -a --stage pre-push` — passed

Closes #1783
