### PR TITLE
fix: retype loose role annotations in lifecycle Protocol and watcher tests

### DIFF
--- a/src/hassette/resources/mixins.py
+++ b/src/hassette/resources/mixins.py
@@ -6,7 +6,7 @@ from typing import Any, Protocol
 
 from hassette.exceptions import InvalidLifecycleTransitionError
 from hassette.resources.teardown import TeardownReport
-from hassette.types.enums import ResourceStatus
+from hassette.types.enums import ResourceRole, ResourceStatus
 from hassette.types.types import CoroLikeT
 
 if typing.TYPE_CHECKING:
@@ -111,7 +111,7 @@ if typing.TYPE_CHECKING:
     class _LifecycleHostP(Protocol):
         logger: Logger
         hassette: _HassetteP
-        role: Any
+        role: ResourceRole
         class_name: str
         unique_name: str
         task_bucket: _TaskBucketP

--- a/tests/unit/core/test_service_watcher_coverage.py
+++ b/tests/unit/core/test_service_watcher_coverage.py
@@ -252,7 +252,7 @@ class TestCooldownAndRetry:
         spec = RestartSpec(restart_type=RestartType.TRANSIENT, cooldown_seconds=0.001, max_cooldown_cycles=0)
 
         # Should not raise despite no matching service.
-        await watcher.cooldown_and_retry("GoneService", "Service", "GoneService:Service", spec)
+        await watcher.cooldown_and_retry("GoneService", ResourceRole.SERVICE, "GoneService:Service", spec)
 
 
 class TestGetService:

--- a/tests/unit/core/test_service_watcher_coverage.py
+++ b/tests/unit/core/test_service_watcher_coverage.py
@@ -252,7 +252,8 @@ class TestCooldownAndRetry:
         spec = RestartSpec(restart_type=RestartType.TRANSIENT, cooldown_seconds=0.001, max_cooldown_cycles=0)
 
         # Should not raise despite no matching service.
-        await watcher.cooldown_and_retry("GoneService", ResourceRole.SERVICE, "GoneService:Service", spec)
+        key = watcher.service_key("GoneService", ResourceRole.SERVICE)
+        await watcher.cooldown_and_retry("GoneService", ResourceRole.SERVICE, key, spec)
 
 
 class TestGetService:


### PR DESCRIPTION
## Summary

Retypes the two remaining loose `role` annotations left behind by #1768's `service_watcher.py` sweep:

- `_LifecycleHostP.role` in `src/hassette/resources/mixins.py` was typed `Any` instead of `ResourceRole`. Because it's a typing-only Protocol that `Resource`/`LifecycleMixin` structurally satisfy, `Any` let `resource.role` silently lose its real type on the way into `create_service_status_event(role=resource.role, ...)` (`src/hassette/resources/lifecycle.py:137`), which expects a genuine `ResourceRole` — pyright never flagged the mismatch because `Any` suppresses checking entirely, unlike the `object`-typed instances #1768 fixed with visible suppression comments.
- `test_service_watcher_coverage.py` passed the bare string `"Service"` as the `role` argument to `cooldown_and_retry`, which didn't even match `ResourceRole.SERVICE`'s actual lowercased value (`"service"`). This slipped past CI because `pyrightconfig.json` excludes `**/tests` from analysis.

## Changes

- `src/hassette/resources/mixins.py`: `_LifecycleHostP.role: Any` → `role: ResourceRole`
- `tests/unit/core/test_service_watcher_coverage.py`: `"Service"` → `ResourceRole.SERVICE`

## Testing

- `uv run nox -s dev` — 7661 passed, 1 skipped, 2 xfailed
- `prek -a` — all hooks pass
- `prek pyright -a --stage pre-push` — pyright passes across `src/`
- `grep -rn "role: Any\|role: object" src/` — no matches (satisfies the issue's third acceptance criterion)

Closes #1792
