### PR TITLE
test: shrink stale dup-ignore rationale in tests/unit/core

### DIFF
--- a/tests/unit/core/CLAUDE.md
+++ b/tests/unit/core/CLAUDE.md
@@ -42,4 +42,4 @@ surface stable; only the definitions moved.
   whichever fixtures it needs (`telemetry_repo`, `telemetry_db`, `telemetry_session_id`, `tmp_path`,
   etc.) even when an adjacent test declares the identical set — `tools/check_duplicate_code.py`
   would otherwise flag that repetition. The marker's inline reason stays a one-line pointer back to
-  this note rather than repeating the full explanation at all 19+ sites.
+  this note rather than repeating the full explanation at all 19 sites.

--- a/tests/unit/core/CLAUDE.md
+++ b/tests/unit/core/CLAUDE.md
@@ -36,3 +36,10 @@ surface stable; only the definitions moved.
 ## Key conventions
 
 - Service factories (`make_bus_service`, `make_scheduler_service`, `make_watcher`) bypass `__init__` via `__new__` — set every attribute the real `__init__` would set.
+- `# dup-ignore-start: pytest test function signature` markers precede most test functions in this
+  directory's `test_telemetry_repository_*.py` and `test_manifest_repository.py` files. Python has
+  no way to share a function signature between separate test functions, so every test re-declares
+  whichever fixtures it needs (`telemetry_repo`, `telemetry_db`, `telemetry_session_id`, `tmp_path`,
+  etc.) even when an adjacent test declares the identical set — `tools/check_duplicate_code.py`
+  would otherwise flag that repetition. The marker's inline reason stays a one-line pointer back to
+  this note rather than repeating the full explanation at all 19+ sites.

--- a/tests/unit/core/test_manifest_repository.py
+++ b/tests/unit/core/test_manifest_repository.py
@@ -81,11 +81,8 @@ async def test_manifest_insert_params_schema_parity(
     assert set(params) == expected_keys
 
 
-# dup-ignore-start: pytest test function signature — each test independently declares the
-# telemetry_repo/telemetry_db/tmp_path fixtures it needs; Python has no way to share a function
-# signature between separate test functions, and bundling these three fixtures into one object
-# would require a new tests/unit/core/conftest.py fixture, out of scope for this cluster (see
-# design/specs/099-dedupe-tests-unit-core/design.md — no new conftest.py helpers per task).
+# dup-ignore-start: pytest test function signature — Python has no way to share a function
+# signature between separate test functions (see tests/unit/core/CLAUDE.md).
 async def test_upsert_app_manifest_creates_new_row(
     telemetry_repo: TelemetryRepository,
     telemetry_db: aiosqlite.Connection,
@@ -111,11 +108,8 @@ async def test_upsert_app_manifest_creates_new_row(
     assert row["filename"] == manifest.filename
 
 
-# dup-ignore-start: pytest test function signature — each test independently declares the
-# telemetry_repo/telemetry_db/tmp_path fixtures it needs; Python has no way to share a function
-# signature between separate test functions, and bundling these three fixtures into one object
-# would require a new tests/unit/core/conftest.py fixture, out of scope for this cluster (see
-# design/specs/099-dedupe-tests-unit-core/design.md — no new conftest.py helpers per task).
+# dup-ignore-start: pytest test function signature — Python has no way to share a function
+# signature between separate test functions (see tests/unit/core/CLAUDE.md).
 async def test_upsert_app_manifest_updates_existing_row_preserves_id(
     telemetry_repo: TelemetryRepository,
     telemetry_db: aiosqlite.Connection,
@@ -143,11 +137,8 @@ async def test_upsert_app_manifest_updates_existing_row_preserves_id(
     assert row["count"] == 1, "Upsert should produce a single row, not two inserts"
 
 
-# dup-ignore-start: pytest test function signature — each test independently declares the
-# telemetry_repo/telemetry_db/tmp_path fixtures it needs; Python has no way to share a function
-# signature between separate test functions, and bundling these three fixtures into one object
-# would require a new tests/unit/core/conftest.py fixture, out of scope for this cluster (see
-# design/specs/099-dedupe-tests-unit-core/design.md — no new conftest.py helpers per task).
+# dup-ignore-start: pytest test function signature — Python has no way to share a function
+# signature between separate test functions (see tests/unit/core/CLAUDE.md).
 async def test_upsert_app_manifest_refreshes_updated_at_on_conflict(
     telemetry_repo: TelemetryRepository,
     telemetry_db: aiosqlite.Connection,
@@ -182,11 +173,8 @@ async def test_upsert_app_manifest_refreshes_updated_at_on_conflict(
     )
 
 
-# dup-ignore-start: pytest test function signature — each test independently declares the
-# telemetry_repo/telemetry_db/tmp_path fixtures it needs; Python has no way to share a function
-# signature between separate test functions, and bundling these three fixtures into one object
-# would require a new tests/unit/core/conftest.py fixture, out of scope for this cluster (see
-# design/specs/099-dedupe-tests-unit-core/design.md — no new conftest.py helpers per task).
+# dup-ignore-start: pytest test function signature — Python has no way to share a function
+# signature between separate test functions (see tests/unit/core/CLAUDE.md).
 async def test_get_all_app_manifests_returns_all_rows(
     telemetry_repo: TelemetryRepository,
     telemetry_db: aiosqlite.Connection,
@@ -206,11 +194,8 @@ async def test_get_all_app_manifests_returns_all_rows(
     assert app_keys == {manifest_a.app_key, manifest_b.app_key}
 
 
-# dup-ignore-start: pytest test function signature — each test independently declares the
-# telemetry_repo/telemetry_db/tmp_path fixtures it needs; Python has no way to share a function
-# signature between separate test functions, and bundling these three fixtures into one object
-# would require a new tests/unit/core/conftest.py fixture, out of scope for this cluster (see
-# design/specs/099-dedupe-tests-unit-core/design.md — no new conftest.py helpers per task).
+# dup-ignore-start: pytest test function signature — Python has no way to share a function
+# signature between separate test functions (see tests/unit/core/CLAUDE.md).
 async def test_get_app_manifest_returns_single_row_or_none(
     telemetry_repo: TelemetryRepository,
     telemetry_db: aiosqlite.Connection,

--- a/tests/unit/core/test_telemetry_repository_errors.py
+++ b/tests/unit/core/test_telemetry_repository_errors.py
@@ -47,11 +47,8 @@ async def test_reconcile_rollback_on_exception(
         await telemetry_repo.reconcile_registrations("test_app", [], [])
 
 
-# dup-ignore-start: pytest test function signature — each test independently declares the
-# telemetry_repo/telemetry_db/telemetry_session_id fixtures it needs; Python has no way to share a
-# function signature between separate test functions, and bundling these three fixtures into one
-# object would require a new tests/unit/core/conftest.py fixture, out of scope for this cluster
-# (see design/specs/099-dedupe-tests-unit-core/design.md — no new conftest.py helpers per task).
+# dup-ignore-start: pytest test function signature — Python has no way to share a function
+# signature between separate test functions (see tests/unit/core/CLAUDE.md).
 async def test_persist_execution_batch_with_fk_fallback_success_path(
     telemetry_repo: TelemetryRepository,
     telemetry_db: aiosqlite.Connection,
@@ -94,11 +91,8 @@ async def test_persist_execution_batch_with_fk_fallback_success_path(
     assert row[1] == "job"
 
 
-# dup-ignore-start: pytest test function signature — each test independently declares the
-# telemetry_repo/telemetry_db/telemetry_session_id fixtures it needs; Python has no way to share a
-# function signature between separate test functions, and bundling these three fixtures into one
-# object would require a new tests/unit/core/conftest.py fixture, out of scope for this cluster
-# (see design/specs/099-dedupe-tests-unit-core/design.md — no new conftest.py helpers per task).
+# dup-ignore-start: pytest test function signature — Python has no way to share a function
+# signature between separate test functions (see tests/unit/core/CLAUDE.md).
 async def test_persist_execution_batch_with_fk_fallback_drops_on_listener_fk_violation(
     telemetry_repo: TelemetryRepository,
     telemetry_db: aiosqlite.Connection,
@@ -130,11 +124,8 @@ async def test_persist_execution_batch_with_fk_fallback_drops_on_listener_fk_vio
     assert row[0] == 0, "Row should be dropped — null FK violates CHECK constraint"
 
 
-# dup-ignore-start: pytest test function signature — each test independently declares the
-# telemetry_repo/telemetry_db/telemetry_session_id fixtures it needs; Python has no way to share a
-# function signature between separate test functions, and bundling these three fixtures into one
-# object would require a new tests/unit/core/conftest.py fixture, out of scope for this cluster
-# (see design/specs/099-dedupe-tests-unit-core/design.md — no new conftest.py helpers per task).
+# dup-ignore-start: pytest test function signature — Python has no way to share a function
+# signature between separate test functions (see tests/unit/core/CLAUDE.md).
 async def test_persist_execution_batch_with_fk_fallback_drops_on_job_fk_violation(
     telemetry_repo: TelemetryRepository,
     telemetry_db: aiosqlite.Connection,
@@ -166,11 +157,8 @@ async def test_persist_execution_batch_with_fk_fallback_drops_on_job_fk_violatio
     assert row[0] == 0, "Row should be dropped — null FK violates CHECK constraint"
 
 
-# dup-ignore-start: pytest test function signature — each test independently declares the
-# telemetry_repo/telemetry_db/telemetry_session_id fixtures it needs; Python has no way to share a
-# function signature between separate test functions, and bundling these three fixtures into one
-# object would require a new tests/unit/core/conftest.py fixture, out of scope for this cluster
-# (see design/specs/099-dedupe-tests-unit-core/design.md — no new conftest.py helpers per task).
+# dup-ignore-start: pytest test function signature — Python has no way to share a function
+# signature between separate test functions (see tests/unit/core/CLAUDE.md).
 async def test_persist_execution_batch_with_fk_fallback_drops_row_on_second_failure(
     telemetry_repo: TelemetryRepository,
     telemetry_db: aiosqlite.Connection,
@@ -207,11 +195,8 @@ async def test_persist_execution_batch_with_fk_fallback_drops_row_on_second_fail
     assert dropped == 1, "Row that fails even with null FK should be counted as dropped"
 
 
-# dup-ignore-start: pytest test function signature — each test independently declares the
-# telemetry_repo/telemetry_db/telemetry_session_id fixtures it needs; Python has no way to share a
-# function signature between separate test functions, and bundling these three fixtures into one
-# object would require a new tests/unit/core/conftest.py fixture, out of scope for this cluster
-# (see design/specs/099-dedupe-tests-unit-core/design.md — no new conftest.py helpers per task).
+# dup-ignore-start: pytest test function signature — Python has no way to share a function
+# signature between separate test functions (see tests/unit/core/CLAUDE.md).
 async def test_persist_execution_batch_with_fk_fallback_drops_job_row_on_second_failure(
     telemetry_repo: TelemetryRepository,
     telemetry_db: aiosqlite.Connection,
@@ -256,11 +241,8 @@ async def test_persist_execution_batch_with_fk_fallback_empty_list(
     assert dropped == 0
 
 
-# dup-ignore-start: pytest test function signature — each test independently declares the
-# telemetry_repo/telemetry_db/telemetry_session_id fixtures it needs; Python has no way to share a
-# function signature between separate test functions, and bundling these three fixtures into one
-# object would require a new tests/unit/core/conftest.py fixture, out of scope for this cluster
-# (see design/specs/099-dedupe-tests-unit-core/design.md — no new conftest.py helpers per task).
+# dup-ignore-start: pytest test function signature — Python has no way to share a function
+# signature between separate test functions (see tests/unit/core/CLAUDE.md).
 async def test_persist_execution_batch_with_fk_fallback_rollback_on_exception(
     telemetry_repo: TelemetryRepository,
     telemetry_db: aiosqlite.Connection,
@@ -292,11 +274,8 @@ async def test_persist_execution_batch_with_fk_fallback_rollback_on_exception(
         await telemetry_repo.persist_execution_batch_with_fk_fallback([record])
 
 
-# dup-ignore-start: pytest test function signature — each test independently declares the
-# telemetry_repo/telemetry_db/telemetry_session_id fixtures it needs; Python has no way to share a
-# function signature between separate test functions, and bundling these three fixtures into one
-# object would require a new tests/unit/core/conftest.py fixture, out of scope for this cluster
-# (see design/specs/099-dedupe-tests-unit-core/design.md — no new conftest.py helpers per task).
+# dup-ignore-start: pytest test function signature — Python has no way to share a function
+# signature between separate test functions (see tests/unit/core/CLAUDE.md).
 async def test_persist_execution_batch_rollback_on_exception(
     telemetry_repo: TelemetryRepository,
     telemetry_db: aiosqlite.Connection,

--- a/tests/unit/core/test_telemetry_repository_reconcile.py
+++ b/tests/unit/core/test_telemetry_repository_reconcile.py
@@ -36,11 +36,8 @@ async def test_reconcile_deletes_stale_without_history(
     await assert_job_count(telemetry_db, job_id, 0, "Stale job without history should be deleted")
 
 
-# dup-ignore-start: pytest test function signature — each test independently declares the
-# telemetry_repo/telemetry_db/telemetry_session_id fixtures it needs; Python has no way to share a
-# function signature between separate test functions, and bundling these three fixtures into one
-# object would require a new tests/unit/core/conftest.py fixture, out of scope for this cluster
-# (see design/specs/099-dedupe-tests-unit-core/design.md — no new conftest.py helpers per task).
+# dup-ignore-start: pytest test function signature — Python has no way to share a function
+# signature between separate test functions (see tests/unit/core/CLAUDE.md).
 async def test_reconcile_retires_stale_with_history(
     telemetry_repo: TelemetryRepository,
     telemetry_db: aiosqlite.Connection,
@@ -96,11 +93,8 @@ async def test_reconcile_deletes_once_true_previous_session(
     await assert_listener_count(telemetry_db, once_id, 0, "once=True listener from previous session should be deleted")
 
 
-# dup-ignore-start: pytest test function signature — each test independently declares the
-# telemetry_repo/telemetry_db/telemetry_session_id fixtures it needs; Python has no way to share a
-# function signature between separate test functions, and bundling these three fixtures into one
-# object would require a new tests/unit/core/conftest.py fixture, out of scope for this cluster
-# (see design/specs/099-dedupe-tests-unit-core/design.md — no new conftest.py helpers per task).
+# dup-ignore-start: pytest test function signature — Python has no way to share a function
+# signature between separate test functions (see tests/unit/core/CLAUDE.md).
 async def test_reconcile_preserves_once_true_with_current_executions(
     telemetry_repo: TelemetryRepository,
     telemetry_db: aiosqlite.Connection,
@@ -128,11 +122,8 @@ async def test_reconcile_empty_ids_no_crash(
     await telemetry_repo.reconcile_registrations(DEFAULT_TEST_APP_KEY, [], [])
 
 
-# dup-ignore-start: pytest test function signature — each test independently declares the
-# telemetry_repo/telemetry_db/telemetry_session_id fixtures it needs; Python has no way to share a
-# function signature between separate test functions, and bundling these three fixtures into one
-# object would require a new tests/unit/core/conftest.py fixture, out of scope for this cluster
-# (see design/specs/099-dedupe-tests-unit-core/design.md — no new conftest.py helpers per task).
+# dup-ignore-start: pytest test function signature — Python has no way to share a function
+# signature between separate test functions (see tests/unit/core/CLAUDE.md).
 async def test_reconcile_resets_retired_at_on_reupsert(
     telemetry_repo: TelemetryRepository,
     telemetry_db: aiosqlite.Connection,
@@ -174,11 +165,8 @@ async def test_reconcile_deletes_stale_job_not_in_live_set(
     )
 
 
-# dup-ignore-start: pytest test function signature — each test independently declares the
-# telemetry_repo/telemetry_db/telemetry_session_id fixtures it needs; Python has no way to share a
-# function signature between separate test functions, and bundling these three fixtures into one
-# object would require a new tests/unit/core/conftest.py fixture, out of scope for this cluster
-# (see design/specs/099-dedupe-tests-unit-core/design.md — no new conftest.py helpers per task).
+# dup-ignore-start: pytest test function signature — Python has no way to share a function
+# signature between separate test functions (see tests/unit/core/CLAUDE.md).
 async def test_reconcile_retires_stale_job_with_history_non_empty_live_set(
     telemetry_repo: TelemetryRepository,
     telemetry_db: aiosqlite.Connection,

--- a/tests/unit/core/test_telemetry_repository_schema.py
+++ b/tests/unit/core/test_telemetry_repository_schema.py
@@ -1,8 +1,8 @@
 """Unit tests for TelemetryRepository execution batch persistence, schema shape, and query builders.
 
-Kept as a single file rather than split by concern: no name shorter than the docstring covers all
-three areas, and splitting would trade one imperfect file name for two or three others sharing the
-same fixtures and setup. A reader who searches for `persist_execution_batch`, `_build_delete_query`,
+Kept as a single file rather than split by concern: no shorter filename covers all three areas, and
+splitting would trade one imperfect file name for two or three others sharing the same fixtures and
+setup. A reader who searches for `persist_execution_batch`, `_build_delete_query`,
 or `_build_retire_query` and doesn't find them by name should check this file next.
 """
 

--- a/tests/unit/core/test_telemetry_repository_schema.py
+++ b/tests/unit/core/test_telemetry_repository_schema.py
@@ -1,4 +1,10 @@
-"""Unit tests for TelemetryRepository execution batch persistence, schema shape, and query builders."""
+"""Unit tests for TelemetryRepository execution batch persistence, schema shape, and query builders.
+
+Kept as a single file rather than split by concern: no name shorter than the docstring covers all
+three areas, and splitting would trade one imperfect file name for two or three others sharing the
+same fixtures and setup. A reader who searches for `persist_execution_batch`, `_build_delete_query`,
+or `_build_retire_query` and doesn't find them by name should check this file next.
+"""
 
 import time
 
@@ -19,11 +25,8 @@ from tests.support.factories import (
 )
 
 
-# dup-ignore-start: pytest test function signature — each test independently declares the
-# telemetry_repo/telemetry_db/telemetry_session_id fixtures it needs; Python has no way to share a
-# function signature between separate test functions, and bundling these three fixtures into one
-# object would require a new tests/unit/core/conftest.py fixture, out of scope for this cluster
-# (see design/specs/099-dedupe-tests-unit-core/design.md — no new conftest.py helpers per task).
+# dup-ignore-start: pytest test function signature — Python has no way to share a function
+# signature between separate test functions (see tests/unit/core/CLAUDE.md).
 async def test_persist_execution_batch_inserts_handler_records(
     telemetry_repo: TelemetryRepository,
     telemetry_db: aiosqlite.Connection,
@@ -63,11 +66,8 @@ async def test_persist_execution_batch_inserts_handler_records(
     assert rows[1]["kind"] == "handler"
 
 
-# dup-ignore-start: pytest test function signature — each test independently declares the
-# telemetry_repo/telemetry_db/telemetry_session_id fixtures it needs; Python has no way to share a
-# function signature between separate test functions, and bundling these three fixtures into one
-# object would require a new tests/unit/core/conftest.py fixture, out of scope for this cluster
-# (see design/specs/099-dedupe-tests-unit-core/design.md — no new conftest.py helpers per task).
+# dup-ignore-start: pytest test function signature — Python has no way to share a function
+# signature between separate test functions (see tests/unit/core/CLAUDE.md).
 async def test_persist_execution_batch_inserts_job_records(
     telemetry_repo: TelemetryRepository,
     telemetry_db: aiosqlite.Connection,
@@ -119,11 +119,8 @@ async def test_persist_execution_batch_handles_empty_list(
     assert row["count"] == 0
 
 
-# dup-ignore-start: pytest test function signature — each test independently declares the
-# telemetry_repo/telemetry_db/telemetry_session_id fixtures it needs; Python has no way to share a
-# function signature between separate test functions, and bundling these three fixtures into one
-# object would require a new tests/unit/core/conftest.py fixture, out of scope for this cluster
-# (see design/specs/099-dedupe-tests-unit-core/design.md — no new conftest.py helpers per task).
+# dup-ignore-start: pytest test function signature — Python has no way to share a function
+# signature between separate test functions (see tests/unit/core/CLAUDE.md).
 async def test_persist_execution_batch_unified(
     telemetry_repo: TelemetryRepository,
     telemetry_db: aiosqlite.Connection,


### PR DESCRIPTION
## Summary

Shrinks the repeated `# dup-ignore-start: pytest test function signature` comment block that precedes most test functions in `tests/unit/core/test_telemetry_repository_*.py` and `tests/unit/core/test_manifest_repository.py`. The old 5-line version cited an archived design doc (`design/specs/099-dedupe-tests-unit-core/design.md`) and a "no new conftest.py helpers" constraint that no longer holds now that `conftest.py` re-exports helpers added by #1786.

All 19 occurrences are shrunk to the one durable clause — pytest has no way to share a function signature between separate test functions — with a pointer to the fuller explanation, which now lives once in `tests/unit/core/CLAUDE.md` instead of being repeated at every call site.

Also records, in `test_telemetry_repository_schema.py`'s module docstring, the decision to keep that file's current name rather than split it further, per the issue's "also worth deciding" note — no test function name is a clear subset of `persist_execution_batch` + schema-shape + query-builder coverage, so a reader who searches by name is told to check this file next.

## Changes

- `tests/unit/core/CLAUDE.md`: added the durable rationale for the `dup-ignore-start: pytest test function signature` marker (fixture repetition, `tools/check_duplicate_code.py` exemption).
- `tests/unit/core/test_manifest_repository.py`, `test_telemetry_repository_errors.py`, `test_telemetry_repository_reconcile.py`, `test_telemetry_repository_schema.py`: shrunk all 19 marker comments to a one-line rationale + pointer.
- `test_telemetry_repository_schema.py`: expanded the module docstring to record the naming decision.

No production code or test behavior changed — comment/docstring text only.

## Testing

- `uv run nox -s dev` — 7661 passed, 1 skipped, 2 xfailed
- `prek -a` — all hooks passed
- `prek pyright -a --stage pre-push` — passed

Closes #1793
