### PR TITLE
refactor: centralize duplicated handler/job execution kind union

### DIFF
--- a/frontend/src/components/app-detail/detail-header.tsx
+++ b/frontend/src/components/app-detail/detail-header.tsx
@@ -3,6 +3,7 @@ import type { ReactNode } from "react";
 import { Badge, type BadgeVariant } from "@/components/ui/badge";
 
 import type { StatusKind } from "../../utils/status";
+import type { ExecutionKind } from "../shared/execution-table";
 import { StatusShape } from "../shared/status-shape";
 
 // Maps a StatusKind onto the flattened "kind-*" Badge variants (formerly Chip's
@@ -19,7 +20,7 @@ interface DetailHeaderProps {
   name: string;
   kindLabel: string;
   statusKind: StatusKind;
-  kind: "handler" | "job";
+  kind: ExecutionKind;
   subtitle?: string | null;
   headerActions?: ReactNode;
 }

--- a/frontend/src/components/app-detail/execution-section.tsx
+++ b/frontend/src/components/app-detail/execution-section.tsx
@@ -1,11 +1,11 @@
 import type { HandlerKind } from "../../utils/app-routes";
-import { type ExecutionRecord, ExecutionTable } from "../shared/execution-table";
+import { type ExecutionKind, type ExecutionRecord, ExecutionTable } from "../shared/execution-table";
 import { Spinner } from "../shared/spinner";
 
 interface ExecutionSectionProps {
   heading: string;
   records: ExecutionRecord[] | undefined;
-  kind: "handler" | "job";
+  kind: ExecutionKind;
   tableId: string;
   loading: boolean;
   appKey?: string;

--- a/frontend/src/components/app-detail/registration-footer.tsx
+++ b/frontend/src/components/app-detail/registration-footer.tsx
@@ -3,12 +3,13 @@ import { useState } from "react";
 import { Button } from "@/components/ui/button";
 
 import { parseSourceLocation } from "../../utils/format";
+import { type ExecutionKind } from "../shared/execution-table";
 import { IconArrowRight, IconChevron } from "../shared/icons";
 import { RegistrationSource } from "../shared/registration-source";
 import { SourceLocation } from "../shared/source-location";
 
 interface RegistrationFooterProps {
-  kind: "handler" | "job";
+  kind: ExecutionKind;
   testId: string;
   sourceLocation?: string | null;
   registrationSource?: string | null;

--- a/frontend/src/components/shared/execution-table.tsx
+++ b/frontend/src/components/shared/execution-table.tsx
@@ -147,7 +147,7 @@ const columns: ColumnDef<ExecutionRecord, unknown>[] = [
   },
 ];
 
-type ExecutionKind = "handler" | "job";
+export type ExecutionKind = "handler" | "job";
 
 interface ExecutionTableProps {
   records: ExecutionRecord[];

--- a/frontend/src/hooks/use-scoped-execution.ts
+++ b/frontend/src/hooks/use-scoped-execution.ts
@@ -1,4 +1,5 @@
 import type { WsExecutionCompletedPayload } from "../api/ws-types";
+import type { ExecutionKind } from "../components/shared/execution-table";
 import { useAppStore } from "../state/store";
 
 /**
@@ -30,7 +31,7 @@ export function isExecutionDefined(execution: WsExecutionCompletedPayload | unde
 }
 
 /** This app's first completion in the latest batch, optionally narrowed to one completion kind. */
-export function useAppExecution(appKey: string, kind?: "handler" | "job"): WsExecutionCompletedPayload | undefined {
+export function useAppExecution(appKey: string, kind?: ExecutionKind): WsExecutionCompletedPayload | undefined {
   return useScopedExecution((e) => e.app_key === appKey && (kind === undefined || e.kind === kind));
 }
 


### PR DESCRIPTION
## Summary

The `"handler" | "job"` literal union was independently restated in five hand-written
frontend files instead of being imported from one canonical source, so a third `kind`
value would need to be found and updated at every call site by hand.

This exports `ExecutionKind` from `execution-table.tsx` (which already owns the related
`ExecutionRecord` type) and reuses it in:

- `execution-section.tsx`
- `registration-footer.tsx`
- `detail-header.tsx`
- `use-scoped-execution.ts`

No behavior change — this is a type-only consolidation.

## Testing

- `uv run nox -s dev` — full backend suite passes (one unrelated flake,
  `test_watcher_survives_transition_to_waiting`, failed under xdist parallelism but
  passed cleanly in isolation — a known timing race in scheduler tests, not touched by
  this change)
- `prek -a` — all hooks pass, including `tsc` and `eslint` on the frontend
- `prek pyright -a --stage pre-push` — passes

Closes #1685
