### PR TITLE
test: extract magic cooldown constants in service watcher coverage tests

### DIFF
--- a/tests/unit/core/CLAUDE.md
+++ b/tests/unit/core/CLAUDE.md
@@ -23,6 +23,8 @@ surface stable; only the definitions moved.
 - `make_execute_job_cmd(**kw)` — `MagicMock` spec'd to `ExecuteJob` for executor tests
 - `make_bus_service(**kw)`, `make_scheduler_service(**kw)` — service instances bypassing `Resource.__init__`
 - `make_watcher(hassette)`, `make_watcher_hassette(**kw)` — `ServiceWatcher` test setup
+- `FAST_COOLDOWN_SECONDS` — cooldown value for `RestartSpec` in tests where `cooldown_and_retry`'s sleep is expected to actually complete; shared by `test_service_watcher_coverage.py` and `test_service_watcher_exhausted.py`
+- `COOLDOWN_NEVER_REACHED_SECONDS` — cooldown value for `RestartSpec` in tests where restart admission is blocked before the sleep is ever reached — the number itself is irrelevant to timing, just large enough that a guard regression letting execution fall through would hang the test instead of passing by accident; shared by the same two files
 - `make_blocking_io_hassette(**kw)` — minimal mock Hassette for watchdog and monkeypatch guard tests
 - `make_marker_executor(**kw)` — mock executor with `ExecutionMarker` on `current_execution`
 - `assert_listener_count(db, listener_id, expected, message)` — assert the number of `listeners` rows with that id

--- a/tests/unit/core/_fixtures_service_watcher.py
+++ b/tests/unit/core/_fixtures_service_watcher.py
@@ -12,6 +12,14 @@ from hassette.types.enums import ResourceStatus, RestartType
 from tests.support.helpers import block_until_cancelled
 from tests.support.mock_hassette import make_mock_hassette
 
+FAST_COOLDOWN_SECONDS = 0.001
+"""Cooldown value for tests where cooldown_and_retry's sleep is expected to actually complete."""
+
+COOLDOWN_NEVER_REACHED_SECONDS = 999
+"""Cooldown value for tests where restart admission is blocked before the sleep is ever reached --
+the number itself is irrelevant to timing, just large enough that a guard regression letting
+execution fall through to the sleep would hang the test instead of passing by accident."""
+
 
 class DummyService(Service):
     """Minimal concrete Service for watcher-level tests."""

--- a/tests/unit/core/conftest.py
+++ b/tests/unit/core/conftest.py
@@ -27,7 +27,14 @@ from ._fixtures_command_executor import (
     make_invocation,
     make_mock_cmd_listener,
 )
-from ._fixtures_service_watcher import DummyService, TempService, make_watcher, make_watcher_hassette
+from ._fixtures_service_watcher import (
+    COOLDOWN_NEVER_REACHED_SECONDS,
+    FAST_COOLDOWN_SECONDS,
+    DummyService,
+    TempService,
+    make_watcher,
+    make_watcher_hassette,
+)
 from ._fixtures_telemetry import (
     ONCE_LISTENER_NAME,
     TELEMETRY_TEST_DDL,
@@ -43,6 +50,8 @@ from ._fixtures_telemetry import (
 )
 
 __all__ = [
+    "COOLDOWN_NEVER_REACHED_SECONDS",
+    "FAST_COOLDOWN_SECONDS",
     "ONCE_LISTENER_NAME",
     "TELEMETRY_TEST_DDL",
     "DummyService",

--- a/tests/unit/core/test_service_watcher_coverage.py
+++ b/tests/unit/core/test_service_watcher_coverage.py
@@ -28,15 +28,13 @@ from tests.support.helpers import (
 )
 from tests.support.mock_hassette import make_mock_hassette
 
-from .conftest import DummyService, make_watcher, make_watcher_hassette
-
-FAST_COOLDOWN_SECONDS = 0.001
-"""Cooldown value for tests where cooldown_and_retry's sleep is expected to actually complete."""
-
-COOLDOWN_NEVER_REACHED_SECONDS = 999
-"""Cooldown value for tests where restart admission is blocked before the sleep is ever reached --
-the number itself is irrelevant to timing, just large enough that a guard regression letting
-execution fall through to the sleep would hang the test instead of passing by accident."""
+from .conftest import (
+    COOLDOWN_NEVER_REACHED_SECONDS,
+    FAST_COOLDOWN_SECONDS,
+    DummyService,
+    make_watcher,
+    make_watcher_hassette,
+)
 
 
 class TestConfigLogLevel:

--- a/tests/unit/core/test_service_watcher_coverage.py
+++ b/tests/unit/core/test_service_watcher_coverage.py
@@ -30,6 +30,14 @@ from tests.support.mock_hassette import make_mock_hassette
 
 from .conftest import DummyService, make_watcher, make_watcher_hassette
 
+FAST_COOLDOWN_SECONDS = 0.001
+"""Cooldown value for tests where cooldown_and_retry's sleep is expected to actually complete."""
+
+COOLDOWN_NEVER_REACHED_SECONDS = 999
+"""Cooldown value for tests where restart admission is blocked before the sleep is ever reached --
+the number itself is irrelevant to timing, just large enough that a guard regression letting
+execution fall through to the sleep would hang the test instead of passing by accident."""
+
 
 class TestConfigLogLevel:
     def test_reads_service_watcher_logging_level(self) -> None:
@@ -212,7 +220,9 @@ class TestCooldownAndRetry:
         dummy = DummyService(hassette)
         hassette.children = [dummy]
 
-        spec = RestartSpec(restart_type=RestartType.TRANSIENT, cooldown_seconds=5.0, max_cooldown_cycles=0)
+        spec = RestartSpec(
+            restart_type=RestartType.TRANSIENT, cooldown_seconds=COOLDOWN_NEVER_REACHED_SECONDS, max_cooldown_cycles=0
+        )
         key = watcher.service_key(dummy.class_name, dummy.role)
 
         hassette.shutdown_event.set()
@@ -232,7 +242,9 @@ class TestCooldownAndRetry:
         dummy = DummyService(hassette)
         hassette.children = [dummy]
 
-        spec = RestartSpec(restart_type=RestartType.TRANSIENT, cooldown_seconds=0.001, max_cooldown_cycles=0)
+        spec = RestartSpec(
+            restart_type=RestartType.TRANSIENT, cooldown_seconds=FAST_COOLDOWN_SECONDS, max_cooldown_cycles=0
+        )
         key = watcher.service_key(dummy.class_name, dummy.role)
 
         with patch(
@@ -249,7 +261,9 @@ class TestCooldownAndRetry:
         watcher = make_watcher(hassette)
         hassette.children = []
 
-        spec = RestartSpec(restart_type=RestartType.TRANSIENT, cooldown_seconds=0.001, max_cooldown_cycles=0)
+        spec = RestartSpec(
+            restart_type=RestartType.TRANSIENT, cooldown_seconds=FAST_COOLDOWN_SECONDS, max_cooldown_cycles=0
+        )
 
         # Should not raise despite no matching service.
         key = watcher.service_key("GoneService", ResourceRole.SERVICE)
@@ -570,7 +584,8 @@ class TestExecuteRestartCatchesRefusal:
         dummy = DummyService(hassette)
         key = watcher.service_key(dummy.class_name, dummy.role)
         watcher._restarting.add(key)
-        budget = watcher.get_budget(key, RestartSpec(backoff_base_seconds=1.0))
+        spec = RestartSpec(backoff_base_seconds=1.0)
+        budget = watcher.get_budget(key, spec)
         budget.record_restart()
 
         async def block_after_backoff(_duration: float) -> bool:
@@ -581,9 +596,7 @@ class TestExecuteRestartCatchesRefusal:
             patch.object(watcher, "shutdown_safe_sleep", side_effect=block_after_backoff),
             patch("hassette.core.service_watcher.restart", new_callable=AsyncMock) as mock_restart,
         ):
-            await watcher.execute_restart(
-                dummy.class_name, dummy.role, key, RestartSpec(backoff_base_seconds=1.0), dummy, budget
-            )
+            await watcher.execute_restart(dummy.class_name, dummy.role, key, spec, dummy, budget)
 
         mock_restart.assert_not_called()
         assert key not in watcher._restarting
@@ -595,7 +608,9 @@ class TestCooldownAndRetryCatchesRefusal:
         watcher = make_watcher(hassette)
         dummy = DummyService(hassette)
         hassette.children = [dummy]
-        spec = RestartSpec(restart_type=RestartType.TRANSIENT, cooldown_seconds=0.001, max_cooldown_cycles=0)
+        spec = RestartSpec(
+            restart_type=RestartType.TRANSIENT, cooldown_seconds=FAST_COOLDOWN_SECONDS, max_cooldown_cycles=0
+        )
         key = watcher.service_key(dummy.class_name, dummy.role)
 
         error = make_unsafe_restart_refused_error(dummy.class_name)
@@ -612,7 +627,9 @@ class TestCooldownAndRetryCatchesRefusal:
         hassette.shutdown_event.set()
         watcher = make_watcher(hassette)
         dummy = DummyService(hassette)
-        spec = RestartSpec(restart_type=RestartType.TRANSIENT, cooldown_seconds=999, max_cooldown_cycles=0)
+        spec = RestartSpec(
+            restart_type=RestartType.TRANSIENT, cooldown_seconds=COOLDOWN_NEVER_REACHED_SECONDS, max_cooldown_cycles=0
+        )
         key = watcher.service_key(dummy.class_name, dummy.role)
 
         with patch("hassette.core.service_watcher.restart", new_callable=AsyncMock) as mock_restart:
@@ -629,7 +646,9 @@ class TestCooldownAndRetryCatchesRefusal:
         watcher = make_watcher(hassette)
         dummy = DummyService(hassette)
         hassette.children = [dummy]
-        spec = RestartSpec(restart_type=RestartType.TRANSIENT, cooldown_seconds=0.001, max_cooldown_cycles=0)
+        spec = RestartSpec(
+            restart_type=RestartType.TRANSIENT, cooldown_seconds=FAST_COOLDOWN_SECONDS, max_cooldown_cycles=0
+        )
         key = watcher.service_key(dummy.class_name, dummy.role)
         budget = watcher.get_budget(key, spec)
         budget.record_restart()

--- a/tests/unit/core/test_service_watcher_exhausted.py
+++ b/tests/unit/core/test_service_watcher_exhausted.py
@@ -15,7 +15,14 @@ from hassette.resources.service import Service
 from hassette.types import ResourceStatus
 from hassette.types.enums import ResourceRole, RestartType
 
-from .conftest import DummyService, TempService, make_watcher, make_watcher_hassette
+from .conftest import (
+    COOLDOWN_NEVER_REACHED_SECONDS,
+    FAST_COOLDOWN_SECONDS,
+    DummyService,
+    TempService,
+    make_watcher,
+    make_watcher_hassette,
+)
 
 
 def make_failed_payload(service: Service) -> ServiceStatusPayload:
@@ -41,7 +48,7 @@ async def test_exhausted_cooling_sets_status_on_instance():
     hassette.children = [service]
 
     watcher = make_watcher(hassette)
-    spec = RestartSpec(restart_type=RestartType.TRANSIENT, cooldown_seconds=9999)
+    spec = RestartSpec(restart_type=RestartType.TRANSIENT, cooldown_seconds=COOLDOWN_NEVER_REACHED_SECONDS)
     payload = make_failed_payload(service)
 
     spawned_coros: list = []
@@ -105,7 +112,7 @@ async def test_cooldown_exceeded_sets_exhausted_dead():
     watcher = make_watcher(hassette)
     spec = RestartSpec(
         restart_type=RestartType.TRANSIENT,
-        cooldown_seconds=0.001,
+        cooldown_seconds=FAST_COOLDOWN_SECONDS,
         max_cooldown_cycles=1,
     )
     key = f"{service.class_name}:{service.role}"
@@ -166,7 +173,9 @@ async def test_cooldown_and_retry_proceeds_when_not_admission_blocked():
     hassette.children = [service]
 
     watcher = make_watcher(hassette)
-    spec = RestartSpec(restart_type=RestartType.TRANSIENT, cooldown_seconds=0.001, max_cooldown_cycles=0)
+    spec = RestartSpec(
+        restart_type=RestartType.TRANSIENT, cooldown_seconds=FAST_COOLDOWN_SECONDS, max_cooldown_cycles=0
+    )
     key = f"{service.class_name}:{service.role}"
     budget = watcher.get_budget(key, spec)
     budget.record_restart()


### PR DESCRIPTION
## Summary

Cleans up magic-number cooldown literals in `tests/unit/core/test_service_watcher_coverage.py`'s `TestCooldownAndRetry` and `TestCooldownAndRetryCatchesRefusal` test classes:

- Replaces the repeated `cooldown_seconds=0.001` literal (4 sites) with a named `FAST_COOLDOWN_SECONDS` constant — used where `cooldown_and_retry`'s sleep is expected to actually complete.
- Names the `999`/`5.0` admission-blocked-at-entry sentinel values as `COOLDOWN_NEVER_REACHED_SECONDS` — the value itself is irrelevant to timing, just large enough that a guard regression letting execution fall through to the sleep would hang the test instead of silently passing.
- Deduplicates two identical `RestartSpec(backoff_base_seconds=1.0)` constructions in `test_skips_restart_when_admission_blocked_after_backoff` into one shared `spec` variable.

No behavior change — test-only, mechanical constant extraction (`topic:code-quality`).

## Testing

- `uv run nox -s dev` — 7678 passed, 1 skipped, 2 xfailed
- `prek -a` — all hooks pass (frontend `node_modules` installed fresh in this worktree first)
- `prek pyright -a --stage pre-push` — pass

Closes #1801
