### PR TITLE
refactor: finish ExecutionKind migration in test factories

### DIFF
--- a/frontend/src/components/app-detail/recent-activity-section.rerender.test.tsx
+++ b/frontend/src/components/app-detail/recent-activity-section.rerender.test.tsx
@@ -9,11 +9,12 @@ import { useAppStore } from "../../state/store";
 import { createExecutionCompletedPayload } from "../../test/factories";
 import { renderWithAppState } from "../../test/render-helpers";
 import { server } from "../../test/server";
+import type { ExecutionKind } from "../shared/execution-table";
 import { RecentActivitySection } from "./recent-activity-section";
 
 type ActivityFeedEntry = components["schemas"]["ActivityFeedEntry"];
 
-function makeExecution(appKey: string, kind: "handler" | "job"): WsExecutionCompletedPayload {
+function makeExecution(appKey: string, kind: ExecutionKind): WsExecutionCompletedPayload {
   return createExecutionCompletedPayload({ kind, app_key: appKey });
 }
 

--- a/frontend/src/components/app-detail/registration-footer.tsx
+++ b/frontend/src/components/app-detail/registration-footer.tsx
@@ -3,7 +3,7 @@ import { useState } from "react";
 import { Button } from "@/components/ui/button";
 
 import { parseSourceLocation } from "../../utils/format";
-import { type ExecutionKind } from "../shared/execution-table";
+import type { ExecutionKind } from "../shared/execution-table";
 import { IconArrowRight, IconChevron } from "../shared/icons";
 import { RegistrationSource } from "../shared/registration-source";
 import { SourceLocation } from "../shared/source-location";

--- a/frontend/src/components/shared/execution-table.tsx
+++ b/frontend/src/components/shared/execution-table.tsx
@@ -37,6 +37,8 @@ declare module "@tanstack/react-table" {
 
 type ExecutionStatus = components["schemas"]["ExecutionStatus"];
 
+export type ExecutionKind = "handler" | "job";
+
 const INITIAL_ROWS = 5;
 
 const HEAD_CLASS =
@@ -146,8 +148,6 @@ const columns: ColumnDef<ExecutionRecord, unknown>[] = [
     // flexRender for it (it needs the row's resolved href, not available at column-definition time).
   },
 ];
-
-export type ExecutionKind = "handler" | "job";
 
 interface ExecutionTableProps {
   records: ExecutionRecord[];

--- a/frontend/src/pages/app-detail.rerender.test.tsx
+++ b/frontend/src/pages/app-detail.rerender.test.tsx
@@ -2,6 +2,7 @@ import { act } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { WsExecutionCompletedPayload } from "../api/ws-types";
+import type { ExecutionKind } from "../components/shared/execution-table";
 import { appStatusKey, useAppStore } from "../state/store";
 import { createManifest } from "../test/factories";
 import { createWouterMock } from "../test/mock-wouter";
@@ -50,7 +51,7 @@ vi.mock("../components/shared/spinner", async () => (await import("./app-detail.
 
 vi.mock("../hooks/use-correct-url", () => ({ useCorrectUrl: () => vi.fn() }));
 
-function makeExecution(appKey: string, kind: "handler" | "job"): WsExecutionCompletedPayload {
+function makeExecution(appKey: string, kind: ExecutionKind): WsExecutionCompletedPayload {
   return { kind, app_key: appKey, instance_index: 0, status: "success", duration_ms: 5 };
 }
 

--- a/frontend/src/test/factories.ts
+++ b/frontend/src/test/factories.ts
@@ -11,6 +11,7 @@
 
 import type { components } from "../api/generated-types";
 import type { WsExecutionCompletedPayload } from "../api/ws-types";
+import type { ExecutionKind } from "../components/shared/execution-table";
 import type { ServiceStatusEntry } from "../state/store";
 import type { UnifiedRow } from "../utils/handler-rows";
 
@@ -283,7 +284,7 @@ export function createSystemStatus(overrides: Partial<SystemStatusResponse> = {}
   } satisfies SystemStatusResponse;
 }
 
-export function createExecution(kind: "handler" | "job", overrides: Partial<Execution> = {}): Execution {
+export function createExecution(kind: ExecutionKind, overrides: Partial<Execution> = {}): Execution {
   const kindFields =
     kind === "handler"
       ? { kind: "handler" as const, listener_id: 1, job_id: null, duration_ms: 50 }


### PR DESCRIPTION
Follow-up to #1914, which merged before this fix landed on that branch.

nitpicker caught 3 test-support call sites still spelling out the raw `"handler" | "job"` union that #1914 was meant to eliminate everywhere: `test/factories.ts`, `app-detail.rerender.test.tsx`, and `recent-activity-section.rerender.test.tsx`. Also aligns `registration-footer.tsx` on the `import type { X }` form used everywhere else the new type is consumed, and moves the `ExecutionKind` declaration up next to `ExecutionStatus`/`ExecutionRecord` instead of sitting between the table-column definitions and `ExecutionTableProps`.

Type-only change, no runtime behavior change. `tsc --noEmit` clean, affected tests pass (8/8).