### PR TITLE
fix: clean up CLI dead code and error-path inconsistencies

### DIFF
--- a/src/hassette/cli/client.py
+++ b/src/hassette/cli/client.py
@@ -49,6 +49,22 @@ def query_params(**values: Any) -> dict[str, Any]:
     return {key: value for key, value in values.items() if value is not None}
 
 
+def emit_usage_error(message: str, *, json_mode: bool = False) -> NoReturn:
+    """Print a usage error and exit non-zero.
+
+    Module-level so callers with no live :class:`HassetteCLIClient` — like ``run``, which starts
+    the server directly and never talks to it over HTTP — can format a usage error the same way
+    :meth:`HassetteCLIClient.error_usage` does. ``run`` has no ``--json`` flag today and always
+    calls this with the default ``json_mode=False``; once one is added, its command function can
+    pass through ``ctx.json_mode`` to get full parity with every other command's ``--json`` handling.
+    """
+    if json_mode:
+        _write_json_error(None, message)
+    else:
+        cli_output.stderr_console.print(f"[bold red]Usage error:[/bold red] {message}", highlight=False)
+    sys.exit(1)
+
+
 class HassetteCLIClient:
     """Synchronous HTTP client for querying the hassette REST API."""
 
@@ -317,7 +333,6 @@ class HassetteCLIClient:
     def _instance_not_found(self, app_key: str, instance: str, instances: list[AppInstanceResponse]) -> NoReturn:
         names = ", ".join(repr(inst.instance_name) for inst in instances) if instances else "(none)"
         self.error_usage(f"Instance {instance!r} not found for app {app_key!r}. Available instances: {names}")
-        raise AssertionError("unreachable")
 
     def _find_by_name(
         self, app_key: str, instances: list[AppInstanceResponse], name: str
@@ -360,8 +375,7 @@ class HassetteCLIClient:
         match = self._find_by_name(app_key, instances, instance)
         if match is not None:
             return match.index
-        self._instance_not_found(app_key, instance, instances)
-        raise AssertionError("unreachable")
+        return self._instance_not_found(app_key, instance, instances)
 
     def resolve_instance_with_name(self, app_key: str, instance: str) -> tuple[int, str | None]:
         """Resolve an instance selector to its index and, when known, its canonical ``instance_name``.
@@ -399,8 +413,7 @@ class HassetteCLIClient:
             match = self._find_by_name(app_key, instances, instance)
             if match is not None:
                 return match.index, match.instance_name
-            self._instance_not_found(app_key, instance, instances)
-            raise AssertionError("unreachable") from None
+            return self._instance_not_found(app_key, instance, instances)
         else:
             instances = self._try_fetch_instances(app_key)
             if instances is not None:
@@ -566,11 +579,7 @@ class HassetteCLIClient:
 
     def error_usage(self, message: str) -> NoReturn:
         """Print a usage error and exit non-zero."""
-        if self.json_mode:
-            _write_json_error(None, message)
-        else:
-            cli_output.stderr_console.print(f"[bold red]Usage error:[/bold red] {message}", highlight=False)
-        sys.exit(1)
+        emit_usage_error(message, json_mode=self.json_mode)
 
 
 def make_client(ctx: CLIContext) -> HassetteCLIClient:

--- a/src/hassette/cli/commands/run.py
+++ b/src/hassette/cli/commands/run.py
@@ -7,6 +7,7 @@ from typing import Annotated, Any
 
 from cyclopts import Parameter
 
+from hassette.cli.client import emit_usage_error
 from hassette.config.config import HassetteConfig
 from hassette.exceptions import AppPrecheckFailedError, FatalError
 from hassette.server import main as run_server
@@ -59,7 +60,7 @@ def cmd_run(
     if app:
         only = split_app_keys(app)
         if not only:
-            raise SystemExit("error: --app requires at least one non-empty app key")
+            emit_usage_error("--app requires at least one non-empty app key")
         init_kwargs["only_apps"] = only
 
     config = HassetteConfig(**init_kwargs)

--- a/src/hassette/cli/types.py
+++ b/src/hassette/cli/types.py
@@ -97,8 +97,6 @@ SourceTierArg = Annotated[
     Parameter(name=["--source-tier"], help="Filter by telemetry source tier: 'app', 'framework', or 'all'."),
 ]
 
-JsonArg = Annotated[bool, Parameter(name=["--json"], help="Output results as JSON.", negative=[])]
-
 AppKeyArg = Annotated[str | None, Parameter(name=["--app"], help="Filter by app key.")]
 
 InstanceArg = Annotated[

--- a/tests/unit/cli/test_commands_run.py
+++ b/tests/unit/cli/test_commands_run.py
@@ -9,6 +9,7 @@ import pytest
 from hassette.cli import app
 from hassette.cli.commands.run import cmd_run
 from hassette.exceptions import AppPrecheckFailedError, FatalError
+from tests.unit.cli.conftest import capture_stderr
 
 
 class TestBareHassetteShowsHelp:
@@ -91,6 +92,8 @@ class TestCmdRun:
         ],
     )
     def test_empty_app_values_rejected(self, mock_run_server: AsyncMock, app_values: list[str]) -> None:
-        with pytest.raises(SystemExit):
+        with capture_stderr() as buf, pytest.raises(SystemExit) as exc_info:
             cmd_run(app=app_values)
+        assert exc_info.value.code == 1
+        assert "--app requires at least one non-empty app key" in buf.getvalue()
         mock_run_server.assert_not_called()


### PR DESCRIPTION
## Summary

Mechanical cleanup of dead code and an error-path inconsistency in the CLI, surfaced by the
2026-09-02 run-4 clean-code audit (`design/audits/2026-09-02-cli-docker-triggers-helpers-audit.md`,
F13). No behavior changes for any existing command.

- **Removed `JsonArg`** (`cli/types.py`) — defined but never referenced anywhere in the CLI.
- **Unified the `run` command's usage-error path with the rest of the CLI.** `run` has no live
  `HassetteCLIClient` (it starts the server directly instead of talking to it over HTTP), so it
  previously raised a bare `SystemExit(...)` on an empty `--app` value instead of going through
  `HassetteCLIClient.error_usage()`'s formatted usage-error convention. Extracted
  `emit_usage_error()` as a module-level helper in `cli/client.py` so both `run` (with no client
  instance) and `error_usage()` (as a thin wrapper) share the same formatting and exit path. This
  was latent — `run` has no `--json` flag today — but matters the moment one is added.
- **Removed three unreachable `raise AssertionError("unreachable")` statements** in
  `cli/client.py` that followed calls to `NoReturn`-typed methods. The two call sites that needed
  an explicit terminator for ruff's RET503 check now `return` the `NoReturn` call directly instead.

## Testing

- `uv run nox -s dev` — 7678 passed, 1 skipped, 2 xfailed
- `prek -a` — all hooks pass (ruff, ruff format, flake8-async, eslint, stylelint, tsc, house-lint, etc.)
- `prek pyright -a --stage pre-push` — pass
- Updated `tests/unit/cli/test_commands_run.py::TestCmdRun::test_empty_app_values_rejected` to
  assert on the new formatted stderr message and exit code, instead of just the `SystemExit` type.

Closes #1858
