### PR TITLE
fix: clean up query-param parsing and error-label handling in overview-tab-helpers

### DIFF
--- a/frontend/src/components/app-detail/error-spotlight.tsx
+++ b/frontend/src/components/app-detail/error-spotlight.tsx
@@ -6,7 +6,7 @@ import { cn } from "@/lib/utils";
 import { STATUS_DOT_SIZE } from "../../utils/constants";
 import { StatusShape } from "../shared/status-shape";
 import { OVERVIEW_SECTION_CLASS } from "./overview-section";
-import { handlerHref, itemErrorMessage, itemErrorType } from "./overview-tab-helpers";
+import { handlerHref, itemErrorLabel, itemErrorMessage } from "./overview-tab-helpers";
 import type { UnifiedItem } from "./unified-handler-row";
 
 const SPOTLIGHT_LIMIT = 3;
@@ -18,7 +18,7 @@ interface SpotlightEntryProps {
 }
 
 function SpotlightEntry({ item, appKey, instanceQs }: SpotlightEntryProps) {
-  const errorType = itemErrorType(item);
+  const errorLabel = itemErrorLabel(item);
   const errorMessage = itemErrorMessage(item);
   const href = handlerHref(appKey, item, instanceQs);
 
@@ -33,7 +33,7 @@ function SpotlightEntry({ item, appKey, instanceQs }: SpotlightEntryProps) {
       <span className="shrink-0 whitespace-nowrap font-mono text-[length:var(--text-mono-sm)] font-medium text-foreground">
         {item.name}
       </span>
-      {errorType && <span className="shrink-0 whitespace-nowrap text-sm text-destructive">{errorType}</span>}
+      {errorLabel && <span className="shrink-0 whitespace-nowrap text-sm text-destructive">{errorLabel}</span>}
       {errorMessage && (
         <span className="min-w-0 flex-1 truncate text-sm text-foreground-secondary" title={errorMessage}>
           {errorMessage}

--- a/frontend/src/components/app-detail/execution-detail.tsx
+++ b/frontend/src/components/app-detail/execution-detail.tsx
@@ -10,7 +10,7 @@ import type { components } from "../../api/generated-types";
 import { useDocumentTitle } from "../../hooks/use-document-title";
 import { STATUS_DOT_SIZE } from "../../utils/constants";
 import { formatDuration, formatTimestamp, truncateId } from "../../utils/format";
-import { executionStatusKind } from "../../utils/status";
+import { executionStatusKind, TIMED_OUT_LABEL } from "../../utils/status";
 import type { DetailStatsCell } from "../shared/detail-stats";
 import { DetailStats } from "../shared/detail-stats";
 import { EmptyState } from "../shared/empty-state";
@@ -42,7 +42,7 @@ function statusBadgeFor(status: ExecutionStatus) {
     case "timed_out":
       return (
         <Badge variant="warning" size="sm">
-          timed out
+          {TIMED_OUT_LABEL}
         </Badge>
       );
     case "cancelled":

--- a/frontend/src/components/app-detail/handler-health-card.tsx
+++ b/frontend/src/components/app-detail/handler-health-card.tsx
@@ -13,8 +13,8 @@ import { StatusShape } from "../shared/status-shape";
 import {
   handlerHref,
   isFailing,
+  itemErrorLabel,
   itemErrorMessage,
-  itemErrorType,
   itemKindChip,
   itemLastActiveAt,
   itemRunCount,
@@ -59,7 +59,7 @@ export function HandlerHealthCard({ item, appKey, instanceQs, tabIndex }: Handle
   const href = handlerHref(appKey, item, instanceQs);
   const failing = isFailing(item);
   const chipLabel = itemKindChip(item);
-  const errorType = failing ? itemErrorType(item) : null;
+  const errorLabel = failing ? itemErrorLabel(item) : null;
   const errorMessage = failing ? itemErrorMessage(item) : null;
   const runCount = itemRunCount(item);
   const callLabel = item.kind === "listener" ? "call" : "run";
@@ -107,7 +107,7 @@ export function HandlerHealthCard({ item, appKey, instanceQs, tabIndex }: Handle
           <Badge variant={item.kind} size="sm" aria-label={`kind: ${chipLabel}`}>
             {chipLabel}
           </Badge>
-          {errorType && <span className="whitespace-nowrap text-sm text-destructive">{errorType}</span>}
+          {errorLabel && <span className="whitespace-nowrap text-sm text-destructive">{errorLabel}</span>}
         </div>
 
         {errorMessage && (

--- a/frontend/src/components/app-detail/overview-tab-helpers.ts
+++ b/frontend/src/components/app-detail/overview-tab-helpers.ts
@@ -1,16 +1,12 @@
-import { type HandlerKind, handlerPath } from "../../utils/app-routes";
-import { handlerKindLabel } from "../../utils/status";
+import { handlerPath, parseInstanceParam } from "../../utils/app-routes";
+import { handlerKindLabel, TIMED_OUT_LABEL } from "../../utils/status";
 import { compareFailingFirst } from "./handler-sort";
 import type { UnifiedItem } from "./unified-handler-row";
 
 export function handlerHref(appKey: string, item: UnifiedItem, instanceQs: string): string {
-  const kind: HandlerKind = item.kind === "listener" ? "listener" : "job";
-  return handlerPath(
-    appKey,
-    kind,
-    item.id,
-    instanceQs ? { instance: new URLSearchParams(instanceQs).get("instance") } : undefined,
-  );
+  return handlerPath(appKey, item.kind, item.id, {
+    instance: parseInstanceParam(new URLSearchParams(instanceQs).get("instance")),
+  });
 }
 
 export function isFailing(item: UnifiedItem): boolean {
@@ -33,8 +29,8 @@ export function itemLastActiveAt(item: UnifiedItem): number | null {
   return item.kind === "listener" ? (item.data.last_invoked_at ?? null) : (item.data.last_executed_at ?? null);
 }
 
-export function itemErrorType(item: UnifiedItem): string | null {
-  return item.data.last_error_type ?? (item.data.timed_out > 0 ? "timed out" : null);
+export function itemErrorLabel(item: UnifiedItem): string | null {
+  return item.data.last_error_type ?? (item.data.timed_out > 0 ? TIMED_OUT_LABEL : null);
 }
 
 export function itemErrorMessage(item: UnifiedItem): string | null {

--- a/frontend/src/components/shared/execution-table.tsx
+++ b/frontend/src/components/shared/execution-table.tsx
@@ -20,7 +20,7 @@ import { executionPath, type HandlerKind } from "../../utils/app-routes";
 import { STATUS_DOT_SIZE } from "../../utils/constants";
 import { formatDuration, formatRelativeTime, formatTimestamp } from "../../utils/format";
 import { onActivateKeyDown } from "../../utils/keyboard";
-import { executionStatusKind, type StatusKind } from "../../utils/status";
+import { executionStatusKind, type StatusKind, TIMED_OUT_LABEL } from "../../utils/status";
 import { EmptyState } from "./empty-state";
 import { IconArrowRight } from "./icons";
 import { ShowMoreButton } from "./show-more-button";
@@ -49,7 +49,7 @@ const CELL_CLASS = "px-2 py-1 max-mobile:px-1 max-mobile:text-xs";
 const STATUS_LABEL: Record<StatusKind, string> = {
   ok: "ok",
   err: "failed",
-  warn: "timed out",
+  warn: TIMED_OUT_LABEL,
   cancel: "cancelled",
   mute: "skipped",
 };

--- a/frontend/src/utils/status.ts
+++ b/frontend/src/utils/status.ts
@@ -197,6 +197,8 @@ export function statusToKind(status: StatusKindMapKey): StatusKind {
   return STATUS_KIND_MAP[status] ?? "mute";
 }
 
+export const TIMED_OUT_LABEL = "timed out";
+
 /** Derive a display chip label from handler/job metadata.
  * Listeners use backend-provided `listener_kind`; jobs use trigger_type.
  */


### PR DESCRIPTION
## Summary

Cleans up several code-quality issues in `overview-tab-helpers.ts` and its consumers, surfaced by a quality scan (llm-checker, lazy-checker, nitpicker).

### Changes

- **Use `parseInstanceParam()` in `handlerHref`** instead of passing raw query values to `handlerPath`. This gains the same validation/normalization that every other call site already uses, closing a consistency gap where malformed instance params would be passed through unchecked.

- **Remove redundant `kind` ternary** — `handlerHref` was mapping `item.kind` ("listener" | "job") through a ternary to produce a `HandlerKind`, but `UnifiedItem.kind` already matches the `HandlerKind` type, so the mapping was a no-op.

- **Rename `itemErrorType` → `itemErrorLabel`** — the function returns a display label string (e.g. "timed out"), not an error type category. The new name reflects its actual purpose. Updated all three call sites.

- **Extract `TIMED_OUT_LABEL` constant** to `utils/status.ts` — the string `"timed out"` was hardcoded in three separate files (`overview-tab-helpers.ts`, `execution-detail.tsx`, `execution-table.tsx`). Replaced all occurrences with the shared constant.

## Testing

- All 1601 frontend tests pass with full coverage thresholds met
- All 29 prek hooks pass (including eslint, prettier, tsc, stylelint)
- Pyright clean
- 7688/7689 backend tests pass (1 pre-existing failure in `test_file_watcher` unrelated to this change — verified against main)

Closes #1871
