### PR TITLE
fix(ui): deduplicate AppStatus type and rename wsConnected to isWsConnected

### DIFF
--- a/frontend/src/components/app-detail/overview-tab.tsx
+++ b/frontend/src/components/app-detail/overview-tab.tsx
@@ -20,6 +20,7 @@ import { RecentActivitySection } from "./recent-activity-section";
 
 type ManifestStatus = components["schemas"]["ManifestStatus"];
 type ResourceStatus = components["schemas"]["ResourceStatus"];
+type AppStatus = ManifestStatus | ResourceStatus | "unknown";
 
 interface Props {
   listeners: ListenerData[];
@@ -27,7 +28,7 @@ interface Props {
   appKey: string;
   instanceQs: string;
   resolvedInstanceIndex: number;
-  appStatus?: ManifestStatus | ResourceStatus | "unknown";
+  appStatus?: AppStatus;
 }
 
 const SEARCH_INPUT_CLASS =
@@ -49,13 +50,7 @@ function LogSearchInput({ value, onChange }: { value: string; onChange: (next: s
   );
 }
 
-function RecentLogsSection({
-  appKey,
-  appStatus,
-}: {
-  appKey: string;
-  appStatus?: ManifestStatus | ResourceStatus | "unknown";
-}) {
+function RecentLogsSection({ appKey, appStatus }: { appKey: string; appStatus?: AppStatus }) {
   const isInactive = appStatus !== undefined && INACTIVE_STATUSES.has(appStatus);
   const [search, setSearch] = useState("");
   const log = useLogTable({ context: "app", appKey, useLocalState: true, search });
@@ -90,12 +85,15 @@ function RecentLogsSection({
 
 export function OverviewTab({ listeners, jobs, appKey, instanceQs, resolvedInstanceIndex, appStatus }: Props) {
   const connection = useAppStore((s) => s.connection);
-  const wsConnected = connection === "connected";
+  const isWsConnected = connection === "connected";
   const allItems = useMemo(() => buildItems(listeners, jobs), [listeners, jobs]);
   const failingItems = useMemo(() => allItems.filter(isFailing), [allItems]);
 
   return (
-    <div className={cn("flex flex-col gap-7", !wsConnected && "opacity-[var(--op-muted)]")} data-testid="overview-tab">
+    <div
+      className={cn("flex flex-col gap-7", !isWsConnected && "opacity-[var(--op-muted)]")}
+      data-testid="overview-tab"
+    >
       <OverviewHealthStrip listeners={listeners} jobs={jobs} />
 
       {failingItems.length > 0 && (


### PR DESCRIPTION
## Summary

Extract a named `AppStatus` type alias for the `ManifestStatus | ResourceStatus | "unknown"` union that was written out twice in `overview-tab.tsx` (once in `Props` and once in `RecentLogsSection`'s inline prop type). Also rename `wsConnected` to `isWsConnected` to match the file's existing `is*` boolean naming convention (`isInactive`, `isFailing`).

## Changes

- **`frontend/src/components/app-detail/overview-tab.tsx`**:
  - Define `type AppStatus = ManifestStatus | ResourceStatus | "unknown"` once at module scope
  - Use the alias in both `Props.appStatus` and `RecentLogsSection`'s prop type
  - Rename `wsConnected` → `isWsConnected` and update its one usage site

## Testing

- Frontend build: clean
- Frontend tests: all pass (93.66% statement coverage)
- Backend tests: 7689 passed
- Lint (`prek -a`): all 29 hooks passed
- Pyright (pre-push): passed

Closes #1876