### PR TITLE
refactor: replace scattered magic-number config/timeout literals with named constants

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -18,17 +18,16 @@ from hassette.core.database_service import DatabaseService
 from hassette.core.execution_record import ExecutionRecord
 from hassette.core.sync_executor import SyncExecutor
 from hassette.types.enums import ExecutionMode
-from tests.support.helpers import cleanup_hassette_streams
+from tests.support.helpers import (
+    DB_HASSETTE_DATABASE_MAX_SIZE_MB,
+    DB_HASSETTE_RESOURCE_SHUTDOWN_TIMEOUT_SECONDS,
+    DB_HASSETTE_TELEMETRY_WRITE_QUEUE_MAX,
+    cleanup_hassette_streams,
+)
 from tests.support.mock_hassette import make_mock_hassette
 
 if TYPE_CHECKING:
     from hassette.testing import HassetteHarness
-
-
-# db_hassette config overrides — named so re-tuning is a single-site edit.
-DB_HASSETTE_TELEMETRY_WRITE_QUEUE_MAX = 500
-DB_HASSETTE_DATABASE_MAX_SIZE_MB = 0
-DB_HASSETTE_RESOURCE_SHUTDOWN_TIMEOUT_SECONDS = 5
 
 _HARNESS_FIXTURES = frozenset(
     {

--- a/tests/integration/database/test_database_service.py
+++ b/tests/integration/database/test_database_service.py
@@ -13,8 +13,15 @@ from hassette.const.misc import SECONDS_PER_DAY
 from hassette.core.database_service import DatabaseService
 from hassette.utils.aiosqlite_utils import connect_daemon
 from tests.support.factories import TEST_SOURCE_LOCATION
-from tests.support.helpers import async_noop
+from tests.support.helpers import (
+    DB_HASSETTE_RESOURCE_SHUTDOWN_TIMEOUT_SECONDS,
+    DB_HASSETTE_TELEMETRY_WRITE_QUEUE_MAX,
+    async_noop,
+)
 from tests.support.mock_hassette import make_mock_hassette
+
+SIZE_FAILSAFE_TRIGGER_MB = 0.0001
+"""Tiny max_size_mb guaranteed to trigger the size failsafe on any non-empty DB."""
 
 
 @pytest.fixture
@@ -24,8 +31,8 @@ def mock_hassette_fresh(tmp_path: Path) -> AsyncMock:
         sealed=False,
         data_dir=tmp_path,
         set_ready=False,
-        database={"telemetry_write_queue_max": 500},
-        lifecycle={"resource_shutdown_timeout_seconds": 5},
+        database={"telemetry_write_queue_max": DB_HASSETTE_TELEMETRY_WRITE_QUEUE_MAX},
+        lifecycle={"resource_shutdown_timeout_seconds": DB_HASSETTE_RESOURCE_SHUTDOWN_TIMEOUT_SECONDS},
     )
 
 
@@ -528,7 +535,7 @@ async def test_size_failsafe_logs_warning_on_consecutive_triggers(initialized_se
         )
     await db.commit()
 
-    initialized_service.hassette.config.database.max_size_mb = 0.0001  # guaranteed to trigger
+    initialized_service.hassette.config.database.max_size_mb = SIZE_FAILSAFE_TRIGGER_MB
 
     # First trigger — counter goes to 1, no warning logged
     with patch.object(initialized_service, "logger") as mock_logger:

--- a/tests/integration/telemetry/conftest.py
+++ b/tests/integration/telemetry/conftest.py
@@ -8,6 +8,11 @@ from unittest.mock import MagicMock
 import pytest
 
 from hassette.core.telemetry.query_service import TelemetryQueryService
+from tests.support.helpers import (
+    DB_HASSETTE_DATABASE_MAX_SIZE_MB,
+    DB_HASSETTE_RESOURCE_SHUTDOWN_TIMEOUT_SECONDS,
+    DB_HASSETTE_TELEMETRY_WRITE_QUEUE_MAX,
+)
 from tests.support.mock_hassette import make_mock_hassette
 
 from .helpers import DbFixture, open_db_with_session
@@ -19,8 +24,11 @@ def db_hassette(premigrated_db_path: Path) -> MagicMock:
     return make_mock_hassette(
         data_dir=premigrated_db_path.parent,
         set_ready=False,
-        database={"telemetry_write_queue_max": 500, "max_size_mb": 0},
-        lifecycle={"resource_shutdown_timeout_seconds": 5},
+        database={
+            "telemetry_write_queue_max": DB_HASSETTE_TELEMETRY_WRITE_QUEUE_MAX,
+            "max_size_mb": DB_HASSETTE_DATABASE_MAX_SIZE_MB,
+        },
+        lifecycle={"resource_shutdown_timeout_seconds": DB_HASSETTE_RESOURCE_SHUTDOWN_TIMEOUT_SECONDS},
         web_api={"run": True},
     )
 

--- a/tests/integration/telemetry/test_blocking_io_executor_offload.py
+++ b/tests/integration/telemetry/test_blocking_io_executor_offload.py
@@ -48,6 +48,11 @@ from hassette.core.loop_watchdog import LoopWatchdog
 from hassette.exceptions import HassetteBlockingIOWarning
 from hassette.testing import make_test_config
 from hassette.types.enums import BlockingIOBehavior
+from tests.support.helpers import (
+    DB_HASSETTE_DATABASE_MAX_SIZE_MB,
+    DB_HASSETTE_RESOURCE_SHUTDOWN_TIMEOUT_SECONDS,
+    DB_HASSETTE_TELEMETRY_WRITE_QUEUE_MAX,
+)
 
 from .helpers import DbFixture, drain_db_writes, fetch_blocking_events, open_db_with_session, running_command_executor
 
@@ -66,8 +71,11 @@ def _make_ignore_hassette(premigrated_db_path: Path) -> MagicMock:
     """
     config = make_test_config(
         data_dir=premigrated_db_path.parent,
-        database={"telemetry_write_queue_max": 500, "max_size_mb": 0},
-        lifecycle={"resource_shutdown_timeout_seconds": 5},
+        database={
+            "telemetry_write_queue_max": DB_HASSETTE_TELEMETRY_WRITE_QUEUE_MAX,
+            "max_size_mb": DB_HASSETTE_DATABASE_MAX_SIZE_MB,
+        },
+        lifecycle={"resource_shutdown_timeout_seconds": DB_HASSETTE_RESOURCE_SHUTDOWN_TIMEOUT_SECONDS},
         web_api={"run": True},
     )
     mock_hassette = MagicMock()

--- a/tests/integration/telemetry/test_framework_telemetry.py
+++ b/tests/integration/telemetry/test_framework_telemetry.py
@@ -22,6 +22,7 @@ from hassette.core.telemetry.query_service import TelemetryQueryService
 from hassette.testing import HassetteHarness
 from hassette.testing._harness import TEST_TOKEN
 from tests.support.factories import make_job_registration, make_listener_registration
+from tests.support.helpers import DB_HASSETTE_DATABASE_MAX_SIZE_MB, DB_HASSETTE_RESOURCE_SHUTDOWN_TIMEOUT_SECONDS
 from tests.support.mock_hassette import make_mock_hassette
 
 
@@ -40,8 +41,8 @@ async def framework_hassette(premigrated_db_path: Path) -> AsyncIterator[MagicMo
         sealed=False,
         data_dir=premigrated_db_path.parent,
         set_ready=False,
-        database={"max_size_mb": 0},
-        lifecycle={"resource_shutdown_timeout_seconds": 5},
+        database={"max_size_mb": DB_HASSETTE_DATABASE_MAX_SIZE_MB},
+        lifecycle={"resource_shutdown_timeout_seconds": DB_HASSETTE_RESOURCE_SHUTDOWN_TIMEOUT_SECONDS},
     )
 
     db_service = DatabaseService(hassette, parent=None)

--- a/tests/integration/telemetry/test_session_queries.py
+++ b/tests/integration/telemetry/test_session_queries.py
@@ -16,9 +16,17 @@ from hassette.core.telemetry.query_service import TelemetryQueryService
 from hassette.exceptions import TelemetryUnavailableError
 from hassette.schemas.summary_models import SessionRecord
 from hassette.utils.aiosqlite_utils import connect_daemon
+from tests.support.helpers import (
+    DB_HASSETTE_DATABASE_MAX_SIZE_MB,
+    DB_HASSETTE_RESOURCE_SHUTDOWN_TIMEOUT_SECONDS,
+    DB_HASSETTE_TELEMETRY_WRITE_QUEUE_MAX,
+)
 from tests.support.mock_hassette import make_mock_hassette
 
 from .helpers import BASE_TS, DbFixture, open_db_with_session
+
+SHORT_READ_TIMEOUT_SECONDS = 0.1
+"""Short read timeout for testing query-level timeout behavior."""
 
 
 class TestGetSessionList:
@@ -95,8 +103,12 @@ class TestReadTimeout:
         return make_mock_hassette(
             data_dir=premigrated_db_path.parent,
             set_ready=False,
-            database={"telemetry_write_queue_max": 500, "max_size_mb": 0, "read_timeout_seconds": 0.1},
-            lifecycle={"resource_shutdown_timeout_seconds": 5},
+            database={
+                "telemetry_write_queue_max": DB_HASSETTE_TELEMETRY_WRITE_QUEUE_MAX,
+                "max_size_mb": DB_HASSETTE_DATABASE_MAX_SIZE_MB,
+                "read_timeout_seconds": SHORT_READ_TIMEOUT_SECONDS,
+            },
+            lifecycle={"resource_shutdown_timeout_seconds": DB_HASSETTE_RESOURCE_SHUTDOWN_TIMEOUT_SECONDS},
             web_api={"run": True},
         )
 

--- a/tests/integration/test_thread_leaked_observability.py
+++ b/tests/integration/test_thread_leaked_observability.py
@@ -29,6 +29,12 @@ from .conftest import invoke_cmd, pop_execution_record
 
 InvokeFn = Callable[[object], Awaitable[None]]
 
+FAST_TIMEOUT_SECONDS = 0.01
+"""Fires before a queued-but-not-started worker has a chance to dequeue."""
+
+SHORT_TIMEOUT_SECONDS = 0.05
+"""Fires while a blocking handler is still alive on the worker thread."""
+
 
 def sync_invoker(sync_executor: SyncExecutor, handler: Callable[[object], None]) -> InvokeFn:
     """Wrap a sync handler in the async adapter the bus uses, so it runs on a pool worker."""
@@ -94,7 +100,7 @@ async def test_not_started_sync_timeout_no_false_positive(
     listener = make_invoker_listener(sync_invoker(sync_executor, sync_fn))
 
     # 10ms timeout — fires before the pool has a free slot
-    await executor.execute(invoke_cmd(listener, listener_id=4, effective_timeout=0.01))
+    await executor.execute(invoke_cmd(listener, listener_id=4, effective_timeout=FAST_TIMEOUT_SECONDS))
 
     # Release the pool fillers so they exit before teardown.
     pool_gate.set()
@@ -129,7 +135,7 @@ async def test_sync_handler_timeout_sets_thread_leaked(
     listener = make_invoker_listener(sync_invoker(sync_executor, sync_blocking))
 
     # 50ms timeout — the worker will still be alive when it fires
-    await executor.execute(invoke_cmd(listener, effective_timeout=0.05))
+    await executor.execute(invoke_cmd(listener, effective_timeout=SHORT_TIMEOUT_SECONDS))
 
     # Release the worker so it can exit cleanly after the test.
     released.set()
@@ -154,7 +160,7 @@ async def test_async_handler_timeout_does_not_set_thread_leaked(
 
     listener = make_invoker_listener(slow_async)
 
-    await executor.execute(invoke_cmd(listener, listener_id=2, effective_timeout=0.05))
+    await executor.execute(invoke_cmd(listener, listener_id=2, effective_timeout=SHORT_TIMEOUT_SECONDS))
 
     assert_timed_out(
         executor,
@@ -181,7 +187,7 @@ async def test_pure_async_timeout_no_handle_no_thread_leaked(
 
     listener = make_invoker_listener(async_slow)
 
-    await executor.execute(invoke_cmd(listener, listener_id=3, effective_timeout=0.05))
+    await executor.execute(invoke_cmd(listener, listener_id=3, effective_timeout=SHORT_TIMEOUT_SECONDS))
 
     assert_timed_out(
         executor,

--- a/tests/support/helpers.py
+++ b/tests/support/helpers.py
@@ -50,19 +50,17 @@ SHORT_SHUTDOWN_TIMEOUT_SECONDS = 0.1
 """Short ``resource_shutdown_timeout_seconds`` for tests that force a timeout/force-terminal branch."""
 
 DB_HASSETTE_TELEMETRY_WRITE_QUEUE_MAX = 500
-"""``make_mock_hassette`` database queue-max override — matches the production default."""
+"""``make_mock_hassette`` database queue-max override — smaller than the production default (1000) for test speed."""
 
 DB_HASSETTE_DATABASE_MAX_SIZE_MB = 0
 """``make_mock_hassette`` database size-limit override — 0 disables the size failsafe."""
 
 DB_HASSETTE_RESOURCE_SHUTDOWN_TIMEOUT_SECONDS = 5
-"""``make_mock_hassette`` lifecycle override — matches the production default.
-See also ``GENEROUS_SHUTDOWN_TIMEOUT_SECONDS`` (same numeric value, different consumer context)."""
+"""``make_mock_hassette`` lifecycle override — shorter than the production default (10s) for test speed."""
 
 GENEROUS_SHUTDOWN_TIMEOUT_SECONDS = 5.0
-"""Generous ``resource_shutdown_timeout_seconds`` for shutdown-body tests that need the full
-budget to run without racing the coordinator's own outer deadline.
-See also ``DB_HASSETTE_RESOURCE_SHUTDOWN_TIMEOUT_SECONDS`` (same numeric value, different consumer context)."""
+"""``resource_shutdown_timeout_seconds`` for shutdown-body tests that need enough budget
+to run without racing the coordinator's own outer deadline."""
 
 SHORT_TASK_CANCEL_TIMEOUT_SECONDS = 0.1
 """Short ``task_cancellation_timeout_seconds`` for tests that need the TaskBucket cancel stage

--- a/tests/support/helpers.py
+++ b/tests/support/helpers.py
@@ -49,6 +49,25 @@ SETTLE_SECONDS = 0.05
 SHORT_SHUTDOWN_TIMEOUT_SECONDS = 0.1
 """Short ``resource_shutdown_timeout_seconds`` for tests that force a timeout/force-terminal branch."""
 
+DB_HASSETTE_TELEMETRY_WRITE_QUEUE_MAX = 500
+"""``make_mock_hassette`` database queue-max override — matches the production default."""
+
+DB_HASSETTE_DATABASE_MAX_SIZE_MB = 0
+"""``make_mock_hassette`` database size-limit override — 0 disables the size failsafe."""
+
+DB_HASSETTE_RESOURCE_SHUTDOWN_TIMEOUT_SECONDS = 5
+"""``make_mock_hassette`` lifecycle override — matches the production default.
+See also ``GENEROUS_SHUTDOWN_TIMEOUT_SECONDS`` (same numeric value, different consumer context)."""
+
+GENEROUS_SHUTDOWN_TIMEOUT_SECONDS = 5.0
+"""Generous ``resource_shutdown_timeout_seconds`` for shutdown-body tests that need the full
+budget to run without racing the coordinator's own outer deadline.
+See also ``DB_HASSETTE_RESOURCE_SHUTDOWN_TIMEOUT_SECONDS`` (same numeric value, different consumer context)."""
+
+SHORT_TASK_CANCEL_TIMEOUT_SECONDS = 0.1
+"""Short ``task_cancellation_timeout_seconds`` for tests that need the TaskBucket cancel stage
+to resolve quickly."""
+
 
 class FakeStateReader:
     """Minimal dict-backed implementation of the StateReader protocol.

--- a/tests/unit/core/test_database_service.py
+++ b/tests/unit/core/test_database_service.py
@@ -10,6 +10,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from hassette.core.database_service import _RETENTION_TABLES, DatabaseService, RetentionTarget
+from tests.support.helpers import DB_HASSETTE_RESOURCE_SHUTDOWN_TIMEOUT_SECONDS, DB_HASSETTE_TELEMETRY_WRITE_QUEUE_MAX
 from tests.support.mock_hassette import make_mock_hassette
 
 
@@ -19,8 +20,8 @@ def mock_hassette(tmp_path: Path) -> MagicMock:
     return make_mock_hassette(
         data_dir=tmp_path,
         set_ready=False,
-        database={"telemetry_write_queue_max": 500},
-        lifecycle={"resource_shutdown_timeout_seconds": 5},
+        database={"telemetry_write_queue_max": DB_HASSETTE_TELEMETRY_WRITE_QUEUE_MAX},
+        lifecycle={"resource_shutdown_timeout_seconds": DB_HASSETTE_RESOURCE_SHUTDOWN_TIMEOUT_SECONDS},
     )
 
 

--- a/tests/unit/core/test_log_records_retention.py
+++ b/tests/unit/core/test_log_records_retention.py
@@ -14,6 +14,7 @@ from hassette.const.misc import SECONDS_PER_DAY
 from hassette.core.database_service import DatabaseService
 from hassette.logging_ import LogPersistenceHandler
 from hassette.utils.aiosqlite_utils import connect_daemon
+from tests.support.helpers import DB_HASSETTE_RESOURCE_SHUTDOWN_TIMEOUT_SECONDS, DB_HASSETTE_TELEMETRY_WRITE_QUEUE_MAX
 from tests.support.mock_hassette import make_mock_hassette
 
 from .conftest import TELEMETRY_TEST_DDL as DDL
@@ -48,8 +49,8 @@ def mock_hassette_for_db(tmp_path: Path) -> MagicMock:
     return make_mock_hassette(
         data_dir=tmp_path,
         set_ready=False,
-        database={"telemetry_write_queue_max": 500},
-        lifecycle={"resource_shutdown_timeout_seconds": 5},
+        database={"telemetry_write_queue_max": DB_HASSETTE_TELEMETRY_WRITE_QUEUE_MAX},
+        lifecycle={"resource_shutdown_timeout_seconds": DB_HASSETTE_RESOURCE_SHUTDOWN_TIMEOUT_SECONDS},
     )
 
 

--- a/tests/unit/resources/lifecycle/test_shutdown.py
+++ b/tests/unit/resources/lifecycle/test_shutdown.py
@@ -26,7 +26,7 @@ from hassette.resources.teardown import TeardownCause, TeardownReport
 from hassette.task_bucket import make_task_factory
 from hassette.testing import wait_for
 from hassette.types.enums import ResourceStatus
-from tests.support.helpers import SHORT_SHUTDOWN_TIMEOUT_SECONDS
+from tests.support.helpers import GENEROUS_SHUTDOWN_TIMEOUT_SECONDS, SHORT_SHUTDOWN_TIMEOUT_SECONDS
 from tests.support.mock_hassette import make_mock_hassette
 from tests.unit.resources.conftest import ConcreteResource, wait_for_running
 
@@ -684,7 +684,7 @@ async def test_shutdown_children_uses_remaining_budget_after_slow_cleanup():
     an independent fresh timeout window after cleanup.
     """
     hassette = make_mock_hassette(sealed=False)
-    hassette.config.lifecycle.resource_shutdown_timeout_seconds = 5.0
+    hassette.config.lifecycle.resource_shutdown_timeout_seconds = GENEROUS_SHUTDOWN_TIMEOUT_SECONDS
 
     parent = SlowCleanupParent(hassette)
     hanging = parent.add_child(HangingChild)
@@ -692,14 +692,16 @@ async def test_shutdown_children_uses_remaining_budget_after_slow_cleanup():
     await hanging.initialize()
 
     loop = asyncio.get_running_loop()
-    parent._shutdown_budget = compute_shutdown_budget(5.0, loop.time())
+    parent._shutdown_budget = compute_shutdown_budget(GENEROUS_SHUTDOWN_TIMEOUT_SECONDS, loop.time())
     start_time = loop.time()
 
     report = await asyncio.wait_for(parent._run_post_hook_shutdown_stage(), timeout=10)
     elapsed = loop.time() - start_time
 
     assert report.is_restart_safe is False, "the hanging child must produce an unsafe report"
-    assert elapsed < 5.5, f"the post-hook stage must finish within the body budget — took {elapsed:.2f}s"
+    assert elapsed < GENEROUS_SHUTDOWN_TIMEOUT_SECONDS + 0.5, (
+        f"the post-hook stage must finish within the body budget — took {elapsed:.2f}s"
+    )
 
     stopped_events = [
         call.args[0]

--- a/tests/unit/resources/test_service_edge_cases.py
+++ b/tests/unit/resources/test_service_edge_cases.py
@@ -29,7 +29,11 @@ from hassette.resources.service import Service
 from hassette.resources.teardown import TeardownCause
 from hassette.testing import wait_for
 from hassette.types.enums import ResourceStatus
-from tests.support.helpers import SHORT_SHUTDOWN_TIMEOUT_SECONDS
+from tests.support.helpers import (
+    GENEROUS_SHUTDOWN_TIMEOUT_SECONDS,
+    SHORT_SHUTDOWN_TIMEOUT_SECONDS,
+    SHORT_TASK_CANCEL_TIMEOUT_SECONDS,
+)
 from tests.support.mock_hassette import make_mock_hassette
 from tests.unit.resources.lifecycle.conftest import ShutdownCounter, SimpleService
 
@@ -259,7 +263,7 @@ class TestServiceShutdownBodyServeTaskPending:
         # own TaskBucket.cancel_all() bounds its wait by task_cancellation_timeout_seconds, not
         # resource_shutdown_timeout_seconds. Keep both short so the outer asyncio.wait_for below
         # proves the whole body stays within a bounded budget rather than racing the 5s default.
-        hassette.config.lifecycle.task_cancellation_timeout_seconds = 0.1
+        hassette.config.lifecycle.task_cancellation_timeout_seconds = SHORT_TASK_CANCEL_TIMEOUT_SECONDS
 
         svc = ResistantService(hassette)
         await svc.initialize()
@@ -318,7 +322,7 @@ class TestShutdownBodySurvivesUnresponsiveServeTask:
 
     async def test_body_completes_within_shared_budget_not_a_fresh_one(self) -> None:
         hassette = make_mock_hassette(sealed=False)
-        hassette.config.lifecycle.resource_shutdown_timeout_seconds = 5.0
+        hassette.config.lifecycle.resource_shutdown_timeout_seconds = GENEROUS_SHUTDOWN_TIMEOUT_SECONDS
 
         svc = UnresponsiveService(hassette)
         child = svc.add_child(ShutdownCounter)
@@ -326,7 +330,7 @@ class TestShutdownBodySurvivesUnresponsiveServeTask:
         await wait_for_running(svc)
 
         loop = asyncio.get_running_loop()
-        svc._shutdown_budget = compute_shutdown_budget(5.0, loop.time())
+        svc._shutdown_budget = compute_shutdown_budget(GENEROUS_SHUTDOWN_TIMEOUT_SECONDS, loop.time())
         start_time = loop.time()
 
         report = await asyncio.wait_for(svc._shutdown_body(), timeout=10)
@@ -335,7 +339,9 @@ class TestShutdownBodySurvivesUnresponsiveServeTask:
         assert TeardownCause.SERVE_TASK_PENDING in report.causes, (
             "the serve task never honoring cancellation must still be recorded as evidence"
         )
-        assert elapsed < 5.5, f"the body must finish within the 5.0s budget — took {elapsed:.2f}s"
+        assert elapsed < GENEROUS_SHUTDOWN_TIMEOUT_SECONDS + 0.5, (
+            f"the body must finish within the budget — took {elapsed:.2f}s"
+        )
 
         assert child.shutdown_completed is True, "child shutdown must still be attempted, not skipped entirely"
 
@@ -355,7 +361,7 @@ class TestServiceResistantServeNeverReplaced:
     async def test_shutdown_refuses_restart_and_never_spawns_replacement(self) -> None:
         hassette = make_mock_hassette(sealed=False)
         hassette.config.lifecycle.resource_shutdown_timeout_seconds = SHORT_SHUTDOWN_TIMEOUT_SECONDS
-        hassette.config.lifecycle.task_cancellation_timeout_seconds = 0.1
+        hassette.config.lifecycle.task_cancellation_timeout_seconds = SHORT_TASK_CANCEL_TIMEOUT_SECONDS
 
         svc = ResistantService(hassette)
         await svc.initialize()
@@ -411,7 +417,7 @@ async def test_slow_serve_wait_records_late_hooks_as_failed():
     mandatory tail is guaranteed regardless of how the pool is divided.
     """
     hassette = make_mock_hassette(sealed=False)
-    hassette.config.lifecycle.resource_shutdown_timeout_seconds = 5.0
+    hassette.config.lifecycle.resource_shutdown_timeout_seconds = GENEROUS_SHUTDOWN_TIMEOUT_SECONDS
 
     svc = SlowServeService(hassette)
 
@@ -431,4 +437,6 @@ async def test_slow_serve_wait_records_late_hooks_as_failed():
     assert TeardownCause.SHUTDOWN_HOOK_FAILED in report.causes, (
         "on_shutdown must be recorded as failed when the serve-wait consumed the hooks pool"
     )
-    assert elapsed < 5.5, f"shutdown must stay within the coordinator budget — took {elapsed:.2f}s"
+    assert elapsed < GENEROUS_SHUTDOWN_TIMEOUT_SECONDS + 0.5, (
+        f"shutdown must stay within the coordinator budget — took {elapsed:.2f}s"
+    )

--- a/tests/unit/test_state_manager.py
+++ b/tests/unit/test_state_manager.py
@@ -12,6 +12,7 @@ from hassette.state_manager.state_manager import DomainStates, StateManager
 from hassette.testing import make_light_state_dict, make_state_dict
 from tests.support.mock_hassette import make_mock_hassette
 
+FIXED_TIMESTAMP = "2026-01-01T00:00:00+00:00"
 BAD_TIMESTAMP = "INVALID-TIMESTAMP"
 BAD_CONTEXT = {"id": None, "parent_id": None, "user_id": None}
 
@@ -99,7 +100,7 @@ def domain_states() -> DomainStates[LightState]:
 class TestDomainStatesCacheValidation:
     def test_last_updated_match_returns_cached_object(self, domain_states: DomainStates[LightState]) -> None:
         ds = domain_states
-        ts = "2026-01-01T00:00:00+00:00"
+        ts = FIXED_TIMESTAMP
         ctx = {"id": "fixed-context-id", "parent_id": None, "user_id": None}
 
         state_1 = make_light_state_dict(
@@ -129,7 +130,7 @@ class TestDomainStatesCacheValidation:
     def test_frozen_state_match_returns_cached_object(self, domain_states: DomainStates[LightState]) -> None:
         """Without last_updated to compare, identical states still hit the cache."""
         ds = domain_states
-        ts = "2026-01-01T00:00:00+00:00"
+        ts = FIXED_TIMESTAMP
 
         def state_without_last_updated() -> dict:
             state = make_light_state_dict(


### PR DESCRIPTION
## Summary

Extract repeated DB config values, shutdown budget timeouts, execution timeout thresholds, and timestamp literals into named constants across the test suite. This eliminates ~40 raw numeric/string literals scattered across 13 test files, replacing them with imports from shared constant definitions.

## Changes

- Move `DB_HASSETTE_TELEMETRY_WRITE_QUEUE_MAX`, `DB_HASSETTE_DATABASE_MAX_SIZE_MB`, and `DB_HASSETTE_RESOURCE_SHUTDOWN_TIMEOUT_SECONDS` to `tests/support/helpers.py` (previously only in `tests/integration/conftest.py`) and import them in 7 test files that were retyping the raw values
- Add `GENEROUS_SHUTDOWN_TIMEOUT_SECONDS` and `SHORT_TASK_CANCEL_TIMEOUT_SECONDS` for shutdown-body and task-cancellation timing tests
- Add `SIZE_FAILSAFE_TRIGGER_MB` for the guaranteed-to-trigger database size threshold
- Add `FAST_TIMEOUT_SECONDS` and `SHORT_TIMEOUT_SECONDS` for thread-leaked observability tests
- Add `SHORT_READ_TIMEOUT_SECONDS` for telemetry read-timeout tests
- Factor repeated timestamp literal into `FIXED_TIMESTAMP` constant in `test_state_manager.py`

## Testing

- Full test suite passes: 7689 passed, 1 skipped, 2 xfailed
- `prek -a` (ruff check, ruff format, all custom hooks): all passed
- pyright: passed

Closes #1879