### PR TITLE
chore(ui): name remaining StatusShape size literals

### DIFF
--- a/frontend/src/app.tsx
+++ b/frontend/src/app.tsx
@@ -47,6 +47,7 @@ import { NotFoundPage } from "./pages/not-found";
 import { type AppStatusEntry, RELATIVE_TIME_TICK_MS, useAppStore } from "./state/store";
 import { appLiveStatus } from "./utils/app-data";
 import { HOME_PATH, LOGIN_PATH } from "./utils/app-routes";
+import { COMPACT_STATUS_DOT_SIZE } from "./utils/constants";
 import { isFailureStatus, statusToKind } from "./utils/status";
 
 const PALETTE_STALE_TIME_MS = 300_000;
@@ -391,7 +392,9 @@ function CommandPalette({ open, onClose }: CommandPaletteProps) {
                 data-testid={`cmd-result-${item.id}`}
                 onSelect={() => item.action()}
               >
-                {item.status !== undefined && <StatusShape kind={statusToKind(item.status)} size={8} />}
+                {item.status !== undefined && (
+                  <StatusShape kind={statusToKind(item.status)} size={COMPACT_STATUS_DOT_SIZE} />
+                )}
                 <span>{item.label}</span>
                 {item.sub && <span className="ml-1 text-xs text-muted-foreground">{item.sub}</span>}
                 <span className="ml-auto text-xs text-muted-foreground">{item.kind}</span>

--- a/frontend/src/components/app-detail/detail-header.tsx
+++ b/frontend/src/components/app-detail/detail-header.tsx
@@ -2,6 +2,7 @@ import type { ReactNode } from "react";
 
 import { Badge, type BadgeVariant } from "@/components/ui/badge";
 
+import { BADGE_STATUS_DOT_SIZE } from "../../utils/constants";
 import type { StatusKind } from "../../utils/status";
 import type { ExecutionKind } from "../shared/execution-table";
 import { StatusShape } from "../shared/status-shape";
@@ -42,7 +43,7 @@ export function DetailHeader({ name, kindLabel, statusKind, kind, subtitle, head
 
       <div className="mb-3 flex flex-wrap items-center gap-2 text-sm text-muted-foreground">
         <Badge variant={KIND_BADGE_VARIANT[statusKind]} aria-label={`kind: ${kindLabel}`}>
-          <StatusShape kind={statusKind} size={8} />
+          <StatusShape kind={statusKind} size={BADGE_STATUS_DOT_SIZE} />
           {kindLabel}
         </Badge>
         {subtitle && <span data-testid={`${kind}-human-description`}>{subtitle}</span>}

--- a/frontend/src/components/layout/sidebar.tsx
+++ b/frontend/src/components/layout/sidebar.tsx
@@ -12,7 +12,7 @@ import { useSidebarHidden } from "../../hooks/use-sidebar-hidden";
 import { type AppStatusEntry, useAppStore } from "../../state/store";
 import { appLiveStatus, instanceLiveStatus } from "../../utils/app-data";
 import { appDetailPath, HOME_PATH, NAV_PAGES } from "../../utils/app-routes";
-import { STATUS_DOT_SIZE } from "../../utils/constants";
+import { COMPACT_STATUS_DOT_SIZE, GROUP_HEADER_STATUS_SHAPE_SIZE, STATUS_DOT_SIZE } from "../../utils/constants";
 import { SHORTCUT_HINT } from "../../utils/keyboard";
 import { statusToKind } from "../../utils/status";
 import { Spinner } from "../shared/spinner";
@@ -113,7 +113,7 @@ function AppEntry({ manifest, location, searchString, appStatuses }: AppEntryPro
                       )}
                       aria-current={instActive ? "page" : undefined}
                     >
-                      <StatusShape kind={statusToKind(instStatus)} size={8} />
+                      <StatusShape kind={statusToKind(instStatus)} size={COMPACT_STATUS_DOT_SIZE} />
                       <span className="truncate">{inst.instance_name}</span>
                     </Link>
                   </li>
@@ -149,7 +149,7 @@ const StatusGroupHeader = forwardRef<HTMLButtonElement, StatusGroupHeaderProps>(
       {...props}
     >
       <SidebarChevron open={isOpen} className="shrink-0 text-[var(--ink-4)]" />
-      <StatusShape kind={def.tone} size={7} />
+      <StatusShape kind={def.tone} size={GROUP_HEADER_STATUS_SHAPE_SIZE} />
       <span
         className={cn(
           "flex-1 text-xs font-medium tracking-[0.05em] text-[var(--ink-2)] uppercase",

--- a/frontend/src/components/shared/detail-stats.tsx
+++ b/frontend/src/components/shared/detail-stats.tsx
@@ -8,6 +8,11 @@ export interface DetailStatsCell {
   tone?: StatusKind;
 }
 
+// Intentionally not app-detail's SECTION_LABEL_CLASS, which this matches except for its
+// leading "mb-2". These are stat values inside a gap-1 flex column that already supplies the
+// spacing, and shared/ must not depend on app-detail/.
+const STAT_VALUE_CLASS = "font-sans text-[length:var(--text-h3)] font-semibold text-foreground";
+
 const toneClass: Record<StatusKind, string> = {
   err: "text-destructive",
   warn: "text-[var(--status-warning)]",
@@ -33,13 +38,7 @@ export function DetailStats({ cells, "data-testid": testId }: DetailStatsProps) 
           <span className="whitespace-nowrap text-xs font-medium uppercase tracking-[var(--text-label-tracking)] text-muted-foreground">
             {cell.label}
           </span>
-          <span
-            className={cn(
-              "font-sans text-[length:var(--text-h3)] font-semibold text-foreground",
-              cell.tone && toneClass[cell.tone],
-            )}
-            data-tone={cell.tone}
-          >
+          <span className={cn(STAT_VALUE_CLASS, cell.tone && toneClass[cell.tone])} data-tone={cell.tone}>
             {cell.value}
           </span>
         </div>

--- a/frontend/src/utils/constants.ts
+++ b/frontend/src/utils/constants.ts
@@ -5,11 +5,28 @@ export const DETAIL_FETCH_LIMIT = 50;
 export const SMALL_ICON_SIZE = 12;
 // Status shape scaled to sit alongside heading-sized text (h1/h2).
 export const HEADING_STATUS_SHAPE_SIZE = 14;
+// The StatusShape sizes below are named for the role they play, not the pixel value they
+// happen to hold. Some pairs coincide numerically today; they are still separate names so
+// that retuning one context cannot silently drag an unrelated one with it. Pick by the role
+// being rendered, never by matching a number.
+//
 // Status shape scaled to sit inline inside a badge/pill. Deliberately smaller than the
-// standalone STATUS_DOT_SIZE above, which is sized for table cells and list rows.
+// standalone STATUS_DOT_SIZE above, which is sized for table cells and list rows. Shares its
+// value with COMPACT_STATUS_DOT_SIZE below — that one is for unadorned dense rows, this one
+// only for shapes enclosed in a badge or pill.
 export const BADGE_STATUS_DOT_SIZE = 8;
 // Status shapes in the apps table's own rows — smaller than STATUS_DOT_SIZE (10) to fit the
 // table's tighter row height. The instance sub-row is smaller again to read as nested under
-// its parent app row.
+// its parent app row. APP_ROW shares its value with GROUP_HEADER_STATUS_SHAPE_SIZE below,
+// which sizes a header divider rather than a data row.
 export const APP_ROW_STATUS_SHAPE_SIZE = 7;
 export const INSTANCE_ROW_STATUS_SHAPE_SIZE = 6;
+// Status shape in a dense list row — one tighter than the standard list row STATUS_DOT_SIZE
+// (10) targets, whether because the row is nested under a parent or because its own line
+// height is compressed. Currently the sidebar's instance sub-rows and the command palette's
+// results. Same value as BADGE_STATUS_DOT_SIZE above, which covers badge/pill interiors.
+export const COMPACT_STATUS_DOT_SIZE = 8;
+// Status shape beside a collapsible group header's uppercase micro-label, smaller again than
+// the compact row size so the header reads as a divider rather than another row. Same value
+// as APP_ROW_STATUS_SHAPE_SIZE above, which sizes actual data rows.
+export const GROUP_HEADER_STATUS_SHAPE_SIZE = 7;

--- a/frontend/src/utils/constants.ts
+++ b/frontend/src/utils/constants.ts
@@ -5,28 +5,25 @@ export const DETAIL_FETCH_LIMIT = 50;
 export const SMALL_ICON_SIZE = 12;
 // Status shape scaled to sit alongside heading-sized text (h1/h2).
 export const HEADING_STATUS_SHAPE_SIZE = 14;
+
 // The StatusShape sizes below are named for the role they play, not the pixel value they
-// happen to hold. Some pairs coincide numerically today; they are still separate names so
-// that retuning one context cannot silently drag an unrelated one with it. Pick by the role
-// being rendered, never by matching a number.
+// happen to hold. Some coincide numerically today; they are still separate names so that
+// retuning one context cannot silently drag an unrelated one with it. Pick by the role being
+// rendered, never by matching a number.
 //
 // Status shape scaled to sit inline inside a badge/pill. Deliberately smaller than the
-// standalone STATUS_DOT_SIZE above, which is sized for table cells and list rows. Shares its
-// value with COMPACT_STATUS_DOT_SIZE below — that one is for unadorned dense rows, this one
-// only for shapes enclosed in a badge or pill.
+// standalone STATUS_DOT_SIZE above, which is sized for table cells and list rows.
 export const BADGE_STATUS_DOT_SIZE = 8;
 // Status shapes in the apps table's own rows — smaller than STATUS_DOT_SIZE (10) to fit the
 // table's tighter row height. The instance sub-row is smaller again to read as nested under
-// its parent app row. APP_ROW shares its value with GROUP_HEADER_STATUS_SHAPE_SIZE below,
-// which sizes a header divider rather than a data row.
+// its parent app row.
 export const APP_ROW_STATUS_SHAPE_SIZE = 7;
 export const INSTANCE_ROW_STATUS_SHAPE_SIZE = 6;
 // Status shape in a dense list row — one tighter than the standard list row STATUS_DOT_SIZE
 // (10) targets, whether because the row is nested under a parent or because its own line
 // height is compressed. Currently the sidebar's instance sub-rows and the command palette's
-// results. Same value as BADGE_STATUS_DOT_SIZE above, which covers badge/pill interiors.
+// results.
 export const COMPACT_STATUS_DOT_SIZE = 8;
 // Status shape beside a collapsible group header's uppercase micro-label, smaller again than
-// the compact row size so the header reads as a divider rather than another row. Same value
-// as APP_ROW_STATUS_SHAPE_SIZE above, which sizes actual data rows.
+// the compact row size so the header reads as a divider rather than another row.
 export const GROUP_HEADER_STATUS_SHAPE_SIZE = 7;


### PR DESCRIPTION
## Summary

Finishes the magic-number cleanup started in #1734: every `<StatusShape size={...}>` call site outside tests now passes a named constant from `frontend/src/utils/constants.ts` instead of a bare number.

`multi-instance.tsx` and `apps-table-row.tsx` were already converted on `main`, so this PR covers the four remaining sites plus the `detail-stats.tsx` item from the issue's checklist.

## What changed

**Two new constants** for roles the existing vocabulary had no name for:

- `COMPACT_STATUS_DOT_SIZE` (8) — dense list rows that sit tighter than the standard `STATUS_DOT_SIZE` row. Used by the sidebar's instance sub-rows and the command palette's results.
- `GROUP_HEADER_STATUS_SHAPE_SIZE` (7) — the glyph beside a collapsible group header's micro-label.

**Call sites converted:**

| Site | Was | Now |
|---|---|---|
| `app.tsx` (command palette result) | `8` | `COMPACT_STATUS_DOT_SIZE` |
| `detail-header.tsx` (inside a `Badge`) | `8` | `BADGE_STATUS_DOT_SIZE` |
| `sidebar.tsx` (instance sub-row) | `8` | `COMPACT_STATUS_DOT_SIZE` |
| `sidebar.tsx` (group header) | `7` | `GROUP_HEADER_STATUS_SHAPE_SIZE` |

**Why separate names for values that coincide.** `COMPACT_STATUS_DOT_SIZE` and `BADGE_STATUS_DOT_SIZE` are both 8; `GROUP_HEADER_STATUS_SHAPE_SIZE` and `APP_ROW_STATUS_SHAPE_SIZE` are both 7. They stay separate so that retuning one context can't silently drag an unrelated one along with it. Each pair now cross-references the other in `constants.ts`, so a reader landing on either name learns the other exists and which role it serves — the guidance being to pick by role, never by matching a number.

**`detail-stats.tsx`** takes the second option the issue offered: it keeps its own `STAT_VALUE_CLASS` rather than importing app-detail's `SECTION_LABEL_CLASS`, with a comment explaining why. The two strings differ by a leading `mb-2` that this layout's `gap-1` column already supplies, and `shared/` has no other dependency on `app-detail/`.

## No visual change

Every substitution preserves the rendered value (8 → 8, 7 → 7), so no pixels move and no `docs/_static/web_ui_*.png` needs regenerating. Tagged `no-visual-change` for the screenshot CI guard.

## Testing

- `npm run build` — clean (includes `tsc`)
- `npx vitest run` — 1601 passed / 110 files
- `prek -a` — all 29 hooks pass (ruff, eslint, prettier, stylelint, tsc, house-lint, breakpoint/dead-token checks)
- `prek pyright -a --stage pre-push` — pass
- `uv run nox -s dev` — 7688 passed, 1 skipped, 2 xfailed, **1 unrelated flake**

### About that flake

`tests/integration/test_scheduler_entity_time.py::test_watcher_survives_transition_to_waiting` failed once in the full parallel run on a timing-sensitive assertion (`schedule_status` still `scheduled`, not yet `waiting`). It is not caused by this branch:

- `git diff --name-only origin/main...HEAD` returns **only** the five `frontend/` files — this branch touches zero Python.
- The test file and all of `src/hassette/scheduler/` are byte-identical to `origin/main`.
- It passes on re-run in isolation (`1 passed in 0.91s`) and with the whole file under parallel load (`19 passed`, `-n 4`).

Same shape as the timing-fragile integration tests tracked in #1571.

Closes #1735
