### PR TITLE
test: use named constants for app key and FK sentinel in telemetry repository error tests

### DIFF
--- a/tests/unit/core/test_telemetry_repository_errors.py
+++ b/tests/unit/core/test_telemetry_repository_errors.py
@@ -13,7 +13,15 @@ import pytest
 import hassette.core.telemetry.repository as telemetry_repository_module
 from hassette.core.execution_record import ExecutionRecord
 from hassette.core.telemetry.repository import TelemetryRepository
-from tests.support.factories import make_execution_record, make_job_registration, make_listener_registration
+from tests.support.factories import (
+    DEFAULT_TEST_APP_KEY,
+    make_execution_record,
+    make_job_registration,
+    make_listener_registration,
+)
+
+# Row id far beyond anything the test fixtures insert, so it reliably violates the FK constraint.
+NONEXISTENT_FK_ID = 99999
 
 
 async def forward_execute(
@@ -44,7 +52,7 @@ async def test_reconcile_rollback_on_exception(
         patch.object(telemetry_db, "execute", side_effect=failing_execute),
         pytest.raises(RuntimeError, match="simulated DB error"),
     ):
-        await telemetry_repo.reconcile_registrations("test_app", [], [])
+        await telemetry_repo.reconcile_registrations(DEFAULT_TEST_APP_KEY, [], [])
 
 
 # dup-ignore-start: pytest test function signature — Python has no way to share a function
@@ -105,10 +113,9 @@ async def test_persist_execution_batch_with_fk_fallback_drops_on_listener_fk_vio
     """
     # dup-ignore-end
     now = time.time()
-    bad_listener_id = 99999
     record = ExecutionRecord(
         kind="handler",
-        listener_id=bad_listener_id,
+        listener_id=NONEXISTENT_FK_ID,
         session_id=telemetry_session_id,
         execution_start_ts=now,
         duration_ms=5.0,
@@ -138,10 +145,9 @@ async def test_persist_execution_batch_with_fk_fallback_drops_on_job_fk_violatio
     """
     # dup-ignore-end
     now = time.time()
-    bad_job_id = 99999
     record = ExecutionRecord(
         kind="job",
-        job_id=bad_job_id,
+        job_id=NONEXISTENT_FK_ID,
         session_id=telemetry_session_id,
         execution_start_ts=now,
         duration_ms=10.0,


### PR DESCRIPTION
## Summary

Replaces magic literals in `tests/unit/core/test_telemetry_repository_errors.py` with named constants that already exist (or now exist) in the surrounding test module family.

## What changed

- **`"test_app"` → `DEFAULT_TEST_APP_KEY`** — the `reconcile_registrations` call was the one site in this module family still passing the app key as a bare string literal. Every sibling module (e.g. `test_telemetry_repository_reconcile.py`) imports the constant from `tests.support.factories`; this brings the file in line so a future change to the default test app key doesn't silently skip this test.
- **Two independent `99999` sentinels → one `NONEXISTENT_FK_ID`** — `bad_listener_id` and `bad_job_id` were separately-declared copies of the same value chosen for the same reason (a row id far past anything the fixtures insert, so the FK constraint reliably fires). They're now one module-level constant with a comment stating *why* that value works, rather than two unexplained magic numbers a reader has to correlate by eye.

## Why

Both are pre-existing findings surfaced by `/mine-clean-code` (nitpicker) while reviewing #1890 — outside that PR's diff, so they were split out into #1891 rather than fixed there.

## Testing

Test-only change; no source behavior is touched.

- `uv run nox -s dev` — 7689 passed, 1 skipped, 2 xfailed
- `prek -a` — all hooks pass (ruff, ruff-format, flake8-async, house-lint, eslint, stylelint, tsc, and the repo's custom checks)
- `prek pyright -a --stage pre-push` — passes

Closes #1891
