### PR TITLE
test: name repeated fixture literals in registration-footer tests

### DIFF
--- a/frontend/src/components/app-detail/registration-footer.test.tsx
+++ b/frontend/src/components/app-detail/registration-footer.test.tsx
@@ -4,15 +4,19 @@ import { describe, expect, it, vi } from "vitest";
 
 import { RegistrationFooter } from "./registration-footer";
 
+const HANDLER_TEST_ID = "handler-detail-1";
+const SOURCE_LINE = 12;
+const SOURCE_LOCATION = `apps/foo.py:${SOURCE_LINE}`;
+
 describe("RegistrationFooter", () => {
   it("renders nothing when no sourceLocation and no registrationSource", () => {
-    const { container } = render(<RegistrationFooter kind="handler" testId="handler-detail-1" />);
+    const { container } = render(<RegistrationFooter kind="handler" testId={HANDLER_TEST_ID} />);
     expect(container.innerHTML).toBe("");
   });
 
   it("shows source location when provided", () => {
     const { getByTestId } = render(
-      <RegistrationFooter kind="handler" testId="handler-detail-1" sourceLocation="apps/foo.py:12" />,
+      <RegistrationFooter kind="handler" testId={HANDLER_TEST_ID} sourceLocation={SOURCE_LOCATION} />,
     );
     expect(getByTestId("handler-source-location")).not.toBeNull();
   });
@@ -23,19 +27,19 @@ describe("RegistrationFooter", () => {
     const { getByTestId } = render(
       <RegistrationFooter
         kind="handler"
-        testId="handler-detail-1"
-        sourceLocation="apps/foo.py:12"
+        testId={HANDLER_TEST_ID}
+        sourceLocation={SOURCE_LOCATION}
         onViewCode={onViewCode}
       />,
     );
-    const btn = getByTestId("view-in-code-btn");
-    await user.click(btn);
-    expect(onViewCode).toHaveBeenCalledWith(12);
+    const viewCodeButton = getByTestId("view-in-code-btn");
+    await user.click(viewCodeButton);
+    expect(onViewCode).toHaveBeenCalledWith(SOURCE_LINE);
   });
 
   it("hides view-in-code button when onViewCode is not provided", () => {
     const { queryByTestId } = render(
-      <RegistrationFooter kind="handler" testId="handler-detail-1" sourceLocation="apps/foo.py:12" />,
+      <RegistrationFooter kind="handler" testId={HANDLER_TEST_ID} sourceLocation={SOURCE_LOCATION} />,
     );
     expect(queryByTestId("view-in-code-btn")).toBeNull();
   });


### PR DESCRIPTION
## Summary

Cleans up repeated inline fixture literals in `frontend/src/components/app-detail/registration-footer.test.tsx`, surfaced by the quality scanner in #1892. Test-only change — no production code or behavior is touched.

## What changed

- **Named the source-location fixture pair.** `"apps/foo.py:12"` appeared in three tests, and a fourth assertion separately expected `toHaveBeenCalledWith(12)`. That `12` is derived from the `:12` suffix (the component parses it via `parseSourceLocation`), but nothing in the test made the coupling visible — editing the fixture string would have silently desynced the assertion. Both are now defined once as `SOURCE_LINE` and `` SOURCE_LOCATION = `apps/foo.py:${SOURCE_LINE}` ``, and the assertion reads `toHaveBeenCalledWith(SOURCE_LINE)`.
- **Hoisted the repeated handler testId.** `"handler-detail-1"` was re-declared inline in four tests; it is now a single `HANDLER_TEST_ID` constant. No correctness risk either way — the component only uses `testId` to build `aria-controls`/`aria-labelledby` ids — this is purely deduplication.
- **Spelled out an abbreviated local.** `btn` → `viewCodeButton`, matching the file's other locals (`toggle`, `user`).

Deliberately left alone: the single-use `"scheduler.run_in(foo, 5)"` and `"job-detail-42"` literals. Each appears exactly once and is not asserted on elsewhere, so inline fixture data in the test that consumes it is the right shape — there is no duplication to consolidate and no drift to prevent.

## Testing

- `npx vitest run src/components/app-detail/registration-footer.test.tsx` — 5 passed
- `uv run nox -s dev` — 7690 passed, 1 failed. The single failure is
  `tests/integration/test_file_watcher.py::test_event_emitted_on_file_change`, a real-clock
  2s deadline that flakes under 4 parallel xdist workers. It is unrelated to this branch:
  the branch's only changed file is the frontend test above, and `test_file_watcher.py` and
  all of `src/hassette/` are byte-identical to `origin/main`. It passes on isolated re-run
  (`uv run pytest tests/integration/test_file_watcher.py` — 1 passed).
- `prek -a` — all 29 hooks pass (ruff, eslint, stylelint, tsc, prettier, house-lint)
- `prek pyright -a --stage pre-push` — passes

Closes #1892
