### PR TITLE
test: widen shutdown-hook race test timeout past CI scheduling jitter

### DIFF
--- a/tests/support/helpers.py
+++ b/tests/support/helpers.py
@@ -47,7 +47,13 @@ SETTLE_SECONDS = 0.05
 """Default settle window: seconds to let a stray extra handler call land before a negative assertion."""
 
 SHORT_SHUTDOWN_TIMEOUT_SECONDS = 0.1
-"""Short ``resource_shutdown_timeout_seconds`` for tests that force a timeout/force-terminal branch."""
+"""Short ``resource_shutdown_timeout_seconds`` for tests that force a timeout/force-terminal branch.
+
+Only for tests that *want* the coordinator's outer bound to fire. It leaves under 100ms of real
+wall-clock margin between the hooks pool and the total deadline, so a test asserting that an
+inner bound (a hook's own ``asyncio.timeout``) wins that race will flake on a loaded CI runner.
+Use ``GENEROUS_SHUTDOWN_TIMEOUT_SECONDS`` for those.
+"""
 
 DB_HASSETTE_TELEMETRY_WRITE_QUEUE_MAX = 500
 """``make_mock_hassette`` database queue-max override — smaller than the production default (1000) for test speed."""

--- a/tests/unit/resources/lifecycle/test_shutdown.py
+++ b/tests/unit/resources/lifecycle/test_shutdown.py
@@ -312,12 +312,19 @@ async def test_resource_own_hanging_hook_wins_race_against_coordinator_timeout()
     and letting ``_shutdown_body()`` proceed through its later stages — rather than losing the
     race to the coordinator's own outer ``asyncio.wait([body_task], timeout=timeout)`` bound.
 
-    The up-front budget's ``COORDINATOR_MARGIN_FRACTION`` guarantees that the body's stages
-    (hooks pool + mandatory tail) finish before the coordinator's outer wait, so the hook's
-    inner timeout always fires first by construction.
+    The up-front budget's ``COORDINATOR_MARGIN_FRACTION`` fixes the *ordering* by construction
+    (hooks pool < body deadline < total deadline), but ordering alone is not what makes this
+    test pass: the body task still has to be scheduled and reach ``run_hooks()`` before the
+    coordinator's outer bound expires. The real invariant is therefore the absolute wall-clock
+    gap between the hooks pool and the total deadline, which must stay generous enough to
+    absorb CI scheduling jitter — hence ``GENEROUS_SHUTDOWN_TIMEOUT_SECONDS`` rather than the
+    short timeout the force-terminal tests use. That short value leaves under 100ms of margin,
+    which a loaded ``-n 4`` runner reaches; the coordinator's outer wait then fires first and
+    the report carries ``FORCED_TERMINAL`` + ``SHUTDOWN_BODY_TIMED_OUT`` with no hook evidence
+    at all.
     """
     hassette = make_mock_hassette(sealed=False)
-    hassette.config.lifecycle.resource_shutdown_timeout_seconds = SHORT_SHUTDOWN_TIMEOUT_SECONDS
+    hassette.config.lifecycle.resource_shutdown_timeout_seconds = GENEROUS_SHUTDOWN_TIMEOUT_SECONDS
 
     resource = HangingChild(hassette)
     await resource.initialize()


### PR DESCRIPTION
## Summary

`test_resource_own_hanging_hook_wins_race_against_coordinator_timeout` was flaky on CI — it failed on PR #1791, an annotations-only diff that touches nothing in the lifecycle path, and a plain rerun of the same commit went green.

The test asserts that a resource's *own* hanging shutdown hook hits its inner `asyncio.timeout` (producing `SHUTDOWN_HOOK_FAILED`) before the coordinator's outer `asyncio.wait([body_task], timeout=...)` bound fires. It set `resource_shutdown_timeout_seconds = SHORT_SHUTDOWN_TIMEOUT_SECONDS` (`0.1`), which `compute_shutdown_budget()` splits into a 15 ms hooks-pool bound and a 100 ms total deadline.

`COORDINATOR_MARGIN_FRACTION` guarantees the *ordering* of those bounds (15 < 90 < 100), and the docstring claimed that made the hook "always fire first by construction." But ordering isn't the whole invariant: the body task still has to be scheduled and reach `run_hooks()` inside that window, and the absolute real-clock margin was only 85 ms. On a loaded `-n 4` xdist runner, 85 ms of asyncio callback-scheduling delay is easily reachable — the coordinator's outer bound wins instead, and the report comes back `FORCED_TERMINAL` + `SHUTDOWN_BODY_TIMED_OUT` with no hook evidence at all. That is exactly the observed CI failure.

## What changed

- Switched the test to the existing `GENEROUS_SHUTDOWN_TIMEOUT_SECONDS` (`5.0`). Nothing in this test depends on the shutdown budget being small — only on the hook hanging past its pool — so per CLAUDE.md's "Config-driven real-clock timeouts" guidance the fix widens the override rather than shrinking the deliberate delay under test. At `5.0` the budget is also above the ~3.33s threshold in `lifecycle.py`, so it uses its real named floors instead of the degenerate proportionally-scaled branch, meaning the test now exercises the production code path.
- Rewrote the test docstring to state the real invariant (the absolute wall-clock gap between the hooks pool and the total deadline) instead of the "by construction" ordering claim that misled the original value choice.
- Documented on `SHORT_SHUTDOWN_TIMEOUT_SECONDS` that it is only for tests that *want* the coordinator's outer bound to fire, and to reach for `GENEROUS_SHUTDOWN_TIMEOUT_SECONDS` otherwise. Every other consumer of the short value asserts the timeout/force-terminal branch does fire, so they correctly keep it.

No production code is touched — this is test infrastructure only.

## Testing

- `uv run nox -s dev` — 7716 passed, 1 skipped, 2 xfailed.
- `prek -a` — all hooks pass. `prek pyright -a --stage pre-push` — passes.
- The fixed test run 20x in a loop: 20/20 pass, ~0.38s each. Despite the 5.0s budget the test still resolves in well under half a second, because the hook's inner bound is what actually ends it.

Closes #1794
