### PR TITLE
fix: stop app failures from triggering ServiceWatcher restarts and process shutdown

### DIFF
--- a/src/hassette/core/service_watcher.py
+++ b/src/hassette/core/service_watcher.py
@@ -31,14 +31,14 @@ IS_NOT_APP_ROLE = ~P.ValueIs(source=get_path(SERVICE_ROLE_PATH), condition=Resou
 
 Every ``Resource`` emits ``HASSETTE_EVENT_SERVICE_STATUS`` through the shared lifecycle
 machinery, so an app's status transitions land on the same topic the framework's own do. This
-guards the watcher's *acting* handlers -- the ones that do something to the resource they
+guards the watcher's *acting* handlers — the ones that do something to the resource they
 observe (restart it, or take the process down), as opposed to ``log_service_event``, which only
 describes it. One app's failure is not a framework failure.
 
 Excludes APP rather than admitting SERVICE only, and the difference matters: the watcher is not
 services-only. ``shutdown_if_crashed`` is the process-level fatal handler for every framework
 resource, and several of those are plain ``Resource`` subclasses (RESOURCE role), not
-``Service`` -- ``AppLifecycleService`` reaches ``handle_crash`` when ``bootstrap_apps()`` fails,
+``Service`` — ``AppLifecycleService`` reaches ``handle_crash`` when ``bootstrap_apps()`` fails,
 and that crash must still stop the process. A SERVICE-only filter would swallow it, leaving
 Hassette running with no apps bootstrapped. Negating APP also fails open on a missing or
 malformed role, matching the unfiltered behavior this narrows.
@@ -649,7 +649,7 @@ class ServiceWatcher(Resource):
     async def shutdown_if_crashed(self, event: HassetteServiceEvent) -> None:
         """Record the fatal reason and request shutdown when a service has crashed.
 
-        Reacts to a CRASHED event from any framework resource -- SERVICE and RESOURCE roles
+        Reacts to a CRASHED event from any framework resource — SERVICE and RESOURCE roles
         alike; the subscription's role filter keeps only APP-role crashes out, so one crashed app
         cannot take the process down while a crashed framework resource still can (see
         ``IS_NOT_APP_ROLE``). Records the fatal reason (unless a more specific one is already set)

--- a/src/hassette/core/service_watcher.py
+++ b/src/hassette/core/service_watcher.py
@@ -641,12 +641,13 @@ class ServiceWatcher(Resource):
     async def shutdown_if_crashed(self, event: HassetteServiceEvent) -> None:
         """Record the fatal reason and request shutdown when a service has crashed.
 
-        Universal reaction to a CRASHED event from any source. Records the fatal reason
-        (unless a more specific one is already set) before calling request_shutdown() so
-        run_forever()'s shutdown_event.wait() unblocks, runs the full teardown (including
-        finalize_session), and then raises FatalError via _raise_if_fatal_shutdown(). This
-        makes a crash-driven exit non-zero to external supervisors (systemd Restart=on-failure,
-        Docker healthcheck).
+        Reacts to a CRASHED event from any SERVICE-role resource; the subscription's role filter
+        keeps APP-role crashes out, so one crashed app cannot take the process down (see
+        ``IS_SERVICE_ROLE``). Records the fatal reason (unless a more specific one is already set)
+        before calling request_shutdown() so run_forever()'s shutdown_event.wait() unblocks, runs
+        the full teardown (including finalize_session), and then raises FatalError via
+        _raise_if_fatal_shutdown(). This makes a crash-driven exit non-zero to external
+        supervisors (systemd Restart=on-failure, Docker healthcheck).
         """
         status_payload = event.payload.data
         name = status_payload.resource_name
@@ -801,7 +802,12 @@ class ServiceWatcher(Resource):
         )
 
     async def on_bus_service_running(self, event: HassetteServiceEvent) -> None:
-        """Trigger reconciliation scan when BusService recovers."""
+        """Trigger reconciliation scan when BusService recovers.
+
+        Carries no role filter, unlike the watcher's other acting subscriptions: it narrows to a
+        single named resource below, and only a SERVICE can be named ``BusService``, so an
+        APP-role event cannot reach the reconciliation call (see ``IS_SERVICE_ROLE``).
+        """
         status_payload = event.payload.data
         if status_payload.resource_name != BusService.__name__:
             return

--- a/src/hassette/core/service_watcher.py
+++ b/src/hassette/core/service_watcher.py
@@ -24,6 +24,17 @@ if typing.TYPE_CHECKING:
     from hassette import Hassette
 
 SERVICE_STATUS_PATH = "payload.data.status"
+SERVICE_ROLE_PATH = "payload.data.role"
+
+IS_SERVICE_ROLE = P.ValueIs(source=get_path(SERVICE_ROLE_PATH), condition=ResourceRole.SERVICE)
+"""Restricts a service-status subscription to SERVICE-role resources.
+
+Every ``Resource`` emits ``HASSETTE_EVENT_SERVICE_STATUS`` through the shared lifecycle
+machinery, so APP-role events land on the same topic as service events. The watcher supervises
+services only -- its restart flow resolves a ``Service`` child by (name, role) and its crash
+handler shuts the whole process down -- so both would misfire on an app's status transitions.
+Filtering at registration makes that a structural guarantee rather than a convention.
+"""
 
 _STATUS_EVENT_DISPATCH_TIMEOUT_SECONDS = 5.0
 """Upper bound on how long dispatch_status_event_best_effort() waits for send_event() to accept
@@ -602,6 +613,13 @@ class ServiceWatcher(Resource):
             self._restarting.discard(key)
 
     async def log_service_event(self, event: HassetteServiceEvent) -> None:
+        """Log every status transition on the service-status topic at debug level.
+
+        Deliberately not role-filtered, unlike the watcher's other subscriptions: this handler
+        takes no action on the resource it observes, so an APP-role event costs a debug line and
+        nothing else. Keeping apps in makes the watcher's log a complete transition trace for the
+        topic, which is what it is read for when reconstructing a startup or shutdown sequence.
+        """
         status_payload = event.payload.data
         name = status_payload.resource_name
         role = status_payload.role
@@ -756,13 +774,13 @@ class ServiceWatcher(Resource):
             topic=topic,
             handler=self.restart_service,
             name="hassette.service_watcher.restart_service",
-            where=P.ValueIs(source=get_path(SERVICE_STATUS_PATH), condition=ResourceStatus.FAILED),
+            where=P.ValueIs(source=get_path(SERVICE_STATUS_PATH), condition=ResourceStatus.FAILED) & IS_SERVICE_ROLE,
         )
         await self.bus.on(
             topic=topic,
             handler=self.shutdown_if_crashed,
             name="hassette.service_watcher.shutdown_if_crashed",
-            where=P.ValueIs(source=get_path(SERVICE_STATUS_PATH), condition=ResourceStatus.CRASHED),
+            where=P.ValueIs(source=get_path(SERVICE_STATUS_PATH), condition=ResourceStatus.CRASHED) & IS_SERVICE_ROLE,
         )
         await self.bus.on(
             topic=topic,
@@ -773,7 +791,7 @@ class ServiceWatcher(Resource):
             topic=topic,
             handler=self.on_service_running,
             name="hassette.service_watcher.on_service_running",
-            where=P.ValueIs(source=get_path(SERVICE_STATUS_PATH), condition=ResourceStatus.RUNNING),
+            where=P.ValueIs(source=get_path(SERVICE_STATUS_PATH), condition=ResourceStatus.RUNNING) & IS_SERVICE_ROLE,
         )
         await self.bus.on(
             topic=topic,

--- a/src/hassette/core/service_watcher.py
+++ b/src/hassette/core/service_watcher.py
@@ -26,14 +26,22 @@ if typing.TYPE_CHECKING:
 SERVICE_STATUS_PATH = "payload.data.status"
 SERVICE_ROLE_PATH = "payload.data.role"
 
-IS_SERVICE_ROLE = P.ValueIs(source=get_path(SERVICE_ROLE_PATH), condition=ResourceRole.SERVICE)
-"""Restricts a service-status subscription to SERVICE-role resources.
+IS_NOT_APP_ROLE = ~P.ValueIs(source=get_path(SERVICE_ROLE_PATH), condition=ResourceRole.APP)
+"""Excludes APP-role resources from a service-status subscription.
 
 Every ``Resource`` emits ``HASSETTE_EVENT_SERVICE_STATUS`` through the shared lifecycle
-machinery, so APP-role events land on the same topic as service events. The watcher supervises
-services only -- its restart flow resolves a ``Service`` child by (name, role) and its crash
-handler shuts the whole process down -- so both would misfire on an app's status transitions.
-Filtering at registration makes that a structural guarantee rather than a convention.
+machinery, so an app's status transitions land on the same topic the framework's own do. This
+guards the watcher's *acting* handlers -- the ones that do something to the resource they
+observe (restart it, or take the process down), as opposed to ``log_service_event``, which only
+describes it. One app's failure is not a framework failure.
+
+Excludes APP rather than admitting SERVICE only, and the difference matters: the watcher is not
+services-only. ``shutdown_if_crashed`` is the process-level fatal handler for every framework
+resource, and several of those are plain ``Resource`` subclasses (RESOURCE role), not
+``Service`` -- ``AppLifecycleService`` reaches ``handle_crash`` when ``bootstrap_apps()`` fails,
+and that crash must still stop the process. A SERVICE-only filter would swallow it, leaving
+Hassette running with no apps bootstrapped. Negating APP also fails open on a missing or
+malformed role, matching the unfiltered behavior this narrows.
 """
 
 _STATUS_EVENT_DISPATCH_TIMEOUT_SECONDS = 5.0
@@ -641,9 +649,10 @@ class ServiceWatcher(Resource):
     async def shutdown_if_crashed(self, event: HassetteServiceEvent) -> None:
         """Record the fatal reason and request shutdown when a service has crashed.
 
-        Reacts to a CRASHED event from any SERVICE-role resource; the subscription's role filter
-        keeps APP-role crashes out, so one crashed app cannot take the process down (see
-        ``IS_SERVICE_ROLE``). Records the fatal reason (unless a more specific one is already set)
+        Reacts to a CRASHED event from any framework resource -- SERVICE and RESOURCE roles
+        alike; the subscription's role filter keeps only APP-role crashes out, so one crashed app
+        cannot take the process down while a crashed framework resource still can (see
+        ``IS_NOT_APP_ROLE``). Records the fatal reason (unless a more specific one is already set)
         before calling request_shutdown() so run_forever()'s shutdown_event.wait() unblocks, runs
         the full teardown (including finalize_session), and then raises FatalError via
         _raise_if_fatal_shutdown(). This makes a crash-driven exit non-zero to external
@@ -775,13 +784,13 @@ class ServiceWatcher(Resource):
             topic=topic,
             handler=self.restart_service,
             name="hassette.service_watcher.restart_service",
-            where=P.ValueIs(source=get_path(SERVICE_STATUS_PATH), condition=ResourceStatus.FAILED) & IS_SERVICE_ROLE,
+            where=P.ValueIs(source=get_path(SERVICE_STATUS_PATH), condition=ResourceStatus.FAILED) & IS_NOT_APP_ROLE,
         )
         await self.bus.on(
             topic=topic,
             handler=self.shutdown_if_crashed,
             name="hassette.service_watcher.shutdown_if_crashed",
-            where=P.ValueIs(source=get_path(SERVICE_STATUS_PATH), condition=ResourceStatus.CRASHED) & IS_SERVICE_ROLE,
+            where=P.ValueIs(source=get_path(SERVICE_STATUS_PATH), condition=ResourceStatus.CRASHED) & IS_NOT_APP_ROLE,
         )
         await self.bus.on(
             topic=topic,
@@ -792,7 +801,7 @@ class ServiceWatcher(Resource):
             topic=topic,
             handler=self.on_service_running,
             name="hassette.service_watcher.on_service_running",
-            where=P.ValueIs(source=get_path(SERVICE_STATUS_PATH), condition=ResourceStatus.RUNNING) & IS_SERVICE_ROLE,
+            where=P.ValueIs(source=get_path(SERVICE_STATUS_PATH), condition=ResourceStatus.RUNNING) & IS_NOT_APP_ROLE,
         )
         await self.bus.on(
             topic=topic,
@@ -806,7 +815,7 @@ class ServiceWatcher(Resource):
 
         Carries no role filter, unlike the watcher's other acting subscriptions: it narrows to a
         single named resource below, and only a SERVICE can be named ``BusService``, so an
-        APP-role event cannot reach the reconciliation call (see ``IS_SERVICE_ROLE``).
+        APP-role event cannot reach the reconciliation call (see ``IS_NOT_APP_ROLE``).
         """
         status_payload = event.payload.data
         if status_payload.resource_name != BusService.__name__:

--- a/tests/integration/test_service_watcher.py
+++ b/tests/integration/test_service_watcher.py
@@ -8,7 +8,7 @@ import contextlib
 import time
 from collections.abc import AsyncIterator, Callable
 from typing import ClassVar, NamedTuple
-from unittest.mock import Mock, patch
+from unittest.mock import patch
 
 import pytest
 
@@ -27,9 +27,17 @@ from hassette.testing._reset import reset_hassette_lifecycle
 from hassette.types import ResourceRole, ResourceStatus, Topic
 from hassette.types.enums import RestartType
 from tests.support.harness import preserve_config
-from tests.support.helpers import make_crashed_event, make_service_failed_event, make_service_running_event
+from tests.support.helpers import (
+    PLACEHOLDER_APP_NAME,
+    make_crashed_event,
+    make_service_failed_event,
+    make_service_running_event,
+)
 
 AWAIT_TIMEOUT = 5.0
+
+SERVICE_RESOURCE_NAME_PATH = "payload.data.resource_name"
+"""Accessor path to a service-status event's resource_name, for narrowing test listeners."""
 
 
 def make_call_counts() -> dict[str, int]:
@@ -1026,13 +1034,20 @@ async def test_restart_refusal_shutdown_survives_event_dispatch_failure(
 async def dispatch_and_wait(watcher: ServiceWatcher, event: HassetteServiceEvent) -> None:
     """Send `event` through the real bus and return once dispatch for it has completed.
 
-    Registers a throwaway sentinel listener with the same status filter the watcher's own
-    handlers carry, minus the role filter, so it fires for exactly the events under test. That
-    makes "the watcher's handler did not run" a checked negative rather than a race with an
-    event that had not been delivered yet.
+    Registers a throwaway sentinel listener carrying the same status filter the watcher's own
+    handlers do, minus the role filter, narrowed further to `event`'s own resource_name so an
+    unrelated resource reaching the same status mid-test cannot satisfy the wait. That makes
+    "the watcher's handler did not run" a checked negative rather than a race with an event that
+    had not been delivered yet.
+
+    The sentinel firing proves the event was delivered and matched, but each matching handler
+    runs as its own task -- so this also waits for dispatch to go idle, otherwise a watcher
+    handler that *did* wrongly match could still be mid-flight when the caller asserts it never
+    ran.
     """
     fired = asyncio.Event()
     hassette = watcher.hassette
+    data = event.payload.data
 
     async def sentinel(_: HassetteServiceEvent) -> None:
         hassette.task_bucket.post_to_loop(fired.set)
@@ -1040,12 +1055,14 @@ async def dispatch_and_wait(watcher: ServiceWatcher, event: HassetteServiceEvent
     await watcher.bus.on(
         topic=str(Topic.HASSETTE_EVENT_SERVICE_STATUS),
         handler=sentinel,
-        name=f"test.service_watcher.sentinel.{event.payload.data.status}",
-        where=P.ValueIs(source=get_path(SERVICE_STATUS_PATH), condition=event.payload.data.status),
+        name=f"test.service_watcher.sentinel.{data.resource_name}.{data.status}",
+        where=P.ValueIs(source=get_path(SERVICE_STATUS_PATH), condition=data.status)
+        & P.ValueIs(source=get_path(SERVICE_RESOURCE_NAME_PATH), condition=data.resource_name),
     )
 
     await hassette.send_event(event)
     await asyncio.wait_for(fired.wait(), timeout=AWAIT_TIMEOUT)
+    await hassette.bus_service.await_dispatch_idle(timeout=AWAIT_TIMEOUT)
 
 
 async def test_app_role_crashed_event_does_not_shut_down_process(
@@ -1061,27 +1078,39 @@ async def test_app_role_crashed_event_does_not_shut_down_process(
         hassette = watcher.hassette
         await watcher.register_internal_event_listeners()
 
-        await dispatch_and_wait(watcher, make_crashed_event(resource_name="MyApp", role=ResourceRole.APP))
+        await dispatch_and_wait(watcher, make_crashed_event(resource_name=PLACEHOLDER_APP_NAME, role=ResourceRole.APP))
 
         assert hassette.fatal_shutdown_reason is None, "APP-role crash must not record a fatal reason"
         assert not hassette.shutdown_event.is_set(), "APP-role crash must not request shutdown"
 
 
-async def test_app_role_failed_event_does_not_warn_about_missing_service(
+async def test_app_role_failed_event_does_not_reach_restart_service(
     test_config_class: type[HassetteConfig], unused_tcp_port_factory: "Callable[[], int]"
 ):
-    """An APP-role FAILED event never reaches restart_service, so it logs no lookup warning."""
+    """An APP-role FAILED event never reaches restart_service.
+
+    restart_service resolves a Service child by (name, role); for an app it resolves nothing and
+    bails out before touching a restart budget, so the only observable difference between "the
+    filter worked" and "the handler ran and found nothing" is whether the handler ran at all.
+    A pass-through spy installed before registration records that directly.
+    """
     async with isolated_watcher(test_config_class, unused_tcp_port_factory) as watcher:
+        received: list[HassetteServiceEvent] = []
+        real_restart_service = watcher.restart_service
+
+        async def spy(event: HassetteServiceEvent) -> None:
+            received.append(event)
+            await real_restart_service(event)
+
+        watcher.restart_service = spy  # pyright: ignore[reportAttributeAccessIssue]
         await watcher.register_internal_event_listeners()
-        watcher.logger = Mock()
 
         failed_event = HassetteServiceEvent.from_service_status(
-            resource_name="MyApp",
+            resource_name=PLACEHOLDER_APP_NAME,
             role=ResourceRole.APP,
             status=ResourceStatus.FAILED,
             exception=RuntimeError("app init blew up"),
         )
         await dispatch_and_wait(watcher, failed_event)
 
-        watcher.logger.warning.assert_not_called()
-        assert not watcher._budgets, "APP-role failure must not open a restart budget"
+        assert not received, "APP-role failure must not reach restart_service"

--- a/tests/integration/test_service_watcher.py
+++ b/tests/integration/test_service_watcher.py
@@ -29,6 +29,7 @@ from hassette.types.enums import RestartType
 from tests.support.harness import preserve_config
 from tests.support.helpers import (
     PLACEHOLDER_APP_NAME,
+    PLACEHOLDER_RESOURCE_NAME,
     make_crashed_event,
     make_service_failed_event,
     make_service_running_event,
@@ -1082,6 +1083,32 @@ async def test_app_role_crashed_event_does_not_shut_down_process(
 
         assert hassette.fatal_shutdown_reason is None, "APP-role crash must not record a fatal reason"
         assert not hassette.shutdown_event.is_set(), "APP-role crash must not request shutdown"
+
+
+async def test_resource_role_crashed_event_still_shuts_down_process(
+    test_config_class: type[HassetteConfig], unused_tcp_port_factory: "Callable[[], int]"
+):
+    """A RESOURCE-role CRASHED event still records a fatal reason and requests shutdown.
+
+    The role filter excludes apps, not everything that is not a Service. Several framework
+    components are plain ``Resource`` subclasses rather than ``Service`` -- notably
+    ``AppLifecycleService``, which calls ``handle_crash`` when ``bootstrap_apps()`` raises. That
+    crash reaches the watcher as a RESOURCE-role event, and it must still stop the process:
+    ``AppHandler`` runs bootstrap as a detached task, so nothing else converts the failure into a
+    non-zero exit, and Hassette would otherwise keep running with no apps bootstrapped.
+    """
+    async with isolated_watcher(test_config_class, unused_tcp_port_factory) as watcher:
+        hassette = watcher.hassette
+        await watcher.register_internal_event_listeners()
+
+        await dispatch_and_wait(
+            watcher,
+            make_crashed_event(resource_name=PLACEHOLDER_RESOURCE_NAME, role=ResourceRole.RESOURCE),
+        )
+
+        assert hassette.fatal_shutdown_reason is not None, "RESOURCE-role crash must record a fatal reason"
+        assert PLACEHOLDER_RESOURCE_NAME in hassette.fatal_shutdown_reason
+        assert hassette.shutdown_event.is_set(), "RESOURCE-role crash must request shutdown"
 
 
 async def test_app_role_failed_event_does_not_reach_restart_service(

--- a/tests/integration/test_service_watcher.py
+++ b/tests/integration/test_service_watcher.py
@@ -8,12 +8,14 @@ import contextlib
 import time
 from collections.abc import AsyncIterator, Callable
 from typing import ClassVar, NamedTuple
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 import pytest
 
 from hassette import HassetteConfig, context
-from hassette.core.service_watcher import ServiceWatcher
+from hassette.core.service_watcher import SERVICE_STATUS_PATH, ServiceWatcher
+from hassette.event_handling import predicates as P
+from hassette.event_handling.accessors import get_path
 from hassette.events import Event, HassetteServiceEvent
 from hassette.events.base import HassettePayload
 from hassette.events.hassette import ServiceStatusPayload
@@ -22,10 +24,10 @@ from hassette.resources.restart import RestartSpec
 from hassette.resources.service import Service
 from hassette.testing import EventCapture, HassetteHarness, build_harness, wait_for
 from hassette.testing._reset import reset_hassette_lifecycle
-from hassette.types import ResourceStatus, Topic
+from hassette.types import ResourceRole, ResourceStatus, Topic
 from hassette.types.enums import RestartType
 from tests.support.harness import preserve_config
-from tests.support.helpers import make_service_failed_event, make_service_running_event
+from tests.support.helpers import make_crashed_event, make_service_failed_event, make_service_running_event
 
 AWAIT_TIMEOUT = 5.0
 
@@ -1019,3 +1021,67 @@ async def test_restart_refusal_shutdown_survives_event_dispatch_failure(
         assert hassette.fatal_shutdown_reason is not None
         assert service.class_name in hassette.fatal_shutdown_reason
         assert hassette.shutdown_event.is_set()
+
+
+async def dispatch_and_wait(watcher: ServiceWatcher, event: HassetteServiceEvent) -> None:
+    """Send `event` through the real bus and return once dispatch for it has completed.
+
+    Registers a throwaway sentinel listener with the same status filter the watcher's own
+    handlers carry, minus the role filter, so it fires for exactly the events under test. That
+    makes "the watcher's handler did not run" a checked negative rather than a race with an
+    event that had not been delivered yet.
+    """
+    fired = asyncio.Event()
+    hassette = watcher.hassette
+
+    async def sentinel(_: HassetteServiceEvent) -> None:
+        hassette.task_bucket.post_to_loop(fired.set)
+
+    await watcher.bus.on(
+        topic=str(Topic.HASSETTE_EVENT_SERVICE_STATUS),
+        handler=sentinel,
+        name=f"test.service_watcher.sentinel.{event.payload.data.status}",
+        where=P.ValueIs(source=get_path(SERVICE_STATUS_PATH), condition=event.payload.data.status),
+    )
+
+    await hassette.send_event(event)
+    await asyncio.wait_for(fired.wait(), timeout=AWAIT_TIMEOUT)
+
+
+async def test_app_role_crashed_event_does_not_shut_down_process(
+    test_config_class: type[HassetteConfig], unused_tcp_port_factory: "Callable[[], int]"
+):
+    """An APP-role CRASHED event records no fatal reason and requests no shutdown.
+
+    Apps emit HASSETTE_EVENT_SERVICE_STATUS through the same lifecycle machinery services do,
+    so shutdown_if_crashed would otherwise take the whole process down for one crashed app
+    instance. The role filter on the subscription is what prevents it.
+    """
+    async with isolated_watcher(test_config_class, unused_tcp_port_factory) as watcher:
+        hassette = watcher.hassette
+        await watcher.register_internal_event_listeners()
+
+        await dispatch_and_wait(watcher, make_crashed_event(resource_name="MyApp", role=ResourceRole.APP))
+
+        assert hassette.fatal_shutdown_reason is None, "APP-role crash must not record a fatal reason"
+        assert not hassette.shutdown_event.is_set(), "APP-role crash must not request shutdown"
+
+
+async def test_app_role_failed_event_does_not_warn_about_missing_service(
+    test_config_class: type[HassetteConfig], unused_tcp_port_factory: "Callable[[], int]"
+):
+    """An APP-role FAILED event never reaches restart_service, so it logs no lookup warning."""
+    async with isolated_watcher(test_config_class, unused_tcp_port_factory) as watcher:
+        await watcher.register_internal_event_listeners()
+        watcher.logger = Mock()
+
+        failed_event = HassetteServiceEvent.from_service_status(
+            resource_name="MyApp",
+            role=ResourceRole.APP,
+            status=ResourceStatus.FAILED,
+            exception=RuntimeError("app init blew up"),
+        )
+        await dispatch_and_wait(watcher, failed_event)
+
+        watcher.logger.warning.assert_not_called()
+        assert not watcher._budgets, "APP-role failure must not open a restart budget"

--- a/tests/integration/test_service_watcher.py
+++ b/tests/integration/test_service_watcher.py
@@ -1033,22 +1033,22 @@ async def test_restart_refusal_shutdown_survives_event_dispatch_failure(
 
 
 async def dispatch_and_wait(watcher: ServiceWatcher, event: HassetteServiceEvent) -> None:
-    """Send `event` through the real bus and return once dispatch for it has completed.
+    """Send ``event`` through the real bus and return once dispatch for it has completed.
 
     Registers a throwaway sentinel listener carrying the same status filter the watcher's own
-    handlers do, minus the role filter, narrowed further to `event`'s own resource_name so an
+    handlers do, minus the role filter, narrowed further to ``event``'s own resource_name so an
     unrelated resource reaching the same status mid-test cannot satisfy the wait. That makes
     "the watcher's handler did not run" a checked negative rather than a race with an event that
     had not been delivered yet.
 
     The sentinel firing proves the event was delivered and matched, but each matching handler
-    runs as its own task -- so this also waits for dispatch to go idle, otherwise a watcher
+    runs as its own task — so this also waits for dispatch to go idle, otherwise a watcher
     handler that *did* wrongly match could still be mid-flight when the caller asserts it never
     ran.
     """
     fired = asyncio.Event()
     hassette = watcher.hassette
-    data = event.payload.data
+    status_payload = event.payload.data
 
     async def sentinel(_: HassetteServiceEvent) -> None:
         hassette.task_bucket.post_to_loop(fired.set)
@@ -1056,9 +1056,9 @@ async def dispatch_and_wait(watcher: ServiceWatcher, event: HassetteServiceEvent
     await watcher.bus.on(
         topic=str(Topic.HASSETTE_EVENT_SERVICE_STATUS),
         handler=sentinel,
-        name=f"test.service_watcher.sentinel.{data.resource_name}.{data.status}",
-        where=P.ValueIs(source=get_path(SERVICE_STATUS_PATH), condition=data.status)
-        & P.ValueIs(source=get_path(SERVICE_RESOURCE_NAME_PATH), condition=data.resource_name),
+        name=f"test.service_watcher.sentinel.{status_payload.resource_name}.{status_payload.status}",
+        where=P.ValueIs(source=get_path(SERVICE_STATUS_PATH), condition=status_payload.status)
+        & P.ValueIs(source=get_path(SERVICE_RESOURCE_NAME_PATH), condition=status_payload.resource_name),
     )
 
     await hassette.send_event(event)

--- a/tests/support/helpers.py
+++ b/tests/support/helpers.py
@@ -48,6 +48,11 @@ PLACEHOLDER_APP_NAME = "TestApp"
 ``PLACEHOLDER_SERVICE_NAME``. Apps emit on the same status topic services do, so tests covering
 role filtering need a name that reads as an app rather than a service."""
 
+PLACEHOLDER_RESOURCE_NAME = "TestResource"
+"""Stand-in resource_name for RESOURCE-role lifecycle events. Plain ``Resource`` subclasses
+(``AppLifecycleService``, ``StateProxy``, ``AppHandler``) emit on the same status topic under a
+third role, which role-filtering tests must distinguish from both SERVICE and APP."""
+
 SETTLE_SECONDS = 0.05
 """Default settle window: seconds to let a stray extra handler call land before a negative assertion."""
 

--- a/tests/support/helpers.py
+++ b/tests/support/helpers.py
@@ -277,14 +277,19 @@ def make_crashed_event(
     exception_type: str | None = "RuntimeError",
     exception: str | None = "something broke",
     exception_traceback: str | None = "Traceback ...",
+    role: ResourceRole = ResourceRole.SERVICE,
 ) -> HassetteServiceEvent:
-    """Build a CRASHED HassetteServiceEvent for testing."""
+    """Build a CRASHED HassetteServiceEvent for testing.
+
+    ``role`` defaults to SERVICE; pass APP to build the kind of event the ServiceWatcher's
+    role filter must reject.
+    """
     return HassetteServiceEvent(
         topic=Topic.HASSETTE_EVENT_SERVICE_STATUS,
         payload=HassettePayload(
             data=ServiceStatusPayload(
                 resource_name=resource_name,
-                role=ResourceRole.SERVICE,
+                role=role,
                 status=ResourceStatus.CRASHED,
                 previous_status=ResourceStatus.FAILED,
                 exception=exception,

--- a/tests/support/helpers.py
+++ b/tests/support/helpers.py
@@ -43,6 +43,11 @@ PLACEHOLDER_SERVICE_NAME = "TestService"
 """Stand-in resource_name for the service-lifecycle event factories below. Tests that don't
 assert on the name should take this default rather than inventing another placeholder."""
 
+PLACEHOLDER_APP_NAME = "TestApp"
+"""Stand-in resource_name for APP-role lifecycle events, the counterpart to
+``PLACEHOLDER_SERVICE_NAME``. Apps emit on the same status topic services do, so tests covering
+role filtering need a name that reads as an app rather than a service."""
+
 SETTLE_SECONDS = 0.05
 """Default settle window: seconds to let a stray extra handler call land before a negative assertion."""
 

--- a/tests/unit/core/test_service_watcher_coverage.py
+++ b/tests/unit/core/test_service_watcher_coverage.py
@@ -20,6 +20,8 @@ from hassette.testing import wait_for
 from hassette.types import ResourceStatus, Topic
 from hassette.types.enums import ResourceRole, RestartType
 from tests.support.helpers import (
+    PLACEHOLDER_APP_NAME,
+    PLACEHOLDER_RESOURCE_NAME,
     PLACEHOLDER_SERVICE_NAME,
     make_crashed_event,
     make_service_failed_event,
@@ -103,8 +105,15 @@ class TestRegisterInternalEventListeners:
             ("hassette.service_watcher.on_service_running", ResourceStatus.RUNNING),
         ],
     )
-    async def test_acting_handler_is_role_filtered_to_services(self, handler_name: str, status: ResourceStatus) -> None:
-        """Each handler that acts on a resource accepts SERVICE-role events and rejects APP-role ones."""
+    async def test_acting_handler_excludes_apps_but_not_framework_resources(
+        self, handler_name: str, status: ResourceStatus
+    ) -> None:
+        """Each acting handler rejects APP-role events and accepts every other framework role.
+
+        RESOURCE is asserted alongside SERVICE on purpose: plain ``Resource`` subclasses such as
+        ``AppLifecycleService`` reach ``handle_crash``, and a SERVICE-only filter would drop
+        those framework crashes along with the app noise this filter exists to remove.
+        """
         hassette = make_watcher_hassette()
         watcher = make_watcher(hassette)
 
@@ -115,11 +124,15 @@ class TestRegisterInternalEventListeners:
         service_event = HassetteServiceEvent.from_service_status(
             resource_name=PLACEHOLDER_SERVICE_NAME, role=ResourceRole.SERVICE, status=status
         )
+        resource_event = HassetteServiceEvent.from_service_status(
+            resource_name=PLACEHOLDER_RESOURCE_NAME, role=ResourceRole.RESOURCE, status=status
+        )
         app_event = HassetteServiceEvent.from_service_status(
-            resource_name="MyApp", role=ResourceRole.APP, status=status
+            resource_name=PLACEHOLDER_APP_NAME, role=ResourceRole.APP, status=status
         )
 
         assert where(service_event), f"{handler_name} should accept SERVICE-role events"
+        assert where(resource_event), f"{handler_name} should accept RESOURCE-role events"
         assert not where(app_event), f"{handler_name} should reject APP-role events"
 
 

--- a/tests/unit/core/test_service_watcher_coverage.py
+++ b/tests/unit/core/test_service_watcher_coverage.py
@@ -95,29 +95,32 @@ class TestRegisterInternalEventListeners:
         assert registered_by_name["hassette.service_watcher.on_service_running"].get("where") is not None
         assert registered_by_name["hassette.service_watcher.on_bus_service_running"].get("where") is not None
 
-    async def test_acting_handlers_are_role_filtered_to_services(self) -> None:
-        """The three handlers that act on a resource reject APP-role events; the logger keeps them."""
+    @pytest.mark.parametrize(
+        ("handler_name", "status"),
+        [
+            ("hassette.service_watcher.restart_service", ResourceStatus.FAILED),
+            ("hassette.service_watcher.shutdown_if_crashed", ResourceStatus.CRASHED),
+            ("hassette.service_watcher.on_service_running", ResourceStatus.RUNNING),
+        ],
+    )
+    async def test_acting_handler_is_role_filtered_to_services(self, handler_name: str, status: ResourceStatus) -> None:
+        """Each handler that acts on a resource accepts SERVICE-role events and rejects APP-role ones."""
         hassette = make_watcher_hassette()
         watcher = make_watcher(hassette)
 
         await watcher.register_internal_event_listeners()
         registered_by_name = {call.kwargs["name"]: call.kwargs for call in watcher.bus.on.await_args_list}
 
-        acting_handlers = {
-            "hassette.service_watcher.restart_service": ResourceStatus.FAILED,
-            "hassette.service_watcher.shutdown_if_crashed": ResourceStatus.CRASHED,
-            "hassette.service_watcher.on_service_running": ResourceStatus.RUNNING,
-        }
-        for name, status in acting_handlers.items():
-            where = registered_by_name[name]["where"]
-            service_event = HassetteServiceEvent.from_service_status(
-                resource_name=PLACEHOLDER_SERVICE_NAME, role=ResourceRole.SERVICE, status=status
-            )
-            app_event = HassetteServiceEvent.from_service_status(
-                resource_name="MyApp", role=ResourceRole.APP, status=status
-            )
-            assert where(service_event), f"{name} should accept SERVICE-role events"
-            assert not where(app_event), f"{name} should reject APP-role events"
+        where = registered_by_name[handler_name]["where"]
+        service_event = HassetteServiceEvent.from_service_status(
+            resource_name=PLACEHOLDER_SERVICE_NAME, role=ResourceRole.SERVICE, status=status
+        )
+        app_event = HassetteServiceEvent.from_service_status(
+            resource_name="MyApp", role=ResourceRole.APP, status=status
+        )
+
+        assert where(service_event), f"{handler_name} should accept SERVICE-role events"
+        assert not where(app_event), f"{handler_name} should reject APP-role events"
 
 
 def make_running_event(

--- a/tests/unit/core/test_service_watcher_coverage.py
+++ b/tests/unit/core/test_service_watcher_coverage.py
@@ -95,6 +95,30 @@ class TestRegisterInternalEventListeners:
         assert registered_by_name["hassette.service_watcher.on_service_running"].get("where") is not None
         assert registered_by_name["hassette.service_watcher.on_bus_service_running"].get("where") is not None
 
+    async def test_acting_handlers_are_role_filtered_to_services(self) -> None:
+        """The three handlers that act on a resource reject APP-role events; the logger keeps them."""
+        hassette = make_watcher_hassette()
+        watcher = make_watcher(hassette)
+
+        await watcher.register_internal_event_listeners()
+        registered_by_name = {call.kwargs["name"]: call.kwargs for call in watcher.bus.on.await_args_list}
+
+        acting_handlers = {
+            "hassette.service_watcher.restart_service": ResourceStatus.FAILED,
+            "hassette.service_watcher.shutdown_if_crashed": ResourceStatus.CRASHED,
+            "hassette.service_watcher.on_service_running": ResourceStatus.RUNNING,
+        }
+        for name, status in acting_handlers.items():
+            where = registered_by_name[name]["where"]
+            service_event = HassetteServiceEvent.from_service_status(
+                resource_name=PLACEHOLDER_SERVICE_NAME, role=ResourceRole.SERVICE, status=status
+            )
+            app_event = HassetteServiceEvent.from_service_status(
+                resource_name="MyApp", role=ResourceRole.APP, status=status
+            )
+            assert where(service_event), f"{name} should accept SERVICE-role events"
+            assert not where(app_event), f"{name} should reject APP-role events"
+
 
 def make_running_event(
     previous_status: ResourceStatus, resource_name: str = PLACEHOLDER_SERVICE_NAME


### PR DESCRIPTION
## Summary

`ServiceWatcher` subscribed to `HASSETTE_EVENT_SERVICE_STATUS` filtering on **status only**, never on role. Every `Resource` emits on that topic through the shared lifecycle machinery, so APP-role events reached handlers written for the framework.

Two consequences, one visible and one latent:

- **Noise (visible today):** every app init failure drove `handle_failed(app)` → FAILED event → `restart_service()` → `get_service(name, role)` resolved no `Service` child → a `"No App found for 'X', skipping restart"` WARNING. Every failing app produced recurring watcher warnings unrelated to service restarts.
- **Process kill (latent):** `shutdown_if_crashed` had no role filter either, so any path driving an APP-role resource through `handle_crash` would record a fatal reason and request **whole-process shutdown** — taking the framework down for a single crashed app instance. Nothing but convention prevented that; the machinery is plain `Resource`-level code.

## What changed

`restart_service`, `shutdown_if_crashed`, and `on_service_running` now carry a role predicate (`IS_NOT_APP_ROLE`) alongside their existing status filter. Filtering at registration makes "apps are not the watcher's business" a structural guarantee rather than a convention a future caller can break.

The predicate **excludes APP** rather than admitting SERVICE only, and that distinction is load-bearing. The watcher is not services-only: `shutdown_if_crashed` is the process-level fatal handler for every framework resource, and several of those are plain `Resource` subclasses (RESOURCE role) rather than `Service`. `AppLifecycleService` reaches `handle_crash` when `bootstrap_apps()` raises, and `AppHandler` runs that bootstrap as a detached task — so nothing else converts the failure into a non-zero exit. A SERVICE-only filter would have swallowed it, leaving Hassette running with no apps bootstrapped and only a logged task error. Negating APP also fails open on a missing or malformed role, matching the unfiltered behavior it narrows.

`log_service_event` is deliberately left unfiltered, and the reason is now recorded in its docstring: it takes no action on the resource it observes, so an APP-role event costs a debug line and nothing else, and keeping apps in makes the watcher's log a complete transition trace for the topic — which is what it is read for when reconstructing a startup or shutdown sequence.

`on_bus_service_running` is also unchanged: it already narrows to `resource_name == BusService.__name__` before doing anything, so an APP-role event cannot reach its body.

## Testing

- **Integration** (`tests/integration/test_service_watcher.py`): three regression tests dispatch real events through the real bus. An APP-role CRASHED event records no fatal reason and sets no shutdown event; an APP-role FAILED event never reaches `restart_service`, observed via a pass-through spy installed before registration; and a RESOURCE-role CRASHED event **does** still record a fatal reason and request shutdown, pinning the framework-crash path the filter must not break. All use a `dispatch_and_wait` sentinel listener carrying the same status filter minus the role filter, narrowed to the event's own `resource_name` and followed by `await_dispatch_idle()`, so "the watcher's handler did not run" is a checked negative rather than a race against undelivered dispatch or a still-in-flight handler task.
- **Unit** (`tests/unit/core/test_service_watcher_coverage.py`): a parameterized case per acting handler asserts its registered `where=` predicate accepts SERVICE-role *and* RESOURCE-role events while rejecting APP-role ones.
- `uv run nox -s dev` — full suite green; the watcher unit + integration files pass 69/69.
- `prek -a` and `prek pyright -a --stage pre-push` — all hooks pass.

Closes #1799

## Follow-up filed

Review surfaced the same missing-role-filter pattern in `SessionManager.on_service_crashed` (`session_manager.py:53-58`), where an APP-role CRASHED event marks the whole session `failure`. Left out of scope here because whether an app crash *should* mark the session failed is a semantic call, not a mechanical fix — filed as #2153. Related: #1666 covers the same root cause for `RuntimeQueryService`.
