### PR TITLE
fix: resolve dropped queued-invocation futures so dispatch slots are not leaked

### DIFF
--- a/src/hassette/execution_mode.py
+++ b/src/hassette/execution_mode.py
@@ -162,6 +162,8 @@ class ExecutionModeGuard:
         self.current_task = None
         # Drain in arrival order. If a factory raises synchronously, drop it and try the next so a
         # single failed spawn cannot strand the rest of the queue with no live task to re-trigger it.
+        # A dropped factory is responsible for resolving its own completion bridge on the way out
+        # (see ``run_through_guard``), so dropping it here never parks its dispatch task.
         while self.pending:
             run_and_track = self.pending.popleft()
             try:
@@ -231,9 +233,13 @@ async def run_through_guard(
 
     Completion bridge: installs exactly one done-callback on ``pending_done`` per call; that
     callback fires when the spawned task completes, which may be after this function returns.
-    The caller must call ``drain_pending_done(pending_done)`` after every ``guard.release()`` to
-    resolve futures whose factory was dropped without ever running (the QUEUED_ACCEPTED-then-
-    released case), otherwise the parked outer task hangs forever.
+    When ``spawn`` itself raises (a sealed ``TaskBucket``, say), no task exists to fire that
+    callback, so the factory resolves the future before re-raising — ``guard.drain_next`` drops
+    such a factory rather than propagating the error, and an unresolved future there would park
+    the outer dispatch task forever. The caller must call ``drain_pending_done(pending_done)``
+    after every ``guard.release()`` to resolve futures whose factory was dropped without ever
+    running (the QUEUED_ACCEPTED-then-released case), otherwise the parked outer task hangs
+    forever.
 
     Note: the ``drain_next``/``release`` interleave edge (a task spawned by ``drain_next``
     concurrently with ``release()`` may detach rather than cancel) applies to every caller
@@ -250,7 +256,15 @@ async def run_through_guard(
             done.set_result(None)
 
     def run_and_track() -> "asyncio.Task[None]":
-        task = spawn(run_with_stall_watch(invoke, warn, threshold), name=spawn_name)
+        try:
+            task = spawn(run_with_stall_watch(invoke, warn, threshold), name=spawn_name)
+        except Exception:
+            # No task exists, so nothing will ever fire the done-callback below. Resolve the
+            # future here or a caller that drops this factory instead of propagating the error
+            # (``ExecutionModeGuard.drain_next``) leaves the outer dispatch task parked on
+            # ``await done`` forever, holding its dispatch-concurrency slot.
+            resolve_done()
+            raise
         task.add_done_callback(lambda _t: resolve_done())
         return task
 

--- a/src/hassette/execution_mode.py
+++ b/src/hassette/execution_mode.py
@@ -231,15 +231,21 @@ async def run_through_guard(
     ``spawn_name``). ``spawn`` is a bare callable rather than a ``TaskBucket`` so this module
     stays a dependency-free leaf.
 
-    Completion bridge: installs exactly one done-callback on ``pending_done`` per call; that
-    callback fires when the spawned task completes, which may be after this function returns.
-    When ``spawn`` itself raises (a sealed ``TaskBucket``, say), no task exists to fire that
-    callback, so the factory resolves the future before re-raising — ``guard.drain_next`` drops
-    such a factory rather than propagating the error, and an unresolved future there would park
-    the outer dispatch task forever. The caller must call ``drain_pending_done(pending_done)``
-    after every ``guard.release()`` to resolve futures whose factory was dropped without ever
-    running (the QUEUED_ACCEPTED-then-released case), otherwise the parked outer task hangs
-    forever.
+    Completion bridge: every call adds one future to ``pending_done``, and the outer task parks
+    on that future until something resolves it. Three paths do:
+
+    - The spawned task's done-callback, installed by ``run_and_track``. Fires when the task
+      completes, which may be after this function returns.
+    - ``run_and_track`` itself, when ``spawn`` raises (a sealed ``TaskBucket``, say) and so no
+      task exists to carry that callback. It resolves before re-raising because the error may
+      never reach a caller: ``guard.drain_next`` drops such a factory and keeps draining.
+      Resolving here rather than in ``drain_next`` is not a preference — ``drain_next`` holds
+      only the opaque factory and never sees ``pending_done``.
+    - ``drain_pending_done(pending_done)``, which the caller must invoke after every
+      ``guard.release()`` to cover futures whose factory was dropped without ever running (the
+      QUEUED_ACCEPTED-then-released case).
+
+    A future missed by all three parks its outer task forever.
 
     Note: the ``drain_next``/``release`` interleave edge (a task spawned by ``drain_next``
     concurrently with ``release()`` may detach rather than cancel) applies to every caller
@@ -258,11 +264,11 @@ async def run_through_guard(
     def run_and_track() -> "asyncio.Task[None]":
         try:
             task = spawn(run_with_stall_watch(invoke, warn, threshold), name=spawn_name)
-        except Exception:
-            # No task exists, so nothing will ever fire the done-callback below. Resolve the
-            # future here or a caller that drops this factory instead of propagating the error
-            # (``ExecutionModeGuard.drain_next``) leaves the outer dispatch task parked on
-            # ``await done`` forever, holding its dispatch-concurrency slot.
+        except BaseException:
+            # No task, so nothing below will ever fire the done-callback — see the completion
+            # bridge notes in the docstring for why this must resolve here. Same shape as the
+            # by-hand unwind in ``BusService._spawn_dispatch_task``, which releases its
+            # semaphore permit under the same circumstances.
             resolve_done()
             raise
         task.add_done_callback(lambda _t: resolve_done())

--- a/tests/unit/core/test_bus_dispatch_semaphore.py
+++ b/tests/unit/core/test_bus_dispatch_semaphore.py
@@ -10,10 +10,12 @@ import asyncio
 from unittest.mock import AsyncMock, MagicMock
 
 from hassette.core.bus_service import _DISPATCH_SATURATION_WARN_RATE_LIMIT_SECS, BusService
+from hassette.task_bucket import TaskBucket
 from hassette.testing import wait_for
 from hassette.types.enums import BackpressurePolicy, ExecutionMode
 from tests.support.factories import make_mock_event
-from tests.support.helpers import create_listener, make_task_bucket
+from tests.support.helpers import create_listener
+from tests.support.mock_hassette import make_mock_hassette
 
 from .conftest import make_bus_service
 
@@ -314,16 +316,9 @@ async def test_queued_factory_rejected_at_drain_releases_its_dispatch_slot() -> 
     """
     svc = make_bus_service(max_concurrent_dispatches=2)
 
-    sealed = False
-
-    def spawn(coro, *, name: str | None = None) -> asyncio.Task:
-        if sealed:
-            coro.close()  # mirrors TaskBucket.spawn: close the rejected coroutine
-            raise RuntimeError("task bucket is sealed")
-        return asyncio.create_task(coro, name=name)
-
-    handler_bucket = make_task_bucket()
-    handler_bucket.spawn = spawn
+    # A real TaskBucket, so the rejection this test hinges on is the production sealed-spawn
+    # path rather than a stand-in that could drift from it.
+    handler_bucket = TaskBucket(make_mock_hassette())
 
     listener = create_listener(
         topic="test.topic",
@@ -354,7 +349,7 @@ async def test_queued_factory_rejected_at_drain_releases_its_dispatch_slot() -> 
 
     # Seal the handler bucket, then let the running invocation finish: drain_next pops the
     # queued factory and its spawn is rejected.
-    sealed = True
+    handler_bucket.seal()
     gate.set()
 
     await asyncio.wait_for(svc.await_dispatch_idle(timeout=TEST_TIMEOUT), timeout=TEST_TIMEOUT)

--- a/tests/unit/core/test_bus_dispatch_semaphore.py
+++ b/tests/unit/core/test_bus_dispatch_semaphore.py
@@ -7,12 +7,13 @@ enforcement added in #1076 (Layer 2).
 """
 
 import asyncio
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
 
 from hassette.core.bus_service import _DISPATCH_SATURATION_WARN_RATE_LIMIT_SECS, BusService
-from hassette.types.enums import BackpressurePolicy
+from hassette.testing import wait_for
+from hassette.types.enums import BackpressurePolicy, ExecutionMode
 from tests.support.factories import make_mock_event
-from tests.support.helpers import create_listener
+from tests.support.helpers import create_listener, make_task_bucket
 
 from .conftest import make_bus_service
 
@@ -301,3 +302,62 @@ async def test_drop_newest_does_not_perturb_dispatch_idle() -> None:
     await asyncio.wait_for(svc.await_dispatch_idle(timeout=TEST_TIMEOUT), timeout=TEST_TIMEOUT)
 
     svc._dispatch_semaphore.release()
+
+
+async def test_queued_factory_rejected_at_drain_releases_its_dispatch_slot() -> None:
+    """A queued invocation whose spawn is rejected at drain time still frees its slot (#1805).
+
+    ``ExecutionModeGuard.drain_next`` drops a factory whose spawn raises (a sealed TaskBucket
+    during teardown) and keeps draining. Without the bridge resolving that factory's completion
+    future, the queued trigger's dispatch task parks forever holding one of the
+    ``max_concurrent_dispatches`` permits — a silent, permanent capacity leak.
+    """
+    svc = make_bus_service(max_concurrent_dispatches=2)
+
+    sealed = False
+
+    def spawn(coro, *, name: str | None = None) -> asyncio.Task:
+        if sealed:
+            coro.close()  # mirrors TaskBucket.spawn: close the rejected coroutine
+            raise RuntimeError("task bucket is sealed")
+        return asyncio.create_task(coro, name=name)
+
+    handler_bucket = make_task_bucket()
+    handler_bucket.spawn = spawn
+
+    listener = create_listener(
+        topic="test.topic",
+        name="queued",
+        mode=ExecutionMode.QUEUED,
+        task_bucket=handler_bucket,
+    )
+    svc.router.add_route(listener.topic, listener)
+
+    gate = asyncio.Event()
+    running = asyncio.Event()
+
+    async def gated_execute(_cmd) -> None:
+        running.set()
+        await gate.wait()
+
+    svc._executor.execute = AsyncMock(side_effect=gated_execute)
+
+    # First event runs and blocks inside the handler.
+    await asyncio.wait_for(svc.dispatch("test.topic", make_mock_event()), timeout=TEST_TIMEOUT)
+    await asyncio.wait_for(running.wait(), timeout=TEST_TIMEOUT)
+
+    # Second event is QUEUED_ACCEPTED — its dispatch task parks on the completion future
+    # while holding the second permit.
+    await asyncio.wait_for(svc.dispatch("test.topic", make_mock_event()), timeout=TEST_TIMEOUT)
+    await wait_for(lambda: len(listener.invoker.guard.pending) >= 1)
+    assert svc._dispatch_semaphore.locked(), "both permits are held while one trigger is queued"
+
+    # Seal the handler bucket, then let the running invocation finish: drain_next pops the
+    # queued factory and its spawn is rejected.
+    sealed = True
+    gate.set()
+
+    await asyncio.wait_for(svc.await_dispatch_idle(timeout=TEST_TIMEOUT), timeout=TEST_TIMEOUT)
+
+    assert svc._dispatch_pending == 0
+    await assert_all_slots_reacquirable(svc, 2)

--- a/tests/unit/test_execution_mode_helpers.py
+++ b/tests/unit/test_execution_mode_helpers.py
@@ -301,6 +301,71 @@ class TestRunThroughGuard:
         assert len(spawn_calls) == 1
         assert spawn_calls[0]["name"] == "my-task"
 
+    async def test_dropped_at_drain_time_resolves_its_own_future(self) -> None:
+        """A queued factory whose spawn raises at drain time resolves its own future (#1805).
+
+        ``ExecutionModeGuard.drain_next`` drops such a factory and keeps draining rather than
+        propagating the error, so nothing downstream would ever resolve the bridge future — the
+        outer dispatch task would stay parked on ``await done`` forever.
+        """
+        guard = ExecutionModeGuard(ExecutionMode.QUEUED)
+        pending_done: set[asyncio.Future[None]] = set()
+
+        sealed = False
+
+        def spawn(coro: Coroutine[Any, Any, None], *, name: str) -> asyncio.Task[None]:
+            if sealed:
+                coro.close()  # mirrors TaskBucket.spawn: close the rejected coroutine
+                raise RuntimeError("task bucket is sealed")
+            return asyncio.create_task(coro, name=name)
+
+        gate = asyncio.Event()
+        started = asyncio.Event()
+
+        async def invoke_running() -> None:
+            started.set()
+            await gate.wait()
+
+        async def invoke_queued() -> None:
+            raise AssertionError("the queued factory must never run once its spawn is rejected")
+
+        first = asyncio.create_task(
+            run_through_guard(guard, spawn, pending_done, invoke_running, MagicMock(), "r", 60.0)
+        )
+        await asyncio.wait_for(started.wait(), timeout=2.0)
+
+        second = asyncio.create_task(
+            run_through_guard(guard, spawn, pending_done, invoke_queued, MagicMock(), "q", 60.0)
+        )
+        await wait_for(lambda: len(guard.pending) >= 1)
+
+        # Seal, then let the running invocation finish so drain_next pops the queued factory
+        # and its spawn is rejected.
+        sealed = True
+        gate.set()
+
+        await asyncio.wait_for(first, timeout=2.0)
+        await asyncio.wait_for(second, timeout=2.0)
+        assert len(pending_done) == 0
+        assert len(guard.pending) == 0
+
+    async def test_spawn_failure_propagates_when_the_guard_does_not_swallow_it(self) -> None:
+        """On the non-drain paths the spawn error still reaches the caller, future resolved."""
+        guard = ExecutionModeGuard(ExecutionMode.SINGLE)
+        pending_done: set[asyncio.Future[None]] = set()
+
+        def spawn(coro: Coroutine[Any, Any, None], *, name: str) -> asyncio.Task[None]:  # noqa: ARG001
+            coro.close()
+            raise RuntimeError("task bucket is sealed")
+
+        async def invoke() -> None:
+            raise AssertionError("never reached")
+
+        with pytest.raises(RuntimeError, match="sealed"):
+            await run_through_guard(guard, spawn, pending_done, invoke, MagicMock(), "n", 60.0)
+
+        assert len(pending_done) == 0
+
     async def test_drain_pending_done_resolves_queued_accepted_futures(self) -> None:
         """drain_pending_done after guard.release() resolves futures from QUEUED_ACCEPTED runs."""
         guard = ExecutionModeGuard(ExecutionMode.QUEUED)

--- a/tests/unit/test_execution_mode_helpers.py
+++ b/tests/unit/test_execution_mode_helpers.py
@@ -349,8 +349,12 @@ class TestRunThroughGuard:
         assert len(pending_done) == 0
         assert len(guard.pending) == 0
 
-    async def test_spawn_failure_propagates_when_the_guard_does_not_swallow_it(self) -> None:
-        """On the non-drain paths the spawn error still reaches the caller, future resolved."""
+    async def test_single_mode_spawn_failure_propagates_and_resolves_future(self) -> None:
+        """On the non-drain paths the spawn error still reaches the caller, future resolved.
+
+        Unlike the QUEUED drain path above, nothing swallows the error here, so the caller sees
+        it — and the bridge future is still resolved rather than left pending.
+        """
         guard = ExecutionModeGuard(ExecutionMode.SINGLE)
         pending_done: set[asyncio.Future[None]] = set()
 


### PR DESCRIPTION
## Summary

A queued invocation whose spawn is rejected at drain time no longer strands its dispatch task — and, for bus listeners, no longer permanently shrinks `max_concurrent_dispatches`.

`ExecutionModeGuard.drain_next` deliberately drops a queued factory whose `run_and_track()` raises synchronously (the realistic raiser being `TaskBucket.spawn()` on a sealed bucket during teardown) and keeps draining, so one failed spawn can't strand the rest of the queue. But nothing then resolved that factory's completion future in `run_through_guard`'s bridge: no task existed to fire the done-callback, and `drain_pending_done()` only runs after `guard.release()`, which this flow never reaches.

The queued trigger's outer dispatch task therefore parked on `await done` forever. For bus listeners that task holds one `_dispatch_semaphore` permit (released only by its own done-callback), so available dispatch concurrency dropped by one per occurrence, silently, and `_dispatch_pending` never settled. The scheduler side leaks no semaphore but still parks the task.

## What changed

`run_and_track` in `run_through_guard` now wraps the `spawn` call: if it raises, the factory resolves its own completion future before re-raising. This mirrors the by-hand unwind `BusService._spawn_dispatch_task` already performs when its own spawn fails.

Fixing it in the factory rather than in `drain_next`'s `except` branch keeps the future↔factory association where it already lives (the bridge closure) instead of threading it out to every caller that might drop a factory. It also covers the non-drain paths: callers that let the spawn error propagate get the same resolved-future guarantee, so no path can leave an orphaned pending future behind.

`drain_next`'s drop-and-continue behavior is unchanged, and #1099's `drain_next`/`release` interleave edge is untouched.

## Testing

- `tests/unit/test_execution_mode_helpers.py` — two new tests: a queued factory dropped at drain time resolves its own future (`pending_done` empties, both `run_through_guard` calls return), and the non-drain path still propagates the spawn error to the caller with the future resolved.
- `tests/unit/core/test_bus_dispatch_semaphore.py` — end-to-end regression at the `BusService` layer: saturate a `QUEUED` listener so a second trigger is `QUEUED_ACCEPTED` and both permits are held, seal the handler's `TaskBucket`, release the running invocation, then assert `await_dispatch_idle()` settles, `_dispatch_pending` reaches 0, and both semaphore slots are reacquirable.

Both suites use event-gated synchronization rather than `sleep(0)`, per the startup-race pattern in CLAUDE.md.

Verification run locally on this branch:

- `uv run nox -s dev` — 7719 passed, 1 skipped, 2 xfailed
- `prek -a` — all hooks pass
- `prek pyright -a --stage pre-push` — passes

Closes #1805
