### PR TITLE
fix: show skipped executions in the hassette job table

### DIFF
--- a/docs/pages/cli/commands.md
+++ b/docs/pages/cli/commands.md
@@ -237,14 +237,14 @@ Lists all scheduled jobs, or shows execution history for a specific job. A job i
 
 ```console
 $ hassette job
-┏━━━━┳━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━┳━━━━━━━━━━━┳━━━━━━━━━┳━━━━━━━┳━━━━┳━━━━━━┳━━━━━┳━━━━━━━━━━━━━━━━━━━━┓
-┃ ID ┃ App              ┃ Handler              ┃ Trigger  ┃ Status    ┃ Mode    ┃ Total ┃ OK ┃ Fail ┃ Avg ┃ Next Run           ┃
-┡━━━━╇━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━╇━━━━━━━━━━━╇━━━━━━━━━╇━━━━━━━╇━━━━╇━━━━━━╇━━━━━╇━━━━━━━━━━━━━━━━━━━━┩
-│ 1  │ config_app       │ StateProxy.sync_all  │ interval │ Scheduled │ single  │ 0     │ 0  │ 0    │ 0ms │ soon               │
-└────┴──────────────────┴──────────────────────┴──────────┴───────────┴─────────┴───────┴────┴──────┴─────┴────────────────────┘
+┏━━━━┳━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━┳━━━━━━━━━━━┳━━━━━━━━━┳━━━━━━━┳━━━━┳━━━━━━┳━━━━━━━━━┳━━━━━┳━━━━━━━━━━━━━━━━━━━━┓
+┃ ID ┃ App              ┃ Handler              ┃ Trigger  ┃ Status    ┃ Mode    ┃ Total ┃ OK ┃ Fail ┃ Skipped ┃ Avg ┃ Next Run           ┃
+┡━━━━╇━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━╇━━━━━━━━━━━╇━━━━━━━━━╇━━━━━━━╇━━━━╇━━━━━━╇━━━━━━━━━╇━━━━━╇━━━━━━━━━━━━━━━━━━━━┩
+│ 1  │ config_app       │ StateProxy.sync_all  │ interval │ Scheduled │ single  │ 0     │ 0  │ 0    │ 0       │ 0ms │ soon               │
+└────┴──────────────────┴──────────────────────┴──────────┴───────────┴─────────┴───────┴────┴──────┴─────────┴─────┴────────────────────┘
 ```
 
-Each row shows the job ID, app key, handler method, trigger type, schedule status (`scheduled`, `waiting`, `completed`, or `manual`), mode, execution counts, average duration, and next run time. The Next Run column shows a relative time when one is scheduled, or status-aware placeholder text otherwise — `Timing unavailable.`, `Waiting for entity time.`, `Schedule completed.`, or `Manual only.` — rather than a blank cell.
+Each row shows the job ID, app key, handler method, trigger type, schedule status (`scheduled`, `waiting`, `completed`, or `manual`), mode, execution counts, average duration, and next run time. Skipped counts runs where the job's predicate returned `False` and the handler never ran — those runs are included in Total, so a job showing `Total 68 / OK 0 / Fail 0 / Skipped 68` is being filtered out entirely rather than failing. The Next Run column shows a relative time when one is scheduled, or status-aware placeholder text otherwise — `Timing unavailable.`, `Waiting for entity time.`, `Schedule completed.`, or `Manual only.` — rather than a blank cell.
 
 Passing a job ID shows its execution history:
 

--- a/docs/pages/cli/commands.md
+++ b/docs/pages/cli/commands.md
@@ -244,7 +244,7 @@ $ hassette job
 └────┴──────────────────┴──────────────────────┴──────────┴───────────┴─────────┴───────┴────┴──────┴─────────┴─────┴────────────────────┘
 ```
 
-Each row shows the job ID, app key, handler method, trigger type, schedule status (`scheduled`, `waiting`, `completed`, or `manual`), mode, execution counts, average duration, and next run time. Skipped counts runs where the job's predicate returned `False` and the handler never ran — those runs are included in Total, so a job showing `Total 68 / OK 0 / Fail 0 / Skipped 68` is being filtered out entirely rather than failing. The Next Run column shows a relative time when one is scheduled, or status-aware placeholder text otherwise — `Timing unavailable.`, `Waiting for entity time.`, `Schedule completed.`, or `Manual only.` — rather than a blank cell.
+Each row shows the job ID, app key, handler method, trigger type, schedule status (`scheduled`, `waiting`, `completed`, or `manual`), mode, execution counts, average duration, and next run time. `Skipped` counts runs where the job's predicate returned `False` and the handler never ran. Those runs still count toward `Total`, so a job showing `Total 68 / OK 0 / Fail 0 / Skipped 68` is being filtered out entirely rather than failing. The Next Run column shows a relative time when one is scheduled, or status-aware placeholder text otherwise — `Timing unavailable.`, `Waiting for entity time.`, `Schedule completed.`, or `Manual only.` — rather than a blank cell.
 
 Passing a job ID shows its execution history:
 

--- a/src/hassette/cli/commands/job.py
+++ b/src/hassette/cli/commands/job.py
@@ -64,6 +64,7 @@ JOB_LIST_COLUMNS: list[Column] = [
     Column("total_executions", "Total", max_width=7),
     Column("successful", "OK", max_width=6),
     Column("failed", "Fail", max_width=6),
+    Column("skipped", "Skipped", max_width=7),
     Column("avg_duration_ms", "Avg", max_width=7, formatter=fmt_duration_ms),
     Column("next_run", "Next Run", max_width=11, row_formatter=_next_run_display),
 ]

--- a/tests/snapshots/cli_columns.json
+++ b/tests/snapshots/cli_columns.json
@@ -271,6 +271,13 @@
         "overflow": "ellipsis"
       },
       {
+        "field": "skipped",
+        "formatter": null,
+        "header": "Skipped",
+        "max_width": 7,
+        "overflow": "ellipsis"
+      },
+      {
         "field": "avg_duration_ms",
         "formatter": "fmt_duration_ms",
         "header": "Avg",

--- a/tests/unit/cli/conftest.py
+++ b/tests/unit/cli/conftest.py
@@ -27,6 +27,11 @@ REMOTE_SERVER_URL_BARE = "https://example.com"
 #: re-truncates cells that pipe mode is supposed to render in full (see ``_build_table``: a
 #: non-TTY console ignores ``Column.max_width``). Pinning a generous width keeps assertions
 #: about cell *values* from depending on how many columns a table happens to declare.
+#:
+#: The value only has to exceed the widest table any CLI command renders. The largest column
+#: set today (``JOB_LIST_COLUMNS``) needs roughly 156 columns including Rich's borders and
+#: padding. Raise this if a table outgrows it; captured-output assertions silently start
+#: truncating again when it does.
 CAPTURE_CONSOLE_WIDTH = 200
 
 

--- a/tests/unit/cli/conftest.py
+++ b/tests/unit/cli/conftest.py
@@ -23,6 +23,12 @@ NOW_EPOCH = 1_748_000_000.0
 REMOTE_SERVER_URL = "https://example.com/hassette"
 REMOTE_SERVER_URL_BARE = "https://example.com"
 
+#: Console width for captured output. Rich defaults a non-terminal console to 80 columns, which
+#: re-truncates cells that pipe mode is supposed to render in full (see ``_build_table``: a
+#: non-TTY console ignores ``Column.max_width``). Pinning a generous width keeps assertions
+#: about cell *values* from depending on how many columns a table happens to declare.
+CAPTURE_CONSOLE_WIDTH = 200
+
 
 def make_cli_config(
     *,
@@ -136,7 +142,7 @@ def parse_json_stdout(capsys: pytest.CaptureFixture[str]) -> Any:
 def capture_stdout():
     """Capture Rich stdout console output."""
     buf = StringIO()
-    mock_console = Console(file=buf, highlight=False, force_terminal=False)
+    mock_console = Console(file=buf, highlight=False, force_terminal=False, width=CAPTURE_CONSOLE_WIDTH)
     with patch.object(output_module, "stdout_console", mock_console):
         yield buf
 
@@ -150,8 +156,8 @@ def capture_human(func, *args, **kwargs) -> tuple[str, str]:
     """
     stdout_buf = StringIO()
     stderr_buf = StringIO()
-    new_stdout = Console(file=stdout_buf, highlight=False, no_color=True)
-    new_stderr = Console(file=stderr_buf, highlight=False, no_color=True)
+    new_stdout = Console(file=stdout_buf, highlight=False, no_color=True, width=CAPTURE_CONSOLE_WIDTH)
+    new_stderr = Console(file=stderr_buf, highlight=False, no_color=True, width=CAPTURE_CONSOLE_WIDTH)
     with (
         patch.object(output_module, "stdout_console", new_stdout),
         patch.object(output_module, "stderr_console", new_stderr),
@@ -164,7 +170,7 @@ def capture_human(func, *args, **kwargs) -> tuple[str, str]:
 def capture_stderr():
     """Capture Rich stderr console output."""
     buf = StringIO()
-    mock_console = Console(file=buf, stderr=True, highlight=False, force_terminal=False)
+    mock_console = Console(file=buf, stderr=True, highlight=False, force_terminal=False, width=CAPTURE_CONSOLE_WIDTH)
     with patch.object(output_module, "stderr_console", mock_console):
         yield buf
 

--- a/tests/unit/cli/test_commands_job.py
+++ b/tests/unit/cli/test_commands_job.py
@@ -136,8 +136,17 @@ class TestCmdJob:
         assert "mode" in field_names
 
     def test_job_list_columns_count_is_compact(self) -> None:
-        """JOB_LIST_COLUMNS uses at most 11 columns for wide terminal fit."""
-        assert len(JOB_LIST_COLUMNS) <= 11
+        """JOB_LIST_COLUMNS uses at most 12 columns for wide terminal fit."""
+        assert len(JOB_LIST_COLUMNS) <= 12
+
+    def test_job_list_columns_includes_skipped(self) -> None:
+        """Skipped is shown so Total/OK/Fail arithmetic is self-consistent.
+
+        A predicate-gated job that never passes its predicate renders Total N / OK 0 / Fail 0;
+        without this column the missing N skips are invisible in the table.
+        """
+        field_names = [c.field for c in JOB_LIST_COLUMNS]
+        assert "skipped" in field_names
 
     def test_job_list_columns_includes_schedule_status(self) -> None:
         """JOB_LIST_COLUMNS includes a schedule_status column."""

--- a/tests/unit/cli/test_commands_job.py
+++ b/tests/unit/cli/test_commands_job.py
@@ -136,7 +136,12 @@ class TestCmdJob:
         assert "mode" in field_names
 
     def test_job_list_columns_count_is_compact(self) -> None:
-        """JOB_LIST_COLUMNS uses at most 12 columns for wide terminal fit."""
+        """JOB_LIST_COLUMNS uses at most 12 columns for wide terminal fit.
+
+        The ceiling is a terminal-width budget, not headroom over the current count: the
+        declared ``max_width`` values plus Rich's borders have to fit a wide-but-real terminal.
+        Raising it means re-checking that budget, not just matching a new column count.
+        """
         assert len(JOB_LIST_COLUMNS) <= 12
 
     def test_job_list_columns_includes_skipped(self) -> None:

--- a/tests/unit/cli/test_output.py
+++ b/tests/unit/cli/test_output.py
@@ -24,7 +24,7 @@ from hassette.cli.output import (
     render_table,
 )
 from hassette.types.types import CliFormat
-from tests.unit.cli.conftest import capture_human, parse_json_stdout
+from tests.unit.cli.conftest import CAPTURE_CONSOLE_WIDTH, capture_human, parse_json_stdout
 
 # Simple test models
 
@@ -424,7 +424,7 @@ class TestRenderTablePipeDetection:
 
         stdout_buf = StringIO()
         # Simulate non-TTY: is_terminal=False, large width so content isn't wrapped
-        new_stdout_console = Console(file=stdout_buf, highlight=False, no_color=True, width=200)
+        new_stdout_console = Console(file=stdout_buf, highlight=False, no_color=True, width=CAPTURE_CONSOLE_WIDTH)
         new_stderr_console = Console(file=StringIO(), highlight=False, no_color=True)
         with (
             patch.object(output_module, "stdout_console", new_stdout_console),


### PR DESCRIPTION
## Summary

The `hassette job` table rendered only Total / OK / Fail. A predicate-gated job whose predicate never passes therefore displayed `Total 68 / OK 0 / Fail 0` — arithmetic that visibly doesn't add up, while hiding the one signal an operator actually needs: the predicate is filtering every run.

The data was never missing. `JobSummary` already tracks `skipped` and documents the invariant `successful + failed + cancelled + timed_out + skipped == total_executions`, and the telemetry endpoint already served it. Only the CLI column was absent, so the JSON output and the human-readable table disagreed about the same job.

## What changed

- **`src/hassette/cli/commands/job.py`** — added a `Skipped` column to `JOB_LIST_COLUMNS`, positioned after `Fail` so the counter columns read in invariant order.
- **`docs/pages/cli/commands.md`** — regenerated the example table and explained what `Skipped` means, including that skips count toward `Total`, so a reader can interpret `Total 68 / OK 0 / Fail 0 / Skipped 68` without guessing.
- **`tests/unit/cli/conftest.py`** — pinned the captured Rich console to a fixed 200-column width. Rich defaults a non-terminal console to 80 columns, which re-truncates cells that pipe mode renders in full, so assertions about cell *values* were implicitly coupled to how many columns a table happened to declare. Adding a twelfth column would otherwise have broken unrelated CLI tests for reasons having nothing to do with this change.
- **`tests/unit/cli/test_commands_job.py`** — added a regression test asserting `skipped` is present, and raised the compactness ceiling from 11 to 12 columns.
- **`tests/snapshots/cli_columns.json`** — updated the column snapshot.

## Scope note

The issue also asked for "consideration for the other hidden counters" (`cancelled`, `timed_out`, `thread_leaked`). Those are deliberately left out: `skipped` is the one that makes the visible arithmetic self-consistent, and the remaining three are near-always zero, so adding all four would widen the table for little signal. They remain available in `--json` and can be added later if they prove worth the width.

## Testing

- `uv run nox -s dev` — 7717 passed, 1 skipped, 2 xfailed.
- `prek -a` — all hooks pass.
- `prek pyright -a --stage pre-push` — passes.

Note that the three frontend hooks (eslint, stylelint, tsc) fail in a fresh worktree until `cd frontend && npm install` is run, since worktrees don't share `node_modules`. They pass after install. This change touches no frontend files.

Closes #1818
