### PR TITLE
fix: log Home Assistant connection state changes at INFO

### DIFF
--- a/docs/pages/getting-started/index.md
+++ b/docs/pages/getting-started/index.md
@@ -52,13 +52,13 @@ Every app inherits five objects from Hassette: `self.logger` (Python logger), `s
 hassette run -e .env
 ```
 
-You see output like:
+Hassette logs each startup step. Two lines matter:
 
 ```
 --8<-- "pages/getting-started/snippets/run_output.txt"
 ```
 
-The second line (`Hello from Hassette!`) comes from your `on_initialize` method. If you change the `greeting` field in `MyAppConfig` and restart, you see your new text. Open a second terminal to confirm the connection:
+The `Connected to Home Assistant` line confirms your URL and token work. The `Hello from Hassette!` line comes from your `on_initialize` method. If you change the `greeting` field in `MyAppConfig` and restart, you see your new text. Open a second terminal to check on the running instance:
 
 ```bash
 hassette status

--- a/docs/pages/getting-started/snippets/run_output.txt
+++ b/docs/pages/getting-started/snippets/run_output.txt
@@ -1,2 +1,4 @@
-INFO hassette ... ─ Connected to Home Assistant
-INFO hassette.MyApp.0 ... ─ Hello from Hassette!
+...
+2026-01-14T09:12:04.868953 [info     ] Connected to Home Assistant at ws://homeassistant.local:8123/api/websocket [hassette.WebsocketService] execution_id=None source_tier=framework
+...
+2026-01-14T09:12:04.998186 [info     ] Hello from Hassette!           [hassette.MyApp.0] app_key=apps.main.MyApp execution_id=None instance_index=0 instance_name=MyApp.0 source_tier=app

--- a/src/hassette/core/websocket_service.py
+++ b/src/hassette/core/websocket_service.py
@@ -187,6 +187,10 @@ class WebsocketService(Service):
         raises InvalidLifecycleTransitionError for invalid transitions; in non-strict
         (default) mode logs WARNING. Logs every valid transition at DEBUG with previous state.
 
+        Reaching CONNECTED, and leaving it again, are also logged at INFO so the Home
+        Assistant connection is visible at the default log level — this is the line the
+        quickstart tells a new user to look for to confirm their URL and token work.
+
         Args:
             new: The new connection state to transition to.
 
@@ -217,9 +221,22 @@ class WebsocketService(Service):
 
         self.logger.debug("WebSocket: %s → %s", old, new)
         self._connection_state = new
+
+        # Read defensively for the same reason as the hasattr guards above and below: an
+        # instance built without __init__ has neither attribute, and the transition itself
+        # must still work even when the INFO report cannot name a URL.
+        url = getattr(self, "url", None)
+        ever_connected = getattr(self, "_ever_connected", False)
+
         if new == ConnectionState.CONNECTED:
+            if ever_connected:
+                self.logger.info("Reconnected to Home Assistant at %s", url)
+            else:
+                self.logger.info("Connected to Home Assistant at %s", url)
             self._ever_connected = True
         else:
+            if old == ConnectionState.CONNECTED:
+                self.logger.info("Disconnected from Home Assistant at %s", url)
             if hasattr(self, "_connected_event"):
                 self._connected_event.clear()
             if hasattr(self, "_connected_generation"):

--- a/tests/unit/core/test_ws_connection_state.py
+++ b/tests/unit/core/test_ws_connection_state.py
@@ -7,7 +7,7 @@ set_connection_state() validation, and proper state transitions in serve/connect
 import asyncio
 import logging
 import time
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 
@@ -144,6 +144,58 @@ class TestValidTransitionTable:
         websocket_service._connection_state = ConnectionState.CONNECTED
         websocket_service.set_connection_state(ConnectionState.DISCONNECTED)
         assert websocket_service.connection_state == ConnectionState.DISCONNECTED
+
+
+class TestConnectionStateLogging:
+    """Entering and leaving CONNECTED is reported at INFO, so it survives the default log level.
+
+    The quickstart points a new user at the "Connected to Home Assistant" line to confirm their
+    URL and token work, which makes these messages behavior rather than incidental logging.
+    Logger is mocked rather than captured via caplog, matching the convention in
+    test_service_watcher_coverage.py.
+    """
+
+    async def test_first_connection_logs_connected_with_url(self, websocket_service: WebsocketService) -> None:
+        websocket_service._connection_state = ConnectionState.CONNECTING
+        websocket_service.logger = Mock()
+
+        websocket_service.set_connection_state(ConnectionState.CONNECTED)
+
+        websocket_service.logger.info.assert_called_once_with(
+            "Connected to Home Assistant at %s", websocket_service.url
+        )
+
+    async def test_reconnect_logs_reconnected_with_url(self, websocket_service: WebsocketService) -> None:
+        websocket_service._connection_state = ConnectionState.CONNECTING
+        websocket_service.set_connection_state(ConnectionState.CONNECTED)
+        websocket_service.set_connection_state(ConnectionState.CONNECTING)
+
+        websocket_service.logger = Mock()
+        websocket_service.set_connection_state(ConnectionState.CONNECTED)
+
+        websocket_service.logger.info.assert_called_once_with(
+            "Reconnected to Home Assistant at %s", websocket_service.url
+        )
+
+    async def test_leaving_connected_logs_disconnected_with_url(self, websocket_service: WebsocketService) -> None:
+        websocket_service._connection_state = ConnectionState.CONNECTING
+        websocket_service.set_connection_state(ConnectionState.CONNECTED)
+
+        websocket_service.logger = Mock()
+        websocket_service.set_connection_state(ConnectionState.CONNECTING)
+
+        websocket_service.logger.info.assert_called_once_with(
+            "Disconnected from Home Assistant at %s", websocket_service.url
+        )
+
+    async def test_failed_first_attempt_logs_nothing_at_info(self, websocket_service: WebsocketService) -> None:
+        """CONNECTING → DISCONNECTED without ever connecting has no connection to report losing."""
+        websocket_service._connection_state = ConnectionState.CONNECTING
+        websocket_service.logger = Mock()
+
+        websocket_service.set_connection_state(ConnectionState.DISCONNECTED)
+
+        websocket_service.logger.info.assert_not_called()
 
 
 class TestInvalidTransitions:


### PR DESCRIPTION
## Summary

Reaching a Home Assistant connection was only reported at DEBUG, so at the default log level the first question a new user has — *did my token work?* — was answered by silence. Meanwhile the quickstart promised a `Connected to Home Assistant` line that existed nowhere in `src/`, so the docs described output that could not happen.

This makes the connection visible at the default log level and reconciles the quickstart snippet with what the code actually emits.

## What changed

**`src/hassette/core/websocket_service.py`** — `set_connection_state()` now logs at INFO, with the URL, when the connection state enters or leaves `CONNECTED`:

- `Connected to Home Assistant at <url>` — first connection
- `Reconnected to Home Assistant at <url>` — subsequent connections
- `Disconnected from Home Assistant at <url>` — only when leaving `CONNECTED`, so a failed *first* attempt doesn't claim a connection was lost

Connection established / lost / re-established are state transitions, which the project's own logging rules put at INFO. The existing DEBUG transition line is unchanged — it still records every transition, including the ones this INFO reporting deliberately stays quiet about. `url` and `_ever_connected` are read via `getattr` for the same reason as the surrounding `hasattr` guards: an instance built without `__init__` has neither attribute, and the transition itself must still work even when the INFO report can't name a URL.

**`docs/pages/getting-started/snippets/run_output.txt`** — replaced the invented output with the lines the code actually emits, in the structlog `ConsoleRenderer` format hassette actually renders, captured from a real run against a Home Assistant container.

**`docs/pages/getting-started/index.md`** — points the reader at the connection line as the confirmation that their URL and token work, which is what the snippet now actually shows.

## Testing

- New `TestConnectionStateLogging` in `tests/unit/core/test_ws_connection_state.py` covers all four cases: first connection, reconnect, leaving `CONNECTED`, and a failed first attempt logging nothing at INFO. All four pass.
- Full local suite green: `uv run nox -s dev` → **7720 passed, 1 skipped, 2 xfailed** (exit 0).
- `prek -a` → all hooks passed. `prek pyright -a --stage pre-push` → passed.

The logger is mocked rather than captured via `caplog`, matching the existing convention in `test_service_watcher_coverage.py`.

Closes #1821
