### PR TITLE
fix: render callable predicates as qualified names in predicate_description

### DIFF
--- a/src/hassette/core/bus_service.py
+++ b/src/hassette/core/bus_service.py
@@ -30,6 +30,7 @@ from hassette.resources.service import Service
 from hassette.schemas.live_counts import LiveCounts
 from hassette.types.enums import BackpressurePolicy, Topic
 from hassette.types.types import LOG_LEVEL_TYPE, ExecutionStatus
+from hassette.utils.func_utils import describe_predicate
 from hassette.utils.hass_utils import split_entity_id, valid_entity_id
 
 if typing.TYPE_CHECKING:
@@ -234,7 +235,7 @@ class BusService(Service):
             throttle=listener.options.throttle,
             once=listener.options.once,
             priority=listener.options.priority,
-            predicate_description=repr(listener.predicate) if listener.predicate else None,
+            predicate_description=describe_predicate(listener.predicate) if listener.predicate else None,
             human_description=human_description,
             source_location=source_location,
             registration_source=registration_source,

--- a/src/hassette/core/registration.py
+++ b/src/hassette/core/registration.py
@@ -35,7 +35,9 @@ class ListenerRegistration:
     """Listener ordering priority."""
 
     predicate_description: str | None
-    """Python repr of the listener's predicate, or None if no ``where=`` was given."""
+    """Structural description of the listener's predicate — ``repr()`` for composed
+    predicate objects, the qualified name for a bare callable. None if no ``where=``
+    was given."""
 
     human_description: str | None
     """Stable, human-readable summary from predicate.summarize(), or None."""
@@ -119,7 +121,8 @@ class ScheduledJobRegistration:
     the ``scheduled_jobs.mode`` column. The tier-aware default is already applied in the scheduler."""
 
     predicate_description: str | None = None
-    """Python repr of the job's predicate, or None if no ``where=`` was given."""
+    """Structural description of the job's predicate — ``repr()`` for composed predicate
+    objects, the qualified name for a bare callable. None if no ``where=`` was given."""
 
     human_description: str | None = None
     """Stable, human-readable summary of the predicate — ``predicate.summarize()`` when

--- a/src/hassette/core/scheduler_service.py
+++ b/src/hassette/core/scheduler_service.py
@@ -29,7 +29,7 @@ from hassette.scheduler.error_context import SchedulerErrorContext
 from hassette.scheduler.triggers import _WaitingSentinel
 from hassette.types.enums import ExecutionMode
 from hassette.types.types import LOG_LEVEL_TYPE, ExecutionStatus
-from hassette.utils.func_utils import callable_stable_name
+from hassette.utils.func_utils import callable_stable_name, describe_predicate
 from hassette.utils.serialization import safe_json_serialize
 
 if typing.TYPE_CHECKING:
@@ -332,7 +332,7 @@ class SchedulerService(Service):
         predicate_description: str | None = None
         human_description: str | None = None
         if job.predicate is not None:
-            predicate_description = repr(job.predicate)
+            predicate_description = describe_predicate(job.predicate)
             if hasattr(job.predicate, "summarize"):
                 human_description = job.predicate.summarize()  # pyright: ignore[reportFunctionMemberAccess]
             else:

--- a/src/hassette/schemas/job_models.py
+++ b/src/hassette/schemas/job_models.py
@@ -38,7 +38,8 @@ class JobSummary(BaseModel):
     registration_source: str | None
     source_tier: SourceTier = "app"
     predicate_description: str | None = None
-    """Python ``repr()`` of the job's scheduler predicate, or ``None`` when unset."""
+    """Structural description of the job's scheduler predicate — ``repr()`` for composed
+    predicate objects, the qualified name for a bare callable. ``None`` when unset."""
     human_description: str | None = None
     """Human-readable summary of the job's scheduler predicate, or ``None`` when unset."""
     total_executions: int

--- a/src/hassette/utils/func_utils.py
+++ b/src/hassette/utils/func_utils.py
@@ -105,6 +105,28 @@ def callable_stable_name(fn: Any) -> str:
     return "<callable>"
 
 
+def describe_predicate(predicate: Any) -> str:
+    """Return the telemetry ``predicate_description`` for a ``where=`` predicate.
+
+    Composed predicate objects (those exposing ``summarize()``, e.g. ``AllOf`` or
+    ``EntityMatches``) keep their structured ``repr()``, which reads as the predicate's
+    own declarative form. A bare callable renders as its qualified name instead — its
+    ``repr()`` is a bound-method or function repr carrying an object address, which is
+    both unstable across restarts and noise to anyone reading the API, CLI, or UI.
+
+    Args:
+        predicate: The predicate object or callable to describe.
+
+    Returns:
+        A description suitable for persisting and serializing.
+    """
+    if hasattr(predicate, "summarize"):
+        return repr(predicate)
+    if callable(predicate):
+        return callable_stable_name(predicate)
+    return repr(predicate)
+
+
 def callable_short_name(fn: Any, num_parts: int = 1) -> str:
     """Get a short name for a callable object.
 

--- a/src/hassette/utils/func_utils.py
+++ b/src/hassette/utils/func_utils.py
@@ -120,10 +120,13 @@ def describe_predicate(predicate: Any) -> str:
     Returns:
         A description suitable for persisting and serializing.
     """
+    # Order is load-bearing: composed predicates are callable too (they define __call__),
+    # so the summarize() check has to come first or they would collapse to a qualified name.
     if hasattr(predicate, "summarize"):
         return repr(predicate)
     if callable(predicate):
         return callable_stable_name(predicate)
+    # Defensive default — both call sites guard against a None/absent predicate.
     return repr(predicate)
 
 

--- a/tests/integration/test_registration.py
+++ b/tests/integration/test_registration.py
@@ -344,3 +344,73 @@ async def test_group_persisted_at_registration(
     row = await cursor.fetchone()
     assert row is not None
     assert row[0] == "morning", f"Expected group='morning' in DB, got {row[0]!r}"
+
+
+class PredicateDemo:
+    """Stand-in for an app class whose bound method is used as a ``where=`` predicate."""
+
+    def is_motion_detected(self) -> bool:
+        return True
+
+
+class _ComposedPredicate:
+    """Stand-in for a composed predicate object (``AllOf``, ``EntityMatches``, ...)."""
+
+    def summarize(self) -> str:
+        return "entity light.kitchen"
+
+    def __repr__(self) -> str:
+        return "EntityMatches(entity_id='light.kitchen')"
+
+
+async def test_job_callable_predicate_registers_qualified_name(db_hassette: AsyncMock) -> None:
+    """A bound-method ``where=`` is persisted as its qualified name, not an object repr."""
+    executor_mock = MagicMock()
+    executor_mock.register_job = AsyncMock(return_value=42)
+    scheduler_service = SchedulerService(db_hassette, executor=executor_mock, parent=db_hassette)
+    scheduler_service.task_bucket = stub_task_bucket()
+    scheduler_service._job_queue = AsyncMock()
+
+    job = make_mock_job(app_key="my_app", instance_index=1)
+    job.predicate = PredicateDemo().is_motion_detected
+
+    await scheduler_service.add_job(job)
+
+    reg_arg = executor_mock.register_job.call_args.args[0]
+    assert reg_arg.predicate_description == "PredicateDemo.is_motion_detected"
+    assert reg_arg.human_description == "PredicateDemo.is_motion_detected"
+
+
+async def test_job_composed_predicate_keeps_structured_description(db_hassette: AsyncMock) -> None:
+    """A predicate object exposing summarize() keeps its structured repr."""
+    executor_mock = MagicMock()
+    executor_mock.register_job = AsyncMock(return_value=43)
+    scheduler_service = SchedulerService(db_hassette, executor=executor_mock, parent=db_hassette)
+    scheduler_service.task_bucket = stub_task_bucket()
+    scheduler_service._job_queue = AsyncMock()
+
+    job = make_mock_job(app_key="my_app", instance_index=1)
+    job.predicate = _ComposedPredicate()
+
+    await scheduler_service.add_job(job)
+
+    reg_arg = executor_mock.register_job.call_args.args[0]
+    assert reg_arg.predicate_description == "EntityMatches(entity_id='light.kitchen')"
+    assert reg_arg.human_description == "entity light.kitchen"
+
+
+async def test_listener_callable_predicate_registers_qualified_name(db_hassette: AsyncMock) -> None:
+    """A bound-method ``where=`` on the bus is persisted as its qualified name too."""
+    executor_mock = MagicMock()
+    executor_mock.register_listener = AsyncMock(return_value=44)
+    stream = MagicMock()
+    bus_service = BusService(db_hassette, stream=stream, executor=executor_mock, parent=db_hassette)
+    bus_service.task_bucket = stub_task_bucket()
+
+    listener = make_mock_listener(app_key="my_app", instance_index=1)
+    listener.predicate = PredicateDemo().is_motion_detected
+
+    await bus_service.add_listener(listener)
+
+    reg_arg = executor_mock.register_listener.call_args.args[0]
+    assert reg_arg.predicate_description == "PredicateDemo.is_motion_detected"

--- a/tests/unit/bus/test_registration_parity.py
+++ b/tests/unit/bus/test_registration_parity.py
@@ -22,7 +22,7 @@ EXEMPTIONS: set[str] = {
     # Renamed fields — present on a sub-struct under a different name
     "handler_method",  # sourced from ListenerIdentity.handler_name (different name for the DB column)
     # Computed at registration time by BusService, not stored on sub-structs
-    "predicate_description",  # repr(listener.predicate), computed from Listener.predicate at registration
+    "predicate_description",  # describe_predicate(listener.predicate), computed from Listener.predicate at registration
     "human_description",  # summarize_top_level(listener.predicate), computed from Listener.predicate at registration
     # Duration fields sourced from DurationConfig, not ListenerIdentity or ListenerOptions
     "immediate",  # DurationConfig.immediate — duration concern, not behavioral option or identity

--- a/tests/unit/test_func_utils.py
+++ b/tests/unit/test_func_utils.py
@@ -2,7 +2,12 @@
 
 from functools import partial, wraps
 
-from hassette.utils.func_utils import callable_name, callable_short_name, callable_stable_name
+from hassette.utils.func_utils import (
+    callable_name,
+    callable_short_name,
+    callable_stable_name,
+    describe_predicate,
+)
 
 
 def plain_function() -> None:
@@ -168,3 +173,41 @@ class TestCallableShortName:
         obj = CallableClass()
         short = callable_short_name(obj)
         assert short == "__call__"
+
+
+class PredicateHolder:
+    def is_motion_detected(self) -> bool:
+        return True
+
+
+class SummarizingPredicate:
+    def summarize(self) -> str:
+        return "entity light.kitchen"
+
+    def __repr__(self) -> str:
+        return "EntityMatches(entity_id='light.kitchen')"
+
+
+class TestDescribePredicate:
+    def test_bound_method_renders_as_qualified_name(self) -> None:
+        """A bound method describes as its qualname, not a <bound method ... at 0x...> repr."""
+        described = describe_predicate(PredicateHolder().is_motion_detected)
+        assert described == "PredicateHolder.is_motion_detected"
+
+    def test_plain_function_renders_as_qualified_name(self) -> None:
+        assert describe_predicate(plain_function) == "plain_function"
+
+    def test_lambda_renders_as_stable_placeholder(self) -> None:
+        """Lambdas have no stable qualified name, so they collapse to the shared placeholder."""
+        fn = lambda: None  # noqa: E731
+        assert describe_predicate(fn) == "<callable>"
+
+    def test_partial_renders_as_stable_placeholder(self) -> None:
+        assert describe_predicate(partial(plain_function)) == "<callable>"
+
+    def test_composed_predicate_keeps_structured_repr(self) -> None:
+        """Objects exposing summarize() keep their structured repr."""
+        assert describe_predicate(SummarizingPredicate()) == "EntityMatches(entity_id='light.kitchen')"
+
+    def test_non_callable_falls_back_to_repr(self) -> None:
+        assert describe_predicate(None) == "None"


### PR DESCRIPTION
## Summary

Job and listener telemetry stored `repr(predicate)` in `predicate_description`. For a bare
callable `where=` that meant a bound-method repr with an embedded object address —
`<bound method PredicateDemo.is_motion_detected of <PredicateDemo unique_name=...>>` — persisted
to the database and surfaced by every consumer that serializes the field (REST API, CLI `--json`,
UI detail views), sitting directly beside the already-polished `human_description`
(`PredicateDemo.is_motion_detected`). The value is also unstable across restarts, since the
address changes every run.

## What changed

- New `describe_predicate()` in `src/hassette/utils/func_utils.py` decides how a predicate renders:
  - Composed predicate objects (anything exposing `summarize()` — `AllOf`, `EntityMatches`, ...)
    keep their structured `repr()`, which is already a readable declarative form.
  - Bare callables fall back to `callable_stable_name()`, the same qualified-name rendering
    `human_description` uses. Lambdas and partials collapse to the shared `<callable>` placeholder.
  - Non-callables keep `repr()` as a final fallback.
- `BusService.add_listener()` and `SchedulerService.add_job()` now call `describe_predicate()`
  instead of `repr()` when building the registration record.
- Docstrings on `ListenerRegistration.predicate_description`,
  `ScheduledJobRegistration.predicate_description`, and `JobSummary.predicate_description` updated
  to describe the two-branch behavior rather than claiming a plain `repr()`.

No schema or frontend change is needed — the field's type and presence are unchanged, only the
string it carries. `check_schemas_fresh` passes with no regeneration.

## Testing

- `tests/unit/test_func_utils.py` — unit coverage for `describe_predicate()` across bound methods,
  plain functions, lambdas, partials, `summarize()`-bearing objects, and non-callables.
- `tests/integration/test_registration.py` — end-to-end through the real registration path:
  a bound-method `where=` on both a job and a listener persists as
  `PredicateDemo.is_motion_detected`, and a composed predicate still persists its structured repr
  alongside its `summarize()` output.
- `uv run nox -s dev` — 7725 passed, 1 skipped, 2 xfailed.
- `prek -a` and the full `--hook-stage pre-push` set (including pyright and schema freshness) — all green.

Closes #1831
