### PR TITLE
fix: keep a tracked orphaned instance stoppable when its config shrinks

### DIFF
--- a/frontend/src/pages/app-detail.instances.test.tsx
+++ b/frontend/src/pages/app-detail.instances.test.tsx
@@ -299,6 +299,20 @@ describe("AppDetailPage instances", () => {
     expect(mockCorrectUrl).not.toHaveBeenCalled();
   });
 
+  it("corrects an out-of-range index when the manifest omits its instances array", async () => {
+    // `instances` is optional on AppManifestResponse, so the membership check can find nothing
+    // to consult. With no tracked-index evidence, an index past instance_count is not
+    // addressable and the redirect must still fire.
+    const manifest = createManifest({ instance_count: 2, instances: undefined });
+    setupApi(manifest);
+    mockSearchString = "instance=5";
+    renderPage({ key: "test_app", tab: "handlers" });
+
+    await vi.waitFor(() => {
+      expect(mockCorrectUrl).toHaveBeenCalledWith("/apps/test_app/handlers?instance=0");
+    });
+  });
+
   it("corrects negative instance query params before preserving them in links", async () => {
     const manifest = createManifest({
       instance_count: 2,

--- a/frontend/src/pages/app-detail.instances.test.tsx
+++ b/frontend/src/pages/app-detail.instances.test.tsx
@@ -280,6 +280,25 @@ describe("AppDetailPage instances", () => {
     });
   });
 
+  it("keeps a tracked instance orphaned by a config shrink addressable", async () => {
+    // Config shrank to 1 instance while index 2 was still running. The backend reports the
+    // union of configured and tracked indices, so instance_count is 2 while the orphan sits at
+    // index 2 — redirecting away from it would make it unstoppable from the UI.
+    const manifest = createManifest({
+      instance_count: 2,
+      instances: [
+        createInstance({ index: 0, instance_name: "inst_0", status: "running" }),
+        createInstance({ index: 2, instance_name: "inst_2", status: "running" }),
+      ],
+    });
+    setupApi(manifest);
+    mockSearchString = "instance=2";
+    const { findByTestId } = renderPage({ key: "test_app", tab: "handlers" });
+
+    await findByTestId("app-title");
+    expect(mockCorrectUrl).not.toHaveBeenCalled();
+  });
+
   it("corrects negative instance query params before preserving them in links", async () => {
     const manifest = createManifest({
       instance_count: 2,

--- a/frontend/src/pages/app-detail.tsx
+++ b/frontend/src/pages/app-detail.tsx
@@ -36,8 +36,12 @@ interface Props {
   params: { key: string; tab?: TabId; handler?: string; execId?: string };
 }
 
-// An index at or past `instance_count` is still addressable when the manifest tracks it: a
-// running instance orphaned by a config shrink stays listed in `instances` so it can be stopped.
+// `instance_count` is the *size* of `instances`, which the backend builds as the union of the
+// configured indices and the still-tracked ones — so it counts an orphan without covering its
+// index. A running instance orphaned by a config shrink (configured=1, tracked={0, 2}) leaves
+// `instance_count` at 2 while the orphan sits at index 2, so the magnitude check alone would
+// redirect away from the only page offering its Stop control. The membership check is what
+// actually admits it; neither clause is redundant.
 function isAddressableInstance(manifest: AppManifest, index: number): boolean {
   return index < manifest.instance_count || (manifest.instances?.some((i) => i.index === index) ?? false);
 }

--- a/frontend/src/pages/app-detail.tsx
+++ b/frontend/src/pages/app-detail.tsx
@@ -5,7 +5,7 @@ import { Link, useLocation } from "wouter";
 
 import { cn } from "@/lib/utils";
 
-import { getAppJobs, getAppListeners } from "../api/endpoints";
+import { type AppManifest, getAppJobs, getAppListeners } from "../api/endpoints";
 import { AppDetailHeader } from "../components/app-detail/app-detail-header";
 import { AppLogsPanel } from "../components/app-detail/app-logs-panel";
 import { CodeTab } from "../components/app-detail/code-tab";
@@ -34,6 +34,12 @@ export type TabId = AppDetailTab;
 
 interface Props {
   params: { key: string; tab?: TabId; handler?: string; execId?: string };
+}
+
+// An index at or past `instance_count` is still addressable when the manifest tracks it: a
+// running instance orphaned by a config shrink stays listed in `instances` so it can be stopped.
+function isAddressableInstance(manifest: AppManifest, index: number): boolean {
+  return index < manifest.instance_count || (manifest.instances?.some((i) => i.index === index) ?? false);
 }
 
 function instanceCorrectionUrl(appKey: string, activeTab: TabId, lineParam: string | null): string {
@@ -165,7 +171,7 @@ export function AppDetailPage({ params }: Props) {
       correctUrl(instanceCorrectionUrl(appKey, activeTab, lineParam));
       return;
     }
-    if (manifest && instanceIndex !== undefined && instanceIndex >= manifest.instance_count) {
+    if (manifest && instanceIndex !== undefined && !isAddressableInstance(manifest, instanceIndex)) {
       correctUrl(instanceCorrectionUrl(appKey, activeTab, lineParam));
     }
   }, [initialLoading, manifest, instanceParam, instanceIndex, appKey, activeTab, lineParam, correctUrl]);

--- a/src/hassette/core/app_lifecycle_service.py
+++ b/src/hassette/core/app_lifecycle_service.py
@@ -852,17 +852,13 @@ class AppLifecycleService(Resource):
         """
         async with self._get_app_key_lock(app_key):
             app_manifest = self.registry.get_manifest(app_key)
-            # A still-tracked instance whose index fell outside the configured range (the config
-            # shrank while it was still running) stays stoppable. `prune_stale_failed_indices`
-            # only prunes stale *failed* entries, so a running orphan would otherwise have no way
-            # to be shut down.
-            is_tracked = index in self.registry.get_instances(app_key)
-            if (
-                app_manifest is not None
-                and not is_tracked
-                and not self._instance_index_in_range(app_key, index, app_manifest)
-            ):
-                return
+            if app_manifest is not None and not self._instance_index_in_range(app_key, index, app_manifest):
+                # A still-tracked instance whose index fell outside the configured range (the
+                # config shrank while it was still running) stays stoppable.
+                # `prune_stale_failed_indices` only prunes stale *failed* entries, so a running
+                # orphan would otherwise have no way to be shut down.
+                if index not in self.registry.get_instances(app_key):
+                    return
             await self._stop_instance_unlocked(app_key, index)
 
     async def start_instance(

--- a/src/hassette/core/app_lifecycle_service.py
+++ b/src/hassette/core/app_lifecycle_service.py
@@ -683,6 +683,8 @@ class AppLifecycleService(Resource):
         must re-validate the index after acquiring the per-app-key lock, mirroring
         ``start_app()``'s post-lock re-fetch pattern, since the manifest (and therefore the
         valid index range) can change while a caller was parked in ``_admit_start()``.
+        ``stop_instance`` consults this only for an index the registry no longer tracks: a
+        tracked out-of-range instance is an orphan that must stay stoppable.
         """
         valid_index_count = len(self.factory.normalize_configs(app_manifest.app_config))
         if index < 0 or index >= valid_index_count:
@@ -850,7 +852,16 @@ class AppLifecycleService(Resource):
         """
         async with self._get_app_key_lock(app_key):
             app_manifest = self.registry.get_manifest(app_key)
-            if app_manifest is not None and not self._instance_index_in_range(app_key, index, app_manifest):
+            # A still-tracked instance whose index fell outside the configured range (the config
+            # shrank while it was still running) stays stoppable. `prune_stale_failed_indices`
+            # only prunes stale *failed* entries, so a running orphan would otherwise have no way
+            # to be shut down.
+            is_tracked = index in self.registry.get_instances(app_key)
+            if (
+                app_manifest is not None
+                and not is_tracked
+                and not self._instance_index_in_range(app_key, index, app_manifest)
+            ):
                 return
             await self._stop_instance_unlocked(app_key, index)
 

--- a/src/hassette/web/routes/apps.py
+++ b/src/hassette/web/routes/apps.py
@@ -80,6 +80,20 @@ def _orphan_app_permitted(app_key: str, hassette: HassetteDep, action: AppAction
     return action == "stop" and bool(hassette.app_handler.registry.get_instances(app_key))
 
 
+def _orphan_instance_permitted(app_key: str, index: int, hassette: HassetteDep, action: AppAction) -> bool:
+    """Whether ``index`` is a still-tracked instance outside the app's current configured range.
+
+    When an app's configured instance count shrinks while a higher-index instance is still
+    running, that instance is orphaned — ``AppRegistry.prune_stale_failed_indices`` only prunes
+    stale *failed* entries, never running ones, and ``build_manifest_info`` keeps reporting it in
+    ``instances``. Only ``stop`` is permitted through, for the same reason as
+    ``_orphan_app_permitted``: ``AppLifecycleService.stop_instance()`` matches this permissiveness,
+    while ``start_instance``/``reload_instance`` silently no-op on an out-of-range index, so
+    admitting them here would turn a clear 404 into a 202-accepted request that does nothing.
+    """
+    return action == "stop" and index in hassette.app_handler.registry.get_instances(app_key)
+
+
 def _require_known_app(app_key: str, hassette: HassetteDep, action: AppAction) -> None:
     """Validate that ``app_key`` is known, or is an orphaned app that ``action`` still permits."""
     if hassette.app_handler.registry.get_manifest(app_key) is not None:
@@ -90,7 +104,7 @@ def _require_known_app(app_key: str, hassette: HassetteDep, action: AppAction) -
 
 
 def _require_valid_instance_index(app_key: str, index: int, hassette: HassetteDep, action: AppAction) -> None:
-    """Validate that ``app_key`` is known and ``index`` is within its current instance count.
+    """Validate that ``app_key`` is known and ``index`` is addressable for ``action``.
 
     Runs before ``_run_app_action`` so an out-of-range index returns a fast 404 without
     waiting for lock acquisition. ``AppLifecycleService`` re-validates the index itself after
@@ -100,7 +114,8 @@ def _require_valid_instance_index(app_key: str, index: int, hassette: HassetteDe
     web-local reimplementation, so this count can never drift from ``AppFactory``'s.
 
     Skips range validation for an orphaned app that ``action`` still permits (see
-    ``_orphan_app_permitted``'s docstring for the ``stop``-only rationale).
+    ``_orphan_app_permitted``'s docstring for the ``stop``-only rationale), and for a
+    still-tracked instance orphaned by a shrunk config (see ``_orphan_instance_permitted``).
     """
     _validate_app_key(app_key)
     manifest = hassette.app_handler.registry.get_manifest(app_key)
@@ -110,6 +125,8 @@ def _require_valid_instance_index(app_key: str, index: int, hassette: HassetteDe
         raise HTTPException(status_code=404, detail=f"App {app_key!r} not found")
     valid_index_count = len(normalize_app_config(manifest.app_config))
     if index < 0 or index >= valid_index_count:
+        if _orphan_instance_permitted(app_key, index, hassette, action):
+            return
         raise HTTPException(status_code=404, detail=f"Instance {index} not found for app {app_key!r}")
 
 

--- a/tests/integration/web_api/test_endpoints.py
+++ b/tests/integration/web_api/test_endpoints.py
@@ -377,6 +377,37 @@ class TestAppInstanceEndpoints:
         assert response.status_code == 202
         mock_hassette.app_handler.stop_instance.assert_awaited_once_with("orphan_app", 0)
 
+    async def test_stop_instance_tracked_orphan_index_reaches_service_layer(
+        self, client: "AsyncClient", mock_hassette: MagicMock
+    ) -> None:
+        """The configured instance count shrank to 1 while index 2 was still running. That orphan
+        is still reported in the manifest's ``instances`` and must stay stoppable, even though it
+        now sits outside the configured range.
+        """
+        self._seed_manifest(mock_hassette, instance_count=1)
+        mock_hassette._app_handler.registry.get_instances.return_value = {0: MagicMock(), 2: MagicMock()}
+        mock_hassette.app_handler.stop_instance = AsyncMock()
+
+        response = await client.post(instance_action_path("my_app", 2, "stop"))
+
+        assert response.status_code == 202
+        mock_hassette.app_handler.stop_instance.assert_awaited_once_with("my_app", 2)
+
+    @pytest.mark.parametrize("action", ["start", "reload"], ids=["start", "reload"])
+    async def test_tracked_orphan_index_start_or_reload_still_returns_404(
+        self, client: "AsyncClient", mock_hassette: MagicMock, action: str
+    ) -> None:
+        """Only stop gets the orphan-index permissiveness, mirroring the orphaned-app rule:
+        start/reload silently no-op on an out-of-range index in the service layer, so admitting
+        them would swap a clear 404 for a 202 that does nothing.
+        """
+        self._seed_manifest(mock_hassette, instance_count=1)
+        mock_hassette._app_handler.registry.get_instances.return_value = {0: MagicMock(), 2: MagicMock()}
+
+        response = await client.post(instance_action_path("my_app", 2, action))
+
+        assert response.status_code == 404
+
     async def test_stop_app_orphaned_app_reaches_service_layer(
         self, client: "AsyncClient", mock_hassette: MagicMock
     ) -> None:

--- a/tests/integration/web_api/test_endpoints.py
+++ b/tests/integration/web_api/test_endpoints.py
@@ -393,7 +393,7 @@ class TestAppInstanceEndpoints:
         assert response.status_code == 202
         mock_hassette.app_handler.stop_instance.assert_awaited_once_with("my_app", 2)
 
-    @pytest.mark.parametrize("action", ["start", "reload"], ids=["start", "reload"])
+    @pytest.mark.parametrize("action", ["start", "reload"])
     async def test_tracked_orphan_index_start_or_reload_still_returns_404(
         self, client: "AsyncClient", mock_hassette: MagicMock, action: str
     ) -> None:

--- a/tests/unit/core/test_app_lifecycle_service_per_instance_ops.py
+++ b/tests/unit/core/test_app_lifecycle_service_per_instance_ops.py
@@ -122,15 +122,41 @@ class TestStopInstanceBehavior:
         mock_factory: MagicMock,
         mock_manifest: MagicMock,
     ) -> None:
-        """stop_instance no-ops for an index beyond the current manifest's instance count."""
+        """stop_instance no-ops for an untracked index beyond the current manifest's count."""
         mock_manifest.app_config = [{"instance_name": "a"}]
         mock_registry.get_manifest = Mock(return_value=mock_manifest)
+        mock_registry.get_instances = Mock(return_value={0: MagicMock()})
         mock_factory.normalize_configs = Mock(side_effect=lambda cfg: cfg)
         mock_registry.unregister_app = Mock()
 
         await lifecycle_service.stop_instance("test_app", 5)
 
         mock_registry.unregister_app.assert_not_called()
+
+    async def test_tracked_out_of_range_index_is_still_stopped(
+        self,
+        lifecycle_service: AppLifecycleService,
+        mock_registry: MagicMock,
+        mock_factory: MagicMock,
+        mock_manifest: MagicMock,
+    ) -> None:
+        """An instance orphaned by a config shrink (still tracked, index now out of range) stays
+        stoppable — prune_stale_failed_indices only prunes stale *failed* entries, so refusing
+        here would leave it running with no way to shut it down.
+        """
+        mock_manifest.app_config = [{"instance_name": "a"}]
+        mock_registry.get_manifest = Mock(return_value=mock_manifest)
+        mock_registry.get_instances = Mock(return_value={0: MagicMock(), 2: MagicMock()})
+        mock_registry.get_failed_instance_infos = Mock(return_value={})
+        mock_factory.normalize_configs = Mock(side_effect=lambda cfg: cfg)
+        orphan = MagicMock()
+        mock_registry.unregister_app = Mock(return_value={2: orphan})
+        lifecycle_service.shutdown_instances = AsyncMock()
+
+        await lifecycle_service.stop_instance("test_app", 2)
+
+        mock_registry.unregister_app.assert_called_once_with("test_app", 2)
+        lifecycle_service.shutdown_instances.assert_called_once_with({2: orphan})
 
     async def test_succeeds_without_admission_check_before_bootstrap_release(
         self,


### PR DESCRIPTION
## Summary

When an app's configured instance count shrinks while a higher-index instance is still running, that instance is *orphaned*: `AppRegistry.prune_stale_failed_indices` only prunes stale **failed** entries — never running ones — and `build_manifest_info` keeps reporting the index in `instances`. Three layers independently refused to address it by index, so the instance kept running with no way to shut it down from either the API or the web UI.

This makes a still-tracked out-of-range index stoppable, at all three layers.

## What changed

**`src/hassette/web/routes/apps.py`** — new `_orphan_instance_permitted()` helper; `_require_valid_instance_index` now admits a still-tracked out-of-range index for `stop`, mirroring the existing stop-only rule in `_orphan_app_permitted`. `start` and `reload` still return 404: their service-layer counterparts silently no-op on an out-of-range index, so admitting them would swap a clear 404 for a 202 that does nothing.

**`src/hassette/core/app_lifecycle_service.py`** — `stop_instance` skips the configured-range check for an index the registry still tracks, so the route's new permissiveness isn't undone one layer down.

**`frontend/src/pages/app-detail.tsx`** — the out-of-range redirect now checks membership in the manifest's `instances` (the union of configured and tracked indices) before falling back to `instance_count`. Previously the UI redirected away from the orphan's detail page before the user could reach its per-instance Stop control.

## Testing

All green locally:

- `uv run nox -s dev` — 7720 passed, 1 skipped, 2 xfailed
- `npm run test` (frontend) — 1602 passed across 110 files
- `prek -a` and `prek -a --stage pre-push` (includes pyright, schema freshness, facade generation) — all hooks passed

New regression coverage, one test per layer:

- `tests/integration/web_api/test_endpoints.py` — a tracked orphan index reaches the service layer on `stop` (202), and still 404s on `start`/`reload` (parametrized).
- `tests/unit/core/test_app_lifecycle_service_per_instance_ops.py` — `stop_instance` actually unregisters and shuts down a tracked out-of-range instance; the pre-existing no-op test is narrowed to the *untracked* case it was really asserting.
- `frontend/src/pages/app-detail.instances.test.tsx` — no redirect fires for an index orphaned by a config shrink.

## Visual evidence

Labeled `no-visual-change`. The frontend diff changes only the predicate guarding a URL redirect — it makes an existing page reachable that was previously redirected away from. No rendered output, layout, or styling changes, so there is no before/after to capture.

Closes #1882
