### PR TITLE
test: clean up boilerplate in unified-handler-row tests

### DIFF
--- a/frontend/src/components/app-detail/handler-list.test.tsx
+++ b/frontend/src/components/app-detail/handler-list.test.tsx
@@ -3,18 +3,10 @@ import { describe, expect, it, vi } from "vitest";
 
 import { createJob, createListener } from "../../test/factories";
 import { HandlerList } from "./handler-list";
+import type { UnifiedItemKind } from "./unified-handler-row";
+import { ROW_TESTID_PREFIX, rowTestId } from "./unified-row.test-helpers";
 
 const HANDLER_LIST_TEST_ID = "handler-list";
-
-// vi.hoisted so the row test-id convention is shared between the hoisted vi.mock
-// factory below and the assertions that read it.
-const { ROW_TEST_ID_PREFIX, rowTestId } = vi.hoisted(() => {
-  const prefix = "unified-row-";
-  return {
-    ROW_TEST_ID_PREFIX: prefix,
-    rowTestId: (kind: string, id: number) => `${prefix}${kind}-${id}`,
-  };
-});
 
 // Mock UnifiedHandlerRow to isolate HandlerList behavior — the row component
 // calls query hooks which require the Zustand app store (useAppStore) and MSW.
@@ -23,7 +15,7 @@ vi.mock("./unified-handler-row", () => ({
     item,
     isSelected,
   }: {
-    item: { kind: string; id: number; name: string; humanDescription: string | null };
+    item: { kind: UnifiedItemKind; id: number; name: string; humanDescription: string | null };
     isSelected: boolean;
     onSelect: () => void;
   }) => (
@@ -108,7 +100,7 @@ describe("HandlerList", () => {
     const { container } = render(
       <HandlerList listeners={listeners} jobs={jobs} selectedId={null} onSelect={() => {}} />,
     );
-    const rows = container.querySelectorAll(`[data-testid^='${ROW_TEST_ID_PREFIX}']`);
+    const rows = container.querySelectorAll(`[data-testid^='${ROW_TESTID_PREFIX}']`);
     expect(Array.from(rows, (row) => row.getAttribute("data-testid"))).toEqual([
       rowTestId("listener", 2),
       rowTestId("job", 6),

--- a/frontend/src/components/app-detail/handlers-tab.navigation.test.tsx
+++ b/frontend/src/components/app-detail/handlers-tab.navigation.test.tsx
@@ -7,6 +7,7 @@ import { createWouterMock } from "../../test/mock-wouter";
 import { renderWithAppState } from "../../test/render-helpers";
 import { HandlersTab } from "./handlers-tab";
 import { renderHandlersTab } from "./handlers-tab.test-helpers";
+import { rowTestId } from "./unified-row.test-helpers";
 
 // Mock child components that make API calls
 vi.mock("../shared/execution-table", () => ({
@@ -78,7 +79,7 @@ describe("HandlersTab navigation", () => {
     const user = userEvent.setup();
     const listeners = [createListener({ listener_id: 5 })];
     const { getByTestId } = renderHandlersTab(listeners, [], null);
-    await user.click(getByTestId("unified-row-listener-5"));
+    await user.click(getByTestId(rowTestId("listener", 5)));
     expect(mockNavigate).toHaveBeenCalledWith("/apps/test_app/handlers/listener/5");
   });
 
@@ -86,7 +87,7 @@ describe("HandlersTab navigation", () => {
     const user = userEvent.setup();
     const jobs = [createJob({ job_id: 20 })];
     const { getByTestId } = renderHandlersTab([], jobs, null);
-    await user.click(getByTestId("unified-row-job-20"));
+    await user.click(getByTestId(rowTestId("job", 20)));
     expect(mockNavigate).toHaveBeenCalledWith("/apps/test_app/handlers/job/20");
   });
 
@@ -104,7 +105,7 @@ describe("HandlersTab navigation", () => {
       />,
       { storeOverrides: { uptimeSeconds: 120 } },
     );
-    await user.click(getByTestId("unified-row-listener-3"));
+    await user.click(getByTestId(rowTestId("listener", 3)));
     expect(mockNavigate).toHaveBeenCalledWith("/apps/test_app/handlers/listener/3?instance=1");
   });
 

--- a/frontend/src/components/app-detail/unified-handler-row.test.tsx
+++ b/frontend/src/components/app-detail/unified-handler-row.test.tsx
@@ -1,20 +1,21 @@
 import { render } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import type { ComponentProps } from "react";
 import { describe, expect, it, vi } from "vitest";
 
 import type { JobData, ListenerData } from "../../api/endpoints";
 import { createJob, createListener } from "../../test/factories";
 import type { StatusKind } from "../../utils/status";
 import { UnifiedHandlerRow, type UnifiedItem } from "./unified-handler-row";
+import { rowTestId } from "./unified-row.test-helpers";
 
-const TESTID_SUBLINE_ERR = "handler-row-subline-err";
-const TESTID_MODE_CHIP = "handler-row-mode-chip";
-const TESTID_NEXT_RUN = "handler-row-next-run";
-const TESTID_SCHEDULE_STATUS_BADGE = "schedule-status-badge";
+const SUBLINE_ERR_TESTID = "handler-row-subline-err";
+const MODE_CHIP_TESTID = "handler-row-mode-chip";
+const NEXT_RUN_TESTID = "handler-row-next-run";
+const SCHEDULE_STATUS_BADGE_TESTID = "schedule-status-badge";
 
-function rowTestId(kind: "listener" | "job", id: number) {
-  return `unified-row-${kind}-${id}`;
-}
+/** Seconds past "now" used when a job needs a next_run that has not fired yet. */
+const FUTURE_OFFSET_SECONDS = 60;
 
 interface ItemOverrides {
   name?: string;
@@ -22,10 +23,7 @@ interface ItemOverrides {
   statusKind?: StatusKind;
 }
 
-interface RowPropOverrides {
-  isSelected?: boolean;
-  onSelect?: () => void;
-}
+type RowPropOverrides = Partial<Pick<ComponentProps<typeof UnifiedHandlerRow>, "isSelected" | "onSelect">>;
 
 function noop() {}
 
@@ -205,7 +203,7 @@ describe("UnifiedHandlerRow — subline switching", () => {
       { name: "on_change", humanDescription: "When something changes", statusKind: "err" },
     );
     const { queryByTestId } = renderRow(item);
-    const errSubline = queryByTestId(TESTID_SUBLINE_ERR);
+    const errSubline = queryByTestId(SUBLINE_ERR_TESTID);
     expect(errSubline).not.toBeNull();
     expect(errSubline?.textContent).toContain("KeyError");
   });
@@ -216,7 +214,7 @@ describe("UnifiedHandlerRow — subline switching", () => {
       { name: "sync_data", humanDescription: null, statusKind: "err" },
     );
     const { queryByTestId } = renderRow(item);
-    const errSubline = queryByTestId(TESTID_SUBLINE_ERR);
+    const errSubline = queryByTestId(SUBLINE_ERR_TESTID);
     expect(errSubline).not.toBeNull();
     expect(errSubline?.textContent).toContain("ConnectionError");
   });
@@ -233,17 +231,17 @@ describe("UnifiedHandlerRow — subline switching", () => {
       { name: "on_door", humanDescription: "Fires on door open" },
     );
     const { getByTestId, queryByTestId } = renderRow(item);
-    expect(queryByTestId(TESTID_SUBLINE_ERR)).toBeNull();
+    expect(queryByTestId(SUBLINE_ERR_TESTID)).toBeNull();
     expect(getByTestId(rowTestId("listener", 1)).getAttribute("aria-label")).toBe("on_door: Fires on door open");
   });
 
   it("shows next-run line for schedule jobs", () => {
     const item = makeJobItem(
-      { job_id: 1, next_run: Math.floor(Date.now() / 1000) + 60 },
+      { job_id: 1, next_run: Math.floor(Date.now() / 1000) + FUTURE_OFFSET_SECONDS },
       { name: "my_job", humanDescription: null },
     );
     const { queryByTestId } = renderRow(item);
-    expect(queryByTestId(TESTID_NEXT_RUN)).not.toBeNull();
+    expect(queryByTestId(NEXT_RUN_TESTID)).not.toBeNull();
   });
 });
 
@@ -251,31 +249,31 @@ describe("UnifiedHandlerRow — mode chip", () => {
   it("renders mode chip for listener with mode=single", () => {
     const item = makeListenerItem({ mode: "single", listener_id: 1 });
     const { getByTestId } = renderRow(item);
-    expect(getByTestId(TESTID_MODE_CHIP).textContent).toBe("single");
+    expect(getByTestId(MODE_CHIP_TESTID).textContent).toBe("single");
   });
 
   it("renders mode chip for listener with mode=parallel", () => {
     const item = makeListenerItem({ mode: "parallel", listener_id: 2 });
     const { getByTestId } = renderRow(item);
-    expect(getByTestId(TESTID_MODE_CHIP).textContent).toBe("parallel");
+    expect(getByTestId(MODE_CHIP_TESTID).textContent).toBe("parallel");
   });
 
   it("renders mode chip for listener with mode=queued", () => {
     const item = makeListenerItem({ mode: "queued", listener_id: 3 });
     const { getByTestId } = renderRow(item);
-    expect(getByTestId(TESTID_MODE_CHIP).textContent).toBe("queued");
+    expect(getByTestId(MODE_CHIP_TESTID).textContent).toBe("queued");
   });
 
   it("renders mode chip for listener with mode=restart", () => {
     const item = makeListenerItem({ mode: "restart", listener_id: 4 });
     const { getByTestId } = renderRow(item);
-    expect(getByTestId(TESTID_MODE_CHIP).textContent).toBe("restart");
+    expect(getByTestId(MODE_CHIP_TESTID).textContent).toBe("restart");
   });
 
   it("does not render mode chip for job items", () => {
     const item = makeJobItem({ job_id: 5 });
     const { queryByTestId } = renderRow(item);
-    expect(queryByTestId(TESTID_MODE_CHIP)).toBeNull();
+    expect(queryByTestId(MODE_CHIP_TESTID)).toBeNull();
   });
 });
 
@@ -321,24 +319,24 @@ describe("UnifiedHandlerRow — job", () => {
   ] as const)("renders schedule status badge '%s' for jobs", (status, label) => {
     const item = makeJobItem({ job_id: 1, schedule_status: status, next_run: null });
     const { getByTestId } = renderRow(item);
-    expect(getByTestId(TESTID_SCHEDULE_STATUS_BADGE).textContent).toBe(label);
+    expect(getByTestId(SCHEDULE_STATUS_BADGE_TESTID).textContent).toBe(label);
   });
 
   it("does not render a schedule status badge for a normal scheduled job", () => {
     const item = makeJobItem({ job_id: 1, schedule_status: "scheduled", schedule_status_reason: null });
     const { queryByTestId } = renderRow(item);
-    expect(queryByTestId(TESTID_SCHEDULE_STATUS_BADGE)).toBeNull();
+    expect(queryByTestId(SCHEDULE_STATUS_BADGE_TESTID)).toBeNull();
   });
 
   it("renders 'unknown' badge for scheduled jobs with legacy_unknown reason", () => {
     const item = makeJobItem({ job_id: 1, schedule_status: "scheduled", schedule_status_reason: "legacy_unknown" });
     const { getByTestId } = renderRow(item);
-    expect(getByTestId(TESTID_SCHEDULE_STATUS_BADGE).textContent).toBe("unknown");
+    expect(getByTestId(SCHEDULE_STATUS_BADGE_TESTID).textContent).toBe("unknown");
   });
 
   it("does not render a schedule status badge for listeners", () => {
     const item = makeListenerItem();
     const { queryByTestId } = renderRow(item);
-    expect(queryByTestId(TESTID_SCHEDULE_STATUS_BADGE)).toBeNull();
+    expect(queryByTestId(SCHEDULE_STATUS_BADGE_TESTID)).toBeNull();
   });
 });

--- a/frontend/src/components/app-detail/unified-handler-row.test.tsx
+++ b/frontend/src/components/app-detail/unified-handler-row.test.tsx
@@ -7,14 +7,14 @@ import { createJob, createListener } from "../../test/factories";
 import type { StatusKind } from "../../utils/status";
 import { UnifiedHandlerRow, type UnifiedItem } from "./unified-handler-row";
 
-const TESTID_DESC = "handler-row-desc";
-const TESTID_ERR_SUBLINE = "handler-row-subline-err";
+const TESTID_SUBLINE_ERR = "handler-row-subline-err";
 const TESTID_MODE_CHIP = "handler-row-mode-chip";
 const TESTID_NEXT_RUN = "handler-row-next-run";
 const TESTID_SCHEDULE_STATUS_BADGE = "schedule-status-badge";
 
-/** Seconds past "now" used when a job needs a next_run that has not fired yet. */
-const FUTURE_OFFSET_SECONDS = 60;
+function rowTestId(kind: "listener" | "job", id: number) {
+  return `unified-row-${kind}-${id}`;
+}
 
 interface ItemOverrides {
   name?: string;
@@ -29,8 +29,8 @@ interface RowPropOverrides {
 
 function noop() {}
 
-function renderRow(item: UnifiedItem, props: RowPropOverrides = {}) {
-  return render(<UnifiedHandlerRow item={item} isSelected={false} onSelect={noop} {...props} />);
+function renderRow(item: UnifiedItem, overrides: RowPropOverrides = {}) {
+  return render(<UnifiedHandlerRow item={item} isSelected={false} onSelect={noop} {...overrides} />);
 }
 
 function makeListenerItem(overrides: Partial<ListenerData> = {}, itemOverrides: ItemOverrides = {}) {
@@ -69,7 +69,7 @@ describe("UnifiedHandlerRow — listener", () => {
   it("renders with data-testid containing kind and id", () => {
     const item = makeListenerItem({ listener_id: 42 });
     const { getByTestId } = renderRow(item);
-    expect(getByTestId("unified-row-listener-42")).toBeDefined();
+    expect(getByTestId(rowTestId("listener", 42))).toBeDefined();
   });
 
   it("renders handler name", () => {
@@ -84,19 +84,19 @@ describe("UnifiedHandlerRow — listener", () => {
       { name: "on_light_change", humanDescription: "When kitchen light changes" },
     );
     const { getByTestId, queryByText } = renderRow(item);
-    expect(getByTestId("unified-row-listener-1").getAttribute("aria-label")).toBe(
+    expect(getByTestId(rowTestId("listener", 1)).getAttribute("aria-label")).toBe(
       "on_light_change: When kitchen light changes",
     );
     expect(queryByText("When kitchen light changes")).toBeNull();
   });
 
-  it("does not render subtitle when humanDescription is null", () => {
+  it("omits the description from the aria-label when humanDescription is null", () => {
     const item = makeListenerItem(
       { human_description: null, listener_id: 1 },
       { name: "on_change", humanDescription: null },
     );
-    const { container } = renderRow(item);
-    expect(container.querySelector(`[data-testid='${TESTID_DESC}']`)).toBeNull();
+    const { getByTestId } = renderRow(item);
+    expect(getByTestId(rowTestId("listener", 1)).getAttribute("aria-label")).toBe("on_change");
   });
 
   it("renders invocation count in stats", () => {
@@ -128,13 +128,13 @@ describe("UnifiedHandlerRow — listener", () => {
   it("sets aria-pressed=true when isSelected is true", () => {
     const item = makeListenerItem({ listener_id: 1 });
     const { getByTestId } = renderRow(item, { isSelected: true });
-    expect(getByTestId("unified-row-listener-1").getAttribute("aria-pressed")).toBe("true");
+    expect(getByTestId(rowTestId("listener", 1)).getAttribute("aria-pressed")).toBe("true");
   });
 
   it("sets aria-pressed=false when isSelected is false", () => {
     const item = makeListenerItem({ listener_id: 1 });
     const { getByTestId } = renderRow(item, { isSelected: false });
-    expect(getByTestId("unified-row-listener-1").getAttribute("aria-pressed")).toBe("false");
+    expect(getByTestId(rowTestId("listener", 1)).getAttribute("aria-pressed")).toBe("false");
   });
 
   it("calls onSelect when clicked", async () => {
@@ -183,13 +183,13 @@ describe("UnifiedHandlerRow — idle state", () => {
       { statusKind: "mute" },
     );
     const { getByTestId } = renderRow(item);
-    expect(getByTestId("unified-row-listener-1").className).toContain("opacity-60");
+    expect(getByTestId(rowTestId("listener", 1)).className).toContain("opacity-60");
   });
 
   it("does not apply the dimmed idle styling when statusKind is ok", () => {
     const item = makeListenerItem({ listener_id: 1 });
     const { getByTestId } = renderRow(item);
-    expect(getByTestId("unified-row-listener-1").className).not.toContain("opacity-60");
+    expect(getByTestId(rowTestId("listener", 1)).className).not.toContain("opacity-60");
   });
 });
 
@@ -204,8 +204,8 @@ describe("UnifiedHandlerRow — subline switching", () => {
       },
       { name: "on_change", humanDescription: "When something changes", statusKind: "err" },
     );
-    const { container } = renderRow(item);
-    const errSubline = container.querySelector(`[data-testid='${TESTID_ERR_SUBLINE}']`);
+    const { queryByTestId } = renderRow(item);
+    const errSubline = queryByTestId(TESTID_SUBLINE_ERR);
     expect(errSubline).not.toBeNull();
     expect(errSubline?.textContent).toContain("KeyError");
   });
@@ -215,8 +215,8 @@ describe("UnifiedHandlerRow — subline switching", () => {
       { job_id: 1, failed: 3, last_error_message: "ConnectionError: timeout" },
       { name: "sync_data", humanDescription: null, statusKind: "err" },
     );
-    const { container } = renderRow(item);
-    const errSubline = container.querySelector(`[data-testid='${TESTID_ERR_SUBLINE}']`);
+    const { queryByTestId } = renderRow(item);
+    const errSubline = queryByTestId(TESTID_SUBLINE_ERR);
     expect(errSubline).not.toBeNull();
     expect(errSubline?.textContent).toContain("ConnectionError");
   });
@@ -232,19 +232,18 @@ describe("UnifiedHandlerRow — subline switching", () => {
       },
       { name: "on_door", humanDescription: "Fires on door open" },
     );
-    const { container, getByTestId } = renderRow(item);
-    expect(container.querySelector(`[data-testid='${TESTID_DESC}']`)).toBeNull();
-    expect(container.querySelector(`[data-testid='${TESTID_ERR_SUBLINE}']`)).toBeNull();
-    expect(getByTestId("unified-row-listener-1").getAttribute("aria-label")).toBe("on_door: Fires on door open");
+    const { getByTestId, queryByTestId } = renderRow(item);
+    expect(queryByTestId(TESTID_SUBLINE_ERR)).toBeNull();
+    expect(getByTestId(rowTestId("listener", 1)).getAttribute("aria-label")).toBe("on_door: Fires on door open");
   });
 
   it("shows next-run line for schedule jobs", () => {
     const item = makeJobItem(
-      { job_id: 1, next_run: Math.floor(Date.now() / 1000) + FUTURE_OFFSET_SECONDS },
+      { job_id: 1, next_run: Math.floor(Date.now() / 1000) + 60 },
       { name: "my_job", humanDescription: null },
     );
-    const { container } = renderRow(item);
-    expect(container.querySelector(`[data-testid='${TESTID_NEXT_RUN}']`)).not.toBeNull();
+    const { queryByTestId } = renderRow(item);
+    expect(queryByTestId(TESTID_NEXT_RUN)).not.toBeNull();
   });
 });
 
@@ -275,8 +274,8 @@ describe("UnifiedHandlerRow — mode chip", () => {
 
   it("does not render mode chip for job items", () => {
     const item = makeJobItem({ job_id: 5 });
-    const { container } = renderRow(item);
-    expect(container.querySelector(`[data-testid='${TESTID_MODE_CHIP}']`)).toBeNull();
+    const { queryByTestId } = renderRow(item);
+    expect(queryByTestId(TESTID_MODE_CHIP)).toBeNull();
   });
 });
 
@@ -284,7 +283,7 @@ describe("UnifiedHandlerRow — job", () => {
   it("renders with data-testid containing kind='job' and job id", () => {
     const item = makeJobItem({ job_id: 7 });
     const { getByTestId } = renderRow(item);
-    expect(getByTestId("unified-row-job-7")).toBeDefined();
+    expect(getByTestId(rowTestId("job", 7))).toBeDefined();
   });
 
   it("renders job name", () => {
@@ -299,7 +298,7 @@ describe("UnifiedHandlerRow — job", () => {
       { name: "my_job", humanDescription: "every 5 minutes" },
     );
     const { getByTestId } = renderRow(item);
-    expect(getByTestId("unified-row-job-1").getAttribute("aria-label")).toBe("my_job: every 5 minutes");
+    expect(getByTestId(rowTestId("job", 1)).getAttribute("aria-label")).toBe("my_job: every 5 minutes");
   });
 
   it("renders execution count in stats", () => {

--- a/frontend/src/components/app-detail/unified-handler-row.test.tsx
+++ b/frontend/src/components/app-detail/unified-handler-row.test.tsx
@@ -2,9 +2,19 @@ import { render } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
 
+import type { JobData, ListenerData } from "../../api/endpoints";
 import { createJob, createListener } from "../../test/factories";
 import type { StatusKind } from "../../utils/status";
-import { UnifiedHandlerRow } from "./unified-handler-row";
+import { UnifiedHandlerRow, type UnifiedItem } from "./unified-handler-row";
+
+const TESTID_DESC = "handler-row-desc";
+const TESTID_ERR_SUBLINE = "handler-row-subline-err";
+const TESTID_MODE_CHIP = "handler-row-mode-chip";
+const TESTID_NEXT_RUN = "handler-row-next-run";
+const TESTID_SCHEDULE_STATUS_BADGE = "schedule-status-badge";
+
+/** Seconds past "now" used when a job needs a next_run that has not fired yet. */
+const FUTURE_OFFSET_SECONDS = 60;
 
 interface ItemOverrides {
   name?: string;
@@ -12,7 +22,18 @@ interface ItemOverrides {
   statusKind?: StatusKind;
 }
 
-function makeListenerItem(overrides = {}, itemOverrides: ItemOverrides = {}) {
+interface RowPropOverrides {
+  isSelected?: boolean;
+  onSelect?: () => void;
+}
+
+function noop() {}
+
+function renderRow(item: UnifiedItem, props: RowPropOverrides = {}) {
+  return render(<UnifiedHandlerRow item={item} isSelected={false} onSelect={noop} {...props} />);
+}
+
+function makeListenerItem(overrides: Partial<ListenerData> = {}, itemOverrides: ItemOverrides = {}) {
   const listener = createListener(overrides);
   return {
     kind: "listener" as const,
@@ -27,7 +48,7 @@ function makeListenerItem(overrides = {}, itemOverrides: ItemOverrides = {}) {
   };
 }
 
-function makeJobItem(overrides = {}, itemOverrides: ItemOverrides = {}) {
+function makeJobItem(overrides: Partial<JobData> = {}, itemOverrides: ItemOverrides = {}) {
   const job = createJob(overrides);
   return {
     kind: "job" as const,
@@ -47,13 +68,13 @@ function makeJobItem(overrides = {}, itemOverrides: ItemOverrides = {}) {
 describe("UnifiedHandlerRow — listener", () => {
   it("renders with data-testid containing kind and id", () => {
     const item = makeListenerItem({ listener_id: 42 });
-    const { getByTestId } = render(<UnifiedHandlerRow item={item} isSelected={false} onSelect={() => {}} />);
+    const { getByTestId } = renderRow(item);
     expect(getByTestId("unified-row-listener-42")).toBeDefined();
   });
 
   it("renders handler name", () => {
     const item = makeListenerItem({ handler_summary: "on_motion_detected()", listener_id: 1 });
-    const { getByText } = render(<UnifiedHandlerRow item={item} isSelected={false} onSelect={() => {}} />);
+    const { getByText } = renderRow(item);
     expect(getByText("on_motion_detected()")).toBeDefined();
   });
 
@@ -62,9 +83,7 @@ describe("UnifiedHandlerRow — listener", () => {
       { human_description: "When kitchen light changes", listener_id: 1 },
       { name: "on_light_change", humanDescription: "When kitchen light changes" },
     );
-    const { getByTestId, queryByText } = render(
-      <UnifiedHandlerRow item={item} isSelected={false} onSelect={() => {}} />,
-    );
+    const { getByTestId, queryByText } = renderRow(item);
     expect(getByTestId("unified-row-listener-1").getAttribute("aria-label")).toBe(
       "on_light_change: When kitchen light changes",
     );
@@ -76,45 +95,45 @@ describe("UnifiedHandlerRow — listener", () => {
       { human_description: null, listener_id: 1 },
       { name: "on_change", humanDescription: null },
     );
-    const { container } = render(<UnifiedHandlerRow item={item} isSelected={false} onSelect={() => {}} />);
-    expect(container.querySelector("[data-testid='handler-row-desc']")).toBeNull();
+    const { container } = renderRow(item);
+    expect(container.querySelector(`[data-testid='${TESTID_DESC}']`)).toBeNull();
   });
 
   it("renders invocation count in stats", () => {
     const item = makeListenerItem({ total_invocations: 7, listener_id: 1 });
-    const { getByText } = render(<UnifiedHandlerRow item={item} isSelected={false} onSelect={() => {}} />);
+    const { getByText } = renderRow(item);
     expect(getByText("7 calls")).toBeDefined();
   });
 
   it("renders failed count when failed > 0", () => {
     const item = makeListenerItem({ failed: 3, total_invocations: 10, listener_id: 1 });
-    const { getByText } = render(<UnifiedHandlerRow item={item} isSelected={false} onSelect={() => {}} />);
+    const { getByText } = renderRow(item);
     expect(getByText("3 failed")).toBeDefined();
   });
 
   it("renders timed_out count separately from failed", () => {
     const item = makeListenerItem({ timed_out: 2, failed: 1, total_invocations: 5, listener_id: 1 });
-    const { getByText } = render(<UnifiedHandlerRow item={item} isSelected={false} onSelect={() => {}} />);
+    const { getByText } = renderRow(item);
     expect(getByText("2 timed out")).toBeDefined();
     expect(getByText("1 failed")).toBeDefined();
   });
 
   it("does not render failed/timed_out when both are 0", () => {
     const item = makeListenerItem({ failed: 0, timed_out: 0, listener_id: 1 });
-    const { queryByText } = render(<UnifiedHandlerRow item={item} isSelected={false} onSelect={() => {}} />);
+    const { queryByText } = renderRow(item);
     expect(queryByText(/failed/)).toBeNull();
     expect(queryByText(/timed out/)).toBeNull();
   });
 
   it("sets aria-pressed=true when isSelected is true", () => {
     const item = makeListenerItem({ listener_id: 1 });
-    const { getByTestId } = render(<UnifiedHandlerRow item={item} isSelected={true} onSelect={() => {}} />);
+    const { getByTestId } = renderRow(item, { isSelected: true });
     expect(getByTestId("unified-row-listener-1").getAttribute("aria-pressed")).toBe("true");
   });
 
   it("sets aria-pressed=false when isSelected is false", () => {
     const item = makeListenerItem({ listener_id: 1 });
-    const { getByTestId } = render(<UnifiedHandlerRow item={item} isSelected={false} onSelect={() => {}} />);
+    const { getByTestId } = renderRow(item, { isSelected: false });
     expect(getByTestId("unified-row-listener-1").getAttribute("aria-pressed")).toBe("false");
   });
 
@@ -122,7 +141,7 @@ describe("UnifiedHandlerRow — listener", () => {
     const user = userEvent.setup();
     const onSelect = vi.fn();
     const item = makeListenerItem({ listener_id: 1 });
-    const { getByRole } = render(<UnifiedHandlerRow item={item} isSelected={false} onSelect={onSelect} />);
+    const { getByRole } = renderRow(item, { onSelect });
     await user.click(getByRole("button"));
     expect(onSelect).toHaveBeenCalledOnce();
   });
@@ -131,7 +150,7 @@ describe("UnifiedHandlerRow — listener", () => {
     const user = userEvent.setup();
     const onSelect = vi.fn();
     const item = makeListenerItem({ listener_id: 1 });
-    const { getByRole } = render(<UnifiedHandlerRow item={item} isSelected={false} onSelect={onSelect} />);
+    const { getByRole } = renderRow(item, { onSelect });
     const button = getByRole("button");
     button.focus();
     await user.keyboard("{Enter}");
@@ -142,7 +161,7 @@ describe("UnifiedHandlerRow — listener", () => {
     const user = userEvent.setup();
     const onSelect = vi.fn();
     const item = makeListenerItem({ listener_id: 1 });
-    const { getByRole } = render(<UnifiedHandlerRow item={item} isSelected={false} onSelect={onSelect} />);
+    const { getByRole } = renderRow(item, { onSelect });
     const button = getByRole("button");
     button.focus();
     await user.keyboard(" ");
@@ -151,7 +170,7 @@ describe("UnifiedHandlerRow — listener", () => {
 
   it("includes a visible focus outline utility", () => {
     const item = makeListenerItem({ listener_id: 1 });
-    const { getByRole } = render(<UnifiedHandlerRow item={item} isSelected={false} onSelect={() => {}} />);
+    const { getByRole } = renderRow(item);
     expect(getByRole("button").className).toContain("focus-visible:outline-solid");
     expect(getByRole("button").className).toContain("focus-visible:outline-primary");
   });
@@ -163,13 +182,13 @@ describe("UnifiedHandlerRow — idle state", () => {
       { listener_id: 1, total_invocations: 0, failed: 0, timed_out: 0 },
       { statusKind: "mute" },
     );
-    const { getByTestId } = render(<UnifiedHandlerRow item={item} isSelected={false} onSelect={() => {}} />);
+    const { getByTestId } = renderRow(item);
     expect(getByTestId("unified-row-listener-1").className).toContain("opacity-60");
   });
 
   it("does not apply the dimmed idle styling when statusKind is ok", () => {
     const item = makeListenerItem({ listener_id: 1 });
-    const { getByTestId } = render(<UnifiedHandlerRow item={item} isSelected={false} onSelect={() => {}} />);
+    const { getByTestId } = renderRow(item);
     expect(getByTestId("unified-row-listener-1").className).not.toContain("opacity-60");
   });
 });
@@ -185,9 +204,8 @@ describe("UnifiedHandlerRow — subline switching", () => {
       },
       { name: "on_change", humanDescription: "When something changes", statusKind: "err" },
     );
-    const { container } = render(<UnifiedHandlerRow item={item} isSelected={false} onSelect={() => {}} />);
-    // Error message shown
-    const errSubline = container.querySelector("[data-testid='handler-row-subline-err']");
+    const { container } = renderRow(item);
+    const errSubline = container.querySelector(`[data-testid='${TESTID_ERR_SUBLINE}']`);
     expect(errSubline).not.toBeNull();
     expect(errSubline?.textContent).toContain("KeyError");
   });
@@ -197,8 +215,8 @@ describe("UnifiedHandlerRow — subline switching", () => {
       { job_id: 1, failed: 3, last_error_message: "ConnectionError: timeout" },
       { name: "sync_data", humanDescription: null, statusKind: "err" },
     );
-    const { container } = render(<UnifiedHandlerRow item={item} isSelected={false} onSelect={() => {}} />);
-    const errSubline = container.querySelector("[data-testid='handler-row-subline-err']");
+    const { container } = renderRow(item);
+    const errSubline = container.querySelector(`[data-testid='${TESTID_ERR_SUBLINE}']`);
     expect(errSubline).not.toBeNull();
     expect(errSubline?.textContent).toContain("ConnectionError");
   });
@@ -214,64 +232,64 @@ describe("UnifiedHandlerRow — subline switching", () => {
       },
       { name: "on_door", humanDescription: "Fires on door open" },
     );
-    const { container, getByTestId } = render(<UnifiedHandlerRow item={item} isSelected={false} onSelect={() => {}} />);
-    expect(container.querySelector("[data-testid='handler-row-desc']")).toBeNull();
-    expect(container.querySelector("[data-testid='handler-row-subline-err']")).toBeNull();
+    const { container, getByTestId } = renderRow(item);
+    expect(container.querySelector(`[data-testid='${TESTID_DESC}']`)).toBeNull();
+    expect(container.querySelector(`[data-testid='${TESTID_ERR_SUBLINE}']`)).toBeNull();
     expect(getByTestId("unified-row-listener-1").getAttribute("aria-label")).toBe("on_door: Fires on door open");
   });
 
   it("shows next-run line for schedule jobs", () => {
     const item = makeJobItem(
-      { job_id: 1, next_run: Math.floor(Date.now() / 1000) + 60 },
+      { job_id: 1, next_run: Math.floor(Date.now() / 1000) + FUTURE_OFFSET_SECONDS },
       { name: "my_job", humanDescription: null },
     );
-    const { container } = render(<UnifiedHandlerRow item={item} isSelected={false} onSelect={() => {}} />);
-    expect(container.querySelector("[data-testid='handler-row-next-run']")).not.toBeNull();
+    const { container } = renderRow(item);
+    expect(container.querySelector(`[data-testid='${TESTID_NEXT_RUN}']`)).not.toBeNull();
   });
 });
 
 describe("UnifiedHandlerRow — mode chip", () => {
   it("renders mode chip for listener with mode=single", () => {
     const item = makeListenerItem({ mode: "single", listener_id: 1 });
-    const { getByTestId } = render(<UnifiedHandlerRow item={item} isSelected={false} onSelect={() => {}} />);
-    expect(getByTestId("handler-row-mode-chip").textContent).toBe("single");
+    const { getByTestId } = renderRow(item);
+    expect(getByTestId(TESTID_MODE_CHIP).textContent).toBe("single");
   });
 
   it("renders mode chip for listener with mode=parallel", () => {
     const item = makeListenerItem({ mode: "parallel", listener_id: 2 });
-    const { getByTestId } = render(<UnifiedHandlerRow item={item} isSelected={false} onSelect={() => {}} />);
-    expect(getByTestId("handler-row-mode-chip").textContent).toBe("parallel");
+    const { getByTestId } = renderRow(item);
+    expect(getByTestId(TESTID_MODE_CHIP).textContent).toBe("parallel");
   });
 
   it("renders mode chip for listener with mode=queued", () => {
     const item = makeListenerItem({ mode: "queued", listener_id: 3 });
-    const { getByTestId } = render(<UnifiedHandlerRow item={item} isSelected={false} onSelect={() => {}} />);
-    expect(getByTestId("handler-row-mode-chip").textContent).toBe("queued");
+    const { getByTestId } = renderRow(item);
+    expect(getByTestId(TESTID_MODE_CHIP).textContent).toBe("queued");
   });
 
   it("renders mode chip for listener with mode=restart", () => {
     const item = makeListenerItem({ mode: "restart", listener_id: 4 });
-    const { getByTestId } = render(<UnifiedHandlerRow item={item} isSelected={false} onSelect={() => {}} />);
-    expect(getByTestId("handler-row-mode-chip").textContent).toBe("restart");
+    const { getByTestId } = renderRow(item);
+    expect(getByTestId(TESTID_MODE_CHIP).textContent).toBe("restart");
   });
 
   it("does not render mode chip for job items", () => {
     const item = makeJobItem({ job_id: 5 });
-    const { container } = render(<UnifiedHandlerRow item={item} isSelected={false} onSelect={() => {}} />);
-    expect(container.querySelector("[data-testid='handler-row-mode-chip']")).toBeNull();
+    const { container } = renderRow(item);
+    expect(container.querySelector(`[data-testid='${TESTID_MODE_CHIP}']`)).toBeNull();
   });
 });
 
 describe("UnifiedHandlerRow — job", () => {
   it("renders with data-testid containing kind='job' and job id", () => {
     const item = makeJobItem({ job_id: 7 });
-    const { getByTestId } = render(<UnifiedHandlerRow item={item} isSelected={false} onSelect={() => {}} />);
+    const { getByTestId } = renderRow(item);
     expect(getByTestId("unified-row-job-7")).toBeDefined();
   });
 
   it("renders job name", () => {
     const item = makeJobItem({ job_name: "cleanup_task", job_id: 1 });
-    const { getByText } = render(<UnifiedHandlerRow item={item} isSelected={false} onSelect={() => {}} />);
+    const { getByText } = renderRow(item);
     expect(getByText("cleanup_task")).toBeDefined();
   });
 
@@ -280,19 +298,19 @@ describe("UnifiedHandlerRow — job", () => {
       { job_id: 1, trigger_label: "every 5 minutes" },
       { name: "my_job", humanDescription: "every 5 minutes" },
     );
-    const { getByTestId } = render(<UnifiedHandlerRow item={item} isSelected={false} onSelect={() => {}} />);
+    const { getByTestId } = renderRow(item);
     expect(getByTestId("unified-row-job-1").getAttribute("aria-label")).toBe("my_job: every 5 minutes");
   });
 
   it("renders execution count in stats", () => {
     const item = makeJobItem({ total_executions: 4, job_id: 1 });
-    const { getByText } = render(<UnifiedHandlerRow item={item} isSelected={false} onSelect={() => {}} />);
+    const { getByText } = renderRow(item);
     expect(getByText("4 runs")).toBeDefined();
   });
 
   it("renders timed_out separate from failed for jobs", () => {
     const item = makeJobItem({ timed_out: 1, failed: 2, total_executions: 10, job_id: 1 });
-    const { getByText } = render(<UnifiedHandlerRow item={item} isSelected={false} onSelect={() => {}} />);
+    const { getByText } = renderRow(item);
     expect(getByText("2 failed")).toBeDefined();
     expect(getByText("1 timed out")).toBeDefined();
   });
@@ -303,25 +321,25 @@ describe("UnifiedHandlerRow — job", () => {
     ["completed", "completed"],
   ] as const)("renders schedule status badge '%s' for jobs", (status, label) => {
     const item = makeJobItem({ job_id: 1, schedule_status: status, next_run: null });
-    const { getByTestId } = render(<UnifiedHandlerRow item={item} isSelected={false} onSelect={() => {}} />);
-    expect(getByTestId("schedule-status-badge").textContent).toBe(label);
+    const { getByTestId } = renderRow(item);
+    expect(getByTestId(TESTID_SCHEDULE_STATUS_BADGE).textContent).toBe(label);
   });
 
   it("does not render a schedule status badge for a normal scheduled job", () => {
     const item = makeJobItem({ job_id: 1, schedule_status: "scheduled", schedule_status_reason: null });
-    const { queryByTestId } = render(<UnifiedHandlerRow item={item} isSelected={false} onSelect={() => {}} />);
-    expect(queryByTestId("schedule-status-badge")).toBeNull();
+    const { queryByTestId } = renderRow(item);
+    expect(queryByTestId(TESTID_SCHEDULE_STATUS_BADGE)).toBeNull();
   });
 
   it("renders 'unknown' badge for scheduled jobs with legacy_unknown reason", () => {
     const item = makeJobItem({ job_id: 1, schedule_status: "scheduled", schedule_status_reason: "legacy_unknown" });
-    const { getByTestId } = render(<UnifiedHandlerRow item={item} isSelected={false} onSelect={() => {}} />);
-    expect(getByTestId("schedule-status-badge").textContent).toBe("unknown");
+    const { getByTestId } = renderRow(item);
+    expect(getByTestId(TESTID_SCHEDULE_STATUS_BADGE).textContent).toBe("unknown");
   });
 
   it("does not render a schedule status badge for listeners", () => {
     const item = makeListenerItem();
-    const { queryByTestId } = render(<UnifiedHandlerRow item={item} isSelected={false} onSelect={() => {}} />);
-    expect(queryByTestId("schedule-status-badge")).toBeNull();
+    const { queryByTestId } = renderRow(item);
+    expect(queryByTestId(TESTID_SCHEDULE_STATUS_BADGE)).toBeNull();
   });
 });

--- a/frontend/src/components/app-detail/unified-row.test-helpers.ts
+++ b/frontend/src/components/app-detail/unified-row.test-helpers.ts
@@ -1,0 +1,8 @@
+import type { UnifiedItemKind } from "./unified-handler-row";
+
+export const ROW_TESTID_PREFIX = "unified-row-";
+
+/** Mirrors the `data-testid` UnifiedHandlerRow renders for each row. */
+export function rowTestId(kind: UnifiedItemKind, id: number) {
+  return `${ROW_TESTID_PREFIX}${kind}-${id}`;
+}


### PR DESCRIPTION
## Summary

Test-only cleanup of `unified-handler-row.test.tsx`, surfaced by an automated quality scan.
No production code changes. Two assertions changed what they check (see "Assertion changes"
below); everything else is mechanical.

## What changed

- **Extracted a `renderRow()` helper.** `render(<UnifiedHandlerRow item={item} isSelected={false} onSelect={() => {}} />)`
  was repeated near-verbatim at ~30 call sites. `renderRow(item, overrides?)` defaults
  `isSelected` to `false` and supplies a shared module-level `noop` for `onSelect`, so the
  handful of tests that genuinely vary those props (selection state, click/keyboard handlers)
  now stand out instead of blending into the boilerplate. Its `RowPropOverrides` type is
  derived from the component's own props via `ComponentProps`, so a prop rename cannot drift
  past the helper.
- **Named the repeated `data-testid` literals** as `SUBLINE_ERR_TESTID`, `MODE_CHIP_TESTID`,
  `NEXT_RUN_TESTID`, and `SCHEDULE_STATUS_BADGE_TESTID`, matching the `*_TESTID` suffix form
  already used across this test suite. Renaming a testid in the component previously meant a
  manual find/replace through this file with no compiler safety net.
- **Shared the row testid helper.** `rowTestId(kind, id)` and `ROW_TESTID_PREFIX` now live in
  `unified-row.test-helpers.ts`, following the existing `handler-health.test-helpers.ts`
  precedent. `handler-list.test.tsx` had independently defined an identically named helper for
  the same `unified-row-<kind>-<id>` format; it now imports the shared one, so the format has a
  single source of truth on the test side. The helper is typed with the component's exported
  `UnifiedItemKind` rather than a re-declared string union. `handlers-tab.navigation.test.tsx`,
  which hardcoded the same literals, now uses the helper too — the format is defined in exactly
  one place on the test side.
- **Named the magic `60`** in the job `next_run` fixture as `FUTURE_OFFSET_SECONDS`, with a
  docstring explaining it is the offset past "now" for a job that has not fired yet.
- **Typed the override bags.** `makeListenerItem`/`makeJobItem` took `(overrides = {}, itemOverrides: ItemOverrides = {})`
  — the second param was typed but the first was implicitly `{}`. Both now carry explicit
  types (`Partial<ListenerData>` / `Partial<JobData>`), matching their sibling.
- **Dropped the one redundant inline comment** (`// Error message shown`), which restated
  the two assertion lines directly beneath it.

## Assertion changes

Two tests asserted that a `data-testid="handler-row-desc"` element was absent. That testid does
not exist anywhere in `unified-handler-row.tsx`, so both checks were vacuously true and tested
nothing. They were not ported mechanically:

- `does not render subtitle when humanDescription is null` is now
  `omits the description from the aria-label when humanDescription is null`, and asserts the
  `aria-label` the component actually produces.
- `does not show a description line for healthy handlers` drops the dead check and keeps its two
  real assertions.

Net effect: 36 test cases before and after; total `expect(` statements go from 43 to 42, with no
real coverage lost.

The duplicated `makeListenerItem`/`makeJobItem` item-shape construction is deliberately left
alone — it is already tracked by #1282, and touching it here would overlap that work.

## Testing

- `unified-handler-row.test.tsx` (36) and `handler-list.test.tsx` (9) — all pass
- `npx vitest run` — 110 files / 1601 tests pass
- `npx tsc --noEmit` and `npx eslint` — clean
- `prek -a` — all hooks pass

The `pr-screenshots` guard does not apply here: `check_pr_screenshots.py` explicitly excludes
`*.test.tsx` from its rendered-file set, and `unified-row.test-helpers.ts` is not a rendered file.

Closes #1906
