### PR TITLE
refactor: name grid column widths and unify token typing in spacing-tokens showcase

### DIFF
--- a/frontend/src/components/design/spacing-tokens.tsx
+++ b/frontend/src/components/design/spacing-tokens.tsx
@@ -12,6 +12,27 @@ interface SpacingToken {
   px: number;
 }
 
+interface RadiusToken {
+  name: string;
+  cssVar: string;
+  px: number;
+}
+
+interface ShadowToken {
+  name: string;
+  cssVar: string;
+  label: string;
+}
+
+/**
+ * Column widths for the spacing scale rows, applied as an inline grid template.
+ * Tailwind resolves arbitrary values by scanning source text, so a `grid-cols-[...]`
+ * class assembled from these constants would never emit CSS.
+ */
+const SPACING_VAR_COLUMN_WIDTH = "100px";
+const SPACING_PX_COLUMN_WIDTH = "40px";
+const SPACING_ROW_TEMPLATE = `${SPACING_VAR_COLUMN_WIDTH} ${SPACING_PX_COLUMN_WIDTH} minmax(0, 1fr)`;
+
 const SPACING: SpacingToken[] = [
   { name: "px", cssVar: "--sp-px", px: 1 },
   { name: "0", cssVar: "--sp-0", px: 2 },
@@ -31,7 +52,7 @@ const SPACING: SpacingToken[] = [
 
 const MAX_SPACING_PX = SPACING[SPACING.length - 1].px;
 
-const RADII = [
+const RADII: RadiusToken[] = [
   { name: "sm", cssVar: "--r-sm", px: 6 },
   { name: "md", cssVar: "--r-md", px: 8 },
   { name: "lg", cssVar: "--r-lg", px: 12 },
@@ -39,7 +60,7 @@ const RADII = [
   { name: "pill", cssVar: "--r-pill", px: 999 },
 ];
 
-const SHADOWS = [
+const SHADOWS: ShadowToken[] = [
   { name: "shadow-1", cssVar: "--shadow-1", label: "Subtle" },
   { name: "shadow-2", cssVar: "--shadow-2", label: "Medium" },
   { name: "shadow-3", cssVar: "--shadow-3", label: "Elevated" },
@@ -54,7 +75,11 @@ export function SpacingTokens() {
         <h3 className={designGroupLabelClassName}>Spacing Scale</h3>
         <div className="flex flex-col gap-2">
           {SPACING.map((token) => (
-            <div key={token.cssVar} className="grid grid-cols-[100px_40px_minmax(0,1fr)] items-center gap-3">
+            <div
+              key={token.cssVar}
+              className="grid items-center gap-3"
+              style={{ gridTemplateColumns: SPACING_ROW_TEMPLATE }}
+            >
               <code className={designTokenCodeClassName}>{token.cssVar}</code>
               <span className="text-right font-mono text-xs text-foreground-secondary">{token.px}px</span>
               <div className="h-2 overflow-hidden rounded-sm bg-muted">
@@ -71,15 +96,15 @@ export function SpacingTokens() {
       <div className={designGroupClassName}>
         <h3 className={designGroupLabelClassName}>Border Radius</h3>
         <div className="grid grid-cols-[repeat(auto-fill,minmax(100px,1fr))] gap-4">
-          {RADII.map((r) => (
-            <div key={r.cssVar} className="flex flex-col items-center gap-1">
+          {RADII.map((radius) => (
+            <div key={radius.cssVar} className="flex flex-col items-center gap-1">
               <div
                 className="size-14 border border-[var(--primary-border)] bg-[var(--primary-soft)]"
-                style={{ borderRadius: `var(${r.cssVar})` }}
+                style={{ borderRadius: `var(${radius.cssVar})` }}
               />
-              <span className="font-sans text-sm font-medium text-foreground">{r.name}</span>
+              <span className="font-sans text-sm font-medium text-foreground">{radius.name}</span>
               <code className={designTokenCodeClassName}>
-                {r.cssVar} ({r.px}px)
+                {radius.cssVar} ({radius.px}px)
               </code>
             </div>
           ))}


### PR DESCRIPTION
## Summary

Style and consistency cleanup in the spacing-tokens design showcase component. Pure refactor — no behavior or rendering change.

The component renders three token lists (spacing scale, border radii, shadows) but treated them inconsistently: only one had a named interface, one `.map()` callback used a single-letter parameter, and the spacing grid hardcoded two unnamed pixel widths in a file whose entire purpose is showcasing tokenized design values.

## What changed

All three changes are in `frontend/src/components/design/spacing-tokens.tsx`:

- **Consistent `.map()` parameter naming.** Renamed the `RADII.map()` parameter from `r` to `radius`, so all three token-list callbacks (`token`, `radius`, `shadow`) use descriptive names.
- **Consistent type annotations.** Added `RadiusToken` and `ShadowToken` interfaces to match the existing `SpacingToken`, so every token list is explicitly typed rather than only the first.
- **Named grid column widths.** Extracted the `100px` / `40px` spacing-row column widths into `SPACING_VAR_COLUMN_WIDTH` and `SPACING_PX_COLUMN_WIDTH`.

### Why the grid moved to an inline style

Tailwind resolves arbitrary values by scanning source text for the literal class string. A `grid-cols-[...]` class assembled at runtime from the extracted constants would never be seen by the scanner and would emit no CSS, silently breaking the layout. The row therefore uses an inline `gridTemplateColumns` built from the same constants.

The computed value is byte-for-byte equivalent to what the old class produced (`100px 40px minmax(0, 1fr)`), the class had no responsive or state variants, and nothing else targeted it — so the rendered layout is unchanged.

## Testing

- `npm run build` (frontend) — passes
- `npm test` (frontend) — 1601 tests across 110 files pass
- `prek -a` — all hooks pass, including `tsc`, `eslint`, `stylelint`, and `prettier`
- `prek pyright -a --stage pre-push` — passes

### Note on the Python suite

`uv run nox -s dev` reported one failure on each of two local runs, but a **different** test each time — `test_service_watcher.py::test_always_failing_service_stops_after_max_attempts` on the first run, `test_file_watcher.py::test_event_emitted_on_file_change` on the second. Both are timing-sensitive integration tests, and the first passes in isolation.

These are not related to this change: the branch touches exactly one `.tsx` file and zero Python files. A full `nox -s dev` run against `origin/main` in a separate worktree was green (7729 passed), so this is local flakiness under `-n 4` parallel load rather than a regression. Flagging it rather than dropping it — `test_always_failing_service_stops_after_max_attempts` asserts `shutdown_event.is_set()` immediately after awaiting the failure event, with no `wait_for` guard, which looks like a genuine latent race in the test itself.

## Visual evidence

Labeled `no-visual-change`. This is a naming/typing refactor plus an equivalent grid-template rewrite; the rendered output is identical, and this component is not covered by the `docs/screenshots.yml` manifest.

Closes #1924
