### PR TITLE
refactor: rename WEIGHTS map callback param for consistency in typography-tokens showcase

### DIFF
--- a/frontend/src/components/design/typography-tokens.tsx
+++ b/frontend/src/components/design/typography-tokens.tsx
@@ -101,14 +101,14 @@ export function TypographyTokens() {
       <div className={designGroupClassName}>
         <h3 className={designGroupLabelClassName}>Weights</h3>
         <div className="flex flex-col gap-3">
-          {WEIGHTS.map((w) => (
-            <div key={w.cssVar} className="flex items-baseline gap-4">
-              <code className={designTokenCodeClassName}>{w.cssVar}</code>
+          {WEIGHTS.map((weight) => (
+            <div key={weight.cssVar} className="flex items-baseline gap-4">
+              <code className={designTokenCodeClassName}>{weight.cssVar}</code>
               <span
                 className="font-sans text-[length:var(--text-h3)] text-foreground"
-                style={{ fontWeight: `var(${w.cssVar})` }}
+                style={{ fontWeight: `var(${weight.cssVar})` }}
               >
-                {w.label} ({w.value})
+                {weight.label} ({weight.value})
               </span>
             </div>
           ))}


### PR DESCRIPTION
## Summary

Consistency cleanup in the typography design-showcase component. Pure refactor — no behavior or rendering change.

`typography-tokens.tsx` renders three token lists, and two of the three `.map()` callbacks already used descriptive parameter names (`stack`, `spec`). The `WEIGHTS` list was the odd one out, using the single-letter `w` while iterating over conceptually equivalent token-row data.

## Changes

All in `frontend/src/components/design/typography-tokens.tsx`:

- Renamed the `WEIGHTS.map()` callback parameter from `w` to `weight`, and updated all usages in the callback body (`key`, `cssVar` in the `<code>` label, the `fontWeight` inline style, and `label` / `value` in the rendered text).

That is the entire diff: 5 insertions, 5 deletions, one file.

## Impact

None. This is an identifier rename inside a single callback scope — no exported symbol, prop, type, or DOM output changes. No migrations, no follow-ups.

## Testing

- [x] Tests pass
- [x] Manual check done

- `uv run nox -s dev` — **7729 passed**, 1 skipped, 2 xfailed
- `npm test` (frontend) — **1603 tests across 110 files pass**
- `prek -a` — all hooks pass, including `tsc`, `eslint`, `stylelint`, and `prettier`
- `prek pyright -a --stage pre-push` — passes

## Related

Closes #1925

## Notes

Labeled `no-visual-change`. The rename is confined to a callback parameter; the rendered markup, class names, and inline styles are byte-for-byte identical. This component is also not covered by the `docs/screenshots.yml` manifest, so no `docs/_static/web_ui_*.png` regeneration applies.
