### PR TITLE
test: use @/ alias and simplify ts-expect-error comment in boot-issues-panel test

### DIFF
--- a/frontend/src/components/diagnostics/boot-issues-panel.test.tsx
+++ b/frontend/src/components/diagnostics/boot-issues-panel.test.tsx
@@ -12,7 +12,7 @@ describe("BootIssuesPanel", () => {
       // @ts-expect-error intentionally invalid severity to exercise the unknown-severity sort fallback
       { severity: "unrecognized", label: "Mystery issue", detail: "no known severity" },
       { severity: "err", label: "Critical error", detail: "failed to load something" },
-      // @ts-expect-error severity outside the response schema to exercise the defensive fallback tier
+      // @ts-expect-error "info" is absent from the response schema but has its own tier in the panel's sort order
       { severity: "info", label: "Informational issue", detail: "additional information" },
     ];
     const { getByTestId } = render(<BootIssuesPanel bootIssues={issues} />);

--- a/frontend/src/components/diagnostics/boot-issues-panel.test.tsx
+++ b/frontend/src/components/diagnostics/boot-issues-panel.test.tsx
@@ -1,7 +1,8 @@
 import { render } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 
-import type { BootIssue } from "../../api/endpoints";
+import type { BootIssue } from "@/api/endpoints";
+
 import { BootIssuesPanel } from "./boot-issues-panel";
 
 describe("BootIssuesPanel", () => {
@@ -11,8 +12,7 @@ describe("BootIssuesPanel", () => {
       // @ts-expect-error intentionally invalid severity to exercise the unknown-severity sort fallback
       { severity: "unrecognized", label: "Mystery issue", detail: "no known severity" },
       { severity: "err", label: "Critical error", detail: "failed to load something" },
-      // @ts-expect-error "info" is not part of the BootIssueResponse schema but the panel's
-      // SEVERITY_ORDER handles it defensively — exercise that fallback tier explicitly
+      // @ts-expect-error severity outside the response schema to exercise the defensive fallback tier
       { severity: "info", label: "Informational issue", detail: "additional information" },
     ];
     const { getByTestId } = render(<BootIssuesPanel bootIssues={issues} />);


### PR DESCRIPTION
## Summary

Applies the two code-quality cleanups from #1927 to `frontend/src/components/diagnostics/boot-issues-panel.test.tsx`. Both are cosmetic test-file changes with no behavior impact.

## What changed

- **Import alias.** `import type { BootIssue } from "../../api/endpoints"` → `"@/api/endpoints"`, matching how sibling test files (e.g. `log-detail-drawer.test.tsx`) import from the same module. The two-level relative path was the only one of its kind in this directory.
- **`@ts-expect-error` comment.** The second annotation was a two-line comment naming an internal implementation detail (`SEVERITY_ORDER`), while the structurally identical annotation a few lines above was a concise one-liner. Shortened it to a single line so both read the same way, and dropped the reference to the internal constant name so the comment stays accurate if that implementation detail moves.

The import reordering (blank line after the aliased import) is what the repo's Prettier/eslint import-sort hooks produce for that grouping — `simple-import-sort`'s default groups place `@/`-aliased and relative imports in separate groups, and removing the blank line makes `eslint` fail.

## Review follow-up

A readability review caught that the shortened comment described the `"info"` case as exercising the panel's fallback tier. That is not what it exercises: `"info"` has its own explicit tier in the panel's sort order, and only an unrecognized severity falls through to the unknown-severity fallback (the test's own assertions show this — "Informational issue" sorts at index 2, "Mystery issue" at index 3). Both comments previously ended in "fallback", which blurred the two distinct cases. Reworded the second one to state what it actually covers: `"info"` is absent from the response schema type but has its own tier in the panel's sort order. Still a single line, still no reference to the internal constant name, so both acceptance criteria from #1927 remain met.

## Testing

- `npx vitest run src/components/diagnostics/boot-issues-panel.test.tsx` — 1 passed
- `npx tsc --noEmit` — clean (confirms both `@ts-expect-error` directives still suppress real type errors; an unused directive is itself a TS error)
- `npx eslint` / `npx prettier --check` on the changed file — clean
- `prek` pre-commit and pre-push hook suites — all pass

Closes #1927
