### PR TITLE
refactor(ui): unify StatusShape size constants on the _STATUS_SHAPE_SIZE suffix

### DIFF
--- a/frontend/src/app.tsx
+++ b/frontend/src/app.tsx
@@ -47,7 +47,7 @@ import { NotFoundPage } from "./pages/not-found";
 import { type AppStatusEntry, RELATIVE_TIME_TICK_MS, useAppStore } from "./state/store";
 import { appLiveStatus } from "./utils/app-data";
 import { HOME_PATH, LOGIN_PATH } from "./utils/app-routes";
-import { COMPACT_STATUS_DOT_SIZE } from "./utils/constants";
+import { COMPACT_STATUS_SHAPE_SIZE } from "./utils/constants";
 import { isFailureStatus, statusToKind } from "./utils/status";
 
 const PALETTE_STALE_TIME_MS = 300_000;
@@ -393,7 +393,7 @@ function CommandPalette({ open, onClose }: CommandPaletteProps) {
                 onSelect={() => item.action()}
               >
                 {item.status !== undefined && (
-                  <StatusShape kind={statusToKind(item.status)} size={COMPACT_STATUS_DOT_SIZE} />
+                  <StatusShape kind={statusToKind(item.status)} size={COMPACT_STATUS_SHAPE_SIZE} />
                 )}
                 <span>{item.label}</span>
                 {item.sub && <span className="ml-1 text-xs text-muted-foreground">{item.sub}</span>}

--- a/frontend/src/components/app-detail/app-detail-header.tsx
+++ b/frontend/src/components/app-detail/app-detail-header.tsx
@@ -1,7 +1,7 @@
 import { Badge } from "@/components/ui/badge";
 
 import type { components } from "../../api/generated-types";
-import { BADGE_STATUS_DOT_SIZE, HEADING_STATUS_SHAPE_SIZE } from "../../utils/constants";
+import { BADGE_STATUS_SHAPE_SIZE, HEADING_STATUS_SHAPE_SIZE } from "../../utils/constants";
 import { statusToKind, statusToVariant } from "../../utils/status";
 import { ActionButtons, getStableInstanceRef } from "../shared/action-buttons";
 import { AlertShell } from "../shared/alert-shell";
@@ -79,7 +79,7 @@ export function AppDetailHeader({
           {/* Shown for every status, healthy included — "running" should be a
               statement, not the absence of a pill. */}
           <Badge variant={statusToVariant(liveStatus)} size="sm" data-testid="app-status-pill">
-            <StatusShape kind={statusToKind(liveStatus)} size={BADGE_STATUS_DOT_SIZE} /> {liveStatus}
+            <StatusShape kind={statusToKind(liveStatus)} size={BADGE_STATUS_SHAPE_SIZE} /> {liveStatus}
           </Badge>
           <ActionButtons
             appKey={appKey}

--- a/frontend/src/components/app-detail/detail-header.tsx
+++ b/frontend/src/components/app-detail/detail-header.tsx
@@ -2,7 +2,7 @@ import type { ReactNode } from "react";
 
 import { Badge, type BadgeVariant } from "@/components/ui/badge";
 
-import { BADGE_STATUS_DOT_SIZE } from "../../utils/constants";
+import { BADGE_STATUS_SHAPE_SIZE } from "../../utils/constants";
 import type { StatusKind } from "../../utils/status";
 import type { ExecutionKind } from "../shared/execution-table";
 import { StatusShape } from "../shared/status-shape";
@@ -43,7 +43,7 @@ export function DetailHeader({ name, kindLabel, statusKind, kind, subtitle, head
 
       <div className="mb-3 flex flex-wrap items-center gap-2 text-sm text-muted-foreground">
         <Badge variant={KIND_BADGE_VARIANT[statusKind]} aria-label={`kind: ${kindLabel}`}>
-          <StatusShape kind={statusKind} size={BADGE_STATUS_DOT_SIZE} />
+          <StatusShape kind={statusKind} size={BADGE_STATUS_SHAPE_SIZE} />
           {kindLabel}
         </Badge>
         {subtitle && <span data-testid={`${kind}-human-description`}>{subtitle}</span>}

--- a/frontend/src/components/app-detail/error-spotlight.tsx
+++ b/frontend/src/components/app-detail/error-spotlight.tsx
@@ -3,7 +3,7 @@ import { Link } from "wouter";
 
 import { cn } from "@/lib/utils";
 
-import { STATUS_DOT_SIZE } from "../../utils/constants";
+import { STATUS_SHAPE_SIZE } from "../../utils/constants";
 import { StatusShape } from "../shared/status-shape";
 import { OVERVIEW_SECTION_CLASS } from "./overview-section";
 import { handlerHref, itemErrorLabel, itemErrorMessage } from "./overview-tab-helpers";
@@ -28,7 +28,7 @@ function SpotlightEntry({ item, appKey, instanceQs }: SpotlightEntryProps) {
       data-testid={`overview-error-spotlight-entry-${item.kind}-${item.id}`}
     >
       <span aria-hidden="true">
-        <StatusShape kind={item.statusKind} size={STATUS_DOT_SIZE} />
+        <StatusShape kind={item.statusKind} size={STATUS_SHAPE_SIZE} />
       </span>
       <span className="shrink-0 whitespace-nowrap font-mono text-[length:var(--text-mono-sm)] font-medium text-foreground">
         {item.name}

--- a/frontend/src/components/app-detail/execution-detail.tsx
+++ b/frontend/src/components/app-detail/execution-detail.tsx
@@ -8,7 +8,7 @@ import type { ExecutionData } from "../../api/endpoints";
 import { getExecutionById } from "../../api/endpoints";
 import type { components } from "../../api/generated-types";
 import { useDocumentTitle } from "../../hooks/use-document-title";
-import { STATUS_DOT_SIZE } from "../../utils/constants";
+import { STATUS_SHAPE_SIZE } from "../../utils/constants";
 import { formatDuration, formatTimestamp, truncateId } from "../../utils/format";
 import { executionStatusKind, TIMED_OUT_LABEL } from "../../utils/status";
 import type { DetailStatsCell } from "../shared/detail-stats";
@@ -121,7 +121,7 @@ export function ExecutionDetailContent({ record }: ContentProps) {
   return (
     <div>
       <div className="mb-4 flex items-center gap-2">
-        <StatusShape kind={statusKind} size={STATUS_DOT_SIZE} />
+        <StatusShape kind={statusKind} size={STATUS_SHAPE_SIZE} />
         <h2 className="m-0 font-mono text-[length:var(--text-h3)] font-semibold text-foreground">
           Execution {truncated}
         </h2>
@@ -186,7 +186,7 @@ export function ExecutionDetailContent({ record }: ContentProps) {
 
       {record.status === "success" && (
         <div className="mb-4 flex items-center gap-2 rounded-sm bg-[var(--status-success-bg)] px-3 py-2">
-          <StatusShape kind="ok" size={STATUS_DOT_SIZE} />
+          <StatusShape kind="ok" size={STATUS_SHAPE_SIZE} />
           <span className="font-mono text-sm text-foreground-secondary">
             completed in {formatDuration(record.duration_ms)}
           </span>

--- a/frontend/src/components/app-detail/handler-health-card.tsx
+++ b/frontend/src/components/app-detail/handler-health-card.tsx
@@ -6,7 +6,7 @@ import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/comp
 import { cn } from "@/lib/utils";
 
 import { useRelativeTime } from "../../hooks/use-relative-time";
-import { STATUS_DOT_SIZE } from "../../utils/constants";
+import { STATUS_SHAPE_SIZE } from "../../utils/constants";
 import { formatDuration, formatRate, pluralize } from "../../utils/format";
 import { onActivateKeyDown } from "../../utils/keyboard";
 import { StatusShape } from "../shared/status-shape";
@@ -93,7 +93,7 @@ export function HandlerHealthCard({ item, appKey, instanceQs, tabIndex }: Handle
       >
         <div className="flex min-w-0 items-center gap-2">
           <span aria-hidden="true">
-            <StatusShape kind={item.statusKind} size={STATUS_DOT_SIZE} />
+            <StatusShape kind={item.statusKind} size={STATUS_SHAPE_SIZE} />
           </span>
           <span
             className="min-w-0 flex-1 truncate font-mono text-[length:var(--text-mono-sm)] text-foreground"

--- a/frontend/src/components/app-detail/multi-instance.tsx
+++ b/frontend/src/components/app-detail/multi-instance.tsx
@@ -4,7 +4,7 @@ import { cn } from "@/lib/utils";
 import type { AppInstance } from "../../api/endpoints";
 import { useAppStore } from "../../state/store";
 import { instanceLiveError, instanceLiveStatus } from "../../utils/app-data";
-import { BADGE_STATUS_DOT_SIZE, STATUS_DOT_SIZE } from "../../utils/constants";
+import { BADGE_STATUS_SHAPE_SIZE, STATUS_SHAPE_SIZE } from "../../utils/constants";
 import { statusToKind, statusToVariant } from "../../utils/status";
 import { StatusShape } from "../shared/status-shape";
 
@@ -47,7 +47,7 @@ export function InstanceSwitcher({
               if (!isActive) onNavigate(instance.index);
             }}
           >
-            <StatusShape kind={statusToKind(liveStatus)} size={BADGE_STATUS_DOT_SIZE} />
+            <StatusShape kind={statusToKind(liveStatus)} size={BADGE_STATUS_SHAPE_SIZE} />
             <span className="max-w-[140px] overflow-hidden text-ellipsis">{instance.instance_name}</span>
           </button>
         );
@@ -78,7 +78,7 @@ function InstanceCard({
       aria-label={`View ${instance.instance_name}`}
     >
       <div className="flex flex-wrap items-center gap-2">
-        <StatusShape kind={statusToKind(liveStatus)} size={STATUS_DOT_SIZE} />
+        <StatusShape kind={statusToKind(liveStatus)} size={STATUS_SHAPE_SIZE} />
         <span className="min-w-0 flex-1 overflow-hidden text-ellipsis whitespace-nowrap font-medium">
           {instance.instance_name}
         </span>

--- a/frontend/src/components/app-detail/recent-activity-section.tsx
+++ b/frontend/src/components/app-detail/recent-activity-section.tsx
@@ -10,7 +10,7 @@ import { isExecutionDefined, useAppExecution } from "../../hooks/use-scoped-exec
 import { useScopedQuery } from "../../hooks/use-scoped-query";
 import { queryKeys } from "../../lib/query-keys";
 import { useAppStore } from "../../state/store";
-import { STATUS_DOT_SIZE } from "../../utils/constants";
+import { STATUS_SHAPE_SIZE } from "../../utils/constants";
 import { formatDurationOrDash, formatRelativeTime, lastDotSegment } from "../../utils/format";
 import { executionStatusKind } from "../../utils/status";
 import { StatusShape } from "../shared/status-shape";
@@ -109,7 +109,7 @@ function ActivityGroupRow({ group }: { group: ActivityGroup }) {
     <tr data-testid="overview-activity-row">
       <td aria-label={`latest status: ${group.latestStatus}`}>
         <span className="inline-flex items-center gap-1 whitespace-nowrap font-mono text-[length:var(--text-mono-sm)] leading-none">
-          <StatusShape kind={kind} size={STATUS_DOT_SIZE} />
+          <StatusShape kind={kind} size={STATUS_SHAPE_SIZE} />
         </span>
       </td>
       <td className="text-foreground" title={group.handlerName}>

--- a/frontend/src/components/app-detail/unified-handler-row.tsx
+++ b/frontend/src/components/app-detail/unified-handler-row.tsx
@@ -3,7 +3,7 @@ import { cn } from "@/lib/utils";
 
 import type { JobData, ListenerData } from "../../api/endpoints";
 import { useRelativeTime } from "../../hooks/use-relative-time";
-import { STATUS_DOT_SIZE } from "../../utils/constants";
+import { STATUS_SHAPE_SIZE } from "../../utils/constants";
 import { formatTimestamp, pluralize } from "../../utils/format";
 import { scheduleStatusLabel } from "../../utils/handler-rows";
 import type { StatusKind } from "../../utils/status";
@@ -85,7 +85,7 @@ export function UnifiedHandlerRow({ item, isSelected, onSelect }: Props) {
       onClick={onSelect}
     >
       <span className="shrink-0 pt-0" aria-hidden="true">
-        <StatusShape kind={item.statusKind} size={STATUS_DOT_SIZE} />
+        <StatusShape kind={item.statusKind} size={STATUS_SHAPE_SIZE} />
       </span>
       <div className="flex min-w-0 flex-col gap-0">
         <div className="flex min-w-0 items-baseline gap-2">

--- a/frontend/src/components/diagnostics/boot-issues-panel.tsx
+++ b/frontend/src/components/diagnostics/boot-issues-panel.tsx
@@ -1,5 +1,5 @@
 import type { BootIssue } from "../../api/endpoints";
-import { STATUS_DOT_SIZE } from "../../utils/constants";
+import { STATUS_SHAPE_SIZE } from "../../utils/constants";
 import { StatusShape } from "../shared/status-shape";
 import { Panel } from "./panel";
 
@@ -26,7 +26,7 @@ export function BootIssuesPanel({ bootIssues }: BootIssuesPanelProps) {
             className="flex items-start gap-3"
             data-testid={`diag-boot-issue-${i}`}
           >
-            <StatusShape kind={issue.severity === "err" ? "err" : "warn"} size={STATUS_DOT_SIZE} />
+            <StatusShape kind={issue.severity === "err" ? "err" : "warn"} size={STATUS_SHAPE_SIZE} />
             <div className="flex flex-1 flex-col gap-1">
               <span
                 className="text-[length:var(--text-body)] font-medium text-foreground"

--- a/frontend/src/components/diagnostics/service-row.tsx
+++ b/frontend/src/components/diagnostics/service-row.tsx
@@ -3,7 +3,7 @@ import { useState } from "react";
 import { cn } from "@/lib/utils";
 
 import { useRelativeTime } from "../../hooks/use-relative-time";
-import { STATUS_DOT_SIZE } from "../../utils/constants";
+import { STATUS_SHAPE_SIZE } from "../../utils/constants";
 import { statusToKind } from "../../utils/status";
 import { StatusShape } from "../shared/status-shape";
 import type { MergedService } from "./merge-services";
@@ -61,7 +61,7 @@ export function ServiceRow({ service }: ServiceRowProps) {
       data-testid={`diag-service-row-${service.resource_name}`}
     >
       <div className="flex min-w-0 flex-wrap items-center gap-2">
-        <StatusShape kind={statusToKind(service.status)} size={STATUS_DOT_SIZE} />
+        <StatusShape kind={statusToKind(service.status)} size={STATUS_SHAPE_SIZE} />
         <span className="overflow-hidden text-ellipsis whitespace-nowrap font-mono text-[length:var(--text-mono-sm)] font-medium text-foreground">
           {service.resource_name}
         </span>

--- a/frontend/src/components/layout/sidebar.tsx
+++ b/frontend/src/components/layout/sidebar.tsx
@@ -12,7 +12,7 @@ import { useSidebarHidden } from "../../hooks/use-sidebar-hidden";
 import { type AppStatusEntry, useAppStore } from "../../state/store";
 import { appLiveStatus, instanceLiveStatus } from "../../utils/app-data";
 import { appDetailPath, HOME_PATH, NAV_PAGES } from "../../utils/app-routes";
-import { COMPACT_STATUS_DOT_SIZE, GROUP_HEADER_STATUS_SHAPE_SIZE, STATUS_DOT_SIZE } from "../../utils/constants";
+import { COMPACT_STATUS_SHAPE_SIZE, GROUP_HEADER_STATUS_SHAPE_SIZE, STATUS_SHAPE_SIZE } from "../../utils/constants";
 import { SHORTCUT_HINT } from "../../utils/keyboard";
 import { statusToKind } from "../../utils/status";
 import { Spinner } from "../shared/spinner";
@@ -69,7 +69,7 @@ function AppEntry({ manifest, location, searchString, appStatuses }: AppEntryPro
             aria-current={isActive ? "page" : undefined}
             data-testid="app-link"
           >
-            <StatusShape kind={kind} size={STATUS_DOT_SIZE} />
+            <StatusShape kind={kind} size={STATUS_SHAPE_SIZE} />
             <span className="min-w-0 flex-1 truncate">{manifest.display_name}</span>
             {manifest.auto_loaded && (
               <Badge variant="muted" title="Auto-loaded">
@@ -113,7 +113,7 @@ function AppEntry({ manifest, location, searchString, appStatuses }: AppEntryPro
                       )}
                       aria-current={instActive ? "page" : undefined}
                     >
-                      <StatusShape kind={statusToKind(instStatus)} size={COMPACT_STATUS_DOT_SIZE} />
+                      <StatusShape kind={statusToKind(instStatus)} size={COMPACT_STATUS_SHAPE_SIZE} />
                       <span className="truncate">{inst.instance_name}</span>
                     </Link>
                   </li>

--- a/frontend/src/components/shared/execution-table.tsx
+++ b/frontend/src/components/shared/execution-table.tsx
@@ -17,7 +17,7 @@ import { cn } from "@/lib/utils";
 import type { components } from "../../api/generated-types";
 import { useRovingTabIndex } from "../../hooks/use-roving-tab-index";
 import { executionPath, type HandlerKind } from "../../utils/app-routes";
-import { STATUS_DOT_SIZE } from "../../utils/constants";
+import { STATUS_SHAPE_SIZE } from "../../utils/constants";
 import { formatDuration, formatRelativeTime, formatTimestamp } from "../../utils/format";
 import { onActivateKeyDown } from "../../utils/keyboard";
 import { executionStatusKind, type StatusKind, TIMED_OUT_LABEL } from "../../utils/status";
@@ -96,7 +96,7 @@ const columns: ColumnDef<ExecutionRecord, unknown>[] = [
       const statusKind = executionStatusKind(record.status);
       return (
         <div className="flex items-center gap-2">
-          <StatusShape kind={statusKind} size={STATUS_DOT_SIZE} />
+          <StatusShape kind={statusKind} size={STATUS_SHAPE_SIZE} />
           <span className={statusLabelClass(statusKind)}>{STATUS_LABEL[statusKind]}</span>
           {record.thread_leaked && (
             <Badge variant="warning" size="sm" aria-label="thread leaked past timeout">

--- a/frontend/src/pages/apps.tsx
+++ b/frontend/src/pages/apps.tsx
@@ -46,7 +46,7 @@ const SECONDS_PER_HOUR = 3600;
 const VALID_SORT_KEYS: ReadonlySet<string> = new Set<AppSortState["key"]>(["name", "status", "error", "runs", "last"]);
 
 /** StatusShape size (px) for the status-filter menu rows, sized to sit inline with their
- * text-xs labels. Smaller than the shared STATUS_DOT_SIZE (10px), which is sized for the
+ * text-xs labels. Smaller than the shared STATUS_SHAPE_SIZE (10px), which is sized for the
  * list rows and detail panes that import it — this page's table does not use it. */
 const FILTER_SHAPE_SIZE = 8;
 

--- a/frontend/src/utils/constants.ts
+++ b/frontend/src/utils/constants.ts
@@ -1,4 +1,4 @@
-export const STATUS_DOT_SIZE = 10;
+export const STATUS_SHAPE_SIZE = 10;
 export const DETAIL_FETCH_LIMIT = 50;
 // Shared default size (px) for small inline SVG glyphs (FilterIcon, StatusShape)
 // used in table-header contexts.
@@ -12,18 +12,18 @@ export const HEADING_STATUS_SHAPE_SIZE = 14;
 // rendered, never by matching a number.
 //
 // Status shape scaled to sit inline inside a badge/pill. Deliberately smaller than the
-// standalone STATUS_DOT_SIZE above, which is sized for table cells and list rows.
-export const BADGE_STATUS_DOT_SIZE = 8;
-// Status shapes in the apps table's own rows — smaller than STATUS_DOT_SIZE (10) to fit the
+// standalone STATUS_SHAPE_SIZE above, which is sized for table cells and list rows.
+export const BADGE_STATUS_SHAPE_SIZE = 8;
+// Status shapes in the apps table's own rows — smaller than STATUS_SHAPE_SIZE (10) to fit the
 // table's tighter row height. The instance sub-row is smaller again to read as nested under
 // its parent app row.
 export const APP_ROW_STATUS_SHAPE_SIZE = 7;
 export const INSTANCE_ROW_STATUS_SHAPE_SIZE = 6;
-// Status shape in a dense list row — one tighter than the standard list row STATUS_DOT_SIZE
+// Status shape in a dense list row — one tighter than the standard list row STATUS_SHAPE_SIZE
 // (10) targets, whether because the row is nested under a parent or because its own line
 // height is compressed. Currently the sidebar's instance sub-rows and the command palette's
 // results.
-export const COMPACT_STATUS_DOT_SIZE = 8;
+export const COMPACT_STATUS_SHAPE_SIZE = 8;
 // Status shape beside a collapsible group header's uppercase micro-label, smaller again than
 // the compact row size so the header reads as a divider rather than another row.
 export const GROUP_HEADER_STATUS_SHAPE_SIZE = 7;


### PR DESCRIPTION
## Summary

`frontend/src/utils/constants.ts` named the `StatusShape` size family with two different suffixes for the same prop on the same component — `_STATUS_DOT_SIZE` and `_STATUS_SHAPE_SIZE` — with nothing distinguishing them. A reader picking a constant could not tell whether "dot" and "shape" meant different things, because they didn't: all seven feed the same `size` prop on the same `StatusShape` component.

"Shape" is the accurate half. `StatusShape` renders a circle only for `kind="ok"` — `warn` is a triangle, `err` a rounded square, `cancel` a diamond, and `mute` a stroke-only ring — so `..._DOT_SIZE` misdescribed four of the five kinds, while the component's own name already said "shape."

## What changed

Renamed three constants onto the `_STATUS_SHAPE_SIZE` suffix and updated all call sites across 14 files:

| Before | After | Value |
|---|---|---|
| `STATUS_DOT_SIZE` | `STATUS_SHAPE_SIZE` | 10 |
| `BADGE_STATUS_DOT_SIZE` | `BADGE_STATUS_SHAPE_SIZE` | 8 |
| `COMPACT_STATUS_DOT_SIZE` | `COMPACT_STATUS_SHAPE_SIZE` | 8 |

The four constants already on `_STATUS_SHAPE_SIZE` (`HEADING_`, `APP_ROW_`, `INSTANCE_ROW_`, `GROUP_HEADER_`) were already correct and are unchanged. Comments referencing the old names were updated to match.

No aliases or re-exports are left behind for the old names. `SMALL_ICON_SIZE` is deliberately untouched — it is shared with `FilterIcon` and is not `StatusShape`-specific.

## Visual impact: none

This is a rename only. Every value is byte-identical to `main` (10, 12, 14, 8, 7, 6, 8, 7), so nothing renders differently and no `docs/_static/web_ui_*.png` needs regenerating. Labeled `no-visual-change` accordingly.

## Testing

| Gate | Result |
|---|---|
| `uv run nox -s dev` | 7737 passed, 1 skipped, 2 xfailed |
| `npm test` (vitest) | 110 files, 1603 tests passed |
| `npm run build` (tsc + vite) | clean |
| `prek -a` | all 29 hooks passed (ruff, eslint, stylelint, tsc, prettier) |
| `prek pyright -a --stage pre-push` | passed |

Also verified `grep -rn "STATUS_DOT_SIZE"` across `.ts`/`.tsx`/`.md`/`.py` returns no matches, confirming no call site or doc reference was missed.

Closes #1941
