### PR TITLE
chore: correct the inaccurate PANEL_BANNER_CLASS doc comment

### DIFF
--- a/frontend/src/components/diagnostics/panel.tsx
+++ b/frontend/src/components/diagnostics/panel.tsx
@@ -7,10 +7,10 @@ import { cardVariants } from "@/components/ui/card";
 import { cn } from "@/lib/utils";
 
 /**
- * Content classes for an `AlertShell tone="warning"` nested in a panel: `cn()` runs twMerge, so
- * `mb-0`/`rounded-sm` beat the shell's standalone `mb-4 rounded-md` (the panel's flex column
- * already supplies the gap), and the text color/size are set here — `AlertShell` styles only the
- * container's border and background.
+ * Content classes for an `AlertShell tone="warning"` nested in a panel. `cn()` runs twMerge, so
+ * `mb-0 rounded-sm` overrides the shell's standalone `mb-4 rounded-md` — the panel's flex column
+ * already supplies the gap. The text color and size live here because `AlertShell` applies no text
+ * styles of its own; its warning tone sets border and background only.
  */
 export const PANEL_BANNER_CLASS = "mb-0 rounded-sm text-sm text-[var(--status-warning)]";
 

--- a/frontend/src/components/diagnostics/panel.tsx
+++ b/frontend/src/components/diagnostics/panel.tsx
@@ -7,10 +7,10 @@ import { cardVariants } from "@/components/ui/card";
 import { cn } from "@/lib/utils";
 
 /**
- * Geometry overrides for an `AlertShell tone="warning"` rendered *inside* a panel. The shell's
- * own `mb-4 rounded-md` is tuned for standalone page-level banners; in here the panel's flex
- * column already supplies the spacing. `cn()` runs twMerge, so these win over the shell's
- * defaults. The warning tokens themselves stay in AlertShell — this is spacing only.
+ * Content classes for an `AlertShell tone="warning"` nested in a panel: `cn()` runs twMerge, so
+ * `mb-0`/`rounded-sm` beat the shell's standalone `mb-4 rounded-md` (the panel's flex column
+ * already supplies the gap), and the text color/size are set here — `AlertShell` styles only the
+ * container's border and background.
  */
 export const PANEL_BANNER_CLASS = "mb-0 rounded-sm text-sm text-[var(--status-warning)]";
 


### PR DESCRIPTION
## Summary

Corrects the `PANEL_BANNER_CLASS` doc comment in `frontend/src/components/diagnostics/panel.tsx`, which described the constant inaccurately.

The old block claimed the warning text color lived in `AlertShell` and that the constant was "spacing only." Neither is true:

- `AlertShell`'s `TONE_CLASSES.warning` is `border-[var(--status-warning)] bg-[var(--status-warning-bg)]` — border and background only. It sets **no** text color, so `text-[var(--status-warning)]` in this constant is the sole source of the banner's text color, not an override.
- The value also carries `text-sm`, so "spacing only" / "geometry overrides" described at most half of it.

A reader trusting the old comment would go hunting through `AlertShell` for a warning text color that does not exist.

## What changed

The 6-line block is replaced with a shorter one covering only the load-bearing facts: the `cn()`/twMerge override mechanism, why `mb-0` (the panel's flex column already supplies the gap), and where the text color and size actually come from.

Comment text only — `PANEL_BANNER_CLASS`'s value is unchanged, so there is no behavior or rendering change.

## Testing

- `uv run nox -s dev` — 7737 passed, 1 skipped, 2 xfailed
- `prek -a` — all hooks pass (includes prettier, eslint, stylelint, and `tsc` for the frontend)
- `prek pyright -a --stage pre-push` — passes
- Claims in the rewritten comment were re-verified by reading `frontend/src/components/shared/alert-shell.tsx` at its current state

Labeled `no-visual-change`: the diff touches a `.tsx` file but only inside a comment, so there is nothing to screenshot.

Closes #1945
