### PR TITLE
test: name duplicated toggle locators in service-row.test.tsx

### DIFF
--- a/frontend/src/components/diagnostics/service-row.test.tsx
+++ b/frontend/src/components/diagnostics/service-row.test.tsx
@@ -5,6 +5,9 @@ import { describe, expect, it } from "vitest";
 import type { MergedService } from "./merge-services";
 import { ServiceRow } from "./service-row";
 
+const SHOW_EXCEPTION = { name: /show exception/i } as const;
+const HIDE_EXCEPTION = { name: /hide exception/i } as const;
+
 function makeService(overrides: Partial<MergedService> = {}): MergedService {
   return {
     resource_name: "bus",
@@ -20,7 +23,7 @@ function makeService(overrides: Partial<MergedService> = {}): MergedService {
 describe("ServiceRow", () => {
   it("does not render the exception toggle when there is no exception", () => {
     const { queryByRole } = render(<ServiceRow service={makeService({ exception: null })} />);
-    expect(queryByRole("button", { name: /show exception/i })).toBeNull();
+    expect(queryByRole("button", SHOW_EXCEPTION)).toBeNull();
   });
 
   it("toggles the exception text open and closed", async () => {
@@ -30,15 +33,16 @@ describe("ServiceRow", () => {
 
     expect(queryByText(exception)).toBeNull();
 
-    const toggle = getByRole("button", { name: /show exception/i });
+    const toggle = getByRole("button", SHOW_EXCEPTION);
     expect(toggle.getAttribute("aria-expanded")).toBe("false");
 
     await user.click(toggle);
     expect(queryByText(exception)).not.toBeNull();
-    expect(getByRole("button", { name: /hide exception/i }).getAttribute("aria-expanded")).toBe("true");
+    // Re-querying by the flipped name is itself the assertion that the accessible name changed.
+    expect(getByRole("button", HIDE_EXCEPTION).getAttribute("aria-expanded")).toBe("true");
 
-    await user.click(getByRole("button", { name: /hide exception/i }));
+    await user.click(toggle);
     expect(queryByText(exception)).toBeNull();
-    expect(getByRole("button", { name: /show exception/i }).getAttribute("aria-expanded")).toBe("false");
+    expect(getByRole("button", SHOW_EXCEPTION).getAttribute("aria-expanded")).toBe("false");
   });
 });


### PR DESCRIPTION
## Summary

Removes duplicated accessible-name locators in `service-row.test.tsx`. The exception-toggle button was located by re-typed inline regexes at five call sites (`/show exception/i` three times, `/hide exception/i` twice), and one site re-queried a DOM node that was already bound to a local.

Surfaced by an automated quality scan of the file. Pre-existing, mechanical, and scoped to a single test file — no production code touched, no behavior change.

## What changed

- Extracted the two accessible names as file-local constants, `SHOW_EXCEPTION` and `HIDE_EXCEPTION`, so each regex is written exactly once.
- The close click now reuses the already-bound `toggle` element instead of re-querying for it. React reuses the same DOM node across the toggle — only `textContent` and `aria-expanded` change — so the binding stays valid.

Deliberately preserved: the two assertions that re-query by the *flipped* accessible name. `getByRole` throws when nothing matches, so re-querying is itself the assertion that the accessible name changed on toggle. Collapsing those into `toggle` would have quietly dropped that coverage. A comment now records why.

## Testing

- `npx vitest run src/components/diagnostics/service-row.test.tsx` — 2 passed
- Full frontend suite — 110 files, 1603 passed
- `uv run nox -s dev` — 7737 passed, 1 skipped, 2 xfailed
- `prek -a` — all hooks pass; `prek pyright -a --stage pre-push` — pass

The `test:` commit type keeps this out of the generated changelog, which is correct for a test-only cleanup.

Closes #1946
