### PR TITLE
chore: remove redundant ServiceRowProps doc comment in service-row.tsx

### DIFF
--- a/frontend/src/components/diagnostics/service-row.tsx
+++ b/frontend/src/components/diagnostics/service-row.tsx
@@ -8,7 +8,6 @@ import { statusToKind } from "../../utils/status";
 import { StatusShape } from "../shared/status-shape";
 import type { MergedService } from "./merge-services";
 
-/** Both ServiceRow and its ServiceRowMeta child take exactly the merged service and nothing else. */
 interface ServiceRowProps {
   service: MergedService;
 }


### PR DESCRIPTION
## Summary

Removes a single redundant doc comment from `frontend/src/components/diagnostics/service-row.tsx`.

The comment sat above a three-line, single-field props interface and restated exactly what the
declaration beneath it already says:

```tsx
/** Both ServiceRow and its ServiceRowMeta child take exactly the merged service and nothing else. */
interface ServiceRowProps {
  service: MergedService;
}
```

Both consumers (`ServiceRowMeta({ service }: ServiceRowProps)` and `ServiceRow({ service }: ServiceRowProps)`)
are within five lines of it, so their signatures make the same point. The comment documented no
invariant, constraint, or non-obvious reason — it was noise a reader has to check against the type
before discarding.

The sibling comment on `ServiceRowMeta` is deliberately left intact: it states a rendering invariant
("a plainly running service shows none of them") that is genuinely not visible from the signature.

## Why this and nothing else

The quality scan that produced #1948 surfaced several other candidates in this file — magic status
strings, a repeated `font-mono` utility pairing, mixed relative/`@` imports, an arbitrary
`col-[1/-1]` value. All were assessed and dropped as non-defects: they are either already
compile-checked by the generated `ResourceStatus` union, or explicitly endorsed by CLAUDE.md's CSS
Architecture section, or repo-wide conventions rather than problems scoped to this file. The issue
records that reasoning so a future scan doesn't re-file them. This PR implements only the one
surviving finding.

## Testing

- `uv run nox -s dev` — 7737 passed, 1 skipped, 2 xfailed, 0 failures
- `prek -a` — all hooks passed (ruff, prettier, eslint, stylelint, tsc, and the repo's custom checks)
- `prek pyright -a --stage pre-push` — passed
- `cd frontend && npm run build` — succeeded

## Visual impact

None. The diff deletes one comment line; no rendered output changes. Labeled `no-visual-change`
for the screenshot CI guard.

Closes #1948
