### PR TITLE
chore: rename TelemetryCounters to TelemetryHealth

### DIFF
--- a/frontend/src/components/diagnostics/telemetry-panel.tsx
+++ b/frontend/src/components/diagnostics/telemetry-panel.tsx
@@ -1,15 +1,7 @@
+import type { TelemetryHealth } from "../../state/store";
 import { AlertShell } from "../shared/alert-shell";
 import { DropCounterRow } from "./drop-counter-row";
 import { Panel, PANEL_BANNER_CLASS } from "./panel";
-
-/** Telemetry health as carried on the WS stream: drop counters and the degradation flag. */
-export interface TelemetryHealth {
-  droppedOverflow: number;
-  droppedExhausted: number;
-  droppedShutdown: number;
-  errorHandlerFailures: number;
-  telemetryDegraded: boolean;
-}
 
 export function TelemetryPanel({
   droppedOverflow,

--- a/frontend/src/components/diagnostics/telemetry-panel.tsx
+++ b/frontend/src/components/diagnostics/telemetry-panel.tsx
@@ -2,8 +2,8 @@ import { AlertShell } from "../shared/alert-shell";
 import { DropCounterRow } from "./drop-counter-row";
 import { Panel, PANEL_BANNER_CLASS } from "./panel";
 
-/** Telemetry drop counters and degradation flag, as carried on the WS stream. */
-export interface TelemetryCounters {
+/** Telemetry health as carried on the WS stream: drop counters and the degradation flag. */
+export interface TelemetryHealth {
   droppedOverflow: number;
   droppedExhausted: number;
   droppedShutdown: number;
@@ -17,7 +17,7 @@ export function TelemetryPanel({
   droppedShutdown,
   errorHandlerFailures,
   telemetryDegraded,
-}: TelemetryCounters) {
+}: TelemetryHealth) {
   return (
     <Panel title="telemetry health" ariaLabel="Telemetry health" data-testid="diag-telemetry-panel">
       {telemetryDegraded && (

--- a/frontend/src/pages/diagnostics.tsx
+++ b/frontend/src/pages/diagnostics.tsx
@@ -6,12 +6,12 @@ import { BootIssuesPanel } from "../components/diagnostics/boot-issues-panel";
 import { LoggingPanel } from "../components/diagnostics/logging-panel";
 import { type MergedService, mergeServices } from "../components/diagnostics/merge-services";
 import { ServicesPanel } from "../components/diagnostics/services-panel";
-import { type TelemetryHealth, TelemetryPanel } from "../components/diagnostics/telemetry-panel";
+import { TelemetryPanel } from "../components/diagnostics/telemetry-panel";
 import { Spinner } from "../components/shared/spinner";
 import { StatsStrip, type StatsStripCell } from "../components/shared/stats-strip";
 import { useDocumentTitle } from "../hooks/use-document-title";
 import { queryKeys } from "../lib/query-keys";
-import { useAppStore } from "../state/store";
+import { type TelemetryHealth, useAppStore } from "../state/store";
 
 function buildDiagCells(
   services: MergedService[],

--- a/frontend/src/pages/diagnostics.tsx
+++ b/frontend/src/pages/diagnostics.tsx
@@ -6,7 +6,7 @@ import { BootIssuesPanel } from "../components/diagnostics/boot-issues-panel";
 import { LoggingPanel } from "../components/diagnostics/logging-panel";
 import { type MergedService, mergeServices } from "../components/diagnostics/merge-services";
 import { ServicesPanel } from "../components/diagnostics/services-panel";
-import { type TelemetryCounters, TelemetryPanel } from "../components/diagnostics/telemetry-panel";
+import { type TelemetryHealth, TelemetryPanel } from "../components/diagnostics/telemetry-panel";
 import { Spinner } from "../components/shared/spinner";
 import { StatsStrip, type StatsStripCell } from "../components/shared/stats-strip";
 import { useDocumentTitle } from "../hooks/use-document-title";
@@ -42,7 +42,7 @@ interface DiagnosticsData {
   logQueueDrops: number;
   dbWriteQueueDrops: number;
   logPersistenceInactive: boolean;
-  telemetry: TelemetryCounters;
+  telemetry: TelemetryHealth;
   telemetryDrops: number;
   // Derived visibility — a healthy subsystem renders no panel at all
   showLogging: boolean;

--- a/frontend/src/state/store.ts
+++ b/frontend/src/state/store.ts
@@ -57,11 +57,11 @@ export interface ServiceStatusEntry {
 
 /** Telemetry health polled from `/api/telemetry/status`: drop counters and the degradation flag. */
 export interface TelemetryHealth {
-  telemetryDegraded: boolean;
   droppedOverflow: number;
   droppedExhausted: number;
   droppedShutdown: number;
   errorHandlerFailures: number;
+  telemetryDegraded: boolean;
 }
 
 export interface AppStore {

--- a/frontend/src/state/store.ts
+++ b/frontend/src/state/store.ts
@@ -55,8 +55,8 @@ export interface ServiceStatusEntry {
   ready_phase: string | null;
 }
 
-/** Telemetry health fields polled from /api/telemetry/status. Used by setTelemetryHealth's partial update. */
-export interface TelemetryHealthFields {
+/** Telemetry health polled from `/api/telemetry/status`: drop counters and the degradation flag. */
+export interface TelemetryHealth {
   telemetryDegraded: boolean;
   droppedOverflow: number;
   droppedExhausted: number;
@@ -85,7 +85,7 @@ export interface AppStore {
   clearAppStatus: () => void;
   clearServiceStatus: () => void;
   setExecutionCompleted: (data: WsExecutionCompletedPayload[]) => void;
-  setTelemetryHealth: (data: Partial<TelemetryHealthFields>) => void;
+  setTelemetryHealth: (data: Partial<TelemetryHealth>) => void;
 
   // --- preferences ---
   theme: "dark" | "light";


### PR DESCRIPTION
## Summary

Renames the frontend `TelemetryCounters` interface to `TelemetryHealth`, and collapses it together with the store's structurally identical `TelemetryHealthFields` into a single type.

The interface holds four drop counters (`droppedOverflow`, `droppedExhausted`, `droppedShutdown`, `errorHandlerFailures`) plus `telemetryDegraded` — a boolean status flag, not a count. The doc comment had to say "drop counters **and degradation flag**" to describe the shape, which is the tell that the name was covering only part of it.

The mismatch showed up at the consumer rather than the declaration: `diagnostics.tsx` declares `telemetry: TelemetryCounters`, so a reader reaching for that field expecting a bag of numbers got a mixed shape instead. The type also does double duty as `TelemetryPanel`'s props, so `TelemetryPanelProps` was not an option — the name has to read correctly in both roles. `TelemetryHealth` covers counters and the flag together and reads correctly at the `telemetry:` field site.

It also lines the type up with the naming already used across the rest of the telemetry surface: `useTelemetryHealth`, `setTelemetryHealth`, and the panel's own `title="telemetry health"`.

## Deduplicating against the store

Review surfaced that the rename landed one suffix away from an existing type: `store.ts` already declared `TelemetryHealthFields` with the same five fields, hand-synced with the panel's copy. `TelemetryHealth` vs `TelemetryHealthFields` reads as a typo or a subset rather than two independent declarations of one shape, so the two are now a single exported `TelemetryHealth` living in `store.ts` — the module that owns the shape, since `setTelemetryHealth` writes it and `useTelemetryHealth` populates it from the API. The panel and the diagnostics page both reference it. Importing a type from the store is the established pattern here (`ConnectionStatus`, `ServiceStatusEntry`, `AppStatusEntry`, `TimePreset`), including `merge-services.ts` in the same directory.

The doc comment is also corrected while being rewritten. It claimed these fields are "carried on the WS stream"; they are not. `useTelemetryHealth` polls `GET /api/telemetry/status` on a 30s–120s backoff and is the only caller of `setTelemetryHealth`, so there is no WebSocket in this data path. The claim predated this PR, but the PR rewrites that exact line.

## Changes

- `frontend/src/state/store.ts` — renamed `TelemetryHealthFields` to `TelemetryHealth` (now the single declaration of this shape) and updated `setTelemetryHealth`'s parameter type.
- `frontend/src/components/diagnostics/telemetry-panel.tsx` — deleted the duplicate interface; the props annotation now references the store's type.
- `frontend/src/pages/diagnostics.tsx` — the type import moves to `../state/store`; the panel import is value-only.

Type-only changes throughout. No runtime behavior, no rendered output, and no API surface changes.

## Testing

- `npx tsc --noEmit` — clean
- `npm run test` (frontend) — 110 files, 1603 tests passed
- `npx eslint src --max-warnings=0` — clean
- `prek -a` and `prek pyright -a --hook-stage pre-push` — all hooks pass
- `uv run nox -s dev` — 7737 passed, 1 skipped, 2 xfailed (first commit)

Verified no `TelemetryCounters` or `TelemetryHealthFields` references remain anywhere in the repo.

Labeled `no-visual-change`: this renames TypeScript identifiers only, so no pixels move and there is no screenshot to regenerate.

Closes #1951
