### PR TITLE
refactor: deduplicate API error format and credentials literal in client.ts

### DIFF
--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -2,6 +2,12 @@
 
 const BASE_URL = "/api";
 const JSON_CONTENT_TYPE = "application/json";
+const FETCH_CREDENTIALS: RequestCredentials = "same-origin";
+
+/** Fallback message for a non-ok response whose body carried no usable detail. */
+function formatApiError(status: number, statusText: string): string {
+  return `API error: ${status} ${statusText}`;
+}
 
 export class ApiError extends Error {
   constructor(
@@ -9,7 +15,7 @@ export class ApiError extends Error {
     public readonly statusText: string,
     message?: string,
   ) {
-    super(message ?? `API error: ${status} ${statusText}`);
+    super(message ?? formatApiError(status, statusText));
     this.name = "ApiError";
   }
 }
@@ -29,7 +35,7 @@ export async function apiFetch<T>(path: string, init?: RequestInit): Promise<T> 
   const url = `${BASE_URL}${path}`;
   const response = await fetch(url, {
     ...init,
-    credentials: "same-origin",
+    credentials: FETCH_CREDENTIALS,
     headers: {
       Accept: JSON_CONTENT_TYPE,
       ...init?.headers,
@@ -67,7 +73,7 @@ export async function postSession(token: string): Promise<PostSessionResult> {
   try {
     response = await fetch(`${BASE_URL}/auth/session`, {
       method: "POST",
-      credentials: "same-origin",
+      credentials: FETCH_CREDENTIALS,
       headers: { "Content-Type": JSON_CONTENT_TYPE },
       body: JSON.stringify({ token }),
     });
@@ -78,6 +84,6 @@ export async function postSession(token: string): Promise<PostSessionResult> {
   if (response.ok) return { ok: true };
 
   const detail = await extractErrorMessage(response);
-  const message = detail ?? `API error: ${response.status} ${response.statusText}`;
+  const message = detail ?? formatApiError(response.status, response.statusText);
   return { ok: false, message };
 }

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -4,11 +4,6 @@ const BASE_URL = "/api";
 const JSON_CONTENT_TYPE = "application/json";
 const FETCH_CREDENTIALS: RequestCredentials = "same-origin";
 
-/** Fallback message for a non-ok response whose body carried no usable detail. */
-function formatApiError(status: number, statusText: string): string {
-  return `API error: ${status} ${statusText}`;
-}
-
 export class ApiError extends Error {
   constructor(
     public readonly status: number,
@@ -18,6 +13,11 @@ export class ApiError extends Error {
     super(message ?? formatApiError(status, statusText));
     this.name = "ApiError";
   }
+}
+
+/** Builds the generic `API error: <status> <statusText>` message used when no specific detail is available. */
+function formatApiError(status: number, statusText: string): string {
+  return `API error: ${status} ${statusText}`;
 }
 
 /** Extracts a human-readable error message from a non-ok response's JSON body, if present. */


### PR DESCRIPTION
## Summary

Removes two small duplications in `frontend/src/api/client.ts` that a quality scan flagged.

The `API error: <status> <statusText>` fallback string was written out twice — once as `ApiError`'s default message and once in `postSession`, which deliberately bypasses `apiFetch` and so had to build its own fallback. The two copies could drift independently. They now share a module-level `formatApiError(status, statusText)` helper.

The `credentials: "same-origin"` literal appeared in both `fetch` call sites. It is now a `FETCH_CREDENTIALS` constant, typed as `RequestCredentials`, sitting alongside the existing `BASE_URL` and `JSON_CONTENT_TYPE` constants at the top of the module.

## Why

Both are single-source-of-truth cleanups. The error-format duplication is the one with real drift risk: a future change to the fallback wording would need to be made in two places, and missing one would produce two different messages for the same condition depending on which code path produced it.

## Not changed

This is a pure refactor with no behavior change:

- The rendered message text is byte-identical.
- `postSession` still returns its `PostSessionResult` shape rather than throwing.
- `postSession` still bypasses `apiFetch` on purpose — that was left alone.

## Testing

- `uv run nox -s dev` — 7737 passed, 1 skipped, 2 xfailed
- `cd frontend && npm test -- --run` — 110 files, 1603 tests passed
- `prek -a` — all hooks pass, including `eslint`, `prettier`, `stylelint`, and `tsc`
- `prek pyright -a --stage pre-push` — passed

No visual evidence required: `client.ts` is not a rendered file, so it falls outside the `frontend/src/**/*.{tsx,css}` trigger in `tools/frontend/check_pr_screenshots.py`.

Closes #1967
