### PR TITLE
refactor: derive ws-validator error message from DISCRIMINATOR_FIELD

### DIFF
--- a/frontend/src/api/ws-validator.test.ts
+++ b/frontend/src/api/ws-validator.test.ts
@@ -79,6 +79,17 @@ describe("validateWsMessage", () => {
     expect(() => validateWsMessage(null)).toThrow(WsValidationError);
   });
 
+  it("names the missing discriminator field in the synthetic error", () => {
+    expect.assertions(2);
+    try {
+      validateWsMessage({ data: {}, timestamp: BASE_TIME_S });
+    } catch (err) {
+      const { errors } = err as WsValidationError;
+      expect(errors).toHaveLength(1);
+      expect(errors[0].message).toBe("expected object with type field");
+    }
+  });
+
   it("exposes validation errors on the thrown error", () => {
     expect.assertions(3);
     try {

--- a/frontend/src/api/ws-validator.ts
+++ b/frontend/src/api/ws-validator.ts
@@ -20,7 +20,7 @@ export class WsValidationError extends Error {
 function buildMissingTypeFieldError(): ErrorObject {
   return {
     message: `expected object with ${DISCRIMINATOR_FIELD} field`,
-    // ajv's rule name, not the WS field — same string as DISCRIMINATOR_FIELD by coincidence
+    // ajv's JSON Schema keyword, not the WS field — same string as DISCRIMINATOR_FIELD by coincidence
     keyword: "type",
     instancePath: "",
     schemaPath: "#/discriminator",

--- a/frontend/src/api/ws-validator.ts
+++ b/frontend/src/api/ws-validator.ts
@@ -19,9 +19,8 @@ export class WsValidationError extends Error {
 
 function buildMissingTypeFieldError(): ErrorObject {
   return {
-    message: "expected object with type field",
-    // ajv-style keyword label for the synthetic error; coincidentally the same string as
-    // DISCRIMINATOR_FIELD, but it names the validation rule, not the WS message's field.
+    message: `expected object with ${DISCRIMINATOR_FIELD} field`,
+    // ajv's rule name, not the WS field — same string as DISCRIMINATOR_FIELD by coincidence
     keyword: "type",
     instancePath: "",
     schemaPath: "#/discriminator",


### PR DESCRIPTION
## Summary

`ws-validator.ts` declares `const DISCRIMINATOR_FIELD = "type"` and uses it for the actual
membership check, but the synthetic "missing discriminator" error it throws hardcoded the same
value as prose:

```ts
message: "expected object with type field",
```

The guard and the message it produces were free to drift. A rename of `DISCRIMINATOR_FIELD` would
have moved the check while leaving the message reporting the old field name — actively misleading
to whoever is debugging a malformed WebSocket frame.

## Changes

- `message` now interpolates the constant: `` `expected object with ${DISCRIMINATOR_FIELD} field` ``.
  The rendered string is byte-identical today; the point is that it now tracks the constant.
- Collapsed the two-line comment above `keyword: "type"` to one line, preserving the load-bearing
  part: `keyword` names ajv's own validation rule, not the WS message's discriminator field, and
  matches `DISCRIMINATOR_FIELD` only by coincidence.

Deliberately **not** changed: `keyword: "type"` itself. It belongs to ajv's `ErrorObject` contract
and must not follow a rename of the WS discriminator field. The retained comment says exactly that.

## Testing

- `uv run nox -s dev` — 7737 passed, 1 skipped, 2 xfailed (exit 0)
- `prek -a` — all hooks passed, plus the pre-push staged hooks (`pyright`, schema freshness) passed
- `frontend/`: `npm run test` — 1603 passed across 110 files; `npm run build` — exit 0

One backend test (`test_duration_once_removal_on_exception`) timed out on a first run that shared
the machine with the frontend build and type-check. It is a real-clock `asyncio.wait_for`
safety-ceiling wait, it passed in isolation and again on a clean full re-run, and `git diff
origin/main` for this branch touches only `frontend/src/api/ws-validator.ts` — `src/hassette/bus/`
and the test file are identical to `main`. Load-induced flake, unrelated to this change.

No visual evidence included: this touches a non-rendering `.ts` module, not `.tsx`/`.css`.

Closes #1983
