### PR TITLE
test: deduplicate endpoint literal and fixture shape in config-tab tests

### DIFF
--- a/frontend/src/components/app-detail/config-tab.test.tsx
+++ b/frontend/src/components/app-detail/config-tab.test.tsx
@@ -2,9 +2,12 @@ import { render, screen, waitFor } from "@testing-library/react";
 import { delay, http, HttpResponse } from "msw";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+import type { components } from "../../api/generated-types";
 import { server } from "../../test/server";
 import { getShikiHighlighter } from "../../utils/shiki";
 import { ConfigTab } from "./config-tab";
+
+type AppConfigResponse = components["schemas"]["AppConfigResponse"];
 
 /** Mocked at the getShikiHighlighter boundary (not the "shiki" package) so each test controls
  *  resolution/rejection directly — the real module caches per-language, which would make a
@@ -28,8 +31,9 @@ const PORT = 8080;
 /** Long enough to keep the request in flight while the component unmounts mid-request. */
 const MOCK_RESPONSE_DELAY_MS = 100;
 
-/** Fields shared by every app config response fixture below. */
-const baseAppMeta = {
+/** Fields shared by every app config response fixture below. Typed against the generated
+ *  response model so a backend field rename fails the type check instead of silently drifting. */
+const baseAppConfigFields: Pick<AppConfigResponse, "app_key" | "filename" | "class_name" | "enabled" | "autostart"> = {
   app_key: APP_KEY,
   filename: "test_app.py",
   class_name: "TestApp",
@@ -39,7 +43,7 @@ const baseAppMeta = {
 
 /** App config response with a schema that marks 'token' as a secret via anyOf. */
 const defaultConfig = {
-  ...baseAppMeta,
+  ...baseAppConfigFields,
   app_config: {
     token: MASK_SENTINEL,
     host: HOST,
@@ -62,7 +66,7 @@ const defaultConfig = {
 
 /** App config response without a schema — falls back to SimpleConfigTable. */
 const noSchemaConfig = {
-  ...baseAppMeta,
+  ...baseAppConfigFields,
   app_config: {
     api_key: "some-value",
   },

--- a/frontend/src/components/app-detail/config-tab.test.tsx
+++ b/frontend/src/components/app-detail/config-tab.test.tsx
@@ -20,6 +20,7 @@ vi.mock("../../utils/shiki", () => ({
 }));
 
 const APP_KEY = "test_app";
+const CONFIG_ENDPOINT = "/api/apps/:app_key/config";
 const MASK_SENTINEL = "••••••••";
 const HOST = "192.168.1.1";
 const PORT = 8080;
@@ -27,13 +28,18 @@ const PORT = 8080;
 /** Long enough to keep the request in flight while the component unmounts mid-request. */
 const MOCK_RESPONSE_DELAY_MS = 100;
 
-/** App config response with a schema that marks 'token' as a secret via anyOf. */
-const defaultConfig = {
+/** Fields shared by every app config response fixture below. */
+const baseAppMeta = {
   app_key: APP_KEY,
   filename: "test_app.py",
   class_name: "TestApp",
   enabled: true,
   autostart: true,
+};
+
+/** App config response with a schema that marks 'token' as a secret via anyOf. */
+const defaultConfig = {
+  ...baseAppMeta,
   app_config: {
     token: MASK_SENTINEL,
     host: HOST,
@@ -56,11 +62,7 @@ const defaultConfig = {
 
 /** App config response without a schema — falls back to SimpleConfigTable. */
 const noSchemaConfig = {
-  app_key: APP_KEY,
-  filename: "test_app.py",
-  class_name: "TestApp",
-  enabled: true,
-  autostart: true,
+  ...baseAppMeta,
   app_config: {
     api_key: "some-value",
   },
@@ -80,7 +82,7 @@ function waitForTestId(testId: string) {
 describe("ConfigTab", () => {
   beforeEach(() => {
     server.use(
-      http.get("/api/apps/:app_key/config", () => {
+      http.get(CONFIG_ENDPOINT, () => {
         return HttpResponse.json(defaultConfig);
       }),
     );
@@ -119,7 +121,7 @@ describe("ConfigTab", () => {
 
   it("renders empty config message when schema has no properties", async () => {
     server.use(
-      http.get("/api/apps/:app_key/config", () => {
+      http.get(CONFIG_ENDPOINT, () => {
         return HttpResponse.json({
           ...defaultConfig,
           app_config: {},
@@ -134,7 +136,7 @@ describe("ConfigTab", () => {
 
   it("falls back to SimpleConfigTable when no schema is provided", async () => {
     server.use(
-      http.get("/api/apps/:app_key/config", () => {
+      http.get(CONFIG_ENDPOINT, () => {
         return HttpResponse.json(noSchemaConfig);
       }),
     );
@@ -144,7 +146,7 @@ describe("ConfigTab", () => {
   });
 
   it("shows an error card when fetching the config fails", async () => {
-    server.use(http.get("/api/apps/:app_key/config", () => HttpResponse.json(null, { status: 500 })));
+    server.use(http.get(CONFIG_ENDPOINT, () => HttpResponse.json(null, { status: 500 })));
     renderConfigTab();
     await waitForTestId("config-tab-error");
   });
@@ -162,7 +164,7 @@ describe("ConfigTab", () => {
     let requestSignal: AbortSignal | undefined;
 
     server.use(
-      http.get("/api/apps/:app_key/config", async ({ request }) => {
+      http.get(CONFIG_ENDPOINT, async ({ request }) => {
         requestSignal = request.signal;
         await delay(MOCK_RESPONSE_DELAY_MS);
         return HttpResponse.json(defaultConfig);
@@ -180,7 +182,7 @@ describe("ConfigTab", () => {
 
   it("handles multi-instance list config by rendering per-instance blocks", async () => {
     server.use(
-      http.get("/api/apps/:app_key/config", () => {
+      http.get(CONFIG_ENDPOINT, () => {
         return HttpResponse.json({
           ...defaultConfig,
           app_config: [


### PR DESCRIPTION
## Summary

Removes two mechanical duplications in `frontend/src/components/app-detail/config-tab.test.tsx`. Test-only change — no production code or behavior is touched.

## What changed

**Endpoint literal extracted to a constant.** `"/api/apps/:app_key/config"` was written inline at six `http.get` registrations (once in `beforeEach`, once per test override). A missed call site during a route rename would have silently fallen through to the `beforeEach` default handler instead of failing loudly. It is now a single `CONFIG_ENDPOINT` constant alongside the other top-of-file constants, matching the existing precedent in `components/shared/log-table/use-log-data.test.ts`.

**Shared fixture fields composed from one base object.** `defaultConfig` and `noSchemaConfig` independently repeated the same five fields (`app_key`, `filename`, `class_name`, `enabled`, `autostart`), leaving them free to drift and obscuring which fields the "no schema" case actually varies. Both now spread a `baseAppMeta` object, so only the genuinely differing fields (`app_config`, `config_toml`, `config_schema`) appear per fixture.

A shared factory in `test/factories.ts` was deliberately not used — `config_toml` appears in this file only, below the bar for promoting a fixture to the shared registry.

## Testing

- `npx vitest run src/components/app-detail/config-tab.test.tsx` — 13 passed
- `uv run nox -s dev` — 7737 passed, 1 skipped, 2 xfailed
- `prek -a` — all hooks passed
- `prek pyright -a --stage pre-push` — passed

Literal counts verified against the issue's acceptance criteria: `/api/apps/:app_key/config`, `test_app.py`, and `TestApp` each now appear exactly once in the file.

Closes #1998
