### PR TITLE
test: render via renderSection helper and derive mocked ExecutionTable prop type

### DIFF
--- a/frontend/src/components/app-detail/execution-section.test.tsx
+++ b/frontend/src/components/app-detail/execution-section.test.tsx
@@ -9,11 +9,15 @@ vi.mock("../shared/execution-table", async () => {
   const actual = await vi.importActual<typeof import("../shared/execution-table")>("../shared/execution-table");
   return {
     ...actual,
-    ExecutionTable: vi.fn((props: { records: ExecutionRecord[]; tableId: string }) => (
-      <div data-testid="mock-execution-table" data-record-count={props.records.length} data-table-id={props.tableId}>
-        execution table
-      </div>
-    )),
+    ExecutionTable: vi.fn(
+      (
+        props: Pick<ComponentProps<typeof import("../shared/execution-table").ExecutionTable>, "records" | "tableId">,
+      ) => (
+        <div data-testid="mock-execution-table" data-record-count={props.records.length} data-table-id={props.tableId}>
+          execution table
+        </div>
+      ),
+    ),
   };
 });
 
@@ -70,19 +74,15 @@ describe("ExecutionSection", () => {
   });
 
   it("passes the correct props to ExecutionTable", () => {
-    render(
-      <ExecutionSection
-        heading="Executions"
-        records={[SUCCESS_EXECUTION]}
-        kind="job"
-        tableId="table-42"
-        loading={false}
-        appKey="my_app"
-        handlerKind="listener"
-        handlerId={7}
-        instanceQs="?instance=0"
-      />,
-    );
+    renderSection({
+      records: [SUCCESS_EXECUTION],
+      kind: "job",
+      tableId: "table-42",
+      appKey: "my_app",
+      handlerKind: "listener",
+      handlerId: 7,
+      instanceQs: "?instance=0",
+    });
 
     // React calls function components with only a props argument (no Preact-style second
     // "context" argument), so the second call arg is undefined here.


### PR DESCRIPTION
## Summary

Two mechanical hygiene fixes in `frontend/src/components/app-detail/execution-section.test.tsx`. Test-only change — no production code or behavior is touched.

## What changed

**1. `"passes the correct props to ExecutionTable"` now renders via the `renderSection` helper.**

The file already defines `renderSection(overrides)` to avoid repeating the `<ExecutionSection .../>` JSX, and three of the four tests use it. This one hand-wrote its own full `render(<ExecutionSection ... />)` call. Every prop it set is declared on `ExecutionSectionProps`, so all of them pass cleanly through the helper's `Partial<ComponentProps<typeof ExecutionSection>>` overrides. The assertion block below it is unchanged, so the test still proves exactly what it did before.

**2. The mocked `ExecutionTable` stub derives its prop type instead of hand-declaring one.**

The `vi.mock` factory typed its stub as a literal `{ records: ExecutionRecord[]; tableId: string }` — a manually-maintained subset of the real `ExecutionTableProps` that would silently drift if the real component's props changed. It now derives the shape:

```ts
Pick<ComponentProps<typeof import("../shared/execution-table").ExecutionTable>, "records" | "tableId">
```

A type-position `import(...)` is erased at compile time, so it does not collide with `vi.mock`'s hoisting the way a value reference would.

## Why

Both findings are pre-existing and local to this one file. The second is the one with actual teeth: a hand-written prop shadow gives no signal when the real component's props change, so the mock can quietly stop resembling what it stands in for. Deriving it makes `tsc` the enforcement mechanism rather than a reader noticing.

The issue also flagged the inline literals (`handlerId={7}`, `tableId="table-42"`, `instanceQs="?instance=0"`) as magic values. Deliberately left alone — each is asserted verbatim about fifteen lines below, so hoisting them to named constants would insert indirection between the two halves of the test instead of removing it.

## Testing

- `npx vitest run src/components/app-detail/execution-section.test.tsx` — 5 passed
- `npx vitest run` (full frontend suite) — 110 files, 1604 tests passed
- `uv run nox -s dev` — 7737 passed, 1 skipped, 2 xfailed
- `prek -a` — all hooks pass, including `tsc (frontend)` and `eslint (frontend)`
- `prek pyright -a --stage pre-push` — passed

No screenshots: the diff touches only a `.test.tsx` file, which `tools/frontend/check_pr_screenshots.py` excludes from the visual-evidence requirement.

Closes #2010
