### PR TITLE
test: consolidate handler-health-grid test blocks and share section testids

### DIFF
--- a/frontend/src/components/app-detail/handler-health-grid.test.tsx
+++ b/frontend/src/components/app-detail/handler-health-grid.test.tsx
@@ -4,7 +4,7 @@ import { describe, expect, it, vi } from "vitest";
 import { createJob, createListener } from "../../test/factories";
 import { createWouterMock } from "../../test/mock-wouter";
 import { renderWithAppState } from "../../test/render-helpers";
-import { CARD_SELECTOR, cardTestId } from "./handler-health.test-helpers";
+import { CARD_SELECTOR, cardTestId, HEALTH_EMPTY_TESTID, HEALTH_GRID_TESTID } from "./handler-health.test-helpers";
 import { HandlerHealthGrid } from "./handler-health-grid";
 import { buildItems } from "./handler-list";
 import type { UnifiedItem } from "./unified-handler-row";
@@ -18,11 +18,13 @@ vi.mock("wouter", () =>
 
 const DEFAULT_GRID_PROPS = { appKey: "test_app", instanceQs: "" };
 
-function renderGrid(items: UnifiedItem[], overrides: Partial<typeof DEFAULT_GRID_PROPS> = {}) {
+type GridPropOverrides = Partial<typeof DEFAULT_GRID_PROPS>;
+
+function renderGrid(items: UnifiedItem[], overrides: GridPropOverrides = {}) {
   return render(<HandlerHealthGrid items={items} {...DEFAULT_GRID_PROPS} {...overrides} />);
 }
 
-function renderGridWithAppState(items: UnifiedItem[], overrides: Partial<typeof DEFAULT_GRID_PROPS> = {}) {
+function renderGridWithAppState(items: UnifiedItem[], overrides: GridPropOverrides = {}) {
   return renderWithAppState(<HandlerHealthGrid items={items} {...DEFAULT_GRID_PROPS} {...overrides} />);
 }
 
@@ -39,12 +41,12 @@ function makeJobItem(overrides: Parameters<typeof createJob>[0] = {}) {
 describe("HandlerHealthGrid — empty state", () => {
   it("renders the section wrapper with testid even when empty", () => {
     const { getByTestId } = renderGrid([]);
-    expect(getByTestId("overview-health-grid")).toBeDefined();
+    expect(getByTestId(HEALTH_GRID_TESTID)).toBeDefined();
   });
 
   it("renders EmptyState with testid when no items", () => {
     const { getByTestId } = renderGrid([]);
-    expect(getByTestId("overview-health-empty")).toBeDefined();
+    expect(getByTestId(HEALTH_EMPTY_TESTID)).toBeDefined();
   });
 
   it("does not render cards when items are empty", () => {
@@ -61,10 +63,21 @@ describe("HandlerHealthGrid — with items", () => {
     expect(getByTestId(cardTestId("job", 2))).toBeDefined();
   });
 
+  it("renders correct number of cards for given items", () => {
+    const items = [
+      makeListenerItem({ listener_id: 3 }),
+      makeJobItem({ job_id: 7 }),
+      makeListenerItem({ listener_id: 5 }),
+    ];
+    const { container } = renderGridWithAppState(items);
+    const cards = container.querySelectorAll(CARD_SELECTOR);
+    expect(cards).toHaveLength(3);
+  });
+
   it("does not render EmptyState when items are present", () => {
     const items = [makeListenerItem({ listener_id: 1 })];
     const { queryByTestId } = renderGridWithAppState(items);
-    expect(queryByTestId("overview-health-empty")).toBeNull();
+    expect(queryByTestId(HEALTH_EMPTY_TESTID)).toBeNull();
   });
 
   it("renders the section heading", () => {
@@ -85,18 +98,5 @@ describe("HandlerHealthGrid — sorting (failing first)", () => {
     const cards = container.querySelectorAll(CARD_SELECTOR);
     expect(cards[0].getAttribute("data-testid")).toBe(cardTestId("listener", 2));
     expect(cards[1].getAttribute("data-testid")).toBe(cardTestId("listener", 1));
-  });
-});
-
-describe("HandlerHealthGrid — passes props to cards", () => {
-  it("renders correct number of cards for given items", () => {
-    const items = [
-      makeListenerItem({ listener_id: 3 }),
-      makeJobItem({ job_id: 7 }),
-      makeListenerItem({ listener_id: 5 }),
-    ];
-    const { container } = renderGridWithAppState(items, { instanceQs: "?instance=1" });
-    const cards = container.querySelectorAll(CARD_SELECTOR);
-    expect(cards).toHaveLength(3);
   });
 });

--- a/frontend/src/components/app-detail/handler-health.test-helpers.ts
+++ b/frontend/src/components/app-detail/handler-health.test-helpers.ts
@@ -2,6 +2,8 @@ import type { HandlerKind } from "../../utils/app-routes";
 
 export const CARD_TESTID_PREFIX = "overview-health-card-";
 export const CARD_SELECTOR = `[data-testid^='${CARD_TESTID_PREFIX}']`;
+export const HEALTH_GRID_TESTID = "overview-health-grid";
+export const HEALTH_EMPTY_TESTID = "overview-health-empty";
 
 export function cardTestId(kind: HandlerKind, id: number) {
   return `${CARD_TESTID_PREFIX}${kind}-${id}`;

--- a/frontend/src/components/app-detail/overview-tab.test.tsx
+++ b/frontend/src/components/app-detail/overview-tab.test.tsx
@@ -15,6 +15,7 @@ import {
 import { createWouterMock } from "../../test/mock-wouter";
 import { renderWithAppState } from "../../test/render-helpers";
 import { server } from "../../test/server";
+import { HEALTH_EMPTY_TESTID, HEALTH_GRID_TESTID } from "./handler-health.test-helpers";
 import { OverviewTab } from "./overview-tab";
 
 // Overview tab tests are split into two groups:
@@ -218,7 +219,7 @@ describe("OverviewTab — Error Spotlight", () => {
 describe("OverviewTab — Handler Health Grid", () => {
   it("renders the health grid section", () => {
     const { getByTestId } = renderOverviewTab();
-    expect(getByTestId("overview-health-grid")).toBeDefined();
+    expect(getByTestId(HEALTH_GRID_TESTID)).toBeDefined();
   });
 
   it("renders a card for each listener", () => {
@@ -259,7 +260,7 @@ describe("OverviewTab — Handler Health Grid", () => {
 
   it("shows empty state when no listeners or jobs", () => {
     const { getByTestId } = renderOverviewTab({ listeners: [], jobs: [] });
-    expect(getByTestId("overview-health-empty")).toBeDefined();
+    expect(getByTestId(HEALTH_EMPTY_TESTID)).toBeDefined();
   });
 
   it("does not render a table element in the health grid section", () => {
@@ -267,7 +268,7 @@ describe("OverviewTab — Handler Health Grid", () => {
       listeners: [createListener({ listener_id: 1 })],
       jobs: [],
     });
-    const section = getByTestId("overview-health-grid");
+    const section = getByTestId(HEALTH_GRID_TESTID);
     expect(section.querySelector("table")).toBeNull();
   });
 


### PR DESCRIPTION
## Summary

Test-hygiene cleanup in `handler-health-grid.test.tsx`, addressing the three findings from the quality-scanner pass in #2016. No production code changes — this touches only test files and a test-helper module.

## What changed

**1. Removed a misleading `describe` block with an inert prop override**

`describe("HandlerHealthGrid — passes props to cards")` held a single test that asserted only `expect(cards).toHaveLength(3)`. It passed `{ instanceQs: "?instance=1" }` as an override but never asserted that `instanceQs` reached the cards, so the block name promised prop-passing coverage the test did not provide.

The card-count test is now folded into the existing `describe("HandlerHealthGrid — with items")` block with the inert override dropped. No duplicate propagation assertion was added — `overview-tab.test.tsx` ("card navigation includes instanceQs") already owns that coverage by asserting the navigate URL.

**2. Moved section-level testid literals into the shared helper module**

`overview-health-grid` and `overview-health-empty` were hand-typed string literals at six call sites across two test files, while the sibling `handler-health.test-helpers.ts` already existed for this purpose but only covered the card testids. Renaming either testid in `handler-health-grid.tsx` would have required six separate edits with no compiler help.

Both are now exported as `HEALTH_GRID_TESTID` and `HEALTH_EMPTY_TESTID` and used at all six call sites.

**3. Extracted a repeated inline type expression**

`Partial<typeof DEFAULT_GRID_PROPS>` was written out verbatim in both `renderGrid` and `renderGridWithAppState`; it is now a local `type GridPropOverrides`.

## Not done, deliberately

The scanner also flagged the two-level relative imports (`../../test/factories` and friends) as import-hygiene violations that should use the `@/` alias. Left alone, as the issue itself recommends: `frontend/src` currently has 28 files using the relative form against 8 using `@/test/`, so the relative form is the dominant convention here and converging on one style is a separate repo-wide decision.

## Testing

- `npx vitest run` on the two changed files — 47 passed
- `npx vitest run` (full frontend suite) — 110 files, 1604 tests passed
- `uv run nox -s dev` — 7737 passed, 1 skipped, 2 xfailed
- `prek -a` — all hooks passed (includes prettier, eslint, stylelint, tsc)
- `prek pyright -a --stage pre-push` — passed

No screenshots: the diff touches only `*.test.tsx` and a `.ts` helper, both excluded from the rendering-file set that `check_pr_screenshots.py` guards.

Closes #2016
