### PR TITLE
test: collapse render boilerplate and name fixtures in handler-list tests

### DIFF
--- a/frontend/src/components/app-detail/handler-list.test.tsx
+++ b/frontend/src/components/app-detail/handler-list.test.tsx
@@ -1,4 +1,5 @@
 import { render } from "@testing-library/react";
+import type { ComponentProps } from "react";
 import { describe, expect, it, vi } from "vitest";
 
 import { createJob, createListener } from "../../test/factories";
@@ -7,6 +8,8 @@ import type { UnifiedItemKind } from "./unified-handler-row";
 import { ROW_TESTID_PREFIX, rowTestId } from "./unified-row.test-helpers";
 
 const HANDLER_LIST_TEST_ID = "handler-list";
+
+const noop = () => {};
 
 // Mock UnifiedHandlerRow to isolate HandlerList behavior — the row component
 // calls query hooks which require the Zustand app store (useAppStore) and MSW.
@@ -26,87 +29,89 @@ vi.mock("./unified-handler-row", () => ({
   ),
 }));
 
+/** Renders HandlerList with empty/unselected defaults so each test states only the props it varies. */
+function renderHandlerList(overrides: Partial<ComponentProps<typeof HandlerList>> = {}) {
+  return render(<HandlerList listeners={[]} jobs={[]} selectedId={null} onSelect={noop} {...overrides} />);
+}
+
 describe("HandlerList", () => {
   it("renders nothing when both arrays are empty", () => {
-    const { container } = render(<HandlerList listeners={[]} jobs={[]} selectedId={null} onSelect={() => {}} />);
+    const { container } = renderHandlerList();
     expect(container.querySelector(`[data-testid='${HANDLER_LIST_TEST_ID}']`)).toBeNull();
   });
 
   it("renders handler-list container when listeners are present", () => {
-    const listeners = [createListener({ listener_id: 1 })];
-    const { getByTestId } = render(
-      <HandlerList listeners={listeners} jobs={[]} selectedId={null} onSelect={() => {}} />,
-    );
+    const { getByTestId } = renderHandlerList({ listeners: [createListener({ listener_id: 1 })] });
     expect(getByTestId(HANDLER_LIST_TEST_ID)).toBeDefined();
   });
 
   it("renders handler-list container when jobs are present", () => {
-    const jobs = [createJob({ job_id: 10 })];
-    const { getByTestId } = render(<HandlerList listeners={[]} jobs={jobs} selectedId={null} onSelect={() => {}} />);
+    const { getByTestId } = renderHandlerList({ jobs: [createJob({ job_id: 10 })] });
     expect(getByTestId(HANDLER_LIST_TEST_ID)).toBeDefined();
   });
 
   it("renders a row for each listener with kind='listener'", () => {
-    const listeners = [createListener({ listener_id: 1 }), createListener({ listener_id: 2 })];
-    const { getByTestId } = render(
-      <HandlerList listeners={listeners} jobs={[]} selectedId={null} onSelect={() => {}} />,
-    );
+    const { getByTestId } = renderHandlerList({
+      listeners: [createListener({ listener_id: 1 }), createListener({ listener_id: 2 })],
+    });
     expect(getByTestId(rowTestId("listener", 1))).toBeDefined();
     expect(getByTestId(rowTestId("listener", 2))).toBeDefined();
   });
 
   it("renders a row for each job with kind='job'", () => {
-    const jobs = [createJob({ job_id: 5 }), createJob({ job_id: 6 })];
-    const { getByTestId } = render(<HandlerList listeners={[]} jobs={jobs} selectedId={null} onSelect={() => {}} />);
+    const { getByTestId } = renderHandlerList({ jobs: [createJob({ job_id: 5 }), createJob({ job_id: 6 })] });
     expect(getByTestId(rowTestId("job", 5))).toBeDefined();
     expect(getByTestId(rowTestId("job", 6))).toBeDefined();
   });
 
   it("renders both listeners and jobs in the same list", () => {
-    const listeners = [createListener({ listener_id: 1 })];
-    const jobs = [createJob({ job_id: 10 })];
-    const { getByTestId } = render(
-      <HandlerList listeners={listeners} jobs={jobs} selectedId={null} onSelect={() => {}} />,
-    );
+    const { getByTestId } = renderHandlerList({
+      listeners: [createListener({ listener_id: 1 })],
+      jobs: [createJob({ job_id: 10 })],
+    });
     expect(getByTestId(rowTestId("listener", 1))).toBeDefined();
     expect(getByTestId(rowTestId("job", 10))).toBeDefined();
   });
 
   it("renders listener human_description as subtitle via row", () => {
-    const listeners = [createListener({ listener_id: 3, human_description: "Triggers when kitchen light changes" })];
-    const { getByText } = render(<HandlerList listeners={listeners} jobs={[]} selectedId={null} onSelect={() => {}} />);
+    const { getByText } = renderHandlerList({
+      listeners: [createListener({ listener_id: 3, human_description: "Triggers when kitchen light changes" })],
+    });
     expect(getByText("Triggers when kitchen light changes")).toBeDefined();
   });
 
   it("passes isSelected=true for the selected item", () => {
-    const listeners = [createListener({ listener_id: 1 }), createListener({ listener_id: 2 })];
-    const { getByTestId } = render(
-      <HandlerList listeners={listeners} jobs={[]} selectedId={{ kind: "listener", id: 1 }} onSelect={() => {}} />,
-    );
+    const { getByTestId } = renderHandlerList({
+      listeners: [createListener({ listener_id: 1 }), createListener({ listener_id: 2 })],
+      selectedId: { kind: "listener", id: 1 },
+    });
     expect(getByTestId(rowTestId("listener", 1)).getAttribute("data-selected")).toBe("true");
     expect(getByTestId(rowTestId("listener", 2)).getAttribute("data-selected")).toBe("false");
   });
 
   it("renders issues first while preserving source order within each health group", () => {
-    const listeners = [
-      createListener({ listener_id: 1, handler_method: "healthy_listener", total_invocations: 1 }),
-      createListener({ listener_id: 2, handler_method: "failing_listener", failed: 1 }),
-    ];
-    const jobs = [
-      createJob({ job_id: 5, job_name: "healthy_job", total_executions: 1 }),
-      createJob({ job_id: 6, job_name: "failing_job", failed: 1 }),
-      createJob({ job_id: 7, job_name: "idle_job", total_executions: 0 }),
-    ];
-    const { container } = render(
-      <HandlerList listeners={listeners} jobs={jobs} selectedId={null} onSelect={() => {}} />,
-    );
+    const healthyListener = createListener({
+      listener_id: 1,
+      handler_method: "healthy_listener",
+      total_invocations: 1,
+    });
+    const failingListener = createListener({ listener_id: 2, handler_method: "failing_listener", failed: 1 });
+    const healthyJob = createJob({ job_id: 5, job_name: "healthy_job", total_executions: 1 });
+    const failingJob = createJob({ job_id: 6, job_name: "failing_job", failed: 1 });
+    const idleJob = createJob({ job_id: 7, job_name: "idle_job", total_executions: 0 });
+
+    const { container } = renderHandlerList({
+      listeners: [healthyListener, failingListener],
+      jobs: [healthyJob, failingJob, idleJob],
+    });
+
     const rows = container.querySelectorAll(`[data-testid^='${ROW_TESTID_PREFIX}']`);
     expect(Array.from(rows, (row) => row.getAttribute("data-testid"))).toEqual([
-      rowTestId("listener", 2),
-      rowTestId("job", 6),
-      rowTestId("listener", 1),
-      rowTestId("job", 5),
-      rowTestId("job", 7),
+      rowTestId("listener", failingListener.listener_id),
+      rowTestId("job", failingJob.job_id),
+      rowTestId("listener", healthyListener.listener_id),
+      rowTestId("job", healthyJob.job_id),
+      rowTestId("job", idleJob.job_id),
     ]);
   });
 });


### PR DESCRIPTION
## Summary

Test-only cleanup of `frontend/src/components/app-detail/handler-list.test.tsx`, addressing both findings from the automated quality scan in #2021. No production code or component behavior changes.

## What changed

**1. Collapsed nine near-identical render call sites into a local helper.**

Every one of the nine tests hand-rolled the same four-prop `HandlerList` render call, re-declaring an inline `onSelect={() => {}}` no-op each time. Several wrapped onto three lines purely to stay under the 120-char limit, so the wrapping communicated line-length pressure rather than what the test actually varied.

A local `renderHandlerList(overrides)` helper now supplies the empty/unselected defaults (`listeners: []`, `jobs: []`, `selectedId: null`, `onSelect: noop`), with a single module-scope `noop`. Each test now states only the prop under test, and most fit on one line. `Partial<ComponentProps<typeof HandlerList>>` types the overrides, so the helper stays in sync with the component's props automatically. This matches the sibling helper shape already used in this directory.

**2. Named the fixtures in the ordering assertion.**

The `renders issues first while preserving source order within each health group` test built five semantically-named fixtures (`healthy_listener`, `failing_listener`, `healthy_job`, `failing_job`, `idle_job`) but asserted the expected order using bare numeric IDs — `rowTestId("listener", 2)`, `rowTestId("job", 6)`, and so on. Verifying that the assertion actually encodes "issues first, source order preserved within group" meant mapping five integers back to five names by eye, which is the whole point of the test.

Each fixture is now bound to a named variable and the expected array derives its IDs from those objects, so the assertion reads in terms of health group. This is the second, preferred option the issue proposed.

## Testing

- `uv run nox -s dev` — 7737 passed, 1 skipped, 2 xfailed
- `prek -a` — all hooks pass (ruff, eslint, prettier, stylelint, tsc, house-lint, and the rest)
- `prek pyright -a --stage pre-push` — pass
- `npx vitest run src/components/app-detail/handler-list.test.tsx` — 9 passed

The nine tests pass unchanged in name and count; only their construction changed. No screenshots apply — `check_pr_screenshots.py` excludes `*.test.tsx`, and this PR touches no rendered frontend file.

Closes #2021
