### PR TITLE
test: centralize handlers-tab app-key/URL constants and clean up comment noise

### DIFF
--- a/frontend/src/components/app-detail/handlers-tab.job.test.tsx
+++ b/frontend/src/components/app-detail/handlers-tab.job.test.tsx
@@ -8,7 +8,7 @@ import { useAppStore } from "../../state/store";
 import { createJob } from "../../test/factories";
 import { createWouterMock } from "../../test/mock-wouter";
 import { server } from "../../test/server";
-import { renderHandlersTab } from "./handlers-tab.test-helpers";
+import { APP_KEY, HANDLERS_URL, renderHandlersTab } from "./handlers-tab.test-helpers";
 
 vi.mock("sonner", async (importOriginal) => {
   const actual = await importOriginal<typeof import("sonner")>();
@@ -41,7 +41,7 @@ const SCHEDULE_STATUSES = ["scheduled", "waiting", "completed", "manual"] as con
 /** Past RUN_NOW_FEEDBACK_TIMEOUT_MS (8000ms in job-detail.tsx) so the timeout fallback fires. */
 const PAST_RUN_NOW_FEEDBACK_TIMEOUT_MS = 10000;
 
-vi.mock("wouter", () => createWouterMock({ useLocation: () => ["/apps/test_app/handlers", mockNavigate] }));
+vi.mock("wouter", () => createWouterMock({ useLocation: () => [HANDLERS_URL, mockNavigate] }));
 
 vi.mock("../../hooks/use-correct-url", () => ({
   useCorrectUrl: () => mockCorrectUrl,
@@ -373,7 +373,7 @@ describe("HandlersTab job detail", () => {
               {
                 kind: "job",
                 job_id: jobId,
-                app_key: "test_app",
+                app_key: APP_KEY,
                 instance_index: 0,
                 status: "success",
                 duration_ms: 10,
@@ -427,7 +427,7 @@ describe("HandlersTab job detail", () => {
             {
               kind: "job",
               job_id: 999,
-              app_key: "test_app",
+              app_key: APP_KEY,
               instance_index: 0,
               status: "success",
               duration_ms: 10,
@@ -477,7 +477,7 @@ describe("HandlersTab job detail", () => {
             {
               kind: "job",
               job_id: jobId,
-              app_key: "test_app",
+              app_key: APP_KEY,
               instance_index: 0,
               status: "success",
               duration_ms: 10,

--- a/frontend/src/components/app-detail/handlers-tab.listener.test.tsx
+++ b/frontend/src/components/app-detail/handlers-tab.listener.test.tsx
@@ -4,7 +4,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { createListener } from "../../test/factories";
 import { createWouterMock } from "../../test/mock-wouter";
-import { renderHandlersTab } from "./handlers-tab.test-helpers";
+import { HANDLERS_URL, renderHandlersTab } from "./handlers-tab.test-helpers";
 
 // Mock child components that make API calls
 vi.mock("../shared/execution-table", () => ({
@@ -24,7 +24,7 @@ vi.mock("./execution-detail", () => ({
 const mockNavigate = vi.fn();
 const mockCorrectUrl = vi.fn();
 
-vi.mock("wouter", () => createWouterMock({ useLocation: () => ["/apps/test_app/handlers", mockNavigate] }));
+vi.mock("wouter", () => createWouterMock({ useLocation: () => [HANDLERS_URL, mockNavigate] }));
 
 vi.mock("../../hooks/use-correct-url", () => ({
   useCorrectUrl: () => mockCorrectUrl,

--- a/frontend/src/components/app-detail/handlers-tab.navigation.test.tsx
+++ b/frontend/src/components/app-detail/handlers-tab.navigation.test.tsx
@@ -6,7 +6,7 @@ import { createJob, createListener } from "../../test/factories";
 import { createWouterMock } from "../../test/mock-wouter";
 import { renderWithAppState } from "../../test/render-helpers";
 import { HandlersTab } from "./handlers-tab";
-import { renderHandlersTab } from "./handlers-tab.test-helpers";
+import { APP_KEY, HANDLERS_URL, renderHandlersTab } from "./handlers-tab.test-helpers";
 import { rowTestId } from "./unified-row.test-helpers";
 
 // Mock child components that make API calls
@@ -23,9 +23,6 @@ vi.mock("./execution-detail", () => ({
     <div data-testid="execution-detail-fetcher">{props.executionId}</div>
   ),
 }));
-
-const APP_KEY = "test_app";
-const HANDLERS_URL = `/apps/${APP_KEY}/handlers`;
 
 const mockNavigate = vi.fn();
 const mockCorrectUrl = vi.fn();

--- a/frontend/src/components/app-detail/handlers-tab.navigation.test.tsx
+++ b/frontend/src/components/app-detail/handlers-tab.navigation.test.tsx
@@ -24,10 +24,13 @@ vi.mock("./execution-detail", () => ({
   ),
 }));
 
+const APP_KEY = "test_app";
+const HANDLERS_URL = `/apps/${APP_KEY}/handlers`;
+
 const mockNavigate = vi.fn();
 const mockCorrectUrl = vi.fn();
 
-vi.mock("wouter", () => createWouterMock({ useLocation: () => ["/apps/test_app/handlers", mockNavigate] }));
+vi.mock("wouter", () => createWouterMock({ useLocation: () => [HANDLERS_URL, mockNavigate] }));
 
 vi.mock("../../hooks/use-correct-url", () => ({
   useCorrectUrl: () => mockCorrectUrl,
@@ -38,7 +41,6 @@ describe("HandlersTab navigation", () => {
     vi.clearAllMocks();
   });
 
-  // URL-driven selection tests (T03)
   it("selects listener by selectedHandler='listener/1' prop", () => {
     const listeners = [createListener({ listener_id: 1 })];
     const { getByTestId } = renderHandlersTab(listeners, [], "listener/1");
@@ -59,19 +61,17 @@ describe("HandlersTab navigation", () => {
   it("calls correctUrl when selectedHandler references a non-existent listener", () => {
     const listeners = [createListener({ listener_id: 1 })];
     renderHandlersTab(listeners, [], "listener/999");
-    expect(mockCorrectUrl).toHaveBeenCalledWith("/apps/test_app/handlers");
+    expect(mockCorrectUrl).toHaveBeenCalledWith(HANDLERS_URL);
   });
 
   it("calls correctUrl when selectedHandler references a non-existent job", () => {
     const jobs = [createJob({ job_id: 1 })];
     renderHandlersTab([], jobs, "job/999");
-    expect(mockCorrectUrl).toHaveBeenCalledWith("/apps/test_app/handlers");
+    expect(mockCorrectUrl).toHaveBeenCalledWith(HANDLERS_URL);
   });
 
   it("does not call correctUrl when data is empty (loading guard)", () => {
-    // Empty arrays = loading state / no data — should not correct URL
     renderHandlersTab([], [], "listener/999");
-    // The empty-state branch renders, no correctUrl call
     expect(mockCorrectUrl).not.toHaveBeenCalled();
   });
 
@@ -80,7 +80,7 @@ describe("HandlersTab navigation", () => {
     const listeners = [createListener({ listener_id: 5 })];
     const { getByTestId } = renderHandlersTab(listeners, [], null);
     await user.click(getByTestId(rowTestId("listener", 5)));
-    expect(mockNavigate).toHaveBeenCalledWith("/apps/test_app/handlers/listener/5");
+    expect(mockNavigate).toHaveBeenCalledWith(`${HANDLERS_URL}/listener/5`);
   });
 
   it("clicking a job row navigates to job deep-link URL", async () => {
@@ -88,7 +88,7 @@ describe("HandlersTab navigation", () => {
     const jobs = [createJob({ job_id: 20 })];
     const { getByTestId } = renderHandlersTab([], jobs, null);
     await user.click(getByTestId(rowTestId("job", 20)));
-    expect(mockNavigate).toHaveBeenCalledWith("/apps/test_app/handlers/job/20");
+    expect(mockNavigate).toHaveBeenCalledWith(`${HANDLERS_URL}/job/20`);
   });
 
   it("clicking a listener row includes instanceQs in deep-link URL", async () => {
@@ -100,13 +100,13 @@ describe("HandlersTab navigation", () => {
         jobs={[]}
         selectedHandler={null}
         selectedExecId={null}
-        appKey="test_app"
+        appKey={APP_KEY}
         instanceIndex={1}
       />,
       { storeOverrides: { uptimeSeconds: 120 } },
     );
     await user.click(getByTestId(rowTestId("listener", 3)));
-    expect(mockNavigate).toHaveBeenCalledWith("/apps/test_app/handlers/listener/3?instance=1");
+    expect(mockNavigate).toHaveBeenCalledWith(`${HANDLERS_URL}/listener/3?instance=1`);
   });
 
   it("shows placeholder when selectedHandler has invalid format", () => {
@@ -121,7 +121,7 @@ describe("HandlersTab navigation", () => {
 
   it("handler detail: calls onSwitchToCode with line number when view-in-code clicked", async () => {
     const user = userEvent.setup();
-    const onSwitch = vi.fn();
+    const onSwitchToCode = vi.fn();
     const listener = createListener({
       listener_id: 45,
       source_location: "my_app.py:99",
@@ -132,19 +132,19 @@ describe("HandlersTab navigation", () => {
         jobs={[]}
         selectedHandler="listener/45"
         selectedExecId={null}
-        appKey="test_app"
-        onSwitchToCode={onSwitch}
+        appKey={APP_KEY}
+        onSwitchToCode={onSwitchToCode}
       />,
       { storeOverrides: { uptimeSeconds: 120 } },
     );
     await waitFor(() => getByTestId("listener-detail-45"));
     await user.click(getByTestId("view-in-code-btn"));
-    expect(onSwitch).toHaveBeenCalledWith(99);
+    expect(onSwitchToCode).toHaveBeenCalledWith(99);
   });
 
   it("renders execution detail even when no handlers are registered", () => {
     const { getByTestId, queryByTestId } = renderWithAppState(
-      <HandlersTab listeners={[]} jobs={[]} selectedHandler="listener/5" selectedExecId="abc-123" appKey="test_app" />,
+      <HandlersTab listeners={[]} jobs={[]} selectedHandler="listener/5" selectedExecId="abc-123" appKey={APP_KEY} />,
       { storeOverrides: { uptimeSeconds: 120 } },
     );
     expect(getByTestId("execution-detail-fetcher")).toBeTruthy();

--- a/frontend/src/components/app-detail/handlers-tab.rendering.test.tsx
+++ b/frontend/src/components/app-detail/handlers-tab.rendering.test.tsx
@@ -7,7 +7,7 @@ import { createListener } from "../../test/factories";
 import { createWouterMock } from "../../test/mock-wouter";
 import { createTestQueryClient } from "../../test/query-test-utils";
 import { HandlersTab } from "./handlers-tab";
-import { renderHandlersTab } from "./handlers-tab.test-helpers";
+import { APP_KEY, HANDLERS_URL, renderHandlersTab } from "./handlers-tab.test-helpers";
 
 /**
  * Fake ResizeObserver that records the last-observed element and lets tests fire a
@@ -57,7 +57,7 @@ vi.mock("./execution-detail", () => ({
 const mockNavigate = vi.fn();
 const mockCorrectUrl = vi.fn();
 
-vi.mock("wouter", () => createWouterMock({ useLocation: () => ["/apps/test_app/handlers", mockNavigate] }));
+vi.mock("wouter", () => createWouterMock({ useLocation: () => [HANDLERS_URL, mockNavigate] }));
 
 vi.mock("../../hooks/use-correct-url", () => ({
   useCorrectUrl: () => mockCorrectUrl,
@@ -101,7 +101,7 @@ describe("HandlersTab rendering", () => {
 
     const { getByTestId, rerender } = render(
       <QueryClientProvider client={client}>
-        <HandlersTab listeners={[]} jobs={[]} selectedHandler={null} selectedExecId={null} appKey="test_app" />
+        <HandlersTab listeners={[]} jobs={[]} selectedHandler={null} selectedExecId={null} appKey={APP_KEY} />
       </QueryClientProvider>,
     );
 
@@ -115,7 +115,7 @@ describe("HandlersTab rendering", () => {
           jobs={[]}
           selectedHandler="listener/1"
           selectedExecId={null}
-          appKey="test_app"
+          appKey={APP_KEY}
         />
       </QueryClientProvider>,
     );

--- a/frontend/src/components/app-detail/handlers-tab.test-helpers.ts
+++ b/frontend/src/components/app-detail/handlers-tab.test-helpers.ts
@@ -4,6 +4,10 @@ import { createJob, createListener } from "../../test/factories";
 import { renderWithAppState } from "../../test/render-helpers";
 import { HandlersTab } from "./handlers-tab";
 
+/** App key used by every `handlers-tab.*.test.tsx` fixture, and the handlers URL derived from it. */
+export const APP_KEY = "test_app";
+export const HANDLERS_URL = `/apps/${APP_KEY}/handlers`;
+
 /**
  * Renders HandlersTab with sensible listener/job defaults and a fixed uptimeSeconds.
  *
@@ -16,7 +20,7 @@ export function renderHandlersTab(
   selectedHandler: string | null = null,
 ) {
   return renderWithAppState(
-    createElement(HandlersTab, { listeners, jobs, selectedHandler, selectedExecId: null, appKey: "test_app" }),
+    createElement(HandlersTab, { listeners, jobs, selectedHandler, selectedExecId: null, appKey: APP_KEY }),
     { storeOverrides: { uptimeSeconds: 120 } },
   );
 }


### PR DESCRIPTION
## Summary

Mechanical hygiene cleanup of `frontend/src/components/app-detail/handlers-tab.navigation.test.tsx`. Test-only change — no source or behavior is touched.

Four findings from the quality scan in #2033:

1. **Removed the orphaned task-tracker comment** — `// URL-driven selection tests (T03)` referenced a task ID from an orchestration run that `cfl archive` has since removed, so `T03` no longer resolves to anything. The remaining content was already carried by the `describe` block and the test titles below it.
2. **Removed two comments that restated adjacent code** — one repeated the `it(...)` title one line above it, the other repeated the assertion it preceded.
3. **Extracted the repeated URL literal** — `"test_app"` and `"/apps/test_app/handlers"` were hand-typed at eight sites: once in the `vi.mock("wouter", ...)` factory that establishes the mocked location, then re-typed at every assertion and `appKey` prop. They now derive from two module-level constants:
   ```ts
   const APP_KEY = "test_app";
   const HANDLERS_URL = `/apps/${APP_KEY}/handlers`;
   ```
   Previously, changing the mocked location meant updating each assertion independently, and a missed one failed in a way that read as a routing bug rather than a stale literal.
4. **Renamed the mock callback to match its prop** — the local spy was `onSwitch` but was passed as `onSwitchToCode`, so reading the assertion required cross-referencing the prop declaration to confirm which callback fired.

The three sibling files carrying the same orphaned `(T07)` comment are listed as optional in the issue and are left alone here to keep this diff to a single file.

## Testing

- `npx vitest run src/components/app-detail/handlers-tab.navigation.test.tsx` — 12 passed / 12 (the acceptance-criteria check)
- `uv run nox -s dev` — 7737 passed, 1 skipped, 2 xfailed, 0 failed
- `prek -a` — all hooks passed
- `prek pyright -a --stage pre-push` — passed

## Note on draft status

This is opened as a draft only because the automated shipping run found the work uncommitted rather than already committed, so it routed to the draft path. Nothing is failing and every acceptance criterion in #2033 is met — it should be ready to mark for review as-is.

Partial progress on #2033 — needs human review

Closes #2033


---

## Review follow-up (2026-09-09)

All six reviewers (code, integration, WTF, llm-checker, lazy-checker, nitpicker) converged on the
same finding: `APP_KEY`/`HANDLERS_URL` were declared inside the navigation test while
`renderHandlersTab` in `handlers-tab.test-helpers.ts` kept its own hardcoded `appKey: "test_app"`.
The two agreed only by convention, so the extraction named the literal without actually removing
the duplication — most tests received their app key from the helper, not from the constant, and a
future divergence would have surfaced as a failing URL assertion rather than a type error.

Fixed at the root: both constants are now exported from `handlers-tab.test-helpers.ts`, the helper
derives its `appKey` from `APP_KEY`, and the whole `handlers-tab.*.test.tsx` family (navigation,
job, listener, rendering) derives its wouter mock locations, `appKey` props, and store-event
`app_key` fixtures from them. `"test_app"` is now written exactly once in the directory.

Not changed: the two removed "loading guard" comments. Two reviewers noted the removal arguably
drops the *why* (empty arrays mean loading, not an empty state), but the deletion is explicitly
what #2033 asked for and the test title carries `(loading guard)`.

Verification: `npx vitest run src/components/app-detail/` — 291 passed / 18 files; `npx tsc
--noEmit` clean; `prek -a` all hooks passed.
