### PR TITLE
test: derive mobile-breakpoint trigger width from BREAKPOINT_MOBILE

### DIFF
--- a/frontend/src/components/app-detail/handlers-tab.rendering.test.tsx
+++ b/frontend/src/components/app-detail/handlers-tab.rendering.test.tsx
@@ -2,6 +2,7 @@ import { QueryClientProvider } from "@tanstack/react-query";
 import { act, render, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+import { BREAKPOINT_MOBILE } from "../../hooks/use-media-query";
 import { useAppStore } from "../../state/store";
 import { createListener } from "../../test/factories";
 import { createWouterMock } from "../../test/mock-wouter";
@@ -126,7 +127,7 @@ describe("HandlersTab rendering", () => {
     expect(observer?.element).toBeDefined();
 
     act(() => {
-      observer?.trigger(400); // narrower than BREAKPOINT_MOBILE (768)
+      observer?.trigger(BREAKPOINT_MOBILE - 1);
     });
 
     await waitFor(() => expect(getByTestId("back-to-list")).toBeDefined());


### PR DESCRIPTION
## Summary

The `HandlersTab` mobile-layout test triggered its resize observer with a hardcoded `400`
and restated the real breakpoint value in a trailing comment:

```tsx
observer?.trigger(400); // narrower than BREAKPOINT_MOBILE (768)
```

The component under test (`handlers-tab.tsx`) compares `entry.contentRect.width < BREAKPOINT_MOBILE`
against the exported constant in `src/hooks/use-media-query.ts`. This test file does not mock that
module, so it can simply import the constant — the comment was acting as a second source of truth
for a value that already lives in code.

That duplication is a silent-failure risk rather than a cosmetic one. If `BREAKPOINT_MOBILE` were
ever lowered below `400`, the comment would become wrong and the test would stop exercising the
mobile branch entirely. The `back-to-list` assertion would fail with nothing pointing at the magic
number as the cause.

## What changed

- Import `BREAKPOINT_MOBILE` from `../../hooks/use-media-query` in
  `frontend/src/components/app-detail/handlers-tab.rendering.test.tsx`
- Derive the trigger width as `BREAKPOINT_MOBILE - 1` instead of hardcoding `400`
- Drop the now-redundant `// narrower than BREAKPOINT_MOBILE (768)` comment

Test-only change — no production code or rendered output is touched, so this is typed `test:`
and stays out of the changelog.

## Testing

- `npx vitest run src/components/app-detail/handlers-tab.rendering.test.tsx` — 5 passed
- Full frontend suite: `npx vitest run` — 110 files, 1604 tests passed
- `uv run nox -s dev` — 7737 passed, 1 skipped, 2 xfailed
- `prek -a` — all hooks pass (ruff, eslint, tsc, stylelint, breakpoint-drift guard, house lints)
- `prek pyright -a --stage pre-push` — pass

The breakpoint-drift guard (`tools/frontend/check_breakpoint_drift.py`) still passes, confirming
the JS constant this test now imports remains in sync with the Tailwind screen registration in
`global.css`.

Closes #2035
