### PR TITLE
test: rename generic utils binding to result in health-strip render helper

### DIFF
--- a/frontend/src/components/app-detail/health-strip.test.tsx
+++ b/frontend/src/components/app-detail/health-strip.test.tsx
@@ -16,9 +16,9 @@ const COL_ERROR_RATE = 3;
 const COL_AVG_DURATION = 4;
 
 function renderStrip(listeners: ListenerData[] = [], jobs: JobData[] = []) {
-  const utils = render(<OverviewHealthStrip listeners={listeners} jobs={jobs} />);
-  const cards = utils.container.querySelectorAll(CELL_SELECTOR);
-  return { ...utils, cards };
+  const result = render(<OverviewHealthStrip listeners={listeners} jobs={jobs} />);
+  const cards = result.container.querySelectorAll(CELL_SELECTOR);
+  return { ...result, cards };
 }
 
 describe("OverviewHealthStrip", () => {


### PR DESCRIPTION
## Summary

Renames the `utils` binding to `result` in the `renderStrip` helper of
`frontend/src/components/app-detail/health-strip.test.tsx`.

`utils` said nothing about what it held — a Testing Library render result
(`container`, `getByTestId`, `rerender`, ...). It was also the only
`const utils = render(...)` in the frontend test suite; the two other render-result
bindings in `frontend/src/` already use `result`. This aligns the outlier with the
existing convention.

The change is purely local: the binding is read on the next two lines and never
escapes the helper. No production code, no test behavior, no assertions changed.

## Scope note

The scanner also flagged the relative imports at lines 4-5 (`../../api/endpoints`,
`../../test/factories`) as bypassing a `@/` path-alias convention. That finding was
assessed as invalid and deliberately not acted on: relative imports are the dominant
convention in the test suite (29 test files vs. 9 using `@/`), and every sibling in
`components/app-detail/` uses the relative form. Converting this one file would
increase inconsistency, not reduce it.

## Testing

- `npm run test -- health-strip` — 12 passed
- `uv run nox -s dev` — 7737 passed, 1 skipped, 2 xfailed
- `prek -a` — all 29 hooks passed
- `prek pyright -a --stage pre-push` — passed

Closes #2038
