### PR TITLE
test: name the app-key constants in the recent-activity-section rerender test

### DIFF
--- a/frontend/src/components/app-detail/recent-activity-section.rerender.test.tsx
+++ b/frontend/src/components/app-detail/recent-activity-section.rerender.test.tsx
@@ -14,6 +14,9 @@ import { RecentActivitySection } from "./recent-activity-section";
 
 type ActivityFeedEntry = components["schemas"]["ActivityFeedEntry"];
 
+const APP_KEY = "test_app";
+const OTHER_APP_KEY = "other_app";
+
 function makeExecution(appKey: string, kind: ExecutionKind): WsExecutionCompletedPayload {
   return createExecutionCompletedPayload({ kind, app_key: appKey });
 }
@@ -34,7 +37,7 @@ async function renderSettled() {
         counter.renders += 1;
       }}
     >
-      <RecentActivitySection appKey="test_app" resolvedInstanceIndex={0} />
+      <RecentActivitySection appKey={APP_KEY} resolvedInstanceIndex={0} />
     </Profiler>,
     { storeOverrides: { uptimeSeconds: 120 } },
   );
@@ -51,7 +54,7 @@ describe("RecentActivitySection store subscriptions", () => {
     act(() => {
       useAppStore
         .getState()
-        .setExecutionCompleted([makeExecution("other_app", "handler"), makeExecution("other_app", "job")]);
+        .setExecutionCompleted([makeExecution(OTHER_APP_KEY, "handler"), makeExecution(OTHER_APP_KEY, "job")]);
     });
 
     expect(counter.renders).toBe(before);
@@ -62,7 +65,7 @@ describe("RecentActivitySection store subscriptions", () => {
     const before = counter.renders;
 
     act(() => {
-      useAppStore.getState().setExecutionCompleted([makeExecution("test_app", kind)]);
+      useAppStore.getState().setExecutionCompleted([makeExecution(APP_KEY, kind)]);
     });
 
     await waitFor(() => expect(counter.renders).toBeGreaterThan(before));


### PR DESCRIPTION
## Summary

The `recent-activity-section.rerender.test.tsx` suite asserts two opposite things about
`RecentActivitySection`'s store selector: it must re-render when an execution arrives for
the app under test, and must *not* re-render when one arrives for a different app. That
equal/not-equal relationship was carried entirely by matching string literals at three
separate call sites, with nothing in the file stating the invariant.

The failure mode this closes is a silent one. Changing the `appKey` prop without also
changing the matching literal in the "re-renders on its own app" case would turn that test
into a tautology — it would assert that no re-render happens while claiming to assert that
one does, and it would still pass.

## What changed

Two module-scope constants now carry the relationship explicitly:

```ts
const APP_KEY = "test_app";
const OTHER_APP_KEY = "other_app";
```

All three call sites reference them — the `appKey` prop on the rendered component, the
matching-app execution, and the two unrelated-app executions. No behavior change; the same
strings reach the same places.

Scope note: this is deliberately limited to the one finding that survived validity
assessment in #2055. The other candidates raised by the quality scan (import grouping, the
`uptimeSeconds: 120` idiom, the MSW route string, `resolvedInstanceIndex`) were assessed and
excluded there — several are suite-wide idioms where a file-local constant would diverge
from sibling files rather than help.

## Testing

- `npx vitest run src/components/app-detail/recent-activity-section.rerender.test.tsx` — 3 passed
- `uv run nox -s dev` — 7737 passed, 1 skipped, 2 xfailed
- `prek -a` — all hooks passed (includes eslint, tsc, prettier for the frontend)
- `prek pyright -a --stage pre-push` — passed

No screenshots: the only changed file is a `*.test.tsx`, which `check_pr_screenshots.py`
excludes from the rendered-frontend visual evidence requirement.

Closes #2055
