### PR TITLE
refactor(frontend): decouple stat cell labels from lookup literals

### DIFF
--- a/frontend/src/components/app-detail/stat-cell-builders.ts
+++ b/frontend/src/components/app-detail/stat-cell-builders.ts
@@ -2,7 +2,10 @@ import { formatDurationOrDash, formatRate } from "../../utils/format";
 import type { DetailStatsCell } from "../shared/detail-stats";
 
 /** Number of fixed cells `buildCommonStatCells` always produces, before any conditional cells. */
-export const COMMON_STAT_CELL_COUNT = 5;
+const COMMON_STAT_CELL_COUNT = 5;
+
+const LABEL_TIMED_OUT = "Timed Out";
+const LABEL_CANCELLED = "Cancelled";
 
 export interface CommonStatInput {
   totalLabel: string;
@@ -21,37 +24,32 @@ export interface CommonStatInput {
    * Extra cell placed right after "Cancelled" if it renders, else right after
    * "Timed Out" if it renders, else at the start of the conditional zone.
    * Callers never compute this position themselves — the builder owns both
-   * the cell labels and the insertion point. Only `JobDetail`'s "Skipped"
-   * cell needs this today.
+   * the cell labels and the insertion point.
    */
   extraCell?: DetailStatsCell;
 }
 
-/** Index at which to splice `extraCell` into `cells`, per the rule documented on `CommonStatInput.extraCell`. */
 function resolveExtraCellIndex(cells: DetailStatsCell[]): number {
-  const cancelledIndex = cells.findIndex((cell) => cell.label === "Cancelled");
+  const cancelledIndex = cells.findIndex((cell) => cell.label === LABEL_CANCELLED);
   if (cancelledIndex >= 0) return cancelledIndex + 1;
 
-  const timedOutIndex = cells.findIndex((cell) => cell.label === "Timed Out");
+  const timedOutIndex = cells.findIndex((cell) => cell.label === LABEL_TIMED_OUT);
   if (timedOutIndex >= 0) return timedOutIndex + 1;
 
   return COMMON_STAT_CELL_COUNT;
 }
 
 export function buildCommonStatCells(input: CommonStatInput): DetailStatsCell[] {
+  const failedTone = input.failed > 0 ? "err" : undefined;
   const cells: DetailStatsCell[] = [
     { label: input.totalLabel, value: input.total },
-    { label: "Failed", value: input.failed, tone: input.failed > 0 ? "err" : undefined },
-    {
-      label: "Err %",
-      value: formatRate(input.failed, input.total),
-      tone: input.failed > 0 ? "err" : undefined,
-    },
+    { label: "Failed", value: input.failed, tone: failedTone },
+    { label: "Err %", value: formatRate(input.failed, input.total), tone: failedTone },
     { label: "Avg", value: formatDurationOrDash(input.avgDurationMs) },
     { label: input.lastFieldLabel ?? "Last", value: input.lastLabel },
   ];
-  if (input.timedOut > 0) cells.push({ label: "Timed Out", value: input.timedOut, tone: "warn" });
-  if (input.cancelled > 0) cells.push({ label: "Cancelled", value: input.cancelled, tone: "cancel" });
+  if (input.timedOut > 0) cells.push({ label: LABEL_TIMED_OUT, value: input.timedOut, tone: "warn" });
+  if (input.cancelled > 0) cells.push({ label: LABEL_CANCELLED, value: input.cancelled, tone: "cancel" });
   if (input.extraCell) cells.splice(resolveExtraCellIndex(cells), 0, input.extraCell);
   if (input.threadLeaked > 0) cells.push({ label: "Thread Leaked", value: input.threadLeaked, tone: "warn" });
   if (input.suppressedCount > 0) cells.push({ label: "Suppressed", value: input.suppressedCount, tone: "mute" });


### PR DESCRIPTION
## Summary

Removes the implicit coupling between the cell labels `buildCommonStatCells` writes and the label literals `resolveExtraCellIndex` searches for in `frontend/src/components/app-detail/stat-cell-builders.ts`.

`resolveExtraCellIndex` located the `extraCell` splice point by matching label text (`cell.label === "Cancelled"`), while `buildCommonStatCells` wrote those same strings independently. Nothing but naming discipline tied the two together: renaming a user-visible label at the construction site would make `findIndex` return `-1`, silently falling through to the `COMMON_STAT_CELL_COUNT` default and placing the extra cell in the wrong position — no compile error, no test failure.

## What changed

- **Hoisted `LABEL_TIMED_OUT` and `LABEL_CANCELLED` to module constants.** Each label now appears exactly once as a literal and is referenced by both the `findIndex` predicates and the `cells.push` calls, so the lookup and the construction site share one source of truth.
- **Computed the failed tone once.** `input.failed > 0 ? "err" : undefined` was duplicated across the "Failed" and "Err %" cells; it is now a single `failedTone` local reused by both. An "Err %" cell toned differently from its own "Failed" count would be a bug, and this makes the two structurally unable to diverge.
- **Un-exported `COMMON_STAT_CELL_COUNT`.** Its only reference anywhere in `frontend/src` was inside this same module — confirmed by grep across the repo and by a clean `tsc --noEmit` after the change.
- **Trimmed two decaying comments.** Dropped the `resolveExtraCellIndex` docstring (a pure back-reference to the interface JSDoc that restated what the six-line body already shows) and the "Only `JobDetail`'s 'Skipped' cell needs this today" sentence (a point-in-time usage claim that goes stale the moment a second caller passes `extraCell`). The genuinely non-obvious placement rule stays documented on `CommonStatInput.extraCell`, where callers read it.

No behavior change and no call sites touched — `job-detail.tsx` and `listener-detail.tsx` import only `buildCommonStatCells` and `CommonStatInput`, both unchanged.

Per the issue's "Considered and rejected" note, the repeated `"warn"` tone literal was deliberately left alone: `DetailStatsCell.tone` is typed as the closed `StatusKind` union, so a typo there is already a compile error. Extracting constants for a compile-checked union adds indirection without removing risk.

## Testing

- `stat-cell-builders.test.ts` passes unchanged (16/16) — the test file is not modified in this branch, which is what makes it a meaningful regression check on the refactor.
- Full frontend suite: 110 files, 1604 tests passed.
- `npm run typecheck` (`tsc --noEmit`): clean. This is what verifies the un-export broke no importer.
- `uv run nox -s dev`: 7737 passed, 1 skipped, 2 xfailed.
- `prek -a`: all 29 hooks passed; `prek pyright -a --stage pre-push`: passed.

No screenshots: this is a `.ts` logic module with no rendered output change, and the `pr-screenshots` guard scopes to `frontend/src/**/*.{tsx,css}`.

Closes #2065
