### PR TITLE
test: extract repeated RobotMode converter registration into a fixture

### DIFF
--- a/tests/unit/conversion/test_custom_conversion.py
+++ b/tests/unit/conversion/test_custom_conversion.py
@@ -59,6 +59,19 @@ class RobotState(BaseState[RobotMode | None]):
     value_type: ClassVar[type[Any] | tuple[type[Any], ...]] = (RobotMode, type(None))
 
 
+@pytest.fixture
+def robot_mode_converter(_isolate_type_registry: None) -> None:
+    """Register the plain ``str -> RobotMode`` converter for the duration of one test.
+
+    Opt-in rather than autouse: some tests need the converter absent, and others register
+    their own variant of it.
+    """
+
+    @register_type_converter_fn
+    def str_to_robot_mode(value: str) -> RobotMode:
+        return RobotMode(value.lower())
+
+
 class TestCustomStateWithAttributes:
     """Custom state models with typed AttributesBase subclasses."""
 
@@ -147,31 +160,19 @@ class TestCustomStateValueCoercion:
 class TestCustomEnumValueType:
     """Custom state model with a user-defined StrEnum value_type and registered converter."""
 
-    def test_custom_enum_coercion_via_model_validate(self) -> None:
-        @register_type_converter_fn
-        def str_to_robot_mode(value: str) -> RobotMode:
-            return RobotMode(value.lower())
-
+    def test_custom_enum_coercion_via_model_validate(self, robot_mode_converter: None) -> None:
         raw = make_state_dict("custom_robot_test.vacuum", "cleaning")
         state = RobotState.model_validate(raw)
         assert state.value == RobotMode.CLEANING
         assert isinstance(state.value, RobotMode)
 
-    def test_custom_enum_coercion_via_try_convert_state(self) -> None:
-        @register_type_converter_fn
-        def str_to_robot_mode(value: str) -> RobotMode:
-            return RobotMode(value.lower())
-
+    def test_custom_enum_coercion_via_try_convert_state(self, robot_mode_converter: None) -> None:
         raw = make_state_dict("custom_robot_test.vacuum", "idle")
         state = STATE_REGISTRY.try_convert_state(raw)
         assert type(state) is RobotState
         assert state.value == RobotMode.IDLE
 
-    def test_custom_enum_unknown_yields_none(self) -> None:
-        @register_type_converter_fn
-        def str_to_robot_mode(value: str) -> RobotMode:
-            return RobotMode(value.lower())
-
+    def test_custom_enum_unknown_yields_none(self, robot_mode_converter: None) -> None:
         raw = make_state_dict("custom_robot_test.vacuum", "unknown")
         state = STATE_REGISTRY.try_convert_state(raw)
         assert type(state) is RobotState
@@ -189,11 +190,7 @@ class TestCustomEnumValueType:
 class TestRegisterTypeConverterFn:
     """The @register_type_converter_fn decorator registers converters in TypeRegistry."""
 
-    def test_bare_decorator_registers_converter(self) -> None:
-        @register_type_converter_fn
-        def str_to_robot_mode(value: str) -> RobotMode:
-            return RobotMode(value.lower())
-
+    def test_bare_decorator_registers_converter(self, robot_mode_converter: None) -> None:
         result = TYPE_REGISTRY.convert("cleaning", RobotMode)
         assert result == RobotMode.CLEANING
 


### PR DESCRIPTION
## Summary

`tests/unit/conversion/test_custom_conversion.py` re-declared the same plain `str -> RobotMode`
converter verbatim inside four separate tests. This replaces those copies with a single opt-in
`robot_mode_converter` fixture.

The `_isolate_type_registry` autouse fixture already snapshots and restores
`TypeRegistry.conversion_map` around every test, so registration was the only per-test part left —
and it was identical each time.

## What changed

- Added a `robot_mode_converter` fixture that registers the plain `str -> RobotMode` converter for
  the duration of one test.
- Four tests now request the fixture instead of declaring the converter inline:
  `test_custom_enum_coercion_via_model_validate`, `test_custom_enum_coercion_via_try_convert_state`,
  `test_custom_enum_unknown_yields_none`, and `test_bare_decorator_registers_converter`.

Net: 17 insertions, 20 deletions in one test file. No source changes.

## Why the fixture is opt-in, not autouse

Three tests deliberately depend on the converter being absent or on registering their own variant,
so they keep their existing local behavior:

- `test_without_converter_uses_constructor_fallback` — asserts `(str, RobotMode)` is *not* in
  `TypeRegistry.conversion_map`; an autouse fixture would break it.
- `test_decorator_with_error_message` — registers the same converter with an `error_message=`
  argument.
- `test_converter_is_used_by_state_pipeline` — registers a call-recording variant that appends to a
  local list.

Folding those into the shared fixture would erase the distinction each one is testing.

## Testing

- `uv run pytest tests/unit/conversion/test_custom_conversion.py` — 21 passed, including
  `test_without_converter_uses_constructor_fallback`.
- `uv run nox -s dev` — 7741 passed, 1 skipped, 2 xfailed, 0 failures.
- `prek -a` — all hooks pass; `prek pyright -a --stage pre-push` passes.
- `uv run python tools/check_duplicate_code.py` — no longer reports any
  `test_custom_conversion.py` cluster (the tool's remaining output is the pre-existing baseline
  backlog unrelated to this change).

Closes #2091
