### PR TITLE
test: extract shared per-app-key lock assertion in AppLifecycleService tests

### DIFF
--- a/tests/unit/core/CLAUDE.md
+++ b/tests/unit/core/CLAUDE.md
@@ -17,6 +17,7 @@ Fixtures below are defined in family-scoped `_fixtures_*.py` modules in this dir
 ## Shared helpers and constants (module-level, not fixtures)
 
 - `assert_load_completed_count(event_capture, expected)` — assert how many `APP_LOAD_COMPLETED` broadcasts fired (the signal a connected dashboard refetches on)
+- `assert_acquires_app_key_lock_once(lifecycle_service, app_key, operation)` — await `operation()` and assert it took the per-app-key lock exactly once and released it; the internal `asyncio.wait_for` turns a non-reentrant-lock deadlock into a test failure instead of a hung run
 - `stub_detected_changes(lifecycle_service, changes)` — make `detect_changes` report `changes` and stub `apply_changes`, for tests of `handle_change_event`'s own apply/defer/broadcast decisions
 - `set_registry_apps(registry, apps)` — configures a `mock_registry`'s `__contains__`, `app_keys()`, `get_running_apps()`, and `get()` from an `apps`-shaped dict (`dict[str, dict[int, App]]`); use instead of assigning `mock_registry.apps = ...` directly (that attribute no longer exists on the real `AppRegistry`)
 - `make_manifest_obj(app_key, **kw)` — `SimpleNamespace` AppManifest stand-in for `AppRegistry` tests; shared by `test_app_registry.py` and `test_app_registry_snapshot.py`

--- a/tests/unit/core/_fixtures_app_lifecycle.py
+++ b/tests/unit/core/_fixtures_app_lifecycle.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import logging
+from collections.abc import Awaitable, Callable
 from pathlib import Path
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, Mock, patch
@@ -81,6 +82,30 @@ def assert_load_completed_count(event_capture: EventCapture, expected: int) -> N
     """
     completed = event_capture.by_topic(Topic.HASSETTE_EVENT_APP_LOAD_COMPLETED)
     assert len(completed) == expected, f"expected {expected} APP_LOAD_COMPLETED event(s), got {len(completed)}"
+
+
+async def assert_acquires_app_key_lock_once(
+    lifecycle_service: AppLifecycleService,
+    app_key: str,
+    operation: Callable[[], Awaitable[Any]],
+) -> None:
+    """Run `operation` and assert it acquired `app_key`'s lock exactly once, then released it.
+
+    Every public lifecycle entry point that touches one app_key must take that key's lock once
+    for its whole sequence rather than delegating to another public, lock-acquiring method
+    partway through. Doing the latter would hang forever on the non-reentrant `asyncio.Lock`,
+    so the `wait_for` here is load-bearing: it turns that deadlock into a test failure instead
+    of a stuck test run.
+
+    Per-operation mock setup stays in the calling test -- only the lock assertion is shared.
+    """
+    lock = lifecycle_service._get_app_key_lock(app_key)
+    lock.acquire = AsyncMock(wraps=lock.acquire)  # pyright: ignore[reportAttributeAccessIssue]
+
+    await asyncio.wait_for(operation(), timeout=1)
+
+    assert lock.acquire.call_count == 1
+    assert not lock.locked()
 
 
 def stub_detected_changes(lifecycle_service: AppLifecycleService, changes: ChangeSet) -> None:

--- a/tests/unit/core/conftest.py
+++ b/tests/unit/core/conftest.py
@@ -9,6 +9,7 @@ working unchanged. See tests/unit/core/CLAUDE.md for the fixture inventory.
 from ._fixtures_app_lifecycle import (
     app_handler,
     app_handler_mock_hassette,
+    assert_acquires_app_key_lock_once,
     assert_load_completed_count,
     lifecycle_service,
     make_mock_app_instance,
@@ -62,6 +63,7 @@ __all__ = [
     "TempService",
     "app_handler",
     "app_handler_mock_hassette",
+    "assert_acquires_app_key_lock_once",
     "assert_job_count",
     "assert_listener_count",
     "assert_load_completed_count",

--- a/tests/unit/core/test_app_lifecycle_service_per_instance_ops.py
+++ b/tests/unit/core/test_app_lifecycle_service_per_instance_ops.py
@@ -16,6 +16,8 @@ from hassette.testing import EventCapture, wait_for
 from hassette.types import Topic
 from hassette.types.enums import ResourceStatus
 
+from .conftest import assert_acquires_app_key_lock_once
+
 
 class TestReloadInstanceEvents:
     async def test_reload_instance_emits_state_event_scoped_to_failed_index(
@@ -326,14 +328,11 @@ class TestPerInstanceLifecycleLocking:
         mock_manifest.app_config = [{"instance_name": "a"}]
         mock_registry.get_manifest = Mock(return_value=mock_manifest)
 
-        lock = lifecycle_service._get_app_key_lock("test_app")
-        lock.acquire = AsyncMock(wraps=lock.acquire)
         lifecycle_service._reload_instance_unlocked = AsyncMock()  # pyright: ignore[reportAttributeAccessIssue]
 
-        await asyncio.wait_for(lifecycle_service.reload_instance("test_app", 0), timeout=1)
-
-        assert lock.acquire.call_count == 1
-        assert not lock.locked()
+        await assert_acquires_app_key_lock_once(
+            lifecycle_service, "test_app", lambda: lifecycle_service.reload_instance("test_app", 0)
+        )
 
     async def test_stop_instance_acquires_app_key_lock_once(
         self,
@@ -347,13 +346,9 @@ class TestPerInstanceLifecycleLocking:
         mock_registry.unregister_app = Mock(return_value=None)
         mock_registry.get_failed_instance_infos = Mock(return_value={})
 
-        lock = lifecycle_service._get_app_key_lock("test_app")
-        lock.acquire = AsyncMock(wraps=lock.acquire)
-
-        await asyncio.wait_for(lifecycle_service.stop_instance("test_app", 0), timeout=1)
-
-        assert lock.acquire.call_count == 1
-        assert not lock.locked()
+        await assert_acquires_app_key_lock_once(
+            lifecycle_service, "test_app", lambda: lifecycle_service.stop_instance("test_app", 0)
+        )
 
     async def test_start_instance_acquires_app_key_lock_once(
         self,
@@ -370,13 +365,9 @@ class TestPerInstanceLifecycleLocking:
         mock_factory.get_load_error = Mock(return_value=ValueError("boom"))
         mock_registry.get_failed_instance_infos = Mock(return_value={})
 
-        lock = lifecycle_service._get_app_key_lock("test_app")
-        lock.acquire = AsyncMock(wraps=lock.acquire)
-
-        await asyncio.wait_for(lifecycle_service.start_instance("test_app", 0), timeout=1)
-
-        assert lock.acquire.call_count == 1
-        assert not lock.locked()
+        await assert_acquires_app_key_lock_once(
+            lifecycle_service, "test_app", lambda: lifecycle_service.start_instance("test_app", 0)
+        )
 
     async def test_reload_instance_serializes_with_concurrent_reload_app(
         self,

--- a/tests/unit/core/test_app_lifecycle_service_reload.py
+++ b/tests/unit/core/test_app_lifecycle_service_reload.py
@@ -14,7 +14,7 @@ from hassette.exceptions import AppBlockedError, AppBootstrapNotReleasedError
 from hassette.testing import wait_for
 from tests.support.factories import make_change_set
 
-from .conftest import set_registry_apps
+from .conftest import assert_acquires_app_key_lock_once, set_registry_apps
 
 
 class TestApplyChanges:
@@ -146,20 +146,16 @@ class TestReloadAppLocking:
         sequence, rather than each half separately acquiring it. This is a deadlock guard: if
         reload_app instead called the public, lock-acquiring stop_app()/start_app() from
         inside its own lock acquisition, the second acquire would hang forever on the
-        non-reentrant asyncio.Lock — asyncio.wait_for below turns that hang into a test
-        failure instead of a stuck test run.
+        non-reentrant asyncio.Lock — the helper's asyncio.wait_for turns that hang into a
+        test failure instead of a stuck test run.
         """
         mock_registry.unregister_app = Mock(return_value=None)
         mock_registry.get_manifest = Mock(return_value=mock_manifest)
         mock_registry.get_running_apps = Mock(return_value={})
 
-        lock = lifecycle_service._get_app_key_lock("test_app")
-        lock.acquire = AsyncMock(wraps=lock.acquire)
-
-        await asyncio.wait_for(lifecycle_service.reload_app("test_app"), timeout=1)
-
-        assert lock.acquire.call_count == 1
-        assert not lock.locked()
+        await assert_acquires_app_key_lock_once(
+            lifecycle_service, "test_app", lambda: lifecycle_service.reload_app("test_app")
+        )
 
     async def test_concurrent_reload_app_calls_serialize_the_whole_stop_and_start_pair(
         self,


### PR DESCRIPTION
## Summary

The "this operation acquires the per-app-key lock exactly once" assertion was copy-pasted across
four `AppLifecycleService` locking tests. Every copy did the same four things: grab the lock via
`_get_app_key_lock()`, wrap `lock.acquire` in an `AsyncMock`, run the operation under
`asyncio.wait_for(..., timeout=1)`, then assert `call_count == 1` and `not lock.locked()`.

That `wait_for` wrapper is load-bearing rather than incidental. Every public lifecycle entry point
that touches one `app_key` must take that key's lock once for its whole sequence instead of
delegating to another public, lock-acquiring method partway through — doing the latter deadlocks
forever on the non-reentrant `asyncio.Lock`. The timeout is what converts that deadlock into a test
failure instead of a hung run, and it is exactly the kind of detail that silently drifts when it
lives in four places.

This extracts the shared shape into `assert_acquires_app_key_lock_once(lifecycle_service, app_key,
operation)` in `tests/unit/core/_fixtures_app_lifecycle.py`, alongside the existing lifecycle-test
helpers (`assert_load_completed_count`, `set_registry_apps`, `stub_detected_changes`), so no new
module was needed.

## What changed

- **New helper** in `_fixtures_app_lifecycle.py`, re-exported through `tests/unit/core/conftest.py`.
  Its docstring explains why the `wait_for` guard exists, so the rationale now lives in one place
  instead of being restated (or lost) per copy.
- **Four call sites migrated** — `reload_instance`, `stop_instance`, `start_instance`
  (`test_app_lifecycle_service_per_instance_ops.py`) and `reload_app`
  (`test_app_lifecycle_service_reload.py`). PMD/CPD flagged three of these; the fourth
  (`reload_instance`) was the same shape and was folded in too.
- **Per-operation mock setup stays in each test.** Only the lock assertion is shared, so a failure
  still points at the specific lifecycle method under test.
- **Fixture inventory updated** in `tests/unit/core/CLAUDE.md`.

Test-only refactor — no production code is touched.

## Out of scope

A related-but-distinct sibling pattern exists — the "second caller is queued and blocked on the
app-key lock" concurrency assertion that reaches into `asyncio.Lock._waiters`. It appears three
more times, but it asserts something different from the one flagged here and did not fall out
naturally from this extraction, so it is deliberately left alone per the issue's guidance.

## Testing

- `uv run nox -s dev` — **7741 passed**, 1 skipped, 2 xfailed
- `prek -a` — all 29 hooks pass
- `prek pyright -a --stage pre-push` — passes
- Verified no inline copies of the extracted assertion remain: the only surviving
  `_get_app_key_lock` call sites are the three sibling-pattern assertions noted above.

Closes #2093
