### PR TITLE
test: tighten alert-banner assertions and drop redundant store overrides

### DIFF
--- a/frontend/src/components/layout/alert-banner.test.tsx
+++ b/frontend/src/components/layout/alert-banner.test.tsx
@@ -49,7 +49,7 @@ describe("AlertBanner", () => {
 
   it("does not render error span when error_message is null", () => {
     const { container } = render(<AlertBanner failedApps={[{ app_key: "my_app", error_message: null }]} />);
-    expect(container.textContent).not.toContain(" — ");
+    expect(container.querySelector("li span")).toBeNull();
   });
 
   it("renders all failed apps in the list", () => {
@@ -73,14 +73,14 @@ describe("AlertBanner", () => {
 describe("TelemetryDegradedBanner", () => {
   it("renders nothing when telemetryDegraded is false", () => {
     const { container } = renderWithAppState(<TelemetryDegradedBanner />, {
-      storeOverrides: { telemetryDegraded: false, droppedOverflow: 0, droppedExhausted: 0 },
+      storeOverrides: { telemetryDegraded: false },
     });
     expect(container.firstChild).toBeNull();
   });
 
   it("renders banner when telemetryDegraded is true", () => {
     const { getByTestId } = renderWithAppState(<TelemetryDegradedBanner />, {
-      storeOverrides: { telemetryDegraded: true, droppedOverflow: 0, droppedExhausted: 0 },
+      storeOverrides: { telemetryDegraded: true },
     });
     expect(getByTestId("telemetry-degraded-banner")).toBeDefined();
   });
@@ -94,7 +94,7 @@ describe("TelemetryDegradedBanner", () => {
 
   it("has role=alert for screen reader announcement", () => {
     const { container } = renderWithAppState(<TelemetryDegradedBanner />, {
-      storeOverrides: { telemetryDegraded: true, droppedOverflow: 0, droppedExhausted: 0 },
+      storeOverrides: { telemetryDegraded: true },
     });
     const banner = container.querySelector("[role='alert']");
     expect(banner).not.toBeNull();


### PR DESCRIPTION
## Summary

Two hygiene fixes in `frontend/src/components/layout/alert-banner.test.tsx`, both surfaced by the quality scanner's style/hygiene pass. Test-only change — `alert-banner.tsx` is untouched.

### 1. Removed `storeOverrides` values that only restate store defaults

Three of the four `TelemetryDegradedBanner` tests passed `droppedOverflow: 0, droppedExhausted: 0` without ever varying them. `createInitialState` (`frontend/src/state/store.ts:153-154`) already sets both to `0`, and `frontend/src/test-setup.ts:77` resets the store to that initial state in an `afterEach`, so the overrides were no-ops that obscured which field each test actually exercises.

They're now kept only in the drop-count test, where `10` / `5` are the point of the assertion. `telemetryDegraded` stays explicit in all four tests since that flag is the axis each one varies. This also brings the file in line with the sibling convention in `status-bar.test.tsx`, which overrides only the field under test.

### 2. Asserted the error span's absence structurally instead of by separator string

`does not render error span when error_message is null` asserted `container.textContent` did not contain `" — "` — the component's cosmetic separator, not the thing the test name claims to check. Restyling that separator (to `": "`, a different dash, or markup placing the dash outside the text node) would keep the test green while the real regression — the error span rendering for a null `error_message` — went undetected.

It now asserts `container.querySelector("li span")` is `null`. `AppLink` renders only a wouter `<Link>` (an `<a>`, no span), so the error span is the only `span` inside the `li`, making the query an exact structural check for the span's absence.

## Testing

- `npx vitest run src/components/layout/alert-banner.test.tsx` — 11 passed
- `uv run nox -s dev` — 7741 passed, 1 skipped, 2 xfailed
- `prek -a` — all hooks pass
- `prek pyright -a --stage pre-push` — pass

Verified the two load-bearing assumptions directly rather than taking them from the issue: `app-link.tsx` renders a bare `Link`/`<a>` with no `span`, and `test-setup.ts` resets the store to `initialState()` between tests.

No visual evidence needed — `check_pr_screenshots.py` excludes `*.test.tsx` from the rendered-frontend gate, and no rendered files changed.

Closes #2095
