### PR TITLE
test: reset vi.spyOn state between tests in palette-items.test.ts

### DIFF
--- a/frontend/src/components/layout/palette-items.test.ts
+++ b/frontend/src/components/layout/palette-items.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import * as endpoints from "../../api/endpoints";
 import type { AppStatusEntry } from "../../state/store";
@@ -6,6 +6,13 @@ import { createInstance, createManifest } from "../../test/factories";
 import { buildActionItems, buildAppItems } from "./palette-items";
 
 const NO_LIVE_STATUSES: Record<string, AppStatusEntry> = {};
+
+// vitest.config.ts sets neither clearMocks nor restoreMocks, so spies on the endpoints
+// namespace keep their call history across tests. Without this reset, the
+// not.toHaveBeenCalledWith assertions below pass or fail on earlier tests' calls.
+afterEach(() => {
+  vi.restoreAllMocks();
+});
 
 describe("buildAppItems", () => {
   it("includes apps that are in the current config", () => {


### PR DESCRIPTION
## Summary

The four `buildActionItems` tests in `frontend/src/components/layout/palette-items.test.ts` each call `vi.spyOn(endpoints, "reloadApp" | "stopApp")`, but nothing ever resets them. `frontend/vitest.config.ts` sets neither `clearMocks` nor `restoreMocks`, and the global `afterEach` in `src/test-setup.ts` only resets MSW handlers, localStorage, and the Zustand store — it never touches mocks. Spy call history therefore accumulated across every test in the file.

All 10 tests passed before this change, so this was latent fragility rather than a live failure. The exposure is in the negative assertions:

- `expect(endpoints.stopApp).not.toHaveBeenCalledWith("running_app")`
- `expect(endpoints.stopApp).not.toHaveBeenCalledWith("recovered_app")`

Those only held because no earlier test in the file happened to stop an app under those keys. Adding or reordering a test that does would fail them with no production regression behind it — and, in the other direction, a positive `toHaveBeenCalledWith` in a new test could pass on a *prior* test's recorded call, silently masking a real regression in `buildActionItems`' live-status derivation.

## What changed

Added a file-level `afterEach(() => vi.restoreAllMocks())`, matching the pattern already used in `utils/local-storage.test.ts` and the guidance in `test/render-helpers.tsx`.

`restoreAllMocks` rather than `clearAllMocks`: the former also unpatches the `endpoints` module namespace and drops the `mockResolvedValue` implementations, instead of leaving a permanently-mocked export in place for the rest of the file.

Test-only change — no production code touched.

## Testing

**The fix is load-bearing.** Since all tests passed both before and after, a plain re-run proves nothing on its own. To get real evidence, I built two throwaway probe files — one from the pre-fix file at `origin/main`, one from the post-fix file — each with an identical extra test injected ahead of the stop-failing test, stopping an app keyed `running_app` (exactly the failure scenario the issue describes):

| Probe | Result |
|---|---|
| pre-fix + injected test | **1 failed** \| 10 passed — `AssertionError: expected "stopApp" to not be called with arguments: [ 'running_app' ]` at the unrelated `not.toHaveBeenCalledWith` assertion |
| post-fix + injected test | 11 passed |

Both probe files were deleted afterwards; the working tree is clean.

Also run:

- `npx vitest run src/components/layout/palette-items.test.ts` — 10/10 passed
- Same file with `--sequence.shuffle`, 3 runs — 10/10 each time (order-independent). Note the pre-fix file also survives shuffling on its own, since none of the *existing* tests stop `running_app` or `recovered_app`; shuffling alone does not distinguish the two versions, which is why the injected-test probe above is the actual evidence.
- Full frontend suite — 110 files, 1604 tests passed
- `uv run nox -s dev` — 7747 passed, 1 skipped, 2 xfailed
- `prek -a` — all hooks passed; `prek pyright -a --stage pre-push` — passed

## Acceptance criteria

- [x] File resets spy state between tests via `vi.restoreAllMocks()` in an `afterEach`
- [x] All 10 tests in the file still pass
- [x] Reordering the `buildActionItems` tests does not change pass/fail outcomes

Closes #2102
