### PR TITLE
refactor: name the healthy sidebar group key and clarify group-def callback names

### DIFF
--- a/frontend/src/components/layout/sidebar-groups.ts
+++ b/frontend/src/components/layout/sidebar-groups.ts
@@ -6,6 +6,8 @@ type AppManifest = components["schemas"]["AppManifestResponse"];
 
 export type GroupKey = "err" | "blocked" | "warn" | "ok" | "stopped" | "disabled";
 
+export const HEALTHY_GROUP_KEY: GroupKey = "ok";
+
 export interface GroupDef {
   key: GroupKey;
   label: string;
@@ -17,7 +19,7 @@ export const GROUP_DEFS: GroupDef[] = [
   { key: "err", label: "FAILING", tone: "err", defaultOpen: true },
   { key: "blocked", label: "BLOCKED", tone: "err", defaultOpen: true },
   { key: "warn", label: "SLOW", tone: "warn", defaultOpen: true },
-  { key: "ok", label: "RUNNING", tone: "ok", defaultOpen: false },
+  { key: HEALTHY_GROUP_KEY, label: "RUNNING", tone: "ok", defaultOpen: false },
   { key: "stopped", label: "STOPPED", tone: "mute", defaultOpen: true },
   { key: "disabled", label: "DISABLED", tone: "mute", defaultOpen: false },
 ];
@@ -30,7 +32,7 @@ export interface GroupedApps {
 }
 
 export function groupAndSortApps(manifests: AppManifest[], appStatuses: Record<string, AppStatusEntry>): GroupedApps {
-  const groups = new Map<GroupKey, AppManifest[]>(GROUP_DEFS.map((g) => [g.key, []]));
+  const groups = new Map<GroupKey, AppManifest[]>(GROUP_DEFS.map((def) => [def.key, []]));
   for (const m of manifests) {
     const key = getGroupKey(m, appStatuses);
     groups.get(key)!.push(m);
@@ -59,5 +61,5 @@ export function getGroupKey(manifest: AppManifest, appStatuses: Record<string, A
   if (WARN_STATUSES.has(status)) return "warn";
   if (status === "stopped" || status === "not_started") return "stopped";
   // "running", "starting", and any unknown status map to the healthy group
-  return "ok";
+  return HEALTHY_GROUP_KEY;
 }

--- a/frontend/src/components/layout/use-group-open.ts
+++ b/frontend/src/components/layout/use-group-open.ts
@@ -1,16 +1,16 @@
 import { useState } from "react";
 
-import { GROUP_DEFS, type GroupKey } from "./sidebar-groups";
+import { GROUP_DEFS, type GroupKey, HEALTHY_GROUP_KEY } from "./sidebar-groups";
 
 const DEFAULT_GROUP_OPEN: Record<GroupKey, boolean> = Object.fromEntries(
-  GROUP_DEFS.map((g) => [g.key, g.defaultOpen]),
+  GROUP_DEFS.map((def) => [def.key, def.defaultOpen]),
 ) as Record<GroupKey, boolean>;
 
 export function useGroupOpen(allHealthy: boolean) {
   const [groupOpen, setGroupOpen] = useState<Record<GroupKey, boolean>>(DEFAULT_GROUP_OPEN);
 
   function isOpen(key: GroupKey): boolean {
-    if (key === "ok" && allHealthy) return true;
+    if (key === HEALTHY_GROUP_KEY && allHealthy) return true;
     return groupOpen[key];
   }
 


### PR DESCRIPTION
## Summary

Addresses both nitpicker findings from the quality scan in #2124. There is no change in behavior.

- **Named the healthy sidebar group.** `sidebar-groups.ts` now exports `HEALTHY_GROUP_KEY: GroupKey = "ok"`. The `GROUP_DEFS` entry, the fallback return in `getGroupKey`, and the `allHealthy` auto-open check in `useGroupOpen` all use it. Before, the rule "`allHealthy` force-opens the `ok` group" was an unexplained `"ok"` literal, and a reader had to open both files to see the connection.
- **Renamed the single-letter callbacks.** In both `GROUP_DEFS.map(...)` callbacks (`sidebar-groups.ts` and `use-group-open.ts`), `g` is now `def`. This also settles an existing inconsistency: `sidebar.tsx` already used `def` for the same iteration.

The only `"ok"` literals left in these files are the `GroupKey` union that declares the value, the constant's own definition, and the unrelated `tone` union.

## Testing

- `npx tsc --noEmit`: clean
- `npm run build`: succeeds
- `npx vitest run src/components/layout`: 7 files, 107 tests passed, including `sidebar-groups.test.ts`

`sidebar-groups.test.ts` is deliberately left unchanged, still asserting the raw `"ok"` literal rather than importing the new constant. The test is the pin on that constant's value — importing it would make the assertion self-referential and stop it catching a change. The other five group keys are asserted as literals there too, so this also keeps the file internally consistent. #2124's acceptance criteria call for the suite to pass unchanged.

## Note on the earlier draft status

This PR was originally opened as a draft because `tsc (frontend)` failed on an unrelated `main` breakage (`COMMON_STAT_CELL_COUNT` not exported from `stat-cell-builders.ts`). That was fixed on `main` by #2189, which is merged into this branch. `tsc` now passes.

Closes #2124
