### PR TITLE
test: split alert-shell tone test into one render per tone

### DIFF
--- a/frontend/src/components/shared/alert-shell.test.tsx
+++ b/frontend/src/components/shared/alert-shell.test.tsx
@@ -15,19 +15,22 @@ describe("AlertShell", () => {
     expect(el.className).toContain("rounded-md");
   });
 
-  it("applies tone-specific background tokens", () => {
-    const { getByTestId: getDanger } = render(
-      <AlertShell tone="danger" data-testid="danger">
+  it("applies the danger background token", () => {
+    const { getByTestId } = render(
+      <AlertShell tone="danger" data-testid="b">
         x
       </AlertShell>,
     );
-    const { getByTestId: getWarning } = render(
-      <AlertShell tone="warning" data-testid="warning">
+    expect(getByTestId("b").className).toContain("bg-[var(--destructive-bg)]");
+  });
+
+  it("applies the warning background token", () => {
+    const { getByTestId } = render(
+      <AlertShell tone="warning" data-testid="b">
         x
       </AlertShell>,
     );
-    expect(getDanger("danger").className).toContain("bg-[var(--destructive-bg)]");
-    expect(getWarning("warning").className).toContain("bg-[var(--status-warning-bg)]");
+    expect(getByTestId("b").className).toContain("bg-[var(--status-warning-bg)]");
   });
 
   it("forwards role and extra classes", () => {


### PR DESCRIPTION
## Summary

Splits the bundled `it("applies tone-specific background tokens")` block in `frontend/src/components/shared/alert-shell.test.tsx` into two tests, one per tone. Each now renders once and uses a single `getByTestId`:

- `applies the danger background token`: asserts `bg-[var(--destructive-bg)]`
- `applies the warning background token`: asserts `bg-[var(--status-warning-bg)]`

This drops the aliased `getByTestId: getDanger` / `getByTestId: getWarning` destructuring and the one-off semantic test ids (`"danger"`, `"warning"`). Every block in the file now has the same shape and uses the same `data-testid="b"`, matching `badge.test.tsx` and `card.test.tsx`. When a tone breaks, the failing test's name now says which one.

The change is limited to this test file. No production code changes.

## Testing

- `npx vitest run src/components/shared/alert-shell.test.tsx`: 4/4 passed (the file had 3 tests before the split)
- prettier and eslint pre-commit hooks passed

`uv run nox -s dev` was not run, since this change touches no Python.

## Note on the earlier `tsc` failure

An earlier revision of this branch was blocked by a pre-existing `tsc` error on `main`
(`COMMON_STAT_CELL_COUNT` was not exported from `stat-cell-builders.ts`). That has since been
fixed on `main` and merged into this branch; the `frontend` check passes.

Closes #2130
