### PR TITLE
fix(frontend): export COMMON_STAT_CELL_COUNT from stat-cell-builders

### DIFF
--- a/frontend/src/components/app-detail/stat-cell-builders.ts
+++ b/frontend/src/components/app-detail/stat-cell-builders.ts
@@ -2,7 +2,7 @@ import { formatDurationOrDash, formatRate } from "../../utils/format";
 import type { DetailStatsCell } from "../shared/detail-stats";
 
 /** Number of fixed cells `buildCommonStatCells` always produces, before any conditional cells. */
-const COMMON_STAT_CELL_COUNT = 5;
+export const COMMON_STAT_CELL_COUNT = 5;
 
 const LABEL_TIMED_OUT = "Timed Out";
 const LABEL_CANCELLED = "Cancelled";


### PR DESCRIPTION
## Summary

`frontend/src/components/app-detail/stat-cell-builders.ts` declared `const COMMON_STAT_CELL_COUNT = 5;` without exporting it, while `stat-cell-builders.test.ts` imports it as a named export to slice the fixed-cell boundary out of `buildCommonStatCells`'s return value. This has been a `tsc (frontend)` failure on `main` since the interaction of #2139 (test started importing the constant) and #2142 (the export was removed) — and since that check isn't scoped to a PR's own diff, it's now failing for every subsequent PR that touches the frontend at all, regardless of what they actually changed. Several autofix PRs (#2181, #2183, #2184) have had to ship as drafts because of this one unrelated failure.

Fix: add `export` to the one const declaration. No other changes.

## Testing

- `npx tsc --noEmit`: passes clean (previously failed with `TS2459: Module declares 'COMMON_STAT_CELL_COUNT' locally, but it is not exported`)
- `npx vitest run src/components/app-detail/stat-cell-builders.test.ts`: 16/16 passed
- `prek run --group frontend --files frontend/src/components/app-detail/stat-cell-builders.ts`: all hooks pass, including `tsc (frontend)`

Checked for other unexported symbols in the file that might be needed elsewhere (`LABEL_TIMED_OUT`, `LABEL_CANCELLED`, `resolveExtraCellIndex`) — none are referenced outside this module, so no further exports are needed.
