### PR TITLE
test: move stranded AppLink import into the import block in app-link tests

### DIFF
--- a/frontend/src/components/shared/app-link.test.tsx
+++ b/frontend/src/components/shared/app-link.test.tsx
@@ -2,10 +2,9 @@ import { render } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 
 import { createWouterMock } from "../../test/mock-wouter";
+import { AppLink } from "./app-link";
 
 vi.mock("wouter", () => createWouterMock());
-
-import { AppLink } from "./app-link";
 
 describe("AppLink — basic href", () => {
   it("renders a link to /apps/:key with no extras", () => {


### PR DESCRIPTION
## Summary

Moves the `AppLink` import in `frontend/src/components/shared/app-link.test.tsx` up into the import block, so `vi.mock("wouter", () => createWouterMock())` is the first statement after the imports. This matches `pages/apps-table-row.test.tsx` and most of the other `createWouterMock` test files.

The old split layout guards against a hazard that can't happen in this file. `createWouterMock`'s docstring says a top-level import of the component under test is only unsafe when it can sort before `../test/mock-wouter`. That only happens when both imports are at the same relative depth. Here, `../../test/mock-wouter` is parent-relative and `./app-link` is in the same directory, so the mock helper always sorts first.

This is a test-only change with no runtime behavior change.

## Testing

- `npx vitest run src/components/shared/app-link.test.tsx`: 9/9 passed. No "Cannot access before initialization" error, which confirms the import order is safe.
- `npx vitest run` (full frontend suite): 1604/1604 passed across 110 files.
- `npx eslint src/components/shared/app-link.test.tsx`: clean. The import sorter accepts the new order.
- `npx tsc --noEmit`: clean. The `COMMON_STAT_CELL_COUNT` type error that this branch originally hit was a `main` problem, fixed by #2189 and picked up here by merging `main`.
- `uv run nox -s dev` was not run. It covers the Python suite, and this PR touches no Python.

The `duplicate-code` and `file-sizes` lint jobs report FAILURE, as they do on `main`. Both run with `continue-on-error` and track a pre-existing backlog; neither is affected by this diff.

## Follow-up

`frontend/src/components/shared/log-table/log-table-view.test.tsx` has the same unexplained split and was out of scope for this change. Filed as #2194.

Closes #2134
