### PR TITLE
feat: add CI flake scanner for recurring test failures

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -19,6 +19,15 @@ Operational scripts for building, running, and demoing hassette.
 - **`release_contributors.py`** — find external contributors between two git
   tags. Filters bots and repo owner, resolves GitHub usernames from noreply
   emails. Used by the `changelog-review` command during release prep.
+- **`ci_flake_scan.py`** — scan recent GitHub Actions runs (`Tests`, `E2E Tests`
+  by default) for recurring pytest failures, separating real flaky tests from
+  GitHub Actions infra noise (network hiccups, artifact-permission errors).
+  Cross-references `known_flakes.yaml` so already-tracked flakes are reported
+  as known rather than resurfacing every scan. `--days N` to change the
+  lookback window, `--workflow` (repeatable) to scope to specific workflows.
+- **`known_flakes.yaml`** — registry of already-tracked flaky tests, read by
+  `ci_flake_scan.py`. Add an entry after filing an issue for a newly
+  discovered flake.
 - **`docker_start.sh`** — Docker container entrypoint.
 - **`docker/`** — Docker Compose configs for demo/test environments
   (`ha-demo.yml` defines the HA + hassette + Vite demo stack;

--- a/scripts/ci_flake_scan.py
+++ b/scripts/ci_flake_scan.py
@@ -1,0 +1,244 @@
+#!/usr/bin/env python3
+"""Scan recent CI runs for recurring test failures (flaky tests).
+
+Usage:
+    uv run python scripts/ci_flake_scan.py
+    uv run python scripts/ci_flake_scan.py --days 14
+    uv run python scripts/ci_flake_scan.py --workflow Tests --workflow "E2E Tests"
+
+Pulls failed GitHub Actions runs for the given workflow(s) over the lookback
+window, downloads each failed job's log, and extracts pytest FAILED lines.
+Failures are grouped by test id; anything appearing 2+ times across
+independent runs is flagged as recurring and worth a look. Already-tracked
+flakes are read from scripts/known_flakes.yaml so they're reported as known
+instead of resurfacing every scan.
+
+Job failures with no pytest FAILED line in their log (network hiccups,
+artifact-permission errors, and other GitHub Actions infra noise) are
+reported separately, not mixed into the test-failure table.
+
+Requires the `gh` CLI, authenticated for this repo.
+"""
+
+import json
+import re
+import subprocess
+from collections import defaultdict
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, NamedTuple
+
+import cyclopts
+import yaml
+from whenever import Instant
+
+app = cyclopts.App(help=__doc__)
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+KNOWN_FLAKES_PATH = REPO_ROOT / "scripts" / "known_flakes.yaml"
+
+# Documented, continue-on-error baseline failures on main (see CLAUDE.md,
+# "Known-failing lint checks") -- not test flakiness, skip entirely.
+SKIP_JOB_NAMES = frozenset({"file-sizes", "duplicate-code"})
+
+# Matches pytest's short test summary line, e.g.:
+#   FAILED tests/unit/test_foo.py::test_bar - AssertionError: boom
+# `gh run view --log-failed` prefixes every line with "<job>\t<step>\t<timestamp> ",
+# so this intentionally does not anchor to the start of the line.
+FAILED_TEST_RE = re.compile(r"FAILED (\S+) - (.+)$", re.MULTILINE)
+
+# Matches a GitHub Actions error annotation, e.g.:
+#   ##[error]The operation was aborted due to timeout
+# Used as the fallback summary for a failed job whose log has no pytest FAILED
+# line -- infra noise (network hiccups, artifact errors) rather than a test failure.
+GH_ERROR_RE = re.compile(r"##\[error\](.+)$", re.MULTILINE)
+
+RECURRING_THRESHOLD = 2
+
+# `gh` can hang on a slow API response; fail loudly rather than let one bad
+# call stall the whole scan.
+GH_TIMEOUT_SECONDS = 30
+
+# Comfortably above this repo's actual weekly failed-run volume (tens, not
+# hundreds) -- see `gh run list --help` for the underlying API page cap.
+GH_RUN_LIST_LIMIT = 500
+
+
+@dataclass
+class Occurrence:
+    run_id: str
+    branch: str
+    created_at: str
+    error: str
+
+
+class KnownFlake(NamedTuple):
+    pattern: re.Pattern[str]
+    issue: int
+    note: str
+
+
+def gh_json(*args: str) -> Any:
+    result = subprocess.run(["gh", *args], capture_output=True, text=True, check=True, timeout=GH_TIMEOUT_SECONDS)
+    return json.loads(result.stdout)
+
+
+def load_known_flakes() -> list[KnownFlake]:
+    if not KNOWN_FLAKES_PATH.exists():
+        return []
+    data = yaml.safe_load(KNOWN_FLAKES_PATH.read_text()) or {}
+    return [
+        KnownFlake(re.compile(entry["pattern"]), entry["issue"], entry.get("note", "").strip())
+        for entry in data.get("flakes", [])
+    ]
+
+
+def list_failed_runs(workflow: str, since_date: str) -> list[dict]:
+    return gh_json(
+        "run",
+        "list",
+        "--workflow",
+        workflow,
+        "--status",
+        "failure",
+        "--created",
+        f">={since_date}",
+        "--limit",
+        str(GH_RUN_LIST_LIMIT),
+        "--json",
+        "databaseId,headBranch,createdAt",
+    )
+
+
+def failed_jobs(run_id: str) -> list[dict]:
+    data = gh_json("run", "view", run_id, "--json", "jobs")
+    jobs = data["jobs"]
+    return [j for j in jobs if j["conclusion"] == "failure" and j["name"] not in SKIP_JOB_NAMES]
+
+
+def job_log(job_id: str) -> str | None:
+    """Return a failed job's log text, or None if the `gh` call itself failed.
+
+    Kept distinct from "log fetched but had no FAILED/##[error] line" -- a
+    failed `gh` call (auth hiccup, expired log retention, rate limit) must not
+    be silently treated as "this job's failure has no signal."
+    """
+    result = subprocess.run(
+        ["gh", "run", "view", "--job", job_id, "--log-failed"],
+        capture_output=True,
+        text=True,
+        timeout=GH_TIMEOUT_SECONDS,
+    )
+    if result.returncode != 0:
+        return None
+    return result.stdout
+
+
+def scan_run(
+    run: dict,
+    test_failures: dict[str, list[Occurrence]],
+    infra_failures: dict[str, list[Occurrence]],
+) -> None:
+    run_id = str(run["databaseId"])
+    for job in failed_jobs(run_id):
+        occurrence_base = {"run_id": run_id, "branch": run["headBranch"], "created_at": run["createdAt"]}
+
+        log = job_log(str(job["databaseId"]))
+        if log is None:
+            infra_failures[job["name"]].append(
+                Occurrence(error="(gh CLI call failed fetching this job's log)", **occurrence_base)
+            )
+            continue
+
+        test_matches = FAILED_TEST_RE.findall(log)
+        if test_matches:
+            for test_id, error in test_matches:
+                test_failures[test_id].append(Occurrence(error=error.strip(), **occurrence_base))
+            continue
+
+        error_matches = GH_ERROR_RE.findall(log)
+        summary = error_matches[0].strip() if error_matches else "(no FAILED line or ##[error] found in log)"
+        infra_failures[job["name"]].append(Occurrence(error=summary, **occurrence_base))
+
+
+def classify_verdict(
+    test_id: str, occurrences: list[Occurrence], known: list[KnownFlake]
+) -> tuple[str, KnownFlake | None]:
+    """Decide whether a test's failures look known, suite-wide flaky, or one PR's own bug.
+
+    Every `push`-triggered run on `main` is a separate, already-merged commit --
+    unlike a feature branch, "main" is never "one PR's diff." So a test recurring
+    on main (even under one branch name), or recurring across 2+ different
+    non-main branches, is the real flakiness signature: independent commits
+    hitting the same nondeterminism. A test recurring only within one feature
+    branch is more likely that branch's own unfixed bug, not a suite-wide flake.
+    """
+    match = next((k for k in known if k.pattern.search(test_id)), None)
+    if match:
+        return f"known (#{match.issue})", match
+
+    if len(occurrences) < RECURRING_THRESHOLD:
+        return "single occurrence", None
+
+    branches = {o.branch for o in occurrences}
+    non_main_branches = branches - {"main"}
+    if "main" in branches or len(non_main_branches) >= 2:
+        return "NEW -- recurring across independent commits, consider filing", None
+    return "recurring on one branch -- likely a real bug in that PR, not a suite flake", None
+
+
+def render_report(
+    days: int,
+    workflows: list[str],
+    test_failures: dict[str, list[Occurrence]],
+    infra_failures: dict[str, list[Occurrence]],
+    known: list[KnownFlake],
+) -> None:
+    print(f"CI flake scan -- last {days} day(s), workflows: {', '.join(workflows)}\n")
+
+    if not test_failures:
+        print("No pytest failures found.")
+    else:
+        for test_id, occurrences in sorted(test_failures.items(), key=lambda kv: -len(kv[1])):
+            verdict, match = classify_verdict(test_id, occurrences, known)
+            branches = sorted({o.branch for o in occurrences})
+            print(f"{test_id}")
+            print(f"  {len(occurrences)}x -- {verdict}")
+            print(f"  branches: {', '.join(branches)}")
+            print(f"  latest error: {occurrences[-1].error[:160]}")
+            if match and match.note:
+                print(f"  note: {match.note}")
+            print()
+
+    if infra_failures:
+        print("Non-test (infra) job failures -- not test flakiness, shown for awareness:")
+        for job_name, occurrences in sorted(infra_failures.items(), key=lambda kv: -len(kv[1])):
+            print(f"  {job_name}: {len(occurrences)}x -- {occurrences[-1].error[:120]}")
+
+
+@app.default
+def main(*, days: int = 7, workflow: list[str] | None = None) -> None:
+    """Scan recent CI runs for recurring test failures.
+
+    Args:
+        days: Lookback window in days.
+        workflow: Workflow name(s) to scan. Repeat the flag for multiple.
+            Defaults to "Tests" and "E2E Tests".
+    """
+    workflows = workflow if workflow else ["Tests", "E2E Tests"]
+    lookback_start = Instant.now().subtract(hours=24 * days)
+    since_date = lookback_start.to_stdlib().date().isoformat()
+    known = load_known_flakes()
+
+    test_failures: dict[str, list[Occurrence]] = defaultdict(list)
+    infra_failures: dict[str, list[Occurrence]] = defaultdict(list)
+
+    for wf in workflows:
+        for run in list_failed_runs(wf, since_date):
+            scan_run(run, test_failures, infra_failures)
+
+    render_report(days, workflows, test_failures, infra_failures, known)
+
+
+if __name__ == "__main__":
+    app()

--- a/scripts/ci_flake_scan.py
+++ b/scripts/ci_flake_scan.py
@@ -42,11 +42,27 @@ KNOWN_FLAKES_PATH = REPO_ROOT / "scripts" / "known_flakes.yaml"
 # "Known-failing lint checks") -- not test flakiness, skip entirely.
 SKIP_JOB_NAMES = frozenset({"file-sizes", "duplicate-code"})
 
-# Matches pytest's short test summary line, e.g.:
+# Matches pytest's short test summary lines, e.g.:
 #   FAILED tests/unit/test_foo.py::test_bar - AssertionError: boom
+#   ERROR tests/unit/test_foo.py::test_bar - fixture 'db' not found
+# ERROR lines come from collection/fixture/teardown failures, not assertion
+# failures -- still a test-level signal, not infra noise, so they're matched
+# alongside FAILED rather than falling through to GH_ERROR_RE below.
 # `gh run view --log-failed` prefixes every line with "<job>\t<step>\t<timestamp> ",
 # so this intentionally does not anchor to the start of the line.
-FAILED_TEST_RE = re.compile(r"FAILED (\S+) - (.+)$", re.MULTILINE)
+#
+# Deliberately only applied to the "short test summary info" section (see
+# PYTEST_SUMMARY_BANNER below) rather than the whole log -- an unscoped
+# search for "ERROR <token> - <message>" would also match ordinary
+# "LEVEL name - message"-shaped log output from application or third-party
+# code captured in the same job log, misclassifying it as a test failure.
+# Pytest's summary section is the one place this shape is guaranteed to mean
+# an actual test outcome.
+PYTEST_FAILURE_RE = re.compile(r"(?:FAILED|ERROR) (\S+) - (.+)$", re.MULTILINE)
+
+# Marks the start of pytest's summary section; everything after it is exactly
+# one line per failed/errored test, nothing else.
+PYTEST_SUMMARY_BANNER = "short test summary info"
 
 # Matches a GitHub Actions error annotation, e.g.:
 #   ##[error]The operation was aborted due to timeout
@@ -186,7 +202,9 @@ def scan_run(run: dict) -> tuple[dict[str, list[Occurrence]], dict[str, list[Occ
             )
             continue
 
-        test_matches = FAILED_TEST_RE.findall(log)
+        summary_start = log.find(PYTEST_SUMMARY_BANNER)
+        pytest_summary = log[summary_start:] if summary_start != -1 else ""
+        test_matches = PYTEST_FAILURE_RE.findall(pytest_summary)
         if test_matches:
             for test_id, error in test_matches:
                 test_failures[test_id].append(Occurrence(error=error.strip(), **occurrence_base))
@@ -215,8 +233,13 @@ def classify_verdict(
     if match:
         return f"known (#{match.issue})", match
 
-    if len(occurrences) < RECURRING_THRESHOLD:
-        return "single occurrence", None
+    # A single run fans a test out across multiple job-level occurrences (one
+    # per Python version in the test matrix) while still being one commit's
+    # worth of signal -- count distinct runs, not raw occurrences, so matrix
+    # fanout within one run doesn't look like recurrence across commits.
+    distinct_runs = {o.run_id for o in occurrences}
+    if len(distinct_runs) < RECURRING_THRESHOLD:
+        return "single run", None
 
     branches = {o.branch for o in occurrences}
     non_main_branches = branches - {"main"}

--- a/scripts/ci_flake_scan.py
+++ b/scripts/ci_flake_scan.py
@@ -46,13 +46,16 @@ SKIP_JOB_NAMES = frozenset({"file-sizes", "duplicate-code"})
 #   FAILED tests/unit/test_foo.py::test_bar - AssertionError: boom
 #   ERROR tests/unit/test_foo.py::test_bar - fixture 'db' not found
 #   FAILED tests/unit/test_foo.py::test_bar[media_artist-Artist Name] - ...
+#   ERROR tests/unit/test_syntax_error.py
 # ERROR lines come from collection/fixture/teardown failures, not assertion
 # failures -- still a test-level signal, not infra noise, so they're matched
 # alongside FAILED rather than falling through to GH_ERROR_RE below. The node
 # id is captured non-greedily up to the first " - " rather than with \S+ --
 # parametrized test ids can contain spaces (e.g. readable ids like
 # "Artist Name"), and \S+ would stop at the first space and drop the rest of
-# the id into the message capture instead.
+# the id into the message capture instead. The " - <message>" suffix is
+# optional -- a collection error (e.g. a syntax error) produces an ERROR line
+# with just the path and no message at all.
 # `gh run view --log-failed` prefixes every line with "<job>\t<step>\t<timestamp> ",
 # so this intentionally does not anchor to the start of the line.
 #
@@ -63,7 +66,12 @@ SKIP_JOB_NAMES = frozenset({"file-sizes", "duplicate-code"})
 # code captured in the same job log, misclassifying it as a test failure.
 # Pytest's summary section is the one place this shape is guaranteed to mean
 # an actual test outcome.
-PYTEST_FAILURE_RE = re.compile(r"(?:FAILED|ERROR) (.+?) - (.+)$", re.MULTILINE)
+PYTEST_FAILURE_RE = re.compile(r"(?:FAILED|ERROR) (.+?)(?: - (.+))?$", re.MULTILINE)
+
+# Message text used when a matched ERROR line has no " - <message>" suffix
+# (a bare collection error, e.g. a syntax error) -- PYTEST_FAILURE_RE's
+# message group doesn't participate in the match for these lines.
+COLLECTION_ERROR_PLACEHOLDER = "(collection error, no message in summary line)"
 
 # Marks the start of pytest's summary section; everything after it is exactly
 # one line per failed/errored test, nothing else.
@@ -105,6 +113,16 @@ class KnownFlake(NamedTuple):
     pattern: re.Pattern[str]
     issue: int
     note: str
+
+
+def latest_occurrence(occurrences: list[Occurrence]) -> Occurrence:
+    """Return the most recent occurrence by created_at, not by list/insertion order.
+
+    `gh run list` returns newest-first, and results are combined across
+    multiple workflows -- occurrences[-1] would silently pick whichever
+    occurrence happened to be appended last, not the actual latest one.
+    """
+    return max(occurrences, key=lambda o: Instant.parse_iso(o.created_at))
 
 
 def gh_json(*args: str) -> Any | None:
@@ -218,7 +236,8 @@ def scan_run(run: dict) -> tuple[dict[str, list[Occurrence]], dict[str, list[Occ
         test_matches = PYTEST_FAILURE_RE.findall(pytest_summary)
         if test_matches:
             for test_id, error in test_matches:
-                test_failures[test_id].append(Occurrence(error=error.strip(), **occurrence_base))
+                error_text = error.strip() or COLLECTION_ERROR_PLACEHOLDER
+                test_failures[test_id].append(Occurrence(error=error_text, **occurrence_base))
             continue
 
         error_matches = GH_ERROR_RE.findall(log)
@@ -283,7 +302,7 @@ def render_report(
             print(f"{test_id}")
             print(f"  {len(occurrences)}x -- {verdict}")
             print(f"  branches: {', '.join(branches)}")
-            print(f"  latest error: {occurrences[-1].error[:TEST_ERROR_TRUNCATE_LEN]}")
+            print(f"  latest error: {latest_occurrence(occurrences).error[:TEST_ERROR_TRUNCATE_LEN]}")
             if match and match.note:
                 print(f"  note: {match.note}")
             print()
@@ -291,7 +310,8 @@ def render_report(
     if infra_failures:
         print("Non-test (infra) job failures -- not test flakiness, shown for awareness:")
         for job_name, occurrences in sorted(infra_failures.items(), key=lambda kv: -len(kv[1])):
-            print(f"  {job_name}: {len(occurrences)}x -- {occurrences[-1].error[:INFRA_ERROR_TRUNCATE_LEN]}")
+            latest_error = latest_occurrence(occurrences).error[:INFRA_ERROR_TRUNCATE_LEN]
+            print(f"  {job_name}: {len(occurrences)}x -- {latest_error}")
 
 
 @app.default

--- a/scripts/ci_flake_scan.py
+++ b/scripts/ci_flake_scan.py
@@ -235,10 +235,12 @@ def classify_verdict(
 
     Every `push`-triggered run on `main` is a separate, already-merged commit --
     unlike a feature branch, "main" is never "one PR's diff." So a test recurring
-    on main across 2+ distinct commits, or recurring across 2+ different
-    non-main branches, is the real flakiness signature: independent commits
-    hitting the same nondeterminism. A test recurring only within one feature
-    branch is more likely that branch's own unfixed bug, not a suite-wide flake.
+    across 2+ distinct branches (main+branch or branch+branch -- either pairing
+    is necessarily 2 independent lines of history), or recurring on main alone
+    across 2+ distinct commits, is the real flakiness signature: independent
+    commits hitting the same nondeterminism. A test recurring only within one
+    feature branch is more likely that branch's own unfixed bug, not a
+    suite-wide flake.
 
     Recurrence is counted by distinct commit SHA, not by run or occurrence
     count, for two reasons: a single run fans a test out across multiple
@@ -257,9 +259,8 @@ def classify_verdict(
         return "single commit", None
 
     branches = {o.branch for o in occurrences}
-    non_main_branches = branches - {"main"}
     main_shas = {o.commit_sha for o in occurrences if o.branch == "main"}
-    if len(main_shas) >= RECURRING_THRESHOLD or len(non_main_branches) >= 2:
+    if len(branches) >= 2 or len(main_shas) >= RECURRING_THRESHOLD:
         return "NEW -- recurring across independent commits, consider filing", None
     return "recurring on one branch -- likely a real bug in that PR, not a suite flake", None
 

--- a/scripts/ci_flake_scan.py
+++ b/scripts/ci_flake_scan.py
@@ -23,6 +23,7 @@ Requires the `gh` CLI, authenticated for this repo.
 import json
 import re
 import subprocess
+import sys
 from collections import defaultdict
 from dataclasses import dataclass
 from pathlib import Path
@@ -63,6 +64,12 @@ GH_TIMEOUT_SECONDS = 30
 # hundreds) -- see `gh run list --help` for the underlying API page cap.
 GH_RUN_LIST_LIMIT = 500
 
+# Truncation lengths for the "latest error" line in the report. Test failures
+# carry pytest's assertion detail (more useful, worth more room); infra
+# failures are usually a single short GitHub Actions annotation.
+TEST_ERROR_TRUNCATE_LEN = 160
+INFRA_ERROR_TRUNCATE_LEN = 120
+
 
 @dataclass
 class Occurrence:
@@ -78,8 +85,20 @@ class KnownFlake(NamedTuple):
     note: str
 
 
-def gh_json(*args: str) -> Any:
-    result = subprocess.run(["gh", *args], capture_output=True, text=True, check=True, timeout=GH_TIMEOUT_SECONDS)
+def gh_json(*args: str) -> Any | None:
+    """Run a `gh` CLI command and parse its JSON output.
+
+    Returns None if `gh` exits non-zero (auth hiccup, rate limit, transient
+    network error) instead of raising -- mirrors job_log()'s handling so one
+    bad call doesn't crash the whole scan and discard every run's signal
+    already gathered. A hung call still raises subprocess.TimeoutExpired
+    (see GH_TIMEOUT_SECONDS) -- that failure mode is deliberately not caught.
+    """
+    try:
+        result = subprocess.run(["gh", *args], capture_output=True, text=True, check=True, timeout=GH_TIMEOUT_SECONDS)
+    except subprocess.CalledProcessError as exc:
+        print(f"warning: gh {' '.join(args)} failed: {exc.stderr.strip()}", file=sys.stderr)
+        return None
     return json.loads(result.stdout)
 
 
@@ -94,7 +113,7 @@ def load_known_flakes() -> list[KnownFlake]:
 
 
 def list_failed_runs(workflow: str, since_date: str) -> list[dict]:
-    return gh_json(
+    runs = gh_json(
         "run",
         "list",
         "--workflow",
@@ -108,10 +127,23 @@ def list_failed_runs(workflow: str, since_date: str) -> list[dict]:
         "--json",
         "databaseId,headBranch,createdAt",
     )
+    if runs is None:
+        print(f"warning: could not list failed runs for workflow {workflow!r}, skipping it", file=sys.stderr)
+        return []
+    if len(runs) == GH_RUN_LIST_LIMIT:
+        print(
+            f"warning: hit the {GH_RUN_LIST_LIMIT}-run cap for workflow {workflow!r} -- "
+            "results for this lookback window may be truncated",
+            file=sys.stderr,
+        )
+    return runs
 
 
 def failed_jobs(run_id: str) -> list[dict]:
     data = gh_json("run", "view", run_id, "--json", "jobs")
+    if data is None:
+        print(f"warning: could not fetch jobs for run {run_id}, skipping it", file=sys.stderr)
+        return []
     jobs = data["jobs"]
     return [j for j in jobs if j["conclusion"] == "failure" and j["name"] not in SKIP_JOB_NAMES]
 
@@ -134,11 +166,15 @@ def job_log(job_id: str) -> str | None:
     return result.stdout
 
 
-def scan_run(
-    run: dict,
-    test_failures: dict[str, list[Occurrence]],
-    infra_failures: dict[str, list[Occurrence]],
-) -> None:
+def scan_run(run: dict) -> tuple[dict[str, list[Occurrence]], dict[str, list[Occurrence]]]:
+    """Scan one run's failed jobs and return (test_failures, infra_failures) for it.
+
+    Returns fresh dicts rather than mutating caller-owned state -- the caller
+    merges them into its running totals.
+    """
+    test_failures: dict[str, list[Occurrence]] = defaultdict(list)
+    infra_failures: dict[str, list[Occurrence]] = defaultdict(list)
+
     run_id = str(run["databaseId"])
     for job in failed_jobs(run_id):
         occurrence_base = {"run_id": run_id, "branch": run["headBranch"], "created_at": run["createdAt"]}
@@ -159,6 +195,8 @@ def scan_run(
         error_matches = GH_ERROR_RE.findall(log)
         summary = error_matches[0].strip() if error_matches else "(no FAILED line or ##[error] found in log)"
         infra_failures[job["name"]].append(Occurrence(error=summary, **occurrence_base))
+
+    return test_failures, infra_failures
 
 
 def classify_verdict(
@@ -205,7 +243,7 @@ def render_report(
             print(f"{test_id}")
             print(f"  {len(occurrences)}x -- {verdict}")
             print(f"  branches: {', '.join(branches)}")
-            print(f"  latest error: {occurrences[-1].error[:160]}")
+            print(f"  latest error: {occurrences[-1].error[:TEST_ERROR_TRUNCATE_LEN]}")
             if match and match.note:
                 print(f"  note: {match.note}")
             print()
@@ -213,7 +251,7 @@ def render_report(
     if infra_failures:
         print("Non-test (infra) job failures -- not test flakiness, shown for awareness:")
         for job_name, occurrences in sorted(infra_failures.items(), key=lambda kv: -len(kv[1])):
-            print(f"  {job_name}: {len(occurrences)}x -- {occurrences[-1].error[:120]}")
+            print(f"  {job_name}: {len(occurrences)}x -- {occurrences[-1].error[:INFRA_ERROR_TRUNCATE_LEN]}")
 
 
 @app.default
@@ -235,7 +273,11 @@ def main(*, days: int = 7, workflow: list[str] | None = None) -> None:
 
     for wf in workflows:
         for run in list_failed_runs(wf, since_date):
-            scan_run(run, test_failures, infra_failures)
+            run_test_failures, run_infra_failures = scan_run(run)
+            for test_id, occurrences in run_test_failures.items():
+                test_failures[test_id].extend(occurrences)
+            for job_name, occurrences in run_infra_failures.items():
+                infra_failures[job_name].extend(occurrences)
 
     render_report(days, workflows, test_failures, infra_failures, known)
 

--- a/scripts/ci_flake_scan.py
+++ b/scripts/ci_flake_scan.py
@@ -45,9 +45,14 @@ SKIP_JOB_NAMES = frozenset({"file-sizes", "duplicate-code"})
 # Matches pytest's short test summary lines, e.g.:
 #   FAILED tests/unit/test_foo.py::test_bar - AssertionError: boom
 #   ERROR tests/unit/test_foo.py::test_bar - fixture 'db' not found
+#   FAILED tests/unit/test_foo.py::test_bar[media_artist-Artist Name] - ...
 # ERROR lines come from collection/fixture/teardown failures, not assertion
 # failures -- still a test-level signal, not infra noise, so they're matched
-# alongside FAILED rather than falling through to GH_ERROR_RE below.
+# alongside FAILED rather than falling through to GH_ERROR_RE below. The node
+# id is captured non-greedily up to the first " - " rather than with \S+ --
+# parametrized test ids can contain spaces (e.g. readable ids like
+# "Artist Name"), and \S+ would stop at the first space and drop the rest of
+# the id into the message capture instead.
 # `gh run view --log-failed` prefixes every line with "<job>\t<step>\t<timestamp> ",
 # so this intentionally does not anchor to the start of the line.
 #
@@ -58,7 +63,7 @@ SKIP_JOB_NAMES = frozenset({"file-sizes", "duplicate-code"})
 # code captured in the same job log, misclassifying it as a test failure.
 # Pytest's summary section is the one place this shape is guaranteed to mean
 # an actual test outcome.
-PYTEST_FAILURE_RE = re.compile(r"(?:FAILED|ERROR) (\S+) - (.+)$", re.MULTILINE)
+PYTEST_FAILURE_RE = re.compile(r"(?:FAILED|ERROR) (.+?) - (.+)$", re.MULTILINE)
 
 # Marks the start of pytest's summary section; everything after it is exactly
 # one line per failed/errored test, nothing else.
@@ -90,6 +95,7 @@ INFRA_ERROR_TRUNCATE_LEN = 120
 @dataclass
 class Occurrence:
     run_id: str
+    commit_sha: str
     branch: str
     created_at: str
     error: str
@@ -141,7 +147,7 @@ def list_failed_runs(workflow: str, since_date: str) -> list[dict]:
         "--limit",
         str(GH_RUN_LIST_LIMIT),
         "--json",
-        "databaseId,headBranch,createdAt",
+        "databaseId,headBranch,headSha,createdAt",
     )
     if runs is None:
         print(f"warning: could not list failed runs for workflow {workflow!r}, skipping it", file=sys.stderr)
@@ -193,7 +199,12 @@ def scan_run(run: dict) -> tuple[dict[str, list[Occurrence]], dict[str, list[Occ
 
     run_id = str(run["databaseId"])
     for job in failed_jobs(run_id):
-        occurrence_base = {"run_id": run_id, "branch": run["headBranch"], "created_at": run["createdAt"]}
+        occurrence_base = {
+            "run_id": run_id,
+            "commit_sha": run["headSha"],
+            "branch": run["headBranch"],
+            "created_at": run["createdAt"],
+        }
 
         log = job_log(str(job["databaseId"]))
         if log is None:
@@ -224,26 +235,31 @@ def classify_verdict(
 
     Every `push`-triggered run on `main` is a separate, already-merged commit --
     unlike a feature branch, "main" is never "one PR's diff." So a test recurring
-    on main (even under one branch name), or recurring across 2+ different
+    on main across 2+ distinct commits, or recurring across 2+ different
     non-main branches, is the real flakiness signature: independent commits
     hitting the same nondeterminism. A test recurring only within one feature
     branch is more likely that branch's own unfixed bug, not a suite-wide flake.
+
+    Recurrence is counted by distinct commit SHA, not by run or occurrence
+    count, for two reasons: a single run fans a test out across multiple
+    job-level occurrences (one per Python version in the test matrix) while
+    still being one commit's worth of signal, and both workflows also support
+    `workflow_dispatch` -- a manual rerun gets a new run id but the same SHA,
+    so run-id counting alone would still misread repeated manual reruns of one
+    main commit as independent recurrence.
     """
     match = next((k for k in known if k.pattern.search(test_id)), None)
     if match:
         return f"known (#{match.issue})", match
 
-    # A single run fans a test out across multiple job-level occurrences (one
-    # per Python version in the test matrix) while still being one commit's
-    # worth of signal -- count distinct runs, not raw occurrences, so matrix
-    # fanout within one run doesn't look like recurrence across commits.
-    distinct_runs = {o.run_id for o in occurrences}
-    if len(distinct_runs) < RECURRING_THRESHOLD:
-        return "single run", None
+    distinct_shas = {o.commit_sha for o in occurrences}
+    if len(distinct_shas) < RECURRING_THRESHOLD:
+        return "single commit", None
 
     branches = {o.branch for o in occurrences}
     non_main_branches = branches - {"main"}
-    if "main" in branches or len(non_main_branches) >= 2:
+    main_shas = {o.commit_sha for o in occurrences if o.branch == "main"}
+    if len(main_shas) >= RECURRING_THRESHOLD or len(non_main_branches) >= 2:
         return "NEW -- recurring across independent commits, consider filing", None
     return "recurring on one branch -- likely a real bug in that PR, not a suite flake", None
 

--- a/scripts/known_flakes.yaml
+++ b/scripts/known_flakes.yaml
@@ -1,0 +1,21 @@
+# Registry of already-tracked flaky tests, read by scripts/ci_flake_scan.py.
+#
+# When the scanner reports a test as "NEW — recurring", investigate it. If it
+# turns out to be a genuine flake (not a one-off real bug) and you file an
+# issue for it, add an entry here so future scans report it as known instead
+# of re-flagging it.
+#
+# `pattern` is matched with re.search against the full pytest test id
+# (e.g. "tests/unit/core/test_execution.py::TestRunThroughGuard::test_foo").
+
+flakes:
+  - pattern: "test_command_executor_pipeline_serve"
+    issue: 1773
+    note: >
+      Process-wide time.monotonic patch races asyncio's own clock reads.
+      See CLAUDE.md ("time.monotonic patch flake").
+
+  - pattern: "TestRunThroughGuard::test_dropped_at_drain_time_resolves_its_own_future"
+    issue: 2178
+    note: >
+      Same clock-racing family as #1773, different test file.

--- a/scripts/known_flakes.yaml
+++ b/scripts/known_flakes.yaml
@@ -9,7 +9,7 @@
 # (e.g. "tests/unit/core/test_execution.py::TestRunThroughGuard::test_foo").
 
 flakes:
-  - pattern: "test_command_executor_pipeline_serve"
+  - pattern: "test_emit_completion_events_unowned_warning_fires_after_rate_limit_window"
     issue: 1773
     note: >
       Process-wide time.monotonic patch races asyncio's own clock reads.


### PR DESCRIPTION
## Summary

Adds `scripts/ci_flake_scan.py`, an on-demand tool for the "are we seeing flaky tests?" question. It scans recent GitHub Actions runs (`Tests` and `E2E Tests` by default), pulls the failed jobs' logs, and extracts pytest `FAILED` lines via `gh run view --log-failed`. Failures are grouped by test id and classified as:

- **known** — matched against `scripts/known_flakes.yaml`, a small registry of already-tracked flakes (seeded with #1773 and #2178)
- **recurring across independent commits** — appears on `main` (every `push`-triggered run there is a separate merged commit) or across 2+ distinct feature branches. This is the real flakiness signature and worth filing.
- **recurring on one branch** — same test failing repeatedly, but confined to a single feature branch. More likely that branch's own unfixed bug than suite-wide nondeterminism, so it's called out separately rather than flagged as a flake.
- **single occurrence** — not enough data yet.

Job failures with no pytest `FAILED` line (network hiccups fetching `uv`, artifact-permission 403s, etc.) are reported in a separate "infra noise" section rather than mixed into the test-failure table — `scripts/file-sizes`/`duplicate-code` jobs are skipped outright since those are CLAUDE.md's documented pre-existing baseline failures.

## Why

Manually diagnosing "is this test actually flaky or just broken on this PR" this week involved listing failed runs, opening each job, grepping the log, and cross-referencing prior issues by hand — repeated enough times in one session that it was worth turning into a script (see `build-the-lever.md`). It already caught a real bug in its own first draft: an early version's verdict logic classified repeated `main` failures as "single branch, probably one PR's fault" because every push-triggered run on `main` shares the same branch name — fixed by treating `main` as never being "one PR's diff."

## Verification

- `prek -a` clean, `uv run pyright scripts/ci_flake_scan.py` — 0 errors/warnings
- Ran against real CI history (`--days 8`) and cross-checked output against failures traced by hand in this session, including the corrected `main`-recurrence case (`test_always_failing_service_stops_after_max_attempts`, confirmed on both `autofix/issue-1951` and `main`)
- code-reviewer / integration-reviewer / wtf-reviewer all run; the code-reviewer's one HIGH (the `main`-branch classification bug above) and both MEDIUMs (silent `gh` subprocess failures, missing timeouts) are fixed in this PR; wtf-reviewer's LOW/MEDIUM readability findings (tuple → `NamedTuple`, extracted `classify_verdict()`, documented regexes/magic numbers) are also addressed

## Not in scope

This is report-only — no auto-filing of issues, no scheduled run. Deliberately kept manual for now; can revisit automation once the known-flake registry has more real-world use.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RkB1gwbdnnTPaFnY1S1vkj
