### PR TITLE
test: name the repeated card test id literals as constants

### DIFF
--- a/frontend/src/components/shared/card.test.tsx
+++ b/frontend/src/components/shared/card.test.tsx
@@ -4,70 +4,71 @@ import { describe, expect, it } from "vitest";
 
 import { Card } from "@/components/ui/card";
 
-const TEST_ID = "card";
+const CARD_TEST_ID = "card";
+const PASSTHROUGH_TEST_ID = "my-card";
 
 describe("Card", () => {
   describe("renders as div", () => {
     it("renders a <div> element", () => {
-      const { getByTestId } = render(<Card data-testid={TEST_ID}>content</Card>);
-      expect(getByTestId(TEST_ID).tagName.toLowerCase()).toBe("div");
+      const { getByTestId } = render(<Card data-testid={CARD_TEST_ID}>content</Card>);
+      expect(getByTestId(CARD_TEST_ID).tagName.toLowerCase()).toBe("div");
     });
   });
 
   describe("variant prop", () => {
     it("applies base card styling when variant='default'", () => {
       const { getByTestId } = render(
-        <Card variant="default" data-testid={TEST_ID}>
+        <Card variant="default" data-testid={CARD_TEST_ID}>
           content
         </Card>,
       );
-      expect(getByTestId(TEST_ID).getAttribute("data-variant")).toBe("default");
+      expect(getByTestId(CARD_TEST_ID).getAttribute("data-variant")).toBe("default");
     });
 
     it("applies compact styling when variant='compact'", () => {
       const { getByTestId } = render(
-        <Card variant="compact" data-testid={TEST_ID}>
+        <Card variant="compact" data-testid={CARD_TEST_ID}>
           content
         </Card>,
       );
-      expect(getByTestId(TEST_ID).getAttribute("data-variant")).toBe("compact");
-      expect(getByTestId(TEST_ID).className).toMatch(/p-3/);
+      expect(getByTestId(CARD_TEST_ID).getAttribute("data-variant")).toBe("compact");
+      expect(getByTestId(CARD_TEST_ID).className).toMatch(/p-3/);
     });
 
     it("applies config styling when variant='config'", () => {
       const { getByTestId } = render(
-        <Card variant="config" data-testid={TEST_ID}>
+        <Card variant="config" data-testid={CARD_TEST_ID}>
           content
         </Card>,
       );
-      expect(getByTestId(TEST_ID).className).toMatch(/overflow-hidden/);
-      expect(getByTestId(TEST_ID).className).toMatch(/p-0/);
+      expect(getByTestId(CARD_TEST_ID).className).toMatch(/overflow-hidden/);
+      expect(getByTestId(CARD_TEST_ID).className).toMatch(/p-0/);
     });
 
     it("applies error styling when variant='error'", () => {
       const { getByTestId } = render(
-        <Card variant="error" data-testid={TEST_ID}>
+        <Card variant="error" data-testid={CARD_TEST_ID}>
           content
         </Card>,
       );
-      expect(getByTestId(TEST_ID).getAttribute("data-variant")).toBe("error");
-      expect(getByTestId(TEST_ID).className).toMatch(/text-center/);
+      expect(getByTestId(CARD_TEST_ID).getAttribute("data-variant")).toBe("error");
+      expect(getByTestId(CARD_TEST_ID).className).toMatch(/text-center/);
     });
 
     it("uses default variant when no variant is provided", () => {
-      const { getByTestId } = render(<Card data-testid={TEST_ID}>content</Card>);
-      expect(getByTestId(TEST_ID).getAttribute("data-variant")).toBe("default");
+      const { getByTestId } = render(<Card data-testid={CARD_TEST_ID}>content</Card>);
+      expect(getByTestId(CARD_TEST_ID).getAttribute("data-variant")).toBe("default");
     });
   });
 
   describe("class prop", () => {
     it("merges additional class into div className", () => {
       const { getByTestId } = render(
-        <Card className="my-layout-class" data-testid={TEST_ID}>
+        <Card className="my-layout-class" data-testid={CARD_TEST_ID}>
           content
         </Card>,
       );
-      expect(getByTestId(TEST_ID).className).toMatch(/my-layout-class/);
+      expect(getByTestId(CARD_TEST_ID).className).toMatch(/my-layout-class/);
     });
   });
 
@@ -75,38 +76,40 @@ describe("Card", () => {
     it("forwards ref to the root div element", () => {
       const ref = createRef<HTMLDivElement>();
       const { getByTestId } = render(
-        <Card ref={ref} data-testid={TEST_ID}>
+        <Card ref={ref} data-testid={CARD_TEST_ID}>
           content
         </Card>,
       );
-      expect(ref.current).toBe(getByTestId(TEST_ID));
+      expect(ref.current).toBe(getByTestId(CARD_TEST_ID));
     });
   });
 
   describe("pass-through attributes", () => {
+    // Deliberately not CARD_TEST_ID: this test proves an arbitrary caller-supplied
+    // id reaches the DOM, so it must use a value no other test in this file renders.
     it("passes data-testid through to the div element", () => {
-      const { getByTestId } = render(<Card data-testid={TEST_ID}>content</Card>);
-      expect(getByTestId(TEST_ID)).not.toBeNull();
+      const { getByTestId } = render(<Card data-testid={PASSTHROUGH_TEST_ID}>content</Card>);
+      expect(getByTestId(PASSTHROUGH_TEST_ID)).not.toBeNull();
     });
 
     it("passes style through to the div element", () => {
       const { getByTestId } = render(
-        <Card style={{ color: "red" }} data-testid={TEST_ID}>
+        <Card style={{ color: "red" }} data-testid={CARD_TEST_ID}>
           content
         </Card>,
       );
-      expect(getByTestId(TEST_ID).getAttribute("style")).toBe("color: red;");
+      expect(getByTestId(CARD_TEST_ID).getAttribute("style")).toBe("color: red;");
     });
   });
 
   describe("children", () => {
     it("renders children inside the div", () => {
       const { getByTestId } = render(
-        <Card data-testid={TEST_ID}>
+        <Card data-testid={CARD_TEST_ID}>
           <span data-testid="child">hello</span>
         </Card>,
       );
-      expect(getByTestId(TEST_ID).querySelector("[data-testid='child']")).not.toBeNull();
+      expect(getByTestId(CARD_TEST_ID).querySelector("[data-testid='child']")).not.toBeNull();
     });
   });
 });

--- a/frontend/src/components/shared/card.test.tsx
+++ b/frontend/src/components/shared/card.test.tsx
@@ -85,8 +85,8 @@ describe("Card", () => {
   });
 
   describe("pass-through attributes", () => {
-    // Deliberately not CARD_TEST_ID: this test proves an arbitrary caller-supplied
-    // id reaches the DOM, so it must use a value no other test in this file renders.
+    // Needs an id no other test in this file renders, so the assertion can only pass
+    // if an arbitrary caller-supplied id actually reached the DOM.
     it("passes data-testid through to the div element", () => {
       const { getByTestId } = render(<Card data-testid={PASSTHROUGH_TEST_ID}>content</Card>);
       expect(getByTestId(PASSTHROUGH_TEST_ID)).not.toBeNull();

--- a/frontend/src/components/shared/card.test.tsx
+++ b/frontend/src/components/shared/card.test.tsx
@@ -4,68 +4,70 @@ import { describe, expect, it } from "vitest";
 
 import { Card } from "@/components/ui/card";
 
+const TEST_ID = "card";
+
 describe("Card", () => {
   describe("renders as div", () => {
     it("renders a <div> element", () => {
-      const { getByTestId } = render(<Card data-testid="c">content</Card>);
-      expect(getByTestId("c").tagName.toLowerCase()).toBe("div");
+      const { getByTestId } = render(<Card data-testid={TEST_ID}>content</Card>);
+      expect(getByTestId(TEST_ID).tagName.toLowerCase()).toBe("div");
     });
   });
 
   describe("variant prop", () => {
     it("applies base card styling when variant='default'", () => {
       const { getByTestId } = render(
-        <Card variant="default" data-testid="c">
+        <Card variant="default" data-testid={TEST_ID}>
           content
         </Card>,
       );
-      expect(getByTestId("c").getAttribute("data-variant")).toBe("default");
+      expect(getByTestId(TEST_ID).getAttribute("data-variant")).toBe("default");
     });
 
     it("applies compact styling when variant='compact'", () => {
       const { getByTestId } = render(
-        <Card variant="compact" data-testid="c">
+        <Card variant="compact" data-testid={TEST_ID}>
           content
         </Card>,
       );
-      expect(getByTestId("c").getAttribute("data-variant")).toBe("compact");
-      expect(getByTestId("c").className).toMatch(/p-3/);
+      expect(getByTestId(TEST_ID).getAttribute("data-variant")).toBe("compact");
+      expect(getByTestId(TEST_ID).className).toMatch(/p-3/);
     });
 
     it("applies config styling when variant='config'", () => {
       const { getByTestId } = render(
-        <Card variant="config" data-testid="c">
+        <Card variant="config" data-testid={TEST_ID}>
           content
         </Card>,
       );
-      expect(getByTestId("c").className).toMatch(/overflow-hidden/);
-      expect(getByTestId("c").className).toMatch(/p-0/);
+      expect(getByTestId(TEST_ID).className).toMatch(/overflow-hidden/);
+      expect(getByTestId(TEST_ID).className).toMatch(/p-0/);
     });
 
     it("applies error styling when variant='error'", () => {
       const { getByTestId } = render(
-        <Card variant="error" data-testid="c">
+        <Card variant="error" data-testid={TEST_ID}>
           content
         </Card>,
       );
-      expect(getByTestId("c").getAttribute("data-variant")).toBe("error");
-      expect(getByTestId("c").className).toMatch(/text-center/);
+      expect(getByTestId(TEST_ID).getAttribute("data-variant")).toBe("error");
+      expect(getByTestId(TEST_ID).className).toMatch(/text-center/);
     });
 
     it("uses default variant when no variant is provided", () => {
-      const { getByTestId } = render(<Card data-testid="c">content</Card>);
-      expect(getByTestId("c").getAttribute("data-variant")).toBe("default");
+      const { getByTestId } = render(<Card data-testid={TEST_ID}>content</Card>);
+      expect(getByTestId(TEST_ID).getAttribute("data-variant")).toBe("default");
     });
   });
 
   describe("class prop", () => {
     it("merges additional class into div className", () => {
       const { getByTestId } = render(
-        <Card className="my-layout-class" data-testid="c">
+        <Card className="my-layout-class" data-testid={TEST_ID}>
           content
         </Card>,
       );
-      expect(getByTestId("c").className).toMatch(/my-layout-class/);
+      expect(getByTestId(TEST_ID).className).toMatch(/my-layout-class/);
     });
   });
 
@@ -73,38 +75,38 @@ describe("Card", () => {
     it("forwards ref to the root div element", () => {
       const ref = createRef<HTMLDivElement>();
       const { getByTestId } = render(
-        <Card ref={ref} data-testid="c">
+        <Card ref={ref} data-testid={TEST_ID}>
           content
         </Card>,
       );
-      expect(ref.current).toBe(getByTestId("c"));
+      expect(ref.current).toBe(getByTestId(TEST_ID));
     });
   });
 
   describe("pass-through attributes", () => {
     it("passes data-testid through to the div element", () => {
-      const { getByTestId } = render(<Card data-testid="my-card">content</Card>);
-      expect(getByTestId("my-card")).not.toBeNull();
+      const { getByTestId } = render(<Card data-testid={TEST_ID}>content</Card>);
+      expect(getByTestId(TEST_ID)).not.toBeNull();
     });
 
     it("passes style through to the div element", () => {
       const { getByTestId } = render(
-        <Card style={{ color: "red" }} data-testid="c">
+        <Card style={{ color: "red" }} data-testid={TEST_ID}>
           content
         </Card>,
       );
-      expect(getByTestId("c").getAttribute("style")).toBe("color: red;");
+      expect(getByTestId(TEST_ID).getAttribute("style")).toBe("color: red;");
     });
   });
 
   describe("children", () => {
     it("renders children inside the div", () => {
       const { getByTestId } = render(
-        <Card data-testid="c">
+        <Card data-testid={TEST_ID}>
           <span data-testid="child">hello</span>
         </Card>,
       );
-      expect(getByTestId("c").querySelector("[data-testid='child']")).not.toBeNull();
+      expect(getByTestId(TEST_ID).querySelector("[data-testid='child']")).not.toBeNull();
     });
   });
 });


### PR DESCRIPTION
## Summary

`card.test.tsx` used the single-character literal `"c"` as the `data-testid` in almost every test, and the "pass-through attributes" block used `"my-card"` for the same purpose with no stated reason for the difference.

This PR names both literals as module-level constants:

- `CARD_TEST_ID = "card"` — used for every `data-testid` prop and `getByTestId` lookup in the file except one.
- `PASSTHROUGH_TEST_ID = "my-card"` — used only by `passes data-testid through to the div element`.

The pass-through test keeps a distinct value on purpose. Its assertion is only meaningful if the id it renders appears nowhere else in the file; collapsing it into `CARD_TEST_ID` would make it a near-duplicate of `renders a <div> element` and it would pass whether or not pass-through actually worked. A comment on that test records the invariant. This deviates from acceptance criterion 2 in #2146 ("including the pass-through block") — the issue's objection was two values with no stated reason, and the named constant plus the comment supplies the reason.

The variant string literals (`"default"`, `"compact"`, `"config"`, `"error"`) stay inline on purpose. The tests assert that `data-variant` equals those exact strings, so the literal is the contract under test. Sharing a constant between the prop and the assertion would make those tests tautological.

The `data-testid="child"` literal on the inner `<span>` also stays inline: it identifies a different DOM node, is used once, and module-scoping it would obscure that.

This only touches tests: one file, no production code, no behavior change.

## Testing

- `npx vitest run src/components/shared/card.test.tsx`: 11 passed
- `npx tsc --noEmit`, `npx eslint`, `npx prettier --check`: clean
- `prek` pre-commit hooks: all pass

Closes #2146
