### PR TITLE
test: extract repeated RUNNING sidebar group setup into shared e2e helpers

### DIFF
--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -10,6 +10,7 @@ from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 import pytest
+from playwright.sync_api import Locator, Page, expect
 
 from hassette.logging_ import LogCaptureHandler, LogEntry
 from hassette.web.app import create_fastapi_app
@@ -340,6 +341,36 @@ def seed_time_preset_1h(page, origin_url: str) -> None:
     """
     page.goto(origin_url + "/")
     page.evaluate("localStorage.setItem('hassette:timePreset', JSON.stringify('1h'));")
+
+
+def open_apps_page_with_running_group(page: Page, base_url: str) -> None:
+    """Load /apps at desktop width and open the sidebar's RUNNING status group.
+
+    The sidebar collapses the RUNNING group by default whenever other status groups
+    have apps (the seed data always has a FAILING app), so any test that interacts
+    with a running app in the sidebar must open the group first.
+    """
+    page.set_viewport_size(DESKTOP_VIEWPORT)
+    page.goto(base_url + "/apps")
+    page.wait_for_load_state("networkidle")
+    running_header = page.locator("[data-testid='group-header']", has_text="RUNNING")
+    expect(running_header).to_be_visible()
+    running_header.click()
+    page.wait_for_timeout(ANIMATION_SETTLE_MS)
+
+
+def expand_app_instances(page: Page, app_key: str) -> Locator:
+    """Expand a multi-instance app in the sidebar and return its visible instance list.
+
+    The app's status group must already be open (see ``open_apps_page_with_running_group``).
+    """
+    expand_btn = page.locator(f"[data-testid='app-expand-{app_key}']")
+    expect(expand_btn).to_be_visible()
+    expand_btn.click()
+    page.wait_for_timeout(ANIMATION_SETTLE_MS)
+    instance_list = page.locator(f"[data-testid='app-entry-{app_key}'] [data-testid='instance-list']")
+    expect(instance_list).to_be_visible()
+    return instance_list
 
 
 @pytest.fixture(autouse=True)

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -363,6 +363,14 @@ def expand_app_instances(page: Page, app_key: str) -> Locator:
     """Expand a multi-instance app in the sidebar and return its visible instance list.
 
     The app's status group must already be open (see ``open_apps_page_with_running_group``).
+
+    Args:
+        page: The Playwright page, already on /apps with the app's status group open.
+        app_key: The app's key, used to scope the expand button and instance list locators.
+
+    Returns:
+        The app's ``instance-list`` locator, scoped to this app's sidebar entry and
+        asserted visible.
     """
     expand_btn = page.locator(f"[data-testid='app-expand-{app_key}']")
     expect(expand_btn).to_be_visible()

--- a/tests/e2e/test_navigation.py
+++ b/tests/e2e/test_navigation.py
@@ -219,7 +219,8 @@ def test_sidebar_multi_instance_expand(page: Page, base_url: str) -> None:
     """Multi-instance apps show an expand button in the sidebar."""
     open_apps_page_with_running_group(page, base_url)
     # multi_app has 3 instances — expanding it reveals the instance list
-    expand_app_instances(page, "multi_app")
+    instance_list = expand_app_instances(page, "multi_app")
+    expect(instance_list.locator("a")).to_have_count(3)
 
 
 def test_spa_navigates_without_full_reload(page: Page, base_url: str) -> None:

--- a/tests/e2e/test_navigation.py
+++ b/tests/e2e/test_navigation.py
@@ -5,7 +5,13 @@ import re
 import pytest
 from playwright.sync_api import Page, expect
 
-from tests.e2e.conftest import ANIMATION_SETTLE_MS, DESKTOP_VIEWPORT, MOBILE_VIEWPORT
+from tests.e2e.conftest import (
+    ANIMATION_SETTLE_MS,
+    DESKTOP_VIEWPORT,
+    MOBILE_VIEWPORT,
+    expand_app_instances,
+    open_apps_page_with_running_group,
+)
 
 pytestmark = pytest.mark.e2e
 
@@ -177,20 +183,12 @@ def test_sidebar_icons_are_aria_hidden(page: Page, base_url: str) -> None:
 
 def test_sidebar_app_list_renders(page: Page, base_url: str) -> None:
     """Sidebar renders the app list with app names from seed data."""
-    page.set_viewport_size(DESKTOP_VIEWPORT)
-    page.goto(base_url + "/apps")
-    page.wait_for_load_state("networkidle")
+    open_apps_page_with_running_group(page, base_url)
     # Apps are grouped by status in the sidebar app-nav section.
     # FAILING group (broken_app) is open by default.
     app_nav = page.locator("[data-testid='app-nav']")
     expect(app_nav).to_be_visible()
     expect(app_nav).to_contain_text("Broken App")
-    # RUNNING group is collapsed by default when other groups exist;
-    # open it, then verify My App appears.
-    running_header = page.locator("[data-testid='group-header']", has_text="RUNNING")
-    expect(running_header).to_be_visible()
-    running_header.click()
-    page.wait_for_timeout(ANIMATION_SETTLE_MS)
     expect(app_nav).to_contain_text("My App")
 
 
@@ -211,12 +209,7 @@ def test_sidebar_app_search_filters(page: Page, base_url: str) -> None:
 
 def test_sidebar_clicking_app_navigates(page: Page, base_url: str) -> None:
     """Clicking an app in the sidebar navigates to its detail page."""
-    page.set_viewport_size(DESKTOP_VIEWPORT)
-    page.goto(base_url + "/apps")
-    page.wait_for_load_state("networkidle")
-    # my_app is in the RUNNING group which is collapsed — open it first
-    page.locator("[data-testid='group-header']", has_text="RUNNING").click()
-    page.wait_for_timeout(ANIMATION_SETTLE_MS)
+    open_apps_page_with_running_group(page, base_url)
     # Click the app link in the sidebar
     page.locator("[data-testid='app-link']", has_text="My App").click()
     expect(page).to_have_url(re.compile(r"/apps/my_app"))
@@ -224,22 +217,9 @@ def test_sidebar_clicking_app_navigates(page: Page, base_url: str) -> None:
 
 def test_sidebar_multi_instance_expand(page: Page, base_url: str) -> None:
     """Multi-instance apps show an expand button in the sidebar."""
-    page.set_viewport_size(DESKTOP_VIEWPORT)
-    page.goto(base_url + "/apps")
-    page.wait_for_load_state("networkidle")
-    # multi_app is RUNNING; the RUNNING group starts collapsed when other
-    # status groups have apps. Open the RUNNING group first.
-    running_header = page.locator("[data-testid='group-header']", has_text="RUNNING")
-    expect(running_header).to_be_visible()
-    running_header.click()
-    page.wait_for_timeout(ANIMATION_SETTLE_MS)
-    # multi_app has 3 instances — expand button should be visible
-    expand_btn = page.locator("[data-testid='app-expand-multi_app']")
-    expect(expand_btn).to_be_visible()
-    expand_btn.click()
-    page.wait_for_timeout(ANIMATION_SETTLE_MS)
-    # Instance list should now be visible
-    expect(page.locator("[data-testid='instance-list']").first).to_be_visible()
+    open_apps_page_with_running_group(page, base_url)
+    # multi_app has 3 instances — expanding it reveals the instance list
+    expand_app_instances(page, "multi_app")
 
 
 def test_spa_navigates_without_full_reload(page: Page, base_url: str) -> None:

--- a/tests/e2e/test_url_routing.py
+++ b/tests/e2e/test_url_routing.py
@@ -19,7 +19,13 @@ import re
 import pytest
 from playwright.sync_api import Page, expect
 
-from tests.e2e.conftest import ANIMATION_SETTLE_MS, DATA_LOAD_TIMEOUT_MS, DESKTOP_VIEWPORT, EXTENDED_SETTLE_MS
+from tests.e2e.conftest import (
+    ANIMATION_SETTLE_MS,
+    DATA_LOAD_TIMEOUT_MS,
+    EXTENDED_SETTLE_MS,
+    expand_app_instances,
+    open_apps_page_with_running_group,
+)
 
 pytestmark = pytest.mark.e2e
 
@@ -448,23 +454,9 @@ def test_clicking_tab_button_produces_path_segment_url(page: Page, base_url: str
 
 def test_sidebar_instance_link_uses_query_param_format(page: Page, base_url: str) -> None:
     """Instance links in sidebar use ?instance=N format, not path segment."""
-    page.set_viewport_size(DESKTOP_VIEWPORT)
-    page.goto(base_url + "/apps")
-    page.wait_for_load_state("networkidle")
-    # Open the RUNNING sidebar group first (collapsed by default when
-    # other status groups have apps)
-    running_header = page.locator("[data-testid='group-header']", has_text="RUNNING")
-    expect(running_header).to_be_visible()
-    running_header.click()
-    page.wait_for_timeout(ANIMATION_SETTLE_MS)
-    # Expand multi_app in sidebar
-    expand_btn = page.get_by_label("Expand Multi App", exact=False)
-    expect(expand_btn).to_be_visible()
-    expand_btn.click()
-    page.wait_for_timeout(ANIMATION_SETTLE_MS)
+    open_apps_page_with_running_group(page, base_url)
+    instance_list = expand_app_instances(page, "multi_app")
     # Click instance 0 link
-    instance_list = page.locator("[data-testid='instance-list']").first
-    expect(instance_list).to_be_visible()
     first_instance_link = instance_list.locator("a").first
     expect(first_instance_link).to_be_visible()
     href = first_instance_link.get_attribute("href")


### PR DESCRIPTION
## Summary

Several e2e tests repeated the same inline setup: set the desktop viewport, load `/apps`, wait for `networkidle`, open the collapsed RUNNING sidebar group, and wait for the animation to settle. Each copy also restated why the group starts collapsed. The follow-on step that expands a multi-instance app had already drifted: `test_navigation.py` selected the expand button by `data-testid`, while `test_url_routing.py` used `get_by_label("Expand Multi App")`.

This PR moves both steps into shared helpers in `tests/e2e/conftest.py`:

- `open_apps_page_with_running_group(page, base_url)` loads `/apps` at desktop width and opens the RUNNING group. Its docstring now holds the explanation of why the group is collapsed by default.
- `expand_app_instances(page, app_key)` clicks `app-expand-{app_key}` and returns that app's instance list. The list is scoped to `app-entry-{app_key}` instead of taking the first `instance-list` on the page.

Every call site uses the helpers now: `test_sidebar_app_list_renders`, `test_sidebar_clicking_app_navigates`, `test_sidebar_multi_instance_expand`, and `test_sidebar_instance_link_uses_query_param_format`. The expand step uses the `data-testid` selector everywhere. A grep of `tests/e2e/` finds no other copies of the pattern.

This is a test-only change. Production code is untouched.

## Testing

- `uv run nox -s dev`: 7758 passed, 1 skipped, 2 xfailed
- `prek -a` and `prek run pyright -a --stage pre-push`: all hooks pass
- The four modified e2e tests, run with `uv run pytest -m e2e`: 4 passed

Closes #2147


## Review follow-ups (833c843f)

- `test_sidebar_multi_instance_expand` had no assertion left in its own body once the
  setup moved into the helpers — every check lived inside `expand_app_instances`. It now
  asserts `multi_app` renders 3 instance links, so the test's intent is visible where it
  is read. This also makes the "multi_app has 3 instances" comment a checked claim rather
  than a note.
- `expand_app_instances` gained Google-style `Args:`/`Returns:` sections, since callers
  consume its `Locator` return value.

Note on selector behavior: swapping `get_by_label("Expand Multi App")` for
`app-expand-multi_app` targets the same `<button>` (both attributes are set on it in
`frontend/src/components/layout/sidebar.tsx`), so no coverage is lost here — the
accessible-name contract for that control stays covered by
`frontend/src/components/layout/sidebar.test.tsx`, which asserts it via `findByLabelText`.
