### PR TITLE
test: assert string values render in DetailStats test and dedupe testids

### DIFF
--- a/frontend/src/components/shared/detail-stats.test.tsx
+++ b/frontend/src/components/shared/detail-stats.test.tsx
@@ -45,6 +45,7 @@ describe("DetailStats", () => {
     ];
     const { getByTestId } = render(<DetailStats cells={cells} data-testid={STATS_TEST_ID} />);
     const statCells = getByTestId(STATS_TEST_ID).querySelectorAll(STATS_CELL_SELECTOR);
+    // Each cell renders exactly two children, in order: the label span, then the value span.
     const labelValuePairs = Array.from(statCells, (cell) => Array.from(cell.children, (child) => child.textContent));
     expect(labelValuePairs).toEqual([
       ["Min", "—"],
@@ -54,7 +55,7 @@ describe("DetailStats", () => {
 
   it("generates per-cell testids from parent testid", () => {
     const { getByTestId } = render(<DetailStats cells={baseCells} data-testid={STATS_TEST_ID} />);
-    const cells = getByTestId(STATS_TEST_ID).querySelectorAll(STATS_CELL_SELECTOR);
-    expect(cells.length).toBe(3);
+    const statCells = getByTestId(STATS_TEST_ID).querySelectorAll(STATS_CELL_SELECTOR);
+    expect(statCells.length).toBe(3);
   });
 });

--- a/frontend/src/components/shared/detail-stats.test.tsx
+++ b/frontend/src/components/shared/detail-stats.test.tsx
@@ -3,6 +3,10 @@ import { describe, expect, it } from "vitest";
 
 import { DetailStats, type DetailStatsCell } from "./detail-stats";
 
+const STATS_TEST_ID = "stats";
+// DetailStats derives each cell's testid from the parent testid.
+const STATS_CELL_SELECTOR = `[data-testid='${STATS_TEST_ID}-cell']`;
+
 describe("DetailStats", () => {
   const baseCells: DetailStatsCell[] = [
     { label: "Calls", value: 10 },
@@ -11,8 +15,8 @@ describe("DetailStats", () => {
   ];
 
   it("renders all cells with labels and values", () => {
-    const { getByTestId } = render(<DetailStats cells={baseCells} data-testid="stats" />);
-    const row = getByTestId("stats");
+    const { getByTestId } = render(<DetailStats cells={baseCells} data-testid={STATS_TEST_ID} />);
+    const row = getByTestId(STATS_TEST_ID);
     expect(row.textContent).toContain("Calls");
     expect(row.textContent).toContain("10");
     expect(row.textContent).toContain("Successful");
@@ -20,16 +24,16 @@ describe("DetailStats", () => {
   });
 
   it("applies err tone via data-tone attribute", () => {
-    const { getByTestId } = render(<DetailStats cells={baseCells} data-testid="stats" />);
-    const errValue = getByTestId("stats").querySelector("[data-tone='err']");
+    const { getByTestId } = render(<DetailStats cells={baseCells} data-testid={STATS_TEST_ID} />);
+    const errValue = getByTestId(STATS_TEST_ID).querySelector("[data-tone='err']");
     expect(errValue).not.toBeNull();
     expect(errValue?.textContent).toBe("2");
   });
 
   it("applies warn tone via data-tone attribute", () => {
     const cells: DetailStatsCell[] = [{ label: "Timed Out", value: 3, tone: "warn" }];
-    const { getByTestId } = render(<DetailStats cells={cells} data-testid="stats" />);
-    const warnValue = getByTestId("stats").querySelector("[data-tone='warn']");
+    const { getByTestId } = render(<DetailStats cells={cells} data-testid={STATS_TEST_ID} />);
+    const warnValue = getByTestId(STATS_TEST_ID).querySelector("[data-tone='warn']");
     expect(warnValue).not.toBeNull();
     expect(warnValue?.textContent).toBe("3");
   });
@@ -39,17 +43,18 @@ describe("DetailStats", () => {
       { label: "Min", value: "—" },
       { label: "Max", value: "—" },
     ];
-    const { getByTestId } = render(<DetailStats cells={cells} data-testid="stats" />);
-    const row = getByTestId("stats");
-    expect(row.textContent).toContain("Min");
-    expect(row.textContent).toContain("Max");
-    const dashCells = row.querySelectorAll("[data-testid='stats-cell']");
-    expect(dashCells.length).toBe(2);
+    const { getByTestId } = render(<DetailStats cells={cells} data-testid={STATS_TEST_ID} />);
+    const statCells = getByTestId(STATS_TEST_ID).querySelectorAll(STATS_CELL_SELECTOR);
+    const labelValuePairs = Array.from(statCells, (cell) => Array.from(cell.children, (child) => child.textContent));
+    expect(labelValuePairs).toEqual([
+      ["Min", "—"],
+      ["Max", "—"],
+    ]);
   });
 
   it("generates per-cell testids from parent testid", () => {
-    const { getByTestId } = render(<DetailStats cells={baseCells} data-testid="stats" />);
-    const cells = getByTestId("stats").querySelectorAll("[data-testid='stats-cell']");
+    const { getByTestId } = render(<DetailStats cells={baseCells} data-testid={STATS_TEST_ID} />);
+    const cells = getByTestId(STATS_TEST_ID).querySelectorAll(STATS_CELL_SELECTOR);
     expect(cells.length).toBe(3);
   });
 });


### PR DESCRIPTION
## Summary

Fixes two test-quality findings in `frontend/src/components/shared/detail-stats.test.tsx`:

1. **`renders string values (dashes for empty)` now checks the string values.** Before, it only checked that the `Min`/`Max` labels showed up and that two cells existed, so it would still pass if `DetailStats` stopped rendering `{cell.value}`. It now collects each cell's `[label, value]` text and asserts `[["Min", "—"], ["Max", "—"]]`. With value rendering removed, the value span is empty and the test fails. The duplicate cell-count assertion and the misnamed `dashCells` variable are gone.
2. **Testid literals are defined once.** `STATS_TEST_ID` and `STATS_CELL_SELECTOR` (built from `${STATS_TEST_ID}-cell`, the same way `DetailStats` builds per-cell testids) replace the nine repeated `"stats"` / `[data-testid='stats-cell']` literals.

This is a test-only change with no production or rendered UI changes.

## Review follow-ups

- Added a comment recording the DOM child-order assumption the pair extraction relies on (label span first, then value span).
- Renamed the `cells` binding in `generates per-cell testids from parent testid` to `statCells` so both tests name the same `querySelectorAll(STATS_CELL_SELECTOR)` result identically.

## Testing

- Mutation check: replacing `{cell.value}` with an empty expression in `detail-stats.tsx` makes `renders string values (dashes for empty)` fail, confirming the assertion is load-bearing.
- `npx vitest run src/components/shared/detail-stats.test.tsx`: 5/5 passed
- `npx tsc --noEmit`: clean
- `prek run --files frontend/src/components/shared/detail-stats.test.tsx`: prettier, eslint, tsc and the other applicable hooks all passed
- Not run: the backend `uv run nox -s dev` suite, because no Python files changed

Partial progress on #2157
