### PR TITLE
test: consolidate shared setup and literals in execution-table tests

### DIFF
--- a/frontend/src/components/shared/execution-table.test.tsx
+++ b/frontend/src/components/shared/execution-table.test.tsx
@@ -1,27 +1,38 @@
 import { render } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { createExecution } from "../../test/factories";
 import { createWouterMock } from "../../test/mock-wouter";
 import { formatTimestamp } from "../../utils/format";
 import { ExecutionTable } from "./execution-table";
 
+const INCIDENTAL_TABLE_ID = "t";
+const TEST_EXECUTION_ID = "abc12345-6789-abcd-ef01-234567890abc";
+const BASE_TS = 1_700_000_000;
+const TEN_MINUTES_IN_SECONDS = 600;
+const NAVIGABLE_PROPS = { appKey: "my_app", handlerKind: "job", handlerId: 1 } as const;
+const EXPECTED_DETAIL_PATH = `/apps/${NAVIGABLE_PROPS.appKey}/handlers/${NAVIGABLE_PROPS.handlerKind}/${NAVIGABLE_PROPS.handlerId}/exec/${TEST_EXECUTION_ID}`;
+
 const mockNavigate = vi.fn();
 vi.mock("wouter", () => createWouterMock({ useLocation: () => ["/", mockNavigate] }));
 
 describe("ExecutionTable", () => {
+  beforeEach(() => {
+    mockNavigate.mockClear();
+  });
+
   afterEach(() => {
     vi.useRealTimers();
   });
 
   it("renders handler empty state when records are empty", () => {
-    const { getByText } = render(<ExecutionTable records={[]} kind="handler" tableId="invocation-table-1" />);
+    const { getByText } = render(<ExecutionTable records={[]} kind="handler" tableId={INCIDENTAL_TABLE_ID} />);
     expect(getByText("no invocations recorded")).toBeDefined();
   });
 
   it("renders job empty state when records are empty", () => {
-    const { getByText } = render(<ExecutionTable records={[]} kind="job" tableId="execution-table-1" />);
+    const { getByText } = render(<ExecutionTable records={[]} kind="job" tableId={INCIDENTAL_TABLE_ID} />);
     expect(getByText("no executions recorded.")).toBeDefined();
   });
 
@@ -33,7 +44,9 @@ describe("ExecutionTable", () => {
   });
 
   it("renders unified column headers", () => {
-    const { getByText } = render(<ExecutionTable records={[createExecution("job")]} kind="job" tableId="t" />);
+    const { getByText } = render(
+      <ExecutionTable records={[createExecution("job")]} kind="job" tableId={INCIDENTAL_TABLE_ID} />,
+    );
     expect(getByText("Status")).toBeDefined();
     expect(getByText("Execution")).toBeDefined();
     expect(getByText("Duration")).toBeDefined();
@@ -42,11 +55,11 @@ describe("ExecutionTable", () => {
 
   it("renders correct number of rows", () => {
     const records = [
-      createExecution("job", { execution_start_ts: 1700000001 }),
-      createExecution("job", { execution_start_ts: 1700000002 }),
-      createExecution("job", { execution_start_ts: 1700000003 }),
+      createExecution("job", { execution_start_ts: BASE_TS + 1 }),
+      createExecution("job", { execution_start_ts: BASE_TS + 2 }),
+      createExecution("job", { execution_start_ts: BASE_TS + 3 }),
     ];
-    const { container } = render(<ExecutionTable records={records} kind="job" tableId="t" />);
+    const { container } = render(<ExecutionTable records={records} kind="job" tableId={INCIDENTAL_TABLE_ID} />);
     expect(container.querySelectorAll("[data-testid='execution-row']").length).toBe(3);
   });
 
@@ -55,7 +68,7 @@ describe("ExecutionTable", () => {
       <ExecutionTable
         records={[createExecution("job", { status: "error", error_type: "ValueError", error_message: "Task failed" })]}
         kind="job"
-        tableId="t"
+        tableId={INCIDENTAL_TABLE_ID}
       />,
     );
     expect(container.textContent).toContain("failed");
@@ -64,23 +77,29 @@ describe("ExecutionTable", () => {
 
   it("shows an 'ok' status label for successful rows", () => {
     const { container } = render(
-      <ExecutionTable records={[createExecution("job", { status: "success" })]} kind="job" tableId="t" />,
+      <ExecutionTable
+        records={[createExecution("job", { status: "success" })]}
+        kind="job"
+        tableId={INCIDENTAL_TABLE_ID}
+      />,
     );
     expect(container.textContent).toContain("ok");
   });
 
   it("shows the full execution ID in table rows", () => {
-    const uuid = "abc12345-6789-abcd-ef01-234567890abc";
-    const { container } = render(
-      <ExecutionTable records={[createExecution("job", { execution_id: uuid })]} kind="job" tableId="t" />,
+    const { getByTestId } = render(
+      <ExecutionTable
+        records={[createExecution("job", { execution_id: TEST_EXECUTION_ID })]}
+        kind="job"
+        tableId={INCIDENTAL_TABLE_ID}
+      />,
     );
-    const row = container.querySelector("[data-testid='execution-row']")!;
-    expect(row.textContent).toContain(uuid);
+    expect(getByTestId("execution-row").textContent).toContain(TEST_EXECUTION_ID);
   });
 
   it("renders formatted duration, relative time, and timestamp tooltip", () => {
-    const now = 1_700_000_600;
-    const executionStart = 1_700_000_000;
+    const executionStart = BASE_TS;
+    const now = BASE_TS + TEN_MINUTES_IN_SECONDS;
     vi.useFakeTimers();
     vi.setSystemTime(now * 1000);
 
@@ -88,7 +107,7 @@ describe("ExecutionTable", () => {
       <ExecutionTable
         records={[createExecution("job", { duration_ms: 1234, execution_start_ts: executionStart })]}
         kind="job"
-        tableId="t"
+        tableId={INCIDENTAL_TABLE_ID}
       />,
     );
     const timeCell = getByTestId("execution-row").querySelector("td[title]");
@@ -103,10 +122,8 @@ describe("ExecutionTable", () => {
       <ExecutionTable
         records={[createExecution("job", { execution_id: "execution-id" })]}
         kind="job"
-        tableId="t"
-        appKey="my_app"
-        handlerKind="job"
-        handlerId={1}
+        tableId={INCIDENTAL_TABLE_ID}
+        {...NAVIGABLE_PROPS}
       />,
     );
 
@@ -118,7 +135,7 @@ describe("ExecutionTable", () => {
       <ExecutionTable
         records={[createExecution("job", { status: "timed_out", thread_leaked: true })]}
         kind="job"
-        tableId="t"
+        tableId={INCIDENTAL_TABLE_ID}
       />,
     );
     expect(container.textContent).toContain("thread leaked");
@@ -129,7 +146,7 @@ describe("ExecutionTable", () => {
       <ExecutionTable
         records={[createExecution("job", { status: "timed_out", thread_leaked: false })]}
         kind="job"
-        tableId="t"
+        tableId={INCIDENTAL_TABLE_ID}
       />,
     );
     expect(container.textContent).not.toContain("thread leaked");
@@ -140,7 +157,7 @@ describe("ExecutionTable", () => {
       <ExecutionTable
         records={[createExecution("job", { status: "timed_out", thread_leaked: true })]}
         kind="job"
-        tableId="t"
+        tableId={INCIDENTAL_TABLE_ID}
       />,
     );
     expect(container.textContent).toContain("timed out");
@@ -149,61 +166,71 @@ describe("ExecutionTable", () => {
 
   it("shows manual badge when trigger_mode is manual", () => {
     const { container } = render(
-      <ExecutionTable records={[createExecution("job", { trigger_mode: "manual" })]} kind="job" tableId="t" />,
+      <ExecutionTable
+        records={[createExecution("job", { trigger_mode: "manual" })]}
+        kind="job"
+        tableId={INCIDENTAL_TABLE_ID}
+      />,
     );
     expect(container.textContent).toContain("manual");
   });
 
   it("does not show manual badge when trigger_mode is null", () => {
-    const { container } = render(
-      <ExecutionTable records={[createExecution("job", { trigger_mode: null })]} kind="job" tableId="t" />,
+    const { getByTestId } = render(
+      <ExecutionTable
+        records={[createExecution("job", { trigger_mode: null })]}
+        kind="job"
+        tableId={INCIDENTAL_TABLE_ID}
+      />,
     );
-    const row = container.querySelector("[data-testid='execution-row']")!;
-    expect(row.textContent).not.toContain("manual");
+    expect(getByTestId("execution-row").textContent).not.toContain("manual");
   });
 
   it("shows a cancelled label on a cancelled row", () => {
     const { container } = render(
-      <ExecutionTable records={[createExecution("job", { status: "cancelled" })]} kind="job" tableId="t" />,
+      <ExecutionTable
+        records={[createExecution("job", { status: "cancelled" })]}
+        kind="job"
+        tableId={INCIDENTAL_TABLE_ID}
+      />,
     );
     expect(container.textContent).toContain("cancelled");
   });
 
   it("shows Show More button when records exceed 5", () => {
-    const records = Array.from({ length: 6 }, (_, i) => createExecution("job", { execution_start_ts: 1700000000 + i }));
-    const { getByRole } = render(<ExecutionTable records={records} kind="job" tableId="t" />);
+    const records = Array.from({ length: 6 }, (_, i) => createExecution("job", { execution_start_ts: BASE_TS + i }));
+    const { getByRole } = render(<ExecutionTable records={records} kind="job" tableId={INCIDENTAL_TABLE_ID} />);
     expect(getByRole("button", { name: /show all/i })).toBeDefined();
   });
 
   it("does not show Show More button for 5 or fewer", () => {
-    const records = Array.from({ length: 5 }, (_, i) => createExecution("job", { execution_start_ts: 1700000000 + i }));
-    const { queryByRole } = render(<ExecutionTable records={records} kind="job" tableId="t" />);
+    const records = Array.from({ length: 5 }, (_, i) => createExecution("job", { execution_start_ts: BASE_TS + i }));
+    const { queryByRole } = render(<ExecutionTable records={records} kind="job" tableId={INCIDENTAL_TABLE_ID} />);
     expect(queryByRole("button", { name: /show all/i })).toBeNull();
   });
 
   it("clicking row navigates to execution detail page when handler props are set", async () => {
     const user = userEvent.setup();
-    mockNavigate.mockClear();
-    const execId = "abc12345-6789-abcd-ef01-234567890abc";
-    const { container } = render(
+    const { getByTestId } = render(
       <ExecutionTable
-        records={[createExecution("job", { execution_id: execId })]}
+        records={[createExecution("job", { execution_id: TEST_EXECUTION_ID })]}
         kind="job"
-        tableId="t"
-        appKey="my_app"
-        handlerKind="job"
-        handlerId={1}
+        tableId={INCIDENTAL_TABLE_ID}
+        {...NAVIGABLE_PROPS}
       />,
     );
-    await user.click(container.querySelector("[data-testid='execution-row']")!);
-    expect(mockNavigate).toHaveBeenCalledWith(`/apps/my_app/handlers/job/1/exec/${execId}`);
+    await user.click(getByTestId("execution-row"));
+    expect(mockNavigate).toHaveBeenCalledWith(EXPECTED_DETAIL_PATH);
   });
 
   it("renders no detail affordances or navigation when handler props are not set", async () => {
     const user = userEvent.setup();
-    mockNavigate.mockClear();
     const { getByTestId, queryByLabelText, queryByTestId } = render(
-      <ExecutionTable records={[createExecution("job", { execution_id: "some-id" })]} kind="job" tableId="t" />,
+      <ExecutionTable
+        records={[createExecution("job", { execution_id: "some-id" })]}
+        kind="job"
+        tableId={INCIDENTAL_TABLE_ID}
+      />,
     );
     const row = getByTestId("execution-row");
 
@@ -217,10 +244,10 @@ describe("ExecutionTable", () => {
   it("moves the roving tabindex between rows with arrow keys", async () => {
     const user = userEvent.setup();
     const records = [
-      createExecution("job", { execution_start_ts: 1700000001 }),
-      createExecution("job", { execution_start_ts: 1700000002 }),
+      createExecution("job", { execution_start_ts: BASE_TS + 1 }),
+      createExecution("job", { execution_start_ts: BASE_TS + 2 }),
     ];
-    const { container } = render(<ExecutionTable records={records} kind="job" tableId="t" />);
+    const { container } = render(<ExecutionTable records={records} kind="job" tableId={INCIDENTAL_TABLE_ID} />);
     const rows = container.querySelectorAll<HTMLElement>("[data-testid='execution-row']");
 
     expect(rows[0].tabIndex).toBe(0);
@@ -236,22 +263,18 @@ describe("ExecutionTable", () => {
 
   it("activating a row with the keyboard navigates to execution detail page", async () => {
     const user = userEvent.setup();
-    mockNavigate.mockClear();
-    const execId = "abc12345-6789-abcd-ef01-234567890abc";
     const { getByTestId } = render(
       <ExecutionTable
-        records={[createExecution("job", { execution_id: execId })]}
+        records={[createExecution("job", { execution_id: TEST_EXECUTION_ID })]}
         kind="job"
-        tableId="t"
-        appKey="my_app"
-        handlerKind="job"
-        handlerId={1}
+        tableId={INCIDENTAL_TABLE_ID}
+        {...NAVIGABLE_PROPS}
       />,
     );
 
     getByTestId("execution-row").focus();
     await user.keyboard("{Enter}");
 
-    expect(mockNavigate).toHaveBeenCalledWith(`/apps/my_app/handlers/job/1/exec/${execId}`);
+    expect(mockNavigate).toHaveBeenCalledWith(EXPECTED_DETAIL_PATH);
   });
 });


### PR DESCRIPTION
## Summary

Test-only cleanup of `frontend/src/components/shared/execution-table.test.tsx`, covering the seven findings from the quality-scanner pass in #2172. No test was added, removed, or had its assertions changed. Only the shared setup and literals moved.

- **`mockNavigate` reset:** a suite-level `beforeEach` now calls `mockNavigate.mockClear()`, and the three manual per-test calls are gone. Before this, the click-to-navigate test at the old lines 101–114 didn't clear the mock, and any new test that forgot the manual call would inherit call counts from earlier tests.
- **Execution ID:** one module constant, `TEST_EXECUTION_ID`, replaces the UUID literal that appeared three times under two names (`uuid`, `execId`).
- **Detail-route expectation:** one constant, `EXPECTED_DETAIL_PATH`, built from the shared props, replaces the two hardcoded `` `/apps/my_app/handlers/job/1/exec/${execId}` `` copies.
- **Handler props:** one `NAVIGABLE_PROPS` object replaces the `appKey`/`handlerKind`/`handlerId` trio that was repeated three times. The three navigation tests spread it in.
- **Row lookup:** single-row lookups now use `getByTestId("execution-row")` instead of `container.querySelector(...)!`, so a missing row gives a testing-library error instead of a null dereference. `querySelectorAll` is kept where the test needs a collection (row count, roving tabindex).
- **Timestamps:** all epoch literals now derive from `BASE_TS`. The relative-time test sets `now = BASE_TS + TEN_MINUTES_IN_SECONDS`, which makes it clear where the `"10m ago"` assertion comes from.
- **Table IDs:** tests where the ID doesn't matter now use `INCIDENTAL_TABLE_ID`. The descriptive `"execution-table-99"` stays only in the test that asserts on it. The two empty-state tests passed descriptive IDs without asserting on them, so they moved to the shared constant too.

## Testing

- `prek -a` passes (prettier, eslint, tsc, and the rest of the hooks).
- `npx vitest run src/components/shared/execution-table.test.tsx`: 22/22 pass.
- CI runs the full frontend and backend suites.

Closes #2172
