### PR TITLE
test: fix flaky real-clock hang guards in TestRunThroughGuard

### DIFF
--- a/tests/unit/test_execution_mode_helpers.py
+++ b/tests/unit/test_execution_mode_helpers.py
@@ -20,9 +20,11 @@ from hassette.execution_mode import (
 from hassette.testing import wait_for
 from hassette.types.enums import ExecutionMode
 
-#: Hang guard for TestRunThroughGuard's event handshakes, which complete in milliseconds. It only
-#: converts a genuine hang into a failure, so it needs generous headroom over xdist scheduling
-#: jitter on a loaded CI runner — well above the ``wait_for`` helper's own 3.0s default.
+#: Hang guard for this module's event handshakes, which complete in milliseconds. It only converts
+#: a genuine hang into a failure, so it needs generous headroom over xdist scheduling jitter on a
+#: loaded CI runner — well above the ``wait_for`` helper's own 3.0s default. Distinct from the
+#: ``threshold`` argument passed to ``run_with_stall_watch``/``run_through_guard``, which is the
+#: production stall-warning value under test rather than a test-side wait budget.
 HANG_GUARD_TIMEOUT = 10.0
 
 
@@ -85,10 +87,10 @@ class TestRunWithStallWatch:
 
         threshold = 0.05  # short threshold for testing
         task = asyncio.create_task(run_with_stall_watch(invoke, warn, threshold=threshold))
-        await asyncio.wait_for(started.wait(), timeout=2.0)
+        await asyncio.wait_for(started.wait(), timeout=HANG_GUARD_TIMEOUT)
         # warn.set() unblocks the gate, so awaiting the task is the deterministic
         # signal that the watchdog fired.
-        await asyncio.wait_for(task, timeout=2.0)
+        await asyncio.wait_for(task, timeout=HANG_GUARD_TIMEOUT)
 
         assert warn_calls == [threshold], f"expected warn called with {threshold}, got {warn_calls}"
 
@@ -120,7 +122,7 @@ class TestRunWithStallWatch:
             await asyncio.sleep(10)  # will be cancelled
 
         task = asyncio.create_task(run_with_stall_watch(invoke, warn, threshold=0.05))
-        await asyncio.wait_for(started.wait(), timeout=2.0)
+        await asyncio.wait_for(started.wait(), timeout=HANG_GUARD_TIMEOUT)
         task.cancel()
         with pytest.raises(asyncio.CancelledError):
             await task

--- a/tests/unit/test_execution_mode_helpers.py
+++ b/tests/unit/test_execution_mode_helpers.py
@@ -20,6 +20,11 @@ from hassette.execution_mode import (
 from hassette.testing import wait_for
 from hassette.types.enums import ExecutionMode
 
+#: Hang guard for TestRunThroughGuard's event handshakes, which complete in milliseconds. It only
+#: converts a genuine hang into a failure, so it needs generous headroom over xdist scheduling
+#: jitter on a loaded CI runner — well above the ``wait_for`` helper's own 3.0s default.
+HANG_GUARD_TIMEOUT = 10.0
+
 
 def make_spawn() -> tuple[Callable[..., asyncio.Task[None]], list[asyncio.Task[None]]]:
     """Return a spawn callable (wrapping create_task) and the list of tasks it created."""
@@ -175,7 +180,7 @@ class TestRunThroughGuard:
         first_task = asyncio.create_task(
             run_through_guard(guard, spawn, pending_done, first_invoke, MagicMock(), "t", 60.0)
         )
-        await asyncio.wait_for(first_started.wait(), timeout=2.0)
+        await asyncio.wait_for(first_started.wait(), timeout=HANG_GUARD_TIMEOUT)
 
         # Second call — guard will SUPPRESS it; must return without hanging.
         warn = MagicMock()
@@ -189,14 +194,14 @@ class TestRunThroughGuard:
         second_task = asyncio.create_task(
             run_through_guard(guard, spawn, pending_done, second_invoke, warn, "t2", 60.0)
         )
-        await asyncio.wait_for(second_task, timeout=2.0)
+        await asyncio.wait_for(second_task, timeout=HANG_GUARD_TIMEOUT)
         assert not second_task.exception(), "second task raised unexpectedly"
         # The suppressed future was added then resolved+discarded inline, so the
         # set is back to exactly what it held before (the running first future).
         assert len(pending_done) == pending_before_second
 
         gate.set()
-        await asyncio.wait_for(first_task, timeout=2.0)
+        await asyncio.wait_for(first_task, timeout=HANG_GUARD_TIMEOUT)
 
     async def test_dropped_resolves_future_inline(self) -> None:
         """DROPPED outcome: future is resolved inline; function returns."""
@@ -221,24 +226,24 @@ class TestRunThroughGuard:
         first = asyncio.create_task(
             run_through_guard(guard, spawn, pending_done, invoke_running, MagicMock(), "r", 60.0)
         )
-        await asyncio.wait_for(started.wait(), timeout=2.0)
+        await asyncio.wait_for(started.wait(), timeout=HANG_GUARD_TIMEOUT)
 
         second = asyncio.create_task(
             run_through_guard(guard, spawn, pending_done, invoke_queued, MagicMock(), "q", 60.0)
         )
         # Deterministically wait until the queued factory is parked before the
         # third call, so the third is guaranteed to hit the cap and be DROPPED.
-        await wait_for(lambda: len(guard.pending) >= 1)
+        await wait_for(lambda: len(guard.pending) >= 1, timeout=HANG_GUARD_TIMEOUT)
 
         # Third — queue is full; this should be DROPPED and return quickly.
         third = asyncio.create_task(
             run_through_guard(guard, spawn, pending_done, invoke_dropped, MagicMock(), "d", 60.0)
         )
-        await asyncio.wait_for(third, timeout=2.0)
+        await asyncio.wait_for(third, timeout=HANG_GUARD_TIMEOUT)
 
         gate.set()
-        await asyncio.wait_for(first, timeout=2.0)
-        await asyncio.wait_for(second, timeout=2.0)
+        await asyncio.wait_for(first, timeout=HANG_GUARD_TIMEOUT)
+        await asyncio.wait_for(second, timeout=HANG_GUARD_TIMEOUT)
 
     async def test_ran_awaits_done_future(self) -> None:
         """RAN outcome: await completes after the spawned task finishes."""
@@ -274,12 +279,12 @@ class TestRunThroughGuard:
         dispatch_task = asyncio.create_task(
             run_through_guard(guard, spawn, pending_done, invoke, MagicMock(), "n", 60.0)
         )
-        await asyncio.wait_for(started.wait(), timeout=2.0)
+        await asyncio.wait_for(started.wait(), timeout=HANG_GUARD_TIMEOUT)
         # While the spawned task is running, pending_done should have the future.
         assert len(pending_done) == 1
 
         gate.set()
-        await asyncio.wait_for(dispatch_task, timeout=2.0)
+        await asyncio.wait_for(dispatch_task, timeout=HANG_GUARD_TIMEOUT)
         # After completion it should be gone.
         assert len(pending_done) == 0
 
@@ -332,20 +337,20 @@ class TestRunThroughGuard:
         first = asyncio.create_task(
             run_through_guard(guard, spawn, pending_done, invoke_running, MagicMock(), "r", 60.0)
         )
-        await asyncio.wait_for(started.wait(), timeout=2.0)
+        await asyncio.wait_for(started.wait(), timeout=HANG_GUARD_TIMEOUT)
 
         second = asyncio.create_task(
             run_through_guard(guard, spawn, pending_done, invoke_queued, MagicMock(), "q", 60.0)
         )
-        await wait_for(lambda: len(guard.pending) >= 1)
+        await wait_for(lambda: len(guard.pending) >= 1, timeout=HANG_GUARD_TIMEOUT)
 
         # Seal, then let the running invocation finish so drain_next pops the queued factory
         # and its spawn is rejected.
         sealed = True
         gate.set()
 
-        await asyncio.wait_for(first, timeout=2.0)
-        await asyncio.wait_for(second, timeout=2.0)
+        await asyncio.wait_for(first, timeout=HANG_GUARD_TIMEOUT)
+        await asyncio.wait_for(second, timeout=HANG_GUARD_TIMEOUT)
         assert len(pending_done) == 0
         assert len(guard.pending) == 0
 
@@ -389,20 +394,20 @@ class TestRunThroughGuard:
         first = asyncio.create_task(
             run_through_guard(guard, spawn, pending_done, invoke_running, MagicMock(), "r", 60.0)
         )
-        await asyncio.wait_for(started.wait(), timeout=2.0)
+        await asyncio.wait_for(started.wait(), timeout=HANG_GUARD_TIMEOUT)
 
         # Queue one invocation; its future is in pending_done but the factory won't run until drain.
         second = asyncio.create_task(
             run_through_guard(guard, spawn, pending_done, invoke_queued, MagicMock(), "q", 60.0)
         )
         # Deterministically wait until the queued factory is parked before releasing.
-        await wait_for(lambda: len(guard.pending) >= 1)
+        await wait_for(lambda: len(guard.pending) >= 1, timeout=HANG_GUARD_TIMEOUT)
 
         # Release + drain.
         await guard.release()
         drain_pending_done(pending_done)
 
         # Both futures should now be resolved; second_task should complete.
-        await asyncio.wait_for(second, timeout=2.0)
-        await asyncio.wait_for(first, timeout=2.0)
+        await asyncio.wait_for(second, timeout=HANG_GUARD_TIMEOUT)
+        await asyncio.wait_for(first, timeout=HANG_GUARD_TIMEOUT)
         assert len(pending_done) == 0


### PR DESCRIPTION
## Summary

`TestRunThroughGuard::test_dropped_at_drain_time_resolves_its_own_future` intermittently failed on CI with a bare `TimeoutError` on a PR whose diff didn't touch this test or `execution_mode.py`. The cause was the class's own hang guards. Every `asyncio.wait_for(..., timeout=2.0)` put a 2-second real-clock budget on an event handshake that normally finishes in about 20ms. Under xdist on a loaded CI runner, that budget is sometimes reachable.

The timeouts only turn a real hang into a failure; they aren't the thing being tested. The `run_through_guard(...)` calls pass their own `60.0` timeout separately.

## Changes

- Added a module-level `HANG_GUARD_TIMEOUT = 10.0` in `tests/unit/test_execution_mode_helpers.py`.
- Replaced every `asyncio.wait_for(..., timeout=2.0)` in `TestRunThroughGuard` with it, including sibling tests that haven't flaked yet. Otherwise the next loaded runner would just move the failure to one of them.
- Passed the same constant to the three `wait_for(lambda: len(guard.pending) >= 1)` helper calls that had been using the helper's 3.0s default.

The handshakes themselves are unchanged; they're what the tests exercise.

## Testing

- Set `HANG_GUARD_TIMEOUT` to `0.0` and confirmed all five handshake tests fail with the same bare `TimeoutError` CI showed. This shows the constant controls every guard and that the CI failure came from a guard firing, not a deadlock in `ExecutionModeGuard.drain_next`.
- `uv run pytest tests/unit/test_execution_mode_helpers.py -n 4`: 19 passed.
- `prek -a` and `prek pyright -a --stage pre-push` both pass.

The full backend, system, and e2e suites run in CI.

## Notes

#2163 proposes pulling the shared "one running + one queued invocation" arrange block in this class into a helper. When that lands, the helper can own this constant, so the timeout lives in one place.

Closes #2178
