### PR TITLE
test: move stranded LogTableView import into the import block

### DIFF
--- a/frontend/src/components/shared/log-table/log-table-view.test.tsx
+++ b/frontend/src/components/shared/log-table/log-table-view.test.tsx
@@ -8,6 +8,7 @@ import { formatTimestamp } from "@/utils/format";
 
 import type { ColumnFilters } from "../table-types";
 import { DEFAULT_SORT } from "./constants";
+import { LogTableView } from "./log-table-view";
 import type { ColumnId } from "./types";
 
 vi.mock("@/hooks/use-media-query", () => ({
@@ -20,8 +21,6 @@ vi.mock("@/hooks/use-relative-time", () => ({
 }));
 
 vi.mock("wouter", () => createWouterMock());
-
-import { LogTableView } from "./log-table-view";
 
 function makeEntry(seq: number) {
   return createLogEntry({ seq, timestamp: 1000 + seq, message: `msg-${seq}`, app_key: "app", source_tier: "app" });


### PR DESCRIPTION
## Summary

Moves the `LogTableView` import in `frontend/src/components/shared/log-table/log-table-view.test.tsx` up into the top import block, next to the other relative imports (`./constants`, `./types`). Before this change it sat below the three `vi.mock(...)` calls with no comment explaining why.

The split wasn't needed. `createWouterMock`'s docstring (`frontend/src/test/mock-wouter.ts`) warns about an import-order hazard, but it only fires when the eslint import sorter can place the component-under-test import *before* `@/test/mock-wouter`. Here `./log-table-view` is a same-directory relative import and `@/test/mock-wouter` is an alias-group import, so the sorter always puts the mock helper first. `app-link.test.tsx` had the same layout, and #2134 already removed it there.

Test-only change. No runtime or UI behavior changes.

## Testing

- `cd frontend && npx vitest run src/components/shared/log-table/log-table-view.test.tsx`: 44/44 passed, no "Cannot access before initialization" error
- `npx eslint src/components/shared/log-table/log-table-view.test.tsx`: clean, so the sorter accepts the new position
- `prek -a`: all hooks passed (prettier, eslint, tsc, and the rest)

CI runs the full backend, system, and frontend suites.

Closes #2194
