### PR TITLE
test: name the repeated test id literals in badge and alert-shell tests

### DIFF
--- a/frontend/src/components/shared/alert-shell.test.tsx
+++ b/frontend/src/components/shared/alert-shell.test.tsx
@@ -3,45 +3,47 @@ import { describe, expect, it } from "vitest";
 
 import { AlertShell } from "./alert-shell";
 
+const ALERT_SHELL_TEST_ID = "alert-shell";
+
 describe("AlertShell", () => {
   it("renders children inside the shared shell", () => {
     const { getByTestId } = render(
-      <AlertShell tone="danger" data-testid="b">
+      <AlertShell tone="danger" data-testid={ALERT_SHELL_TEST_ID}>
         boom
       </AlertShell>,
     );
-    const el = getByTestId("b");
+    const el = getByTestId(ALERT_SHELL_TEST_ID);
     expect(el.textContent).toBe("boom");
     expect(el.className).toContain("rounded-md");
   });
 
   it("applies the danger background token", () => {
     const { getByTestId } = render(
-      <AlertShell tone="danger" data-testid="b">
+      <AlertShell tone="danger" data-testid={ALERT_SHELL_TEST_ID}>
         x
       </AlertShell>,
     );
-    expect(getByTestId("b").className).toContain("bg-[var(--destructive-bg)]");
+    expect(getByTestId(ALERT_SHELL_TEST_ID).className).toContain("bg-[var(--destructive-bg)]");
   });
 
   it("applies the warning background token", () => {
     const { getByTestId } = render(
-      <AlertShell tone="warning" data-testid="b">
+      <AlertShell tone="warning" data-testid={ALERT_SHELL_TEST_ID}>
         x
       </AlertShell>,
     );
-    expect(getByTestId("b").className).toContain("bg-[var(--status-warning-bg)]");
+    expect(getByTestId(ALERT_SHELL_TEST_ID).className).toContain("bg-[var(--status-warning-bg)]");
   });
 
   it("lets className override the shell's own geometry", () => {
     // The className contract promises twMerge ordering, so a conflicting utility wins. Pinned
     // because `panel.tsx`'s PANEL_BANNER_CLASS relies on it to drop the standalone bottom margin.
     const { getByTestId } = render(
-      <AlertShell tone="warning" className="mb-0 rounded-sm" data-testid="b">
+      <AlertShell tone="warning" className="mb-0 rounded-sm" data-testid={ALERT_SHELL_TEST_ID}>
         nested
       </AlertShell>,
     );
-    const el = getByTestId("b");
+    const el = getByTestId(ALERT_SHELL_TEST_ID);
     expect(el.className).toContain("mb-0");
     expect(el.className).not.toContain("mb-4");
     expect(el.className).toContain("rounded-sm");
@@ -50,11 +52,16 @@ describe("AlertShell", () => {
 
   it("forwards role and extra classes", () => {
     const { getByTestId } = render(
-      <AlertShell tone="warning" role="alert" className="text-[var(--status-warning)]" data-testid="b">
+      <AlertShell
+        tone="warning"
+        role="alert"
+        className="text-[var(--status-warning)]"
+        data-testid={ALERT_SHELL_TEST_ID}
+      >
         blocked
       </AlertShell>,
     );
-    const el = getByTestId("b");
+    const el = getByTestId(ALERT_SHELL_TEST_ID);
     expect(el.getAttribute("role")).toBe("alert");
     expect(el.className).toContain("text-[var(--status-warning)]");
   });

--- a/frontend/src/components/shared/badge.test.tsx
+++ b/frontend/src/components/shared/badge.test.tsx
@@ -3,210 +3,215 @@ import { describe, expect, it } from "vitest";
 
 import { Badge } from "@/components/ui/badge";
 
+const BADGE_TEST_ID = "badge";
+const PASSTHROUGH_TEST_ID = "my-badge";
+
 describe("Badge", () => {
   describe("status variants (formerly Badge's BadgeVariant)", () => {
     it("applies success variant", () => {
       const { getByTestId } = render(
-        <Badge variant="success" data-testid="b">
+        <Badge variant="success" data-testid={BADGE_TEST_ID}>
           ok
         </Badge>,
       );
-      expect(getByTestId("b").getAttribute("data-variant")).toBe("success");
+      expect(getByTestId(BADGE_TEST_ID).getAttribute("data-variant")).toBe("success");
     });
 
     it("applies danger variant", () => {
       const { getByTestId } = render(
-        <Badge variant="danger" data-testid="b">
+        <Badge variant="danger" data-testid={BADGE_TEST_ID}>
           err
         </Badge>,
       );
-      expect(getByTestId("b").getAttribute("data-variant")).toBe("danger");
+      expect(getByTestId(BADGE_TEST_ID).getAttribute("data-variant")).toBe("danger");
     });
 
     it("applies warning variant", () => {
       const { getByTestId } = render(
-        <Badge variant="warning" data-testid="b">
+        <Badge variant="warning" data-testid={BADGE_TEST_ID}>
           warn
         </Badge>,
       );
-      expect(getByTestId("b").getAttribute("data-variant")).toBe("warning");
+      expect(getByTestId(BADGE_TEST_ID).getAttribute("data-variant")).toBe("warning");
     });
 
     it("applies info variant", () => {
       const { getByTestId } = render(
-        <Badge variant="info" data-testid="b">
+        <Badge variant="info" data-testid={BADGE_TEST_ID}>
           info
         </Badge>,
       );
-      expect(getByTestId("b").getAttribute("data-variant")).toBe("info");
+      expect(getByTestId(BADGE_TEST_ID).getAttribute("data-variant")).toBe("info");
     });
 
     it("applies neutral variant", () => {
       const { getByTestId } = render(
-        <Badge variant="neutral" data-testid="b">
+        <Badge variant="neutral" data-testid={BADGE_TEST_ID}>
           n/a
         </Badge>,
       );
-      expect(getByTestId("b").getAttribute("data-variant")).toBe("neutral");
+      expect(getByTestId(BADGE_TEST_ID).getAttribute("data-variant")).toBe("neutral");
     });
   });
 
   describe("chip-style variants (formerly Chip's ChipVariant, flattened)", () => {
     it("applies job variant", () => {
       const { getByTestId } = render(
-        <Badge variant="job" data-testid="c">
+        <Badge variant="job" data-testid={BADGE_TEST_ID}>
           sched
         </Badge>,
       );
-      expect(getByTestId("c").getAttribute("data-variant")).toBe("job");
+      expect(getByTestId(BADGE_TEST_ID).getAttribute("data-variant")).toBe("job");
     });
 
     it("applies listener variant", () => {
       const { getByTestId } = render(
-        <Badge variant="listener" data-testid="c">
+        <Badge variant="listener" data-testid={BADGE_TEST_ID}>
           mod
         </Badge>,
       );
-      expect(getByTestId("c").getAttribute("data-variant")).toBe("listener");
+      expect(getByTestId(BADGE_TEST_ID).getAttribute("data-variant")).toBe("listener");
     });
 
     it("applies origin variant", () => {
       const { getByTestId } = render(
-        <Badge variant="origin" data-testid="c">
+        <Badge variant="origin" data-testid={BADGE_TEST_ID}>
           origin
         </Badge>,
       );
-      expect(getByTestId("c").getAttribute("data-variant")).toBe("origin");
+      expect(getByTestId(BADGE_TEST_ID).getAttribute("data-variant")).toBe("origin");
     });
 
     it("applies muted variant", () => {
       const { getByTestId } = render(
-        <Badge variant="muted" data-testid="c">
+        <Badge variant="muted" data-testid={BADGE_TEST_ID}>
           muted
         </Badge>,
       );
-      expect(getByTestId("c").getAttribute("data-variant")).toBe("muted");
+      expect(getByTestId(BADGE_TEST_ID).getAttribute("data-variant")).toBe("muted");
     });
   });
 
   describe("kind sub-variants (formerly Chip's variant='kind' kind={ChipKind} union)", () => {
     it("applies kind-ok variant", () => {
       const { getByTestId } = render(
-        <Badge variant="kind-ok" data-testid="c">
+        <Badge variant="kind-ok" data-testid={BADGE_TEST_ID}>
           ok
         </Badge>,
       );
-      expect(getByTestId("c").getAttribute("data-variant")).toBe("kind-ok");
+      expect(getByTestId(BADGE_TEST_ID).getAttribute("data-variant")).toBe("kind-ok");
     });
 
     it("applies kind-warn variant", () => {
       const { getByTestId } = render(
-        <Badge variant="kind-warn" data-testid="c">
+        <Badge variant="kind-warn" data-testid={BADGE_TEST_ID}>
           warn
         </Badge>,
       );
-      expect(getByTestId("c").getAttribute("data-variant")).toBe("kind-warn");
+      expect(getByTestId(BADGE_TEST_ID).getAttribute("data-variant")).toBe("kind-warn");
     });
 
     it("applies kind-err variant", () => {
       const { getByTestId } = render(
-        <Badge variant="kind-err" data-testid="c">
+        <Badge variant="kind-err" data-testid={BADGE_TEST_ID}>
           err
         </Badge>,
       );
-      expect(getByTestId("c").getAttribute("data-variant")).toBe("kind-err");
+      expect(getByTestId(BADGE_TEST_ID).getAttribute("data-variant")).toBe("kind-err");
     });
 
     it("applies kind-cancel variant", () => {
       const { getByTestId } = render(
-        <Badge variant="kind-cancel" data-testid="c">
+        <Badge variant="kind-cancel" data-testid={BADGE_TEST_ID}>
           cancel
         </Badge>,
       );
-      expect(getByTestId("c").getAttribute("data-variant")).toBe("kind-cancel");
+      expect(getByTestId(BADGE_TEST_ID).getAttribute("data-variant")).toBe("kind-cancel");
     });
 
     it("applies kind-mute variant", () => {
       const { getByTestId } = render(
-        <Badge variant="kind-mute" data-testid="c">
+        <Badge variant="kind-mute" data-testid={BADGE_TEST_ID}>
           mute
         </Badge>,
       );
-      expect(getByTestId("c").getAttribute("data-variant")).toBe("kind-mute");
+      expect(getByTestId(BADGE_TEST_ID).getAttribute("data-variant")).toBe("kind-mute");
     });
   });
 
   describe("size prop", () => {
     it("applies xs size", () => {
       const { getByTestId } = render(
-        <Badge variant="success" size="xs" data-testid="b">
+        <Badge variant="success" size="xs" data-testid={BADGE_TEST_ID}>
           ok
         </Badge>,
       );
-      expect(getByTestId("b").className).toMatch(/text-\[11px\]/);
+      expect(getByTestId(BADGE_TEST_ID).className).toMatch(/text-\[11px\]/);
     });
 
     it("applies sm size", () => {
       const { getByTestId } = render(
-        <Badge variant="success" size="sm" data-testid="b">
+        <Badge variant="success" size="sm" data-testid={BADGE_TEST_ID}>
           ok
         </Badge>,
       );
-      expect(getByTestId("b").className).toMatch(/text-xs/);
+      expect(getByTestId(BADGE_TEST_ID).className).toMatch(/text-xs/);
     });
 
     it("applies md size", () => {
       const { getByTestId } = render(
-        <Badge variant="success" size="md" data-testid="b">
+        <Badge variant="success" size="md" data-testid={BADGE_TEST_ID}>
           ok
         </Badge>,
       );
-      expect(getByTestId("b").className).toMatch(/text-sm/);
+      expect(getByTestId(BADGE_TEST_ID).className).toMatch(/text-sm/);
     });
   });
 
   describe("class prop", () => {
     it("merges additional class into span className", () => {
       const { getByTestId } = render(
-        <Badge variant="success" className="my-extra-class" data-testid="b">
+        <Badge variant="success" className="my-extra-class" data-testid={BADGE_TEST_ID}>
           ok
         </Badge>,
       );
-      expect(getByTestId("b").className).toMatch(/my-extra-class/);
+      expect(getByTestId(BADGE_TEST_ID).className).toMatch(/my-extra-class/);
     });
   });
 
   describe("children", () => {
     it("renders text children", () => {
       const { getByTestId } = render(
-        <Badge variant="success" data-testid="b">
+        <Badge variant="success" data-testid={BADGE_TEST_ID}>
           running
         </Badge>,
       );
-      expect(getByTestId("b").textContent).toBe("running");
+      expect(getByTestId(BADGE_TEST_ID).textContent).toBe("running");
     });
 
     it("renders mixed children (text + icon element)", () => {
       const { getByTestId } = render(
-        <Badge variant="kind-ok" data-testid="b">
+        <Badge variant="kind-ok" data-testid={BADGE_TEST_ID}>
           <svg data-testid="icon" />
           running
         </Badge>,
       );
-      const el = getByTestId("b");
+      const el = getByTestId(BADGE_TEST_ID);
       expect(el.querySelector("[data-testid='icon']")).not.toBeNull();
       expect(el.textContent).toContain("running");
     });
   });
 
   describe("pass-through attributes", () => {
+    // Needs an id no other test in this file renders, so the assertion can only pass
+    // if an arbitrary caller-supplied id actually reached the DOM.
     it("passes data-testid through to span element", () => {
       const { getByTestId } = render(
-        <Badge variant="success" data-testid="my-badge">
+        <Badge variant="success" data-testid={PASSTHROUGH_TEST_ID}>
           ok
         </Badge>,
       );
-      expect(getByTestId("my-badge")).not.toBeNull();
+      expect(getByTestId(PASSTHROUGH_TEST_ID)).not.toBeNull();
     });
 
     it("passes aria-label through to span element", () => {
@@ -222,11 +227,11 @@ describe("Badge", () => {
   describe("renders as span", () => {
     it("renders a <span> element", () => {
       const { getByTestId } = render(
-        <Badge variant="neutral" data-testid="b">
+        <Badge variant="neutral" data-testid={BADGE_TEST_ID}>
           text
         </Badge>,
       );
-      expect(getByTestId("b").tagName.toLowerCase()).toBe("span");
+      expect(getByTestId(BADGE_TEST_ID).tagName.toLowerCase()).toBe("span");
     });
   });
 });


### PR DESCRIPTION
## Summary

`badge.test.tsx` and `alert-shell.test.tsx` were the last two test files in `frontend/src/components/shared/` that still wrote `data-testid` literals inline. This PR moves them to module-level constants, the same pattern `card.test.tsx` uses (#2197), `handler-list.test.tsx`, and `registration-footer.test.tsx`.

- `alert-shell.test.tsx`: adds `ALERT_SHELL_TEST_ID`. Every `data-testid` prop and `getByTestId` lookup for the alert-shell root now uses it.
- `badge.test.tsx`: adds `BADGE_TEST_ID`. The badge root had two ids, `"b"` and `"c"`. Each test renders a single badge, so both now use `BADGE_TEST_ID`.
  - The pass-through test keeps its own `PASSTHROUGH_TEST_ID`. Its assertion needs an id that no other test renders, and a comment above the test says so.
  - The child `"icon"` id stays inline because it identifies a different DOM node.

Only test code changes. No component or runtime behavior changes.

## Testing

- `prek -a`: all hooks pass (ruff, prettier, eslint, stylelint, tsc, house lints).
- `npx vitest run src/components/shared/badge.test.tsx src/components/shared/alert-shell.test.tsx`: 2 files, 28 tests, all passing.
- Test counts match `main`: `badge.test.tsx` 23 → 23, `alert-shell.test.tsx` 5 → 5.

CI runs the full backend, system, and frontend suites.

Closes #2198
