### PR TITLE
test: share the breadcrumb trail fixture and widen the drift assertion

### DIFF
--- a/frontend/src/components/shared/breadcrumbs.test.tsx
+++ b/frontend/src/components/shared/breadcrumbs.test.tsx
@@ -2,9 +2,15 @@ import { render } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 
 import { createWouterMock } from "../../test/mock-wouter";
-import { Breadcrumbs, SIDEBAR_VISIBLE_CRUMBS } from "./breadcrumbs";
+import { Breadcrumbs, type Crumb, SIDEBAR_VISIBLE_CRUMBS } from "./breadcrumbs";
 
 vi.mock("wouter", () => createWouterMock());
+
+const THREE_CRUMB_TRAIL: Crumb[] = [
+  { label: "apps", href: "/apps" },
+  { label: "demo_app", href: "/apps/demo_app" },
+  { label: "handlers" },
+];
 
 describe("Breadcrumbs", () => {
   it("renders nothing when the trail is empty", () => {
@@ -13,11 +19,7 @@ describe("Breadcrumbs", () => {
   });
 
   it("links every crumb except the current page", () => {
-    const { getByTestId } = render(
-      <Breadcrumbs
-        items={[{ label: "apps", href: "/apps" }, { label: "demo_app", href: "/apps/demo_app" }, { label: "handlers" }]}
-      />,
-    );
+    const { getByTestId } = render(<Breadcrumbs items={THREE_CRUMB_TRAIL} />);
     const links = getByTestId("breadcrumbs").querySelectorAll("a");
     expect(Array.from(links).map((a) => a.textContent)).toEqual(["apps", "demo_app"]);
   });
@@ -57,25 +59,20 @@ describe("Breadcrumbs", () => {
   });
 
   it("adds an ellipsis stand-in once ancestors can be hidden", () => {
-    const { getByTestId } = render(
-      <Breadcrumbs
-        items={[{ label: "apps", href: "/apps" }, { label: "demo_app", href: "/apps/demo_app" }, { label: "handlers" }]}
-      />,
-    );
+    const { getByTestId } = render(<Breadcrumbs items={THREE_CRUMB_TRAIL} />);
     expect(getByTestId("breadcrumbs").textContent).toContain("…");
   });
 
-  it("keeps the hard-coded nth-last-child selectors in step with SIDEBAR_VISIBLE_CRUMBS", () => {
-    // Tailwind cannot interpolate the constant into class names, so the selectors carry their
-    // own literals. Changing one without the other moves the ellipsis threshold while the
-    // clipping and separator-hiding stay put.
-    const { getByTestId } = render(
-      <Breadcrumbs
-        items={[{ label: "apps", href: "/apps" }, { label: "demo_app", href: "/apps/demo_app" }, { label: "handlers" }]}
-      />,
-    );
-    const crumb = getByTestId("breadcrumbs").querySelector("[aria-current='page']")?.closest("li");
-    expect(crumb?.className).toContain(`nth-last-child(-n+${SIDEBAR_VISIBLE_CRUMBS})`);
-    expect(crumb?.className).toContain(`nth-last-child(${SIDEBAR_VISIBLE_CRUMBS})`);
+  it("keeps the CSS selectors in step with SIDEBAR_VISIBLE_CRUMBS", () => {
+    // The selectors carry their own literals rather than reading the constant; this fails if
+    // either one drifts from it. See breadcrumbs.tsx for why they cannot be interpolated.
+    const { getByTestId } = render(<Breadcrumbs items={THREE_CRUMB_TRAIL} />);
+    // Every crumb carries the same static class string; the ellipsis stand-in is aria-hidden.
+    const crumbs = getByTestId("breadcrumbs").querySelectorAll("li:not([aria-hidden='true'])");
+    expect(crumbs).toHaveLength(THREE_CRUMB_TRAIL.length);
+    for (const crumb of Array.from(crumbs)) {
+      expect(crumb.className).toContain(`nth-last-child(-n+${SIDEBAR_VISIBLE_CRUMBS})`);
+      expect(crumb.className).toContain(`nth-last-child(${SIDEBAR_VISIBLE_CRUMBS})`);
+    }
   });
 });

--- a/frontend/src/components/shared/breadcrumbs.tsx
+++ b/frontend/src/components/shared/breadcrumbs.tsx
@@ -45,10 +45,10 @@ export function Breadcrumbs({ items, "data-testid": testId = "breadcrumbs" }: Pr
             className={cn(
               "inline-flex min-w-0 items-center gap-1",
               // Both selectors hard-code SIDEBAR_VISIBLE_CRUMBS, because Tailwind extracts class
-              // names statically from source and cannot interpolate it; breadcrumbs.test.tsx
-              // fails if either drifts from the constant. They are not the same idiom: -n+N is a
-              // range, clipping every crumb outside the last N, while (N) is a position, hiding
-              // the leading separator on the Nth-from-last crumb — the first one still visible.
+              // names statically from source and cannot interpolate it; a test asserts both stay
+              // in step with the constant. They are not the same idiom: -n+N is a range, clipping
+              // every crumb outside the last N, while (N) is a position, hiding the leading
+              // separator on the Nth-from-last crumb — the first one still visible.
               "max-sidebar:[&:not(:nth-last-child(-n+2))]:sr-only",
               "max-sidebar:[&:nth-last-child(2)>span]:hidden",
             )}


### PR DESCRIPTION
## Summary

Review follow-up to #2212, which merged before this round of review fixes could land on it. No behavior change — test-only plus comments.

#2212 added a drift guard tying `SIDEBAR_VISIBLE_CRUMBS` to the two hard-coded Tailwind `nth-last-child` literals in `breadcrumbs.tsx`. Reviewers raised three points on the shipped version, all addressed here:

- **Shared fixture.** The same three-crumb trail was declared inline in three separate cases in `breadcrumbs.test.tsx`, and the drift test added the third copy. It is now one module-level `THREE_CRUMB_TRAIL` constant, matching the module-level fixture convention already used in sibling tests (`traceback-viewer.test.tsx`, `execution-table.test.tsx`, `log-table-view.test.tsx`).
- **Assertion reaches every crumb, not one arbitrary element.** The guard previously found a single `<li>` via `querySelector("[aria-current='page']")?.closest("li")`. Every crumb carries the identical static class string, so picking the current-page one read as meaningful when it was arbitrary, and the optional chaining meant a failed query surfaced as `expect(undefined).toContain(...)` rather than a clear locator failure. It now selects every crumb `<li>` (`li:not([aria-hidden='true'])`, which excludes the `aria-hidden` ellipsis stand-in), asserts the expected count first, then checks both selectors on each.
- **Comment de-duplication.** The Tailwind-cannot-interpolate rationale was stated in three places. `breadcrumbs.tsx`'s usage-site comment keeps the full explanation; the test comment now says what the test guards and points at the component. That comment also no longer names `breadcrumbs.test.tsx` by filename, so a rename cannot silently stale it.

## Testing

- `npx vitest run src/components/shared/breadcrumbs.test.tsx`: 8/8 pass.
- Full frontend suite: 1613 tests across 110 files pass.
- **Drift verified by mutation, not inspection.** Six mutations of `breadcrumbs.tsx`, each reverted after: constant `2→3`; range selector `-n+2→-n+3`; position selector `(2)→(3)`; range `-n+2→-n+20` and position `(2)→(20)` (superstring cases, to confirm `toContain` cannot match a longer literal); and deleting the range selector outright. Every one fails the guard; the unmutated baseline is green.
- Confirmed by probe that `li:not([aria-hidden='true'])` returns exactly the 3 crumb `<li>`s out of the 4 `<li>`s rendered for a three-crumb trail.
- `prettier --check`, `eslint`, and `tsc --noEmit` all clean; the full pre-commit hook set passed.

## Visual evidence

None — carries `no-visual-change`. `breadcrumbs.tsx` changes only a comment block; no JSX, class string, or style changes, so rendered output is byte-identical to `main`.
