### PR TITLE
test: move stranded LogTableWithDrawer imports into the import block

### DIFF
--- a/frontend/src/components/shared/log-table/log-table-with-drawer.test.tsx
+++ b/frontend/src/components/shared/log-table/log-table-with-drawer.test.tsx
@@ -3,13 +3,13 @@ import { describe, expect, it, vi } from "vitest";
 
 import { createLogEntry } from "@/test/factories";
 
+import { LogTableWithDrawer } from "./log-table-with-drawer";
+import type { LogDrawerProps } from "./use-log-table";
+
 vi.mock("./log-detail-drawer", () => ({
   LogDetailDrawer: (props: { selectedKey: string | null }) =>
     props.selectedKey ? <aside data-testid="drawer" role="complementary" /> : null,
 }));
-
-import { LogTableWithDrawer } from "./log-table-with-drawer";
-import type { LogDrawerProps } from "./use-log-table";
 
 function makeEntry(seq: number) {
   return createLogEntry({ seq, timestamp: 1000 + seq, message: `msg-${seq}`, app_key: "app", source_tier: "app" });


### PR DESCRIPTION
## Summary

In `frontend/src/components/shared/log-table/log-table-with-drawer.test.tsx`, the `LogTableWithDrawer` and `LogDrawerProps` imports were below the `vi.mock("./log-detail-drawer", ...)` call. This PR moves them up into the file's import block.

Nothing depended on that ordering. Vitest hoists `vi.mock` above all imports wherever the call appears in the source. The mocked module (`./log-detail-drawer`) isn't the component under test, and the file doesn't use `createWouterMock`, so there's no TDZ hazard to protect against. Left as it was, the file looked like it was working around a problem it doesn't have.

This is the last instance of the stranded-import pattern that #2134 (`app-link.test.tsx`) and #2210 (`log-table-view.test.tsx`) fixed elsewhere. A grep of `frontend/src` during the #2210 review found no others.

The `vi.mock` call itself is unchanged and still sits below the import block. This PR changes no behavior.

## Testing

- `prek -a`: all hooks pass
- `npx vitest run src/components/shared/log-table/log-table-with-drawer.test.tsx`: 7/7 pass, with no "Cannot access before initialization" error
- `npx eslint src/components/shared/log-table/log-table-with-drawer.test.tsx`: clean

CI runs the full backend, system, and frontend suites.

Closes #2211
