### PR TITLE
test: name repeated literals and derive the selected key in LogTableWithDrawer tests

### DIFF
--- a/frontend/src/components/shared/log-table/log-table-with-drawer.test.tsx
+++ b/frontend/src/components/shared/log-table/log-table-with-drawer.test.tsx
@@ -4,12 +4,17 @@ import { describe, expect, it, vi } from "vitest";
 import { createLogEntry } from "@/test/factories";
 
 import { LogTableWithDrawer } from "./log-table-with-drawer";
+import { rowKey } from "./types";
 import type { LogDrawerProps } from "./use-log-table";
 
 vi.mock("./log-detail-drawer", () => ({
   LogDetailDrawer: (props: { selectedKey: string | null }) =>
     props.selectedKey ? <aside data-testid="drawer" role="complementary" /> : null,
 }));
+
+const WRAPPER_TEST_ID = "log-table-with-drawer";
+const TABLE_AREA_TEST_ID = "log-table-drawer-table-area";
+const DRAWER_OPEN_GRID_CLASS = "grid-cols-[1fr_var(--size-drawer)]";
 
 function makeEntry(seq: number) {
   return createLogEntry({ seq, timestamp: 1000 + seq, message: `msg-${seq}`, app_key: "app", source_tier: "app" });
@@ -25,6 +30,11 @@ function makeDrawerProps(overrides: Partial<LogDrawerProps> = {}): LogDrawerProp
   };
 }
 
+function makeSelectedDrawerProps(): LogDrawerProps {
+  const entry = makeEntry(1);
+  return makeDrawerProps({ selectedKey: rowKey(entry), entries: [entry] });
+}
+
 function renderWithDrawer(drawerProps: LogDrawerProps, children = <div data-testid="table-content" />) {
   return render(<LogTableWithDrawer drawerProps={drawerProps}>{children}</LogTableWithDrawer>);
 }
@@ -33,40 +43,40 @@ describe("LogTableWithDrawer", () => {
   describe("wrapper element", () => {
     it("renders the grid wrapper element", () => {
       const { getByTestId } = renderWithDrawer(makeDrawerProps());
-      expect(getByTestId("log-table-with-drawer")).not.toBeNull();
+      expect(getByTestId(WRAPPER_TEST_ID)).not.toBeNull();
     });
   });
 
   describe("tableArea", () => {
     it("renders children inside the tableArea element", () => {
       const { getByTestId } = renderWithDrawer(makeDrawerProps());
-      const tableArea = getByTestId("log-table-drawer-table-area");
-      expect(tableArea!.contains(getByTestId("table-content"))).toBe(true);
+      const tableArea = getByTestId(TABLE_AREA_TEST_ID);
+      expect(tableArea.contains(getByTestId("table-content"))).toBe(true);
     });
 
     it("renders arbitrary children content inside tableArea", () => {
       const { getByText, getByTestId } = renderWithDrawer(makeDrawerProps(), <span>hello from children</span>);
-      const tableArea = getByTestId("log-table-drawer-table-area");
-      expect(tableArea!.textContent).toContain("hello from children");
+      const tableArea = getByTestId(TABLE_AREA_TEST_ID);
+      expect(tableArea.textContent).toContain("hello from children");
       expect(getByText("hello from children")).not.toBeNull();
     });
   });
 
   describe("open layout state", () => {
     it("switches to a two-column grid when selectedKey is not null", () => {
-      const { getByTestId } = renderWithDrawer(makeDrawerProps({ selectedKey: "1001-1", entries: [makeEntry(1)] }));
-      expect(getByTestId("log-table-with-drawer").className).toContain("grid-cols-[1fr_var(--size-drawer)]");
+      const { getByTestId } = renderWithDrawer(makeSelectedDrawerProps());
+      expect(getByTestId(WRAPPER_TEST_ID).className).toContain(DRAWER_OPEN_GRID_CLASS);
     });
 
     it("does not switch to the drawer-open grid when selectedKey is null", () => {
       const { getByTestId } = renderWithDrawer(makeDrawerProps({ selectedKey: null }));
-      expect(getByTestId("log-table-with-drawer").className).not.toContain("grid-cols-[1fr_var(--size-drawer)]");
+      expect(getByTestId(WRAPPER_TEST_ID).className).not.toContain(DRAWER_OPEN_GRID_CLASS);
     });
   });
 
   describe("LogDetailDrawer", () => {
     it("renders the drawer when selectedKey is not null", () => {
-      const { getByTestId } = renderWithDrawer(makeDrawerProps({ selectedKey: "1001-1", entries: [makeEntry(1)] }));
+      const { getByTestId } = renderWithDrawer(makeSelectedDrawerProps());
       expect(getByTestId("drawer")).not.toBeNull();
     });
 


### PR DESCRIPTION
## Summary

Cleans up `frontend/src/components/shared/log-table/log-table-with-drawer.test.tsx`. This is test-only and changes no runtime behavior.

- **Shared grid-class constant.** The open-drawer Tailwind class `grid-cols-[1fr_var(--size-drawer)]` is now `DRAWER_OPEN_GRID_CLASS`. Both the `toContain` and `not.toContain` assertions use it. Before, the two assertions were separate literals. If only the positive one got updated after a class change, the negative one would keep passing against any class string.
- **Testid constants.** `"log-table-with-drawer"` and `"log-table-drawer-table-area"` are now the file-level constants `WRAPPER_TEST_ID` and `TABLE_AREA_TEST_ID`.
- **Derived selected key.** The hardcoded `"1001-1"` selectedKey is replaced by a `makeSelectedDrawerProps()` helper that builds the entry with `makeEntry(1)` and gets its key from the real `rowKey()` in `./types`. The key can no longer drift from the entry's `timestamp`/`seq` or from how production builds keys.
- **Removed redundant `!`.** Dropped the non-null assertions on `getByTestId(...)` results. `getByTestId` throws when the element is missing, so the `!` did nothing, and the rest of the file already called straight through.

## Testing

- `prek -a`: all hooks pass (ruff, eslint, prettier, tsc, test-factory shadowing, etc.)
- `npx vitest run src/components/shared/log-table/log-table-with-drawer.test.tsx` in `frontend/`: 7/7 tests pass

CI runs the full backend and frontend suites.

Closes #2216
