### PR TITLE
test: assert filter-icon active dot with queryByTestId null check

### DIFF
--- a/frontend/src/components/shared/filter-icon.test.tsx
+++ b/frontend/src/components/shared/filter-icon.test.tsx
@@ -38,8 +38,7 @@ describe("FilterIcon", () => {
 
   it("shows active dot when active=true", () => {
     render(<FilterIcon active={true} />);
-    const dot = screen.getByTestId("filter-icon-dot");
-    expect(dot).toBeTruthy();
+    expect(screen.queryByTestId("filter-icon-dot")).not.toBeNull();
   });
 
   it("does not show active dot when active=false", () => {


### PR DESCRIPTION
## Summary

Replaces the redundant active-dot assertion in `filter-icon.test.tsx` with one that
actually does the checking.

The "shows active dot when active=true" test was written as:

```tsx
const dot = screen.getByTestId("filter-icon-dot");
expect(dot).toBeTruthy();
```

`getByTestId` throws when the element is missing, so the throwing getter was the real
test and `toBeTruthy()` could never fail — it asserted on a value that was guaranteed
non-null by the line above it. Now:

```tsx
expect(screen.queryByTestId("filter-icon-dot")).not.toBeNull();
```

## Why

- The assertion itself is now the check, rather than riding on a side effect of the query helper.
- The positive and the two negative dot tests now use the same `queryByTestId` query and differ
  only by `.not`, so they read as a set.
- `.not.toBeNull()` is the idiom already used elsewhere in this file (lines 10 and 16) and is the
  more common one across `frontend/src` tests.
- The unused `dot` local goes away.

Test coverage is unchanged — this is a hygiene fix, not a behavior change.

## Testing

- `cd frontend && npx vitest run src/components/shared/filter-icon.test.tsx` — 8 passed
- `prek -a` — all hooks pass (ruff, eslint, prettier, stylelint, tsc, and the repo's custom checks)

CI runs the full backend, system, and frontend suites.

No screenshots: the change is confined to a `*.test.tsx` file, which
`tools/frontend/check_pr_screenshots.py` explicitly excludes from the visual-evidence
requirement, and nothing rendered was touched.

Closes #2218
