### PR TITLE
test: assert real Tailwind classes and deduplicate icons smoke tests

### DIFF
--- a/frontend/src/components/shared/icons.test.tsx
+++ b/frontend/src/components/shared/icons.test.tsx
@@ -1,45 +1,45 @@
 import { render } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 
-import { IconPlay, IconRefresh, IconSquare, IconWarning } from "./icons";
+import { IconArrowRight, IconChevron, IconPlay, IconRefresh, IconSquare, IconWarning } from "./icons";
+
+/** Every icon built on the shared `StrokeIcon` wrapper. `IconChevron` renders its own svg, so it is tested separately. */
+const STROKE_ICONS = [IconPlay, IconSquare, IconRefresh, IconArrowRight, IconWarning];
+
+const STROKE_ICON_CASES = STROKE_ICONS.map((Icon) => [Icon.name, Icon] as const);
 
 describe("Icons smoke tests", () => {
-  it("IconPlay renders an SVG element", () => {
-    const { container } = render(<IconPlay />);
+  it.each(STROKE_ICON_CASES)("%s renders an SVG element", (_name, Icon) => {
+    const { container } = render(<Icon />);
     expect(container.querySelector("svg")).not.toBeNull();
   });
 
-  it("IconSquare renders an SVG element", () => {
-    const { container } = render(<IconSquare />);
-    expect(container.querySelector("svg")).not.toBeNull();
+  it.each(STROKE_ICON_CASES)("%s carries the shared wrapper classes", (_name, Icon) => {
+    const { container } = render(<Icon />);
+    const svg = container.querySelector("svg");
+    expect(svg?.getAttribute("class")?.split(/\s+/)).toEqual(
+      expect.arrayContaining(["size-4", "shrink-0", "align-middle"]),
+    );
   });
 
-  it("IconRefresh renders an SVG element", () => {
-    const { container } = render(<IconRefresh />);
-    expect(container.querySelector("svg")).not.toBeNull();
+  it.each(STROKE_ICON_CASES)("%s has aria-hidden='true'", (_name, Icon) => {
+    const { container } = render(<Icon />);
+    expect(container.querySelector("svg")?.getAttribute("aria-hidden")).toBe("true");
   });
 
-  it("IconWarning renders an SVG element", () => {
-    const { container } = render(<IconWarning />);
-    expect(container.querySelector("svg")).not.toBeNull();
-  });
+  it("IconChevron is aria-hidden and swaps its points on open", () => {
+    const closed = render(<IconChevron open={false} />);
+    const closedSvg = closed.container.querySelector("svg");
+    expect(closedSvg?.getAttribute("aria-hidden")).toBe("true");
+    const closedPoints = closedSvg?.querySelector("polyline")?.getAttribute("points");
 
-  it("all icons have the iconSvg module class", () => {
-    const icons = [IconPlay, IconSquare, IconRefresh, IconWarning];
-    for (const Icon of icons) {
-      const { container } = render(<Icon />);
-      const svg = container.querySelector("svg");
-      // CSS modules produce a scoped class name — just verify the svg has a class attribute
-      expect(svg?.getAttribute("class")).toBeTruthy();
-    }
-  });
+    const opened = render(<IconChevron open={true} />);
+    const openedSvg = opened.container.querySelector("svg");
+    expect(openedSvg?.getAttribute("aria-hidden")).toBe("true");
+    const openedPoints = openedSvg?.querySelector("polyline")?.getAttribute("points");
 
-  it("all icons have aria-hidden='true'", () => {
-    const icons = [IconPlay, IconSquare, IconRefresh, IconWarning];
-    for (const Icon of icons) {
-      const { container } = render(<Icon />);
-      const svg = container.querySelector("svg");
-      expect(svg?.getAttribute("aria-hidden")).toBe("true");
-    }
+    expect(closedPoints).toBeTruthy();
+    expect(openedPoints).toBeTruthy();
+    expect(openedPoints).not.toBe(closedPoints);
   });
 });


### PR DESCRIPTION
## Summary

Rewrites `frontend/src/components/shared/icons.test.tsx` so its assertions match how the icons are actually built today, and collapses the hand-unrolled duplication.

The file was written against a CSS-modules setup this repo no longer uses. The old test was named `"all icons have the iconSvg module class"` and asserted only `expect(svg?.getAttribute("class")).toBeTruthy()`, justified by a comment claiming class names are hashed and therefore unassertable. Neither holds: there are no `*.module.css` files, `iconSvg` existed nowhere but in that test's own name, and `StrokeIcon` applies plain Tailwind utilities (`size-4 shrink-0 align-middle`) that are stable source text. The assertion had decayed into a near-tautology that would still pass if the shared wrapper lost all of its sizing and alignment classes.

## What changed

- **Assert the real classes.** The shared-wrapper test now checks for the concrete `size-4`, `shrink-0`, and `align-middle` utilities `StrokeIcon` applies, instead of mere truthiness. The stale CSS-modules test name and comment are gone.
- **One icon list, `it.each` everywhere.** Four near-identical per-icon `it` blocks and two separate inline `[IconPlay, IconSquare, IconRefresh, IconWarning]` array literals collapse into a single module-level `STROKE_ICONS` constant driving `it.each`. Cases are named via `Icon.name`, so a failure still reports which icon broke. Adding an icon is now one edit site instead of six.
- **Cover the two missing icons.** `IconArrowRight` is a zero-prop `StrokeIcon` that was simply absent from the list — it joins `STROKE_ICONS` and needs no other change. `IconChevron` gets its own test, since it deliberately renders a bare `<svg>` rather than the shared wrapper; folding it into the shared loop would force those assertions back toward the vacuous state this PR removes. Its test covers `aria-hidden` plus the `points` swap between `open: true` and `open: false`.

Test-only change — no source, behavior, or rendered output is touched.

## Testing

- `npx vitest run src/components/shared/icons.test.tsx` — 16 passed.
- `prek -a` — all hooks pass, including `tsc`, `eslint`, `prettier`, and `stylelint` for the frontend.

CI runs the full backend, system, and frontend suites across every supported Python version.

No screenshots: this touches only `*.test.tsx`, which `tools/frontend/check_pr_screenshots.py` excludes from the visual-evidence requirement, and nothing rendered changes.

Closes #2221
