### PR TITLE
test: assert filter-icon-dot presence with queryByTestId instead of a no-op toBeTruthy

### DIFF
--- a/frontend/src/components/shared/sort-header.test.tsx
+++ b/frontend/src/components/shared/sort-header.test.tsx
@@ -422,7 +422,7 @@ describe("SortHeader — hasActiveFilter", () => {
         Status
       </SortHeader>,
     );
-    expect(screen.getByTestId("filter-icon-dot")).toBeTruthy();
+    expect(screen.queryByTestId("filter-icon-dot")).not.toBeNull();
   });
 
   it("does not show the active dot when hasActiveFilter=false", () => {

--- a/frontend/src/components/shared/table-footer.test.tsx
+++ b/frontend/src/components/shared/table-footer.test.tsx
@@ -115,7 +115,7 @@ describe("TableFooter", () => {
         },
       };
       render(<TableFooter count="5 apps" columnFilters={filters} />);
-      expect(screen.getByTestId("filter-icon-dot")).toBeTruthy();
+      expect(screen.queryByTestId("filter-icon-dot")).not.toBeNull();
     });
 
     it("shows reset button in mobile panel when onResetFilters provided and a filter is active", async () => {


### PR DESCRIPTION
## Summary

Two positive assertions for the `filter-icon-dot` element were written as
`expect(screen.getByTestId("filter-icon-dot")).toBeTruthy()`. In that form the
`getByTestId` getter is doing the real work — it throws when the element is
absent — and the `.toBeTruthy()` matcher can never fail, because a DOM element
returned by the getter is always truthy. The assertion reads as if the matcher
is the check, but it is decorative.

`filter-icon.test.tsx` already used `queryByTestId` for both polarities, and
`sort-header.test.tsx`'s negative sibling (line 434) already used
`queryByTestId(...).toBeNull()` while its positive case did not — so the three
files asserting the *same* `filter-icon-dot` test id disagreed on how.

This aligns the two stragglers on the `queryByTestId` form:

- `frontend/src/components/shared/sort-header.test.tsx`
- `frontend/src/components/shared/table-footer.test.tsx`

Both now read `expect(screen.queryByTestId("filter-icon-dot")).not.toBeNull()`,
which puts the actual condition in the matcher. In `sort-header.test.tsx` that
also makes the positive case match its negative sibling line-for-line;
`table-footer.test.tsx` has no negative counterpart for this test id, and is
changed for cross-file consistency with the other two `filter-icon-dot` sites.

### Scope

Deliberately limited to the three `filter-icon-dot` assertion sites, per #2223.
The broader `expect(screen.getByTestId(...)).toBeTruthy()` shape appears ~19
more times across `frontend/src`, and `getByTestId` is the dominant
existence-check idiom suite-wide (934 `getByTestId` vs 166 `queryByTestId`). A
blanket rewrite is explicitly **not** proposed — `getByTestId` throws with a DOM
snapshot and so produces a better failure message, making wholesale conversion a
net loss. Those sites are intentionally left alone.

## Testing

Test-only change — no source files touched, so there is no behavior change and
no visual change (the screenshot guard excludes `*.test.tsx` by design).

Scoped locally before pushing:

- `prek -a` — all hooks pass, including `tsc (frontend)`, `eslint (frontend)`, and `prettier (frontend)`
- `npx vitest run src/components/shared/{sort-header,table-footer,filter-icon}.test.tsx` — 3 files, 43 tests, all passing
- Mutation check — forcing `FilterIcon` to never render the dot fails both changed
  assertions, confirming they are load-bearing rather than decorative

CI runs the full backend, system, and frontend suites across every supported
Python version.

Closes #2223
