### PR TITLE
test: assert the disabled-cursor utility across all rows, not just disabled ones

### DIFF
--- a/frontend/src/components/shared/log-table/column-picker.test.tsx
+++ b/frontend/src/components/shared/log-table/column-picker.test.tsx
@@ -138,14 +138,15 @@ describe("ColumnPicker", () => {
       await user.click(getByTestId("column-picker"));
 
       const checkboxes = getAllByRole("checkbox") as HTMLInputElement[];
-      const disabledLabels = checkboxes.filter((cb) => cb.disabled).map((cb) => cb.closest("label"));
+      expect(checkboxes.some((cb) => cb.disabled)).toBe(true);
 
-      expect(disabledLabels.length).toBeGreaterThan(0);
-      for (const label of disabledLabels) {
-        // A disabled row is never toggleable, so it must not show a pointer cursor. jsdom
-        // applies no Tailwind CSS, so this pins the utility's presence rather than the
-        // computed cursor; the cascade itself is Tailwind's guarantee, not this test's.
-        expect(label?.className).toContain("has-[:disabled]:cursor-default");
+      // Every row carries the utility unconditionally; the `:has(:disabled)` selector, not
+      // React, is what narrows it to disabled rows. So this asserts across all rows rather
+      // than filtering to the disabled ones, which would imply a per-row conditional that
+      // does not exist. jsdom applies no Tailwind CSS, so this pins the utility's presence
+      // rather than the computed cursor; the cascade itself is Tailwind's guarantee.
+      for (const checkbox of checkboxes) {
+        expect(checkbox.closest("label")?.className).toContain("has-[:disabled]:cursor-default");
       }
     });
 

--- a/frontend/src/components/shared/log-table/column-picker.tsx
+++ b/frontend/src/components/shared/log-table/column-picker.tsx
@@ -6,8 +6,9 @@ import { cn } from "@/lib/utils";
 import { COLUMNS, REQUIRED_COLUMNS } from "./constants";
 import type { ColumnId } from "./types";
 
-// Hover and focus-ring affordance shared by this popover's two chrome-less buttons, so the
-// pair cannot drift apart. Per-button layout and sizing stay at the call sites.
+// The bare-button look (no border or background) plus the hover and focus-ring affordance,
+// shared by this popover's two buttons so the pair cannot drift apart. Per-button layout
+// and sizing stay at the call sites.
 const BARE_BUTTON_CLASS =
   "cursor-pointer border-none bg-transparent text-muted-foreground transition-colors hover:text-foreground focus-visible:outline focus-visible:outline-2 focus-visible:outline-primary";
 


### PR DESCRIPTION
## Summary

Follow-up to #2232, which auto-merged while the review battery for it was still running — this applies the one substantive finding that pass produced.

**The test asserted something weaker than its shape implied.** `column-picker.tsx`'s label `className` is a static string literal, so `has-[:disabled]:cursor-default` is present on *every* row regardless of disabled state. The test filtered the checkboxes down to the disabled ones before asserting the class was present on their labels — which implied a per-row conditional that does not exist, and would have passed identically had it selected enabled rows instead. It now asserts across all rows and keeps a separate sanity check that at least one disabled row is actually rendered, so the assertion matches what the component really does: React applies the utility unconditionally, and Tailwind's `:has(:disabled)` selector is what narrows it.

Also corrects the `BARE_BUTTON_CLASS` comment, which described the constant as only "hover and focus-ring affordance" while it also carries the bare-button look itself (`border-none`, `bg-transparent`).

No behavior change — test and comment only.

## Verification

- RED/GREEN confirmed: removing `has-[:disabled]:cursor-default` from the component fails the test (1 failed / 14 passed); restoring it passes (15/15).
- Full frontend suite: 1624 tests across 110 files passing.
- `tsc --noEmit`, `eslint`, and `prettier --check` all clean; all pre-commit hooks pass.

Separately re-verified the two substantive claims from #2232's description against the built CSS rather than taking them on trust: `.has-\[\:disabled\]\:cursor-default:has(:disabled)` is emitted at specificity (0,2,0) and later in the stylesheet than `.cursor-pointer` at (0,1,0), so it wins on both counts; and Preflight's `*,:after,:before,::backdrop{...padding:0}` confirms the removed `py-0` on a `<label>` was genuinely a no-op.
